### PR TITLE
Add Emerald Tablet Chest

### DIFF
--- a/SS Rando Logic - Glitched Requirements.yaml
+++ b/SS Rando Logic - Glitched Requirements.yaml
@@ -943,7 +943,10 @@ Knight Academy - Pumpkin Archery - 600 Points:
 Knight Academy - Chest near Goddess Statue:
   Nothing
 
-Knight Academy - Chest in Goddess Statue:
+Knight Academy - First Chest in Goddess Statue:
+  Nothing
+
+Knight Academy - Second Chest in Goddess Statue:
   Nothing
 
 Can Access Dungeon Entrance on Skyloft:

--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -258,7 +258,10 @@ Knight Academy - Pumpkin Archery - 600 Points:
 Knight Academy - Chest near Goddess Statue:
   Nothing
 
-Knight Academy - Chest in Goddess Statue:
+Knight Academy - First Chest in Goddess Statue:
+  Nothing
+
+Knight Academy - Second Chest in Goddess Statue:
   Nothing
 
 Can Access Dungeon Entrance on Skyloft:

--- a/checks.yaml
+++ b/checks.yaml
@@ -38,11 +38,16 @@ Knight Academy - Chest near Goddess Statue:
   type: skyloft, miscellaneous
   Paths:
     - stage/F000/r0/l0/TBox/71
-Knight Academy - Chest in Goddess Statue:
+Knight Academy - First Chest in Goddess Statue:
   original item: Progressive Sword
   type: skyloft, miscellaneous
   Paths:
     - stage/F008r/r0/l0/TBox/95
+Knight Academy - Second Chest in Goddess Statue:
+  original item: Emerald Tablet
+  type: skyloft, miscellaneous
+  Paths:
+    - stage/F008r/r0/l0/TBox/94
 Central Skyloft - Bazaar Goddess Chest:
   original item: Gold Rupee
   type: skyloft, goddess, sand sea goddess

--- a/patches.yaml
+++ b/patches.yaml
@@ -905,7 +905,7 @@ F008r: # Goddess Statue
       posz: -1130
       anglex: 0xFFFF
       angley: 0
-      anglez: 0xBC02 # chest flag 96, item 2
+      anglez: 0xBC02 # chest flag 94, item 2
       id: 0xFC10
       name: TBox
   - name: Delete SwrdSt

--- a/patches.yaml
+++ b/patches.yaml
@@ -892,6 +892,22 @@ F008r: # Goddess Statue
       anglez: 0xBE02 # chest flag 95, item 0, will be filled in later
       id: 0xFC10
       name: TBox
+  - name: Emerald Tablet chest
+    type: objadd
+    layer: 0
+    room: 0
+    objtype: OBJS
+    object:
+      params1: 0xFFFFFFF3
+      params2: 0xFF5FFFFF
+      posx: 0
+      posy: 87.5
+      posz: -1130
+      anglex: 0xFFFF
+      angley: 0
+      anglez: 0xBC02 # chest flag 96, item 2
+      id: 0xFC10
+      name: TBox
   - name: Delete SwrdSt
     type: objdelete
     id: 0xFC05


### PR DESCRIPTION
Adds a new chest in the goddess statue corresponding with the vanilla Emerald Tablet location. Also renames the check `Chest Inside Goddess Statue` to allow both checks to exist