### PR TITLE
Rework cube hints & add item location/zone switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
       - Remove items from the hintable pool
       - Add locations to the always/sometimes pools
       - Remove locations from the always/sometimes pools
+  - Reworked the interaction between Goddess Cubes and hints (by YourAverageLink)
+    - Goddess chests are now linked to the region their associated cube is in for the purpose of hints
+      - For example, a SotS hint that would have previously pointed to the goddess chest next to Isle of Songs would say Mogma Turf is SotS not Thunderhead
+      - Additionally, an option has been added for whether or not cube SotS hints should look different (above example would say Eldin Volcano has a SotS cube)
+      - Barren region calculation now factors in the goddess cubes in the region; a region with no progress items but a cube that unlocks a progress item is NOT barren
   - New hint types
     - Junk
     - Random

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
       - For example, a SotS hint that would have previously pointed to the goddess chest next to Isle of Songs would say Mogma Turf is SotS not Thunderhead
       - Additionally, an option has been added for whether or not cube SotS hints should look different (above example would say Eldin Volcano has a SotS cube)
       - Barren region calculation now factors in the goddess cubes in the region; a region with no progress items but a cube that unlocks a progress item is NOT barren
+  - Added option to choose between specific locations for item hints or just the general region (by YourAverageLink)
+    - Note that the default setting is DISABLED, however previous versions of the randomizer always used the precise locations for item hints (ENABLED).
+    - When this option is disabled (which uses general regions), it will follow the same logic for Goddess Cubes 
+      - Example: Sword in the Goddess Chest next to Isle of Songs -> Progressive Sword can be found in Mogma Turf
   - New hint types
     - Junk
     - Random

--- a/checks.yaml
+++ b/checks.yaml
@@ -48,6 +48,7 @@ Central Skyloft - Bazaar Goddess Chest:
   type: skyloft, goddess, sand sea goddess
   Paths:
     - stage/F004r/r0/l0/TBox/93
+  cube_region: Lanayru Sand Sea
 Central Skyloft - Shed Chest:
   original item: Silver Rupee
   type: skyloft, miscellaneous
@@ -58,16 +59,19 @@ Central Skyloft - Shed Goddess Chest:
   type: skyloft, goddess, eldin goddess
   Paths:
     - stage/F000/r0/l0/TBox/79
+  cube_region: Eldin Volcano
 Central Skyloft - West Cliff Goddess Chest:
   original item: Silver Rupee
   type: skyloft, goddess, faron goddess
   Paths:
     - stage/F000/r0/l0/TBox/78
+  cube_region: Faron Woods
 Central Skyloft - Floating Island Goddess Chest:
   original item: Gold Rupee
   type: skyloft, goddess, floria goddess
   Paths:
     - stage/F000/r0/l0/TBox/91
+  cube_region: Lake Floria
 Central Skyloft - Waterfall Goddess Chest:
   original item: Heart Piece
   type: skyloft, goddess, sand sea goddess, mini dungeon
@@ -75,6 +79,7 @@ Central Skyloft - Waterfall Goddess Chest:
     - stage/F000/r0/l0/TBox/80
   hint: sometimes
   text: a <s<goddess cube>> <r<amongst the pirates>> reveals
+  cube_region: Lanayru Sand Sea
 Knight Academy - Pumpkin Archery - 600 Points:
   original item: Heart Piece
   type: skyloft, minigame
@@ -337,11 +342,13 @@ Sky - Lumpy Pumpkin - Goddess Chest on the Roof:
   type: sky, goddess, faron goddess, dungeon
   Paths:
     - stage/F020/r0/l0/TBox/87
+  cube_region: Skyview
 Sky - Lumpy Pumpkin - Outside Goddess Chest:
   original item: Progressive Pouch
   type: sky, goddess, faron goddess
   Paths:
     - stage/F020/r0/l0/TBox/64
+  cube_region: Faron Woods
 Sky - Lumpy Pumpkin Harp Minigame:
   original item: Heart Piece
   type: sky, long, minigame
@@ -356,16 +363,19 @@ Sky - Bamboo Island Goddess Chest:
   type: sky, goddess, eldin goddess, bombable
   Paths:
     - stage/F020/r0/l0/TBox/82
+  cube_region: Eldin Volcano
 Sky - Goddess Chest on Island next to Bamboo Island:
   original item: Silver Rupee
   type: sky, goddess, eldin goddess
   Paths:
     - stage/F020/r0/l0/TBox/71
