### PR TITLE
fix hint coloring for location hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
     - Random
     - Sometimes
     - Some of these hint types existed in prior versions, but users had no control over them
+- Changed item hints, that point to a specific location, to use the same hint format as location hints
 ### Bugfixes
 - always copy layer 0, this fixes various bugs, where changes from previous randomizations were not reverted
 


### PR DESCRIPTION
also change all hints that hint an item at a specific location to use the same format
make type more specific for location hints
remove special text coloring from junk hints