### PR TITLE
Hints Hotfixes

### DIFF
--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -193,6 +193,10 @@ class HintDistribution:
         self.rng.shuffle(sometimes_hints)
         self.sometimes_hints = sometimes_hints
 
+        # ensure prerandomized locations cannot be hinted
+        self.hinted_locations.extend(self.logic.prerandomization_item_locations.keys())
+        print(self.hinted_locations)
+
         # populate our internal list copies for later manipulation
         for sots_loc, item in self.logic.rando.sots_locations.items():
             if item in self.removed_items:

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -429,7 +429,13 @@ class HintDistribution:
         if not self.hintable_items:
             return None
         hinted_item = self.hintable_items.pop()
-        for location, item in self.logic.done_item_locations.items():
+        locs = [
+            (location, item)
+            for location, item in self.logic.done_item_locations.items()
+            if item == hinted_item and location not in self.hinted_locations
+        ]
+        self.rng.shuffle(locs)
+        for location, item in locs:
             if item == hinted_item and location not in self.hinted_locations:
                 self.hinted_locations.append(location)
                 return ItemGossipStoneHint(location, item, True)

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -268,7 +268,7 @@ class HintDistribution:
             curr_type = self.distribution[type]
             if type == "sometimes":
                 for i in range(curr_type["fixed"]):
-                    if hint := self._create_barren_hint():
+                    if hint := self._create_sometimes_hint():
                         self.hints.extend([hint] * curr_type["copies"])
             elif type == "sots":
                 for i in range(curr_type["fixed"]):

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -195,7 +195,6 @@ class HintDistribution:
 
         # ensure prerandomized locations cannot be hinted
         self.hinted_locations.extend(self.logic.prerandomization_item_locations.keys())
-        print(self.hinted_locations)
 
         # populate our internal list copies for later manipulation
         for sots_loc, item in self.logic.rando.sots_locations.items():


### PR DESCRIPTION
Fixes 3 problems:

- sword rewards being hintable as item, SotS, and random hints.
- item hints being semi-deterministic under specific conditions
- fixed sometimes hints generating barren hints

As a side effect, these changes also prevents the locations of small keys, boss keys, and single crystals from being hinted, outside of an always hint, which in turn prevents Skyloft regions from being SotS hinted for single crystals. It also is likely to decrease the frequency with which sometimes hints are successfully placed. It's possible that this may have unintended consequences for future plando implementations, but we can handle that with the plandos themselves. 