+  cube_region: Eldin Volcano
 Sky - Goddess Chest in Cave on Island Next to Bamboo Island:
   original item: Heart Medal
   type: sky, goddess, lanayru goddess, bombable
   Paths:
     - stage/F020/r0/l0/TBox/83
+  cube_region: Lanayru Desert
 Sky - Beedle's Island Goddess Chest:
   original item: Heart Piece
   type: sky, goddess, lanayru goddess, combat
@@ -373,56 +383,67 @@ Sky - Beedle's Island Goddess Chest:
     - stage/F020/r0/l0/TBox/89
   hint: sometimes
   text: a <s<goddess cube>> at the <r<monument to time>> reveals
+  cube_region: Lanayru Desert
 Sky - Beedle's Island Cage Goddess Chest:
   original item: Rupee Medal
   type: sky, goddess, faron goddess
   Paths:
     - stage/F020/r0/l0/TBox/81
+  cube_region: Faron Woods
 Sky - Northeast Island Goddess Chest behind Bombable Rocks:
   original item: Silver Rupee
   type: sky, goddess, lanayru goddess
   Paths:
     - stage/F020/r0/l0/TBox/72
+  cube_region: Lanayru Mines
 Sky - Northeast Island Cage Goddess Chest:
   original item: Treasure Medal
   type: sky, goddess, eldin goddess
   Paths:
     - stage/F020/r0/l0/TBox/74
+  cube_region: Eldin Volcano
 Sky - Goddess Chest on Island Closest to Faron Pillar:
   original item: Heart Piece
   type: sky, goddess, faron goddess
   Paths:
     - stage/F020/r0/l0/TBox/65
+  cube_region: Faron Woods
 Sky - Goddess Chest outside Volcanic Island:
   original item: Heart Medal
   type: sky, goddess, lanayru goddess
   Paths:
     - stage/F020/r0/l0/TBox/67
+  cube_region: Lanayru Desert
 Sky - Goddess Chest inside Volcanic Island:
   original item: Heart Piece
   type: sky, goddess, faron goddess
   Paths:
     - stage/F020/r0/l0/TBox/68
+  cube_region: Faron Woods
 Sky - Goddess Chest under Fun Fun Island:
   original item: Gold Rupee
   type: sky, goddess, floria goddess
   Paths:
     - stage/F020/r0/l0/TBox/86
+  cube_region: Lake Floria
 Sky - Southwest Triple Island Upper Goddess Chest:
   original item: Small Seed Satchel
   type: sky, goddess, eldin goddess
   Paths:
     - stage/F020/r0/l0/TBox/66
+  cube_region: Eldin Volcano
 Sky - Southwest Triple Island Lower Goddess Chest:
   original item: Life Medal
   type: sky, goddess, lanayru goddess
   Paths:
     - stage/F020/r0/l0/TBox/84
+  cube_region: Lanayru Desert
 Sky - Southwest Triple Island Cage Goddess Chest:
   original item: Potion Medal
   type: sky, goddess, sand sea goddess
   Paths:
     - stage/F020/r0/l0/TBox/75
+  cube_region: Lanayru Sand Sea
 Sky - Dodoh's Crystals:
   original item: Gratitude Crystal Pack
   type: sky, lanayru, long, scrapper
@@ -487,16 +508,19 @@ Thunderhead - Goddess Chest outside Isle of Songs:
   type: thunderhead, goddess, eldin goddess
   Paths:
     - stage/F023/r0/l0/TBox/92
+  cube_region: Mogma Turf
 Thunderhead - Goddess Chest on top of Isle of Songs:
   original item: Small Bomb Bag
   type: thunderhead, goddess, summit goddess
   Paths:
     - stage/F023/r0/l0/TBox/85
+  cube_region: Volcano Summit
 Thunderhead - East Island Goddess Chest:
   original item: Rupee Medal
   type: thunderhead, goddess, faron goddess
   Paths:
     - stage/F023/r0/l0/TBox/73
+  cube_region: Faron Woods
 Thunderhead - East Island Chest:
   original item: Evil Crystal
   type: thunderhead, miscellaneous
@@ -507,11 +531,13 @@ Thunderhead - Bug Heaven Goddess Chest:
   type: thunderhead, goddess, summit goddess
   Paths:
     - stage/F023/r0/l0/TBox/88
