### PR TITLE
Add LMF Spike Maze chest to D300

### DIFF
--- a/checks.yaml
+++ b/checks.yaml
@@ -1113,6 +1113,7 @@ Lanayru Mining Facility - Chest in Spike Maze:
   type: lanayru, dungeon
   Paths:
     - stage/D300_1/r7/l0/TBox/73
+    - stage/D300/r7/l0/TBox/73
 Lanayru Mining Facility - Boss Key Chest:
   original item: LMF Boss Key
   type: lanayru, dungeon


### PR DESCRIPTION
Because you can reach that chest in D300 it needs to be added to the check