### PR TITLE
Fix items shuffled with any restrictions being unable to be hinted

### DIFF
--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -186,56 +186,22 @@ class HintDistribution:
         self.sometimes_hints = sometimes_hints
 
         # ensure prerandomized locations cannot be hinted
-        self.hinted_locations.extend(self.logic.prerandomization_item_locations.keys())
-
-        # filter out prerandomized keys
-        to_remove = []
-        for loc in self.hinted_locations:
-            item = self.logic.done_item_locations[loc]
-            if item.endswith("Small Key"):
-                if self.logic.rando.options["small-key-mode"] not in [
-                    "Anywhere",
-                    "Lanayru Caves Key Only",
-                ]:
-
-                    to_remove.append(loc)
-                elif (
-                    self.logic.rando.options["small-key-mode"]
-                    == "Lanayru Caves Key Only"
-                ):
-                    if item != "LanayruCaves Small Key":
-                        to_remove.append(loc)
-
-            if item.endswith("Boss Key"):
-                if self.logic.rando.options["boss-key-mode"] not in ["Anywhere"]:
-                    to_remove.append(loc)
-
-            if item.endswith("Map"):
-                if self.logic.rando.options["map-mode"] != "Anywhere":
-                    to_remove.append(loc)
-
-        for loc in to_remove:
-            self.hinted_locations.remove(loc)
+        self.hinted_locations.extend(
+            (
+                loc
+                for loc in self.logic.prerandomization_item_locations.keys()
+                if not self.logic.is_restricted_placement_item(
+                    self.logic.done_item_locations[loc]
+                )
+            )
+        )
 
         # populate our internal list copies for later manipulation
         for sots_loc, item in self.logic.rando.sots_locations.items():
             if item in self.removed_items:
                 continue
-            if self.logic.rando.options["small-key-mode"] not in [
-                "Anywhere",
-                "Lanayru Caves Key Only",
-            ]:
-                # don't hint small keys unless keysanity is on
-                if item.endswith("Small Key"):
-                    continue
-            elif self.logic.rando.options["small-key-mode"] == "Lanayru Caves Key Only":
-                if item.endswith("Small Key") and item != "LanayruCaves Small Key":
-                    continue
-
-            if self.logic.rando.options["boss-key-mode"] not in ["Anywhere"]:
-                # don't hint boss keys unless keysanity is on
-                if item.endswith("Boss Key"):
-                    continue
+            if self.logic.is_restricted_placement_item(item):
+                continue
 
             zone, specific_loc = Logic.split_location_name_by_zone(sots_loc)
             self.sots_locations.append((zone, sots_loc, item))

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -188,6 +188,35 @@ class HintDistribution:
         # ensure prerandomized locations cannot be hinted
         self.hinted_locations.extend(self.logic.prerandomization_item_locations.keys())
 
+        # filter out prerandomized keys
+        to_remove = []
+        for loc in self.hinted_locations:
+            item = self.logic.done_item_locations[loc]
+            if item.endswith("Small Key"):
+                if self.logic.rando.options["small-key-mode"] not in [
+                    "Anywhere",
+                    "Lanayru Caves Key Only",
+                ]:
+
+                    to_remove.append(loc)
+                elif (
+                    self.logic.rando.options["small-key-mode"]
+                    == "Lanayru Caves Key Only"
+                ):
+                    if item != "LanayruCaves Small Key":
+                        to_remove.append(loc)
+
+            if item.endswith("Boss Key"):
+                if self.logic.rando.options["boss-key-mode"] not in ["Anywhere"]:
+                    to_remove.append(loc)
+
+            if item.endswith("Map"):
+                if self.logic.rando.options["map-mode"] != "Anywhere":
+                    to_remove.append(loc)
+
+        for loc in to_remove:
+            self.hinted_locations.remove(loc)
+
         # populate our internal list copies for later manipulation
         for sots_loc, item in self.logic.rando.sots_locations.items():
             if item in self.removed_items:

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -1491,6 +1491,27 @@ class Logic:
                     nonprogress.append(region)
         return barren, nonprogress
 
+    def is_restricted_placement_item(self, item):
+        if item.endswith("Small Key"):
+            if self.rando.options["small-key-mode"] not in [
+                "Anywhere",
+                "Lanayru Caves Key Only",
+            ]:
+
+                return True
+            elif self.rando.options["small-key-mode"] == "Lanayru Caves Key Only":
+                if item != "LanayruCaves Small Key":
+                    return True
+
+        if item.endswith("Boss Key"):
+            if self.rando.options["boss-key-mode"] not in ["Anywhere"]:
+                return True
+
+        if item.endswith("Map"):
+            if self.rando.options["map-mode"] != "Anywhere":
+                return True
+        return False
+
     def calculate_playthrough_progression_spheres(self):
         remaining_locations = set(self.item_locations.keys())
         temp_inventory = Inventory()


### PR DESCRIPTION
**This is a critical S2 fix**

This fixes a bug that causes items that have restricted placements to be unable to be hinted by any type of hint besides always. Currently this only affects maps, small keys, and big keys, however it can be expanded for any other items that my be placed under restrictions in the future. This does not impact fully pre-randomized items such as swords at the end of dungeons in the sword reward mode.

This does have a slight side effect - if for whatever reason keys a fully pre-randomized manually by a code edit, they are still eligible to be hinted, which is contrary to the expected behavior. However, there is no way to tell the difference between an item that was pre-randomized directly and one that placed in the early randomization passes