+  cube_region: Volcano Summit
 Thunderhead - First Goddess Chest on Mogma Mitts Island:
   original item: Bottle
   type: thunderhead, goddess, summit goddess
   Paths:
     - stage/F023/r0/l0/TBox/77
+  cube_region: Volcano Summit
 #Thunderhead - Second Goddess Chest on Mogma Mitts Island:
 #  original item: Small Quiver
 #  type: thunderhead, goddess, lanayru goddess TODO: decide if this is a Lanayru or Sand Sea cube

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -1433,6 +1433,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="option_precise_item">
+          <property name="text">
+           <string>Precise Item Hints</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="verticalSpacer_11">
           <property name="orientation">
            <enum>Qt::Vertical</enum>

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -311,7 +311,7 @@
          <x>10</x>
          <y>20</y>
          <width>161</width>
-         <height>102</height>
+         <height>106</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_35">
@@ -1424,6 +1424,13 @@
            <widget class="QComboBox" name="option_hint_distribution"/>
           </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="option_cube_sots">
+          <property name="text">
+           <string>Separate Cube SotS Hints</string>
+          </property>
+         </widget>
         </item>
         <item>
          <spacer name="verticalSpacer_11">

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -946,6 +946,11 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_22.addWidget(self.option_cube_sots)
 
+        self.option_precise_item = QCheckBox(self.verticalLayoutWidget_12)
+        self.option_precise_item.setObjectName(u"option_precise_item")
+
+        self.verticalLayout_22.addWidget(self.option_precise_item)
+
         self.verticalSpacer_11 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
         self.verticalLayout_22.addItem(self.verticalSpacer_11)
@@ -1205,6 +1210,7 @@ class Ui_MainWindow(object):
         self.groupBox_10.setTitle(QCoreApplication.translate("MainWindow", u"Gossip Stone Hints", None))
         self.label_for_option_hint_distribution.setText(QCoreApplication.translate("MainWindow", u"Hint Distribution", None))
         self.option_cube_sots.setText(QCoreApplication.translate("MainWindow", u"Separate Cube SotS Hints", None))
+        self.option_precise_item.setText(QCoreApplication.translate("MainWindow", u"Precise Item Hints", None))
         self.groupBox_11.setTitle(QCoreApplication.translate("MainWindow", u"Other Hints", None))
         self.label_6.setText(QCoreApplication.translate("MainWindow", u"Song Hints", None))
         self.option_impa_sot_hint.setText(QCoreApplication.translate("MainWindow", u"Impa Stone of Trials Hint", None))

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -177,7 +177,7 @@ class Ui_MainWindow(object):
         self.groupBox_15.setGeometry(QRect(510, 130, 181, 131))
         self.verticalLayoutWidget_11 = QWidget(self.groupBox_15)
         self.verticalLayoutWidget_11.setObjectName(u"verticalLayoutWidget_11")
-        self.verticalLayoutWidget_11.setGeometry(QRect(10, 20, 161, 102))
+        self.verticalLayoutWidget_11.setGeometry(QRect(10, 20, 161, 106))
         self.verticalLayout_35 = QVBoxLayout(self.verticalLayoutWidget_11)
         self.verticalLayout_35.setObjectName(u"verticalLayout_35")
         self.verticalLayout_35.setContentsMargins(0, 0, 0, 0)
@@ -941,6 +941,11 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_22.addLayout(self.verticalLayout_24)
 
+        self.option_cube_sots = QCheckBox(self.verticalLayoutWidget_12)
+        self.option_cube_sots.setObjectName(u"option_cube_sots")
+
+        self.verticalLayout_22.addWidget(self.option_cube_sots)
+
         self.verticalSpacer_11 = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
         self.verticalLayout_22.addItem(self.verticalSpacer_11)
@@ -1199,6 +1204,7 @@ class Ui_MainWindow(object):
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_5), QCoreApplication.translate("MainWindow", u"Logic Settings", None))
         self.groupBox_10.setTitle(QCoreApplication.translate("MainWindow", u"Gossip Stone Hints", None))
         self.label_for_option_hint_distribution.setText(QCoreApplication.translate("MainWindow", u"Hint Distribution", None))
