### PR TITLE
Forgotten-tricks

### DIFF
--- a/options.yaml
+++ b/options.yaml
@@ -399,6 +399,10 @@
     - LMF - Minecart Jump
     - LMF - Molderach without Gust Bellows
     # Ancient Cistern
+    - Ancient Cistern - Cistern Clip
+    - Ancient Cistern - Cistern Whip Room Clip
+    - Ancient Cistern - Map Chest Jump
+    - Ancient Cistern - Lever Jump
     - Ancient Cistern - Basement Highflip
     # Sandship
     - Sandship - No Combination Hint


### PR DESCRIPTION
Add forgotten tricks in Ancient Cistern
(there may be a naming debate because I kept the original "Map Chest Jump" name, to be discussed)