+        self.option_cube_sots.setText(QCoreApplication.translate("MainWindow", u"Separate Cube SotS Hints", None))
         self.groupBox_11.setTitle(QCoreApplication.translate("MainWindow", u"Other Hints", None))
         self.label_6.setText(QCoreApplication.translate("MainWindow", u"Song Hints", None))
         self.option_impa_sot_hint.setText(QCoreApplication.translate("MainWindow", u"Impa Stone of Trials Hint", None))

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -447,7 +447,12 @@ class HintDistribution:
             return None
         location, item = self.rng.choice(locs)
         self.hinted_locations.append(location)
-        return ItemGossipStoneHint(location, item, True)
+        if self.logic.rando.options["precise-item"]:
+            return ItemGossipStoneHint(location, item, True, None)
+        zone_override, _ = self.logic.split_location_name_by_zone(location)
+        if "Goddess Chest" in location:
+            zone_override = self.logic.rando.item_locations[location]["cube_region"]
+        return ItemGossipStoneHint(location, item, True, zone_override)
 
     def _create_random_hint(self):
         all_locations_without_hint = self.logic.filter_locations_for_progression(

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -8,7 +8,6 @@ from logic.constants import (
     POTENTIALLY_REQUIRED_DUNGEONS,
     ALL_DUNGEON_AREAS,
     SILENT_REALM_CHECKS,
-    GODDESS_PRECISE_ZONES,
 )
 from logic.logic import Logic
 from paths import RANDO_ROOT_PATH
@@ -107,7 +106,6 @@ class HintDistribution:
         self.junk_hints = []
         self.sometimes_hints = []
         self.hint_descriptors = []
-        self.goddess_cube_zones = GODDESS_PRECISE_ZONES
 
     def read_from_file(self, f):
         self._read_from_json(json.load(f))
@@ -373,14 +371,14 @@ class HintDistribution:
             self.sots_dungeon_placed += 1
         self.hinted_locations.append(loc)
         if "Goddess Chest" in loc:
-            zone = self.goddess_cube_zones[loc]
+            zone = self.logic.rando.item_locations[loc]["cube_region"]
             # place cube sots hint & catch specific zones and fit them into their general zone (as seen in the cube progress options)
             if self.logic.rando.options["cube-sots"]:
                 if zone == "Skyview":
                     zone = "Faron Woods"
-                if zone == "Mogma Turf":
+                elif zone == "Mogma Turf":
                     zone = "Eldin Volcano"
-                if zone == "Lanayru Mines":
+                elif zone == "Lanayru Mines":
                     zone = "Lanayru Desert"
                 return CubeSotSGossipStoneHint(loc, item, True, zone)
         return SpiritOfTheSwordGossipStoneHint(loc, item, True, zone)

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -135,14 +135,13 @@ class HintDistribution:
         self.logic = logic
 
         hint_descriptors = {}
-        
+
         for name, loc in self.logic.item_locations.items():
             if "text" in loc:
                 hint_descriptors[name] = loc["text"]
             else:
                 hint_descriptors[name] = name + " has"
         self.hint_descriptors = hint_descriptors
-
 
         for loc in self.added_locations:
             location = loc["location"]
@@ -219,7 +218,7 @@ class HintDistribution:
                 # don't hint boss keys unless keysanity is on
                 if item.endswith("Boss Key"):
                     continue
-            
+
             zone, specific_loc = Logic.split_location_name_by_zone(sots_loc)
             self.sots_locations.append((zone, sots_loc, item))
         self.rng.shuffle(self.sots_locations)

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -53,7 +53,7 @@ JUNK_TEXT = [
     "They say that you just have to get the right checks to win",
     "They say that rushing Peatrice is the play",
     "They say there is a 0.0000001164% chance your RNG won't change",
-    "If only we could go Back in Time and name the glitch properly..."
+    "If only we could go Back in Time and name the glitch properly...",
     'They say that there is something called a "hash" that makes it easier for people to verify that they are playing the right seed',
     "They say that the bad seed rollers are still in the car, seeking for a safe refugee",
     "Have you heard the tragedy of Darth Kolok the Pause? I thought not, it's not a story the admins would tell you",

--- a/hints/hint_types.py
+++ b/hints/hint_types.py
@@ -120,6 +120,29 @@ class SpiritOfTheSwordGossipStoneHint(GossipStoneHint):
     def __hash__(self):
         return hash(self.location + self.item)
 
+@dataclass
+class CubeSotSGossipStoneHint(GossipStoneHint):
+    cube_zone: str
+
+    def to_gossip_stone_text(self) -> List[str]:
+        return [
+            f"The <ye<goddess>> left a sacred gift for the hero who unites <r<{self.cube_zone}>> with the skies."
+        ]
+
+    def to_spoiler_log_text(self) -> str:
+        return f"{self.cube_zone} has a SotS cube"
+
+    def to_spoiler_log_json(self):
+        return {
+            "location": self.location,
+            "item": self.item,
+            "cube_zone": self.cube_zone,
+            "type": "cube_sots",
+        }
+
+    def __hash__(self):
+        return hash(self.location + self.item)
+
 
 @dataclass
 class BarrenGossipStoneHint(GossipStoneHint):

--- a/hints/hint_types.py
+++ b/hints/hint_types.py
@@ -120,6 +120,7 @@ class SpiritOfTheSwordGossipStoneHint(GossipStoneHint):
     def __hash__(self):
         return hash(self.location + self.item)
 
+
 @dataclass
 class CubeSotSGossipStoneHint(GossipStoneHint):
     cube_zone: str

--- a/hints/hint_types.py
+++ b/hints/hint_types.py
@@ -83,12 +83,18 @@ class LocationGossipStoneHint(GossipStoneHint):
 
 @dataclass
 class ItemGossipStoneHint(GossipStoneHint):
+    zone_override: str | None
+
     def to_gossip_stone_text(self) -> List[str]:
         zone, specific_loc = Logic.split_location_name_by_zone(self.location)
-        return [f"<y<{self.item}>> can be found at <r<{zone}: {specific_loc}>>"]
+        if not self.zone_override:
+            return [f"<y<{self.item}>> can be found at <r<{zone}: {specific_loc}>>"]
+        return [f"<y<{self.item}>> can be found in <r<{self.zone_override}>>"]
 
     def to_spoiler_log_text(self) -> str:
-        return f"{self.item} is on {self.location}"
+        if not self.zone_override:
+            return f"{self.item} is on {self.location}"
+        return f"{self.item} is in {self.zone_override}"
 
     def to_spoiler_log_json(self):
         return {"location": self.location, "item": self.item, "type": "item"}

--- a/hints/hint_types.py
+++ b/hints/hint_types.py
@@ -83,7 +83,7 @@ class LocationGossipStoneHint(GossipStoneHint):
 
 @dataclass
 class ItemGossipStoneHint(GossipStoneHint):
-    zone_override: str | None
+    zone_override: str
 
     def to_gossip_stone_text(self) -> List[str]:
         zone, specific_loc = Logic.split_location_name_by_zone(self.location)

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -131,35 +131,6 @@ STARTING_SWORD_COUNT = {
     "True Master Sword": 6,
 }
 
-GODDESS_PRECISE_ZONES = {
-    "Central Skyloft - Bazaar Goddess Chest": "Lanayru Sand Sea",
-    "Central Skyloft - West Cliff Goddess Chest": "Faron Woods",
-    "Central Skyloft - Shed Goddess Chest": "Eldin Volcano",
-    "Central Skyloft - Waterfall Goddess Chest": "Lanayru Sand Sea",
-    "Central Skyloft - Floating Island Goddess Chest": "Lake Floria",
-    "Sky - Goddess Chest outside Volcanic Island": "Lanayru Desert",
-    "Sky - Goddess Chest inside Volcanic Island": "Faron Woods",
-    "Sky - Goddess Chest under Fun Fun Island": "Lake Floria",
-    "Sky - Southwest Triple Island Upper Goddess Chest": "Eldin Volcano",
-    "Sky - Southwest Triple Island Lower Goddess Chest": "Lanayru Desert",
-    "Sky - Southwest Triple Island Cage Goddess Chest": "Lanayru Sand Sea",
-    "Sky - Lumpy Pumpkin - Outside Goddess Chest": "Faron Woods",
-    "Sky - Lumpy Pumpkin - Goddess Chest on the Roof": "Skyview",
-    "Sky - Goddess Chest on Island Closest to Faron Pillar": "Faron Woods",
-    "Sky - Bamboo Island Goddess Chest": "Eldin Volcano",
-    "Sky - Goddess Chest on Island next to Bamboo Island": "Eldin Volcano",
-    "Sky - Goddess Chest in Cave on Island Next to Bamboo Island": "Lanayru Desert",
-    "Sky - Beedle's Island Goddess Chest": "Lanayru Desert",
-    "Sky - Beedle's Island Cage Goddess Chest": "Faron Woods",
-    "Sky - Northeast Island Goddess Chest behind Bombable Rocks": "Lanayru Mines",
-    "Sky - Northeast Island Cage Goddess Chest": "Eldin Volcano",
-    "Thunderhead - Goddess Chest outside Isle of Songs": "Mogma Turf",
-    "Thunderhead - Goddess Chest on top of Isle of Songs": "Volcano Summit",
-    "Thunderhead - East Island Goddess Chest": "Faron Woods",
-    "Thunderhead - First Goddess Chest on Mogma Mitts Island": "Volcano Summit",
-    "Thunderhead - Bug Heaven Goddess Chest": "Volcano Summit",
-}
-
 ALL_TYPES = [
     "skyloft",
     "sky",

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -131,6 +131,35 @@ STARTING_SWORD_COUNT = {
     "True Master Sword": 6,
 }
 
+GODDESS_PRECISE_ZONES = {
+    "Central Skyloft - Bazaar Goddess Chest": "Lanayru Sand Sea",
+    "Central Skyloft - West Cliff Goddess Chest": "Faron Woods",
+    "Central Skyloft - Shed Goddess Chest": "Eldin Volcano",
+    "Central Skyloft - Waterfall Goddess Chest": "Lanayru Sand Sea",
+    "Central Skyloft - Floating Island Goddess Chest": "Lake Floria",
+    "Sky - Goddess Chest outside Volcanic Island": "Lanayru Desert",
+    "Sky - Goddess Chest inside Volcanic Island": "Faron Woods",
+    "Sky - Goddess Chest under Fun Fun Island": "Lake Floria",
+    "Sky - Southwest Triple Island Upper Goddess Chest": "Eldin Volcano",
+    "Sky - Southwest Triple Island Lower Goddess Chest": "Lanayru Desert",
+    "Sky - Southwest Triple Island Cage Goddess Chest": "Lanayru Sand Sea",
+    "Sky - Lumpy Pumpkin - Outside Goddess Chest": "Faron Woods",
+    "Sky - Lumpy Pumpkin - Goddess Chest on the Roof": "Skyview",
+    "Sky - Goddess Chest on Island Closest to Faron Pillar": "Faron Woods",
+    "Sky - Bamboo Island Goddess Chest": "Eldin Volcano",
+    "Sky - Goddess Chest on Island next to Bamboo Island": "Eldin Volcano",
+    "Sky - Goddess Chest in Cave on Island Next to Bamboo Island": "Lanayru Desert",
+    "Sky - Beedle's Island Goddess Chest": "Lanayru Desert",
+    "Sky - Beedle's Island Cage Goddess Chest": "Faron Woods",
+    "Sky - Northeast Island Goddess Chest behind Bombable Rocks": "Lanayru Mines",
+    "Sky - Northeast Island Cage Goddess Chest": "Eldin Volcano",
+    "Thunderhead - Goddess Chest outside Isle of Songs": "Mogma Turf",
+    "Thunderhead - Goddess Chest on top of Isle of Songs": "Volcano Summit",
+    "Thunderhead - East Island Goddess Chest": "Faron Woods",
+    "Thunderhead - First Goddess Chest on Mogma Mitts Island": "Volcano Summit",
+    "Thunderhead - Bug Heaven Goddess Chest": "Volcano Summit",
+}
+
 ALL_TYPES = [
     "skyloft",
     "sky",

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -31,7 +31,6 @@ from .constants import (
     ENTRANCE_CONNECTIONS,
     ALL_TYPES,
     STARTING_SWORD_COUNT,
-    GODDESS_PRECISE_ZONES,
 )
 from .logic_expression import LogicExpression, parse_logic_expression, Inventory
 
@@ -1466,7 +1465,7 @@ class Logic:
             zone_name, _ = Logic.split_location_name_by_zone(loc)
             # calculate barren regions for goddess CUBES not their chests
             if "Goddess Chest" in loc:
-                zone_name = GODDESS_PRECISE_ZONES[loc]
+                zone_name = self.rando.item_locations[loc]["cube_region"]
             item = self.done_item_locations[loc]
             if (
                 item in non_barren_items

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -31,6 +31,7 @@ from .constants import (
     ENTRANCE_CONNECTIONS,
     ALL_TYPES,
     STARTING_SWORD_COUNT,
+    GODDESS_PRECISE_ZONES,
 )
 from .logic_expression import LogicExpression, parse_logic_expression, Inventory
 
@@ -1463,6 +1464,9 @@ class Logic:
             non_barren_items.remove("Progressive Pouch")
         for loc in self.item_locations:
             zone_name, _ = Logic.split_location_name_by_zone(loc)
+            # calculate barren regions for goddess CUBES not their chests
+            if "Goddess Chest" in loc:
+                zone_name = GODDESS_PRECISE_ZONES[loc]
             item = self.done_item_locations[loc]
             if (
                 item in non_barren_items

--- a/options.yaml
+++ b/options.yaml
@@ -527,6 +527,13 @@
   help: If enabled, the WZSound.brsar file will be patched to allow custom music. Custom music must be installed manually.
   ui: option_allow_custom_music
 
+- name: Separate Cube SotS
+  command: cube-sots
+  type: boolean
+  default: false
+  help: If enabled, when a SotS hint points to a goddess chest, the hint will change to reflect that it points to a cube & display which of the six cube progress regions it falls into.
+  ui: option_cube_sots
+  
 # make this always last for maximum cross version permalink support
 - name: Hint Distribution
   command: hint-distribution
@@ -545,9 +552,3 @@
   help: Sets the distribution of hints. Distributions describe how many hints are placed and in what order, as well
     as specifics about what additional items and locations can and cannot be hinted
   ui: option_hint_distribution
-- name: Separate Cube SotS
-  command: cube-sots
-  type: boolean
-  default: false
-  help: If enabled, when a SotS hint points to a goddess chest, the hint will change to reflect that it points to a cube & display which of the six cube progress regions it falls into.
-  ui: option_cube_sots

--- a/options.yaml
+++ b/options.yaml
@@ -526,14 +526,12 @@
   cosmetic: true
   help: If enabled, the WZSound.brsar file will be patched to allow custom music. Custom music must be installed manually.
   ui: option_allow_custom_music
-
 - name: Separate Cube SotS
   command: cube-sots
   type: boolean
   default: false
   help: If enabled, when a SotS hint points to a goddess chest, the hint will change to reflect that it points to a cube & display which of the six cube progress regions it falls into.
   ui: option_cube_sots
-  
 # make this always last for maximum cross version permalink support
 - name: Hint Distribution
   command: hint-distribution

--- a/options.yaml
+++ b/options.yaml
@@ -545,3 +545,9 @@
   help: Sets the distribution of hints. Distributions describe how many hints are placed and in what order, as well
     as specifics about what additional items and locations can and cannot be hinted
   ui: option_hint_distribution
+- name: Separate Cube SotS
+  command: cube-sots
+  type: boolean
+  default: false
+  help: If enabled, when a SotS hint points to a goddess chest, the hint will change to reflect that it points to a cube & display which of the six cube progress regions it falls into.
+  #TODO: ui: option_cube_sots

--- a/options.yaml
+++ b/options.yaml
@@ -550,4 +550,4 @@
   type: boolean
   default: false
   help: If enabled, when a SotS hint points to a goddess chest, the hint will change to reflect that it points to a cube & display which of the six cube progress regions it falls into.
-  #TODO: ui: option_cube_sots
+  ui: option_cube_sots

--- a/options.yaml
+++ b/options.yaml
@@ -532,6 +532,12 @@
   default: false
   help: If enabled, when a SotS hint points to a goddess chest, the hint will change to reflect that it points to a cube & display which of the six cube progress regions it falls into.
   ui: option_cube_sots
+- name: Precise Item Hints
+  command: precise-item
+  type: boolean
+  default: false
+  help: If enabled, item hints will indicate exactly which check the item lies, otherwise, it will just indicate the region.
+  ui: option_precise_item
 # make this always last for maximum cross version permalink support
 - name: Hint Distribution
   command: hint-distribution


### PR DESCRIPTION
Change the interaction such that barren hints factor their goddess cubes in as well and sots hints pointing to goddess chests display the zone of the associated cube instead of the chest. Also adds an option for modifying the sots hint to say it involves a cube.