### PR TITLE
Decouple Kina from Minigames

### DIFF
--- a/SS Rando Logic - Glitched Requirements.yaml
+++ b/SS Rando Logic - Glitched Requirements.yaml
@@ -1227,8 +1227,8 @@ Sky - Lumpy Pumpkin Harp Minigame:
   Chandelier Quest Over
 
 Sky - Kina's Crystals:
-  Chandelier Quest Over & Can Access Mogma Turf
-  # Unlocked after Chandelier Quest
+  Chandelier Quest Part 1 & Can Access Mogma Turf
+  # Unlocked after giving Eagus the soup
 
 Sky - Lumpy Pumpkin - Outside Goddess Chest:
   Initial Goddess Cube

--- a/SS Rando Logic - Glitched Requirements.yaml
+++ b/SS Rando Logic - Glitched Requirements.yaml
@@ -1228,7 +1228,7 @@ Sky - Lumpy Pumpkin Harp Minigame:
 
 Sky - Kina's Crystals:
   Chandelier Quest Part 1 & Can Access Mogma Turf
-  # Unlocked after giving Eagus the soup
+  # Unlocked after giving Eagus the soup and talking to Pumm to start the Kina pumpkin moving quest
 
 Sky - Lumpy Pumpkin - Outside Goddess Chest:
   Initial Goddess Cube

--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -550,7 +550,7 @@ Sky - Lumpy Pumpkin Harp Minigame:
 
 Sky - Kina's Crystals:
   Chandelier Quest Part 1 & Can Access Mogma Turf
-  # Unlocked after giving Eagus the soup
+  # Unlocked after giving Eagus the soup and talking to Pumm to start the Kina pumpkin moving quest
 
 Sky - Lumpy Pumpkin - Outside Goddess Chest:
   Initial Goddess Cube

--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -549,8 +549,8 @@ Sky - Lumpy Pumpkin Harp Minigame:
   Chandelier Quest Over
 
 Sky - Kina's Crystals:
-  Chandelier Quest Over & Can Access Mogma Turf
-  # Unlocked after Chandelier Quest
+  Chandelier Quest Part 1 & Can Access Mogma Turf
+  # Unlocked after giving Eagus the soup
 
 Sky - Lumpy Pumpkin - Outside Goddess Chest:
   Initial Goddess Cube

--- a/checks.yaml
+++ b/checks.yaml
@@ -472,11 +472,11 @@ Sky - Orielle's Crystals:
     - oarc/F020/l0
 Sky - Kina's Crystals:
   original item: Gratitude Crystal Pack
-  type: sky, eldin, scrapper, minigame, long, crystal quest
+  type: sky, eldin, scrapper, long, crystal quest
   Paths:
     - event/117-Pumpkin/386
     - oarc/F020/l0
-  hint: always
+  hint: sometimes
   text: <r<delivering a mogma to the sky>> is rewarded with
 Sky - Beedle's Crystals:
   original item: Gratitude Crystal Pack

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -1090,14 +1090,14 @@
       param3: 0
     cases:
       - 96 # mogma quest switch
-      - 499 # pumpkin carrying
+      - 200 # pumpkin carrying
       - -1 # nothing
   - name: Show Kina Option
-    type: flowadd
+    type: flowpatch
+    index: 605
     flow:
       type: type1
       next: Kina Quest Switch
-      param3: 82
       param4: New Kina Text Option
 118-Town3:
   - name: Shorten Sparrot quest start text

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -1079,6 +1079,26 @@
     cases:
       - 208
       - 216
+  - name: New Kina Text Option
+    type: textadd
+    text: "Hey, kid, what do you need from me?\n[1]Plowing the fields?[2]Carrying pumpkins![3-]Nothing."
+  - name: Kina Quest Switch
+    type: switchadd
+    flow:
+      subType: 6
+      param2: 0
+      param3: 0
+    cases:
+      - 96 # mogma quest switch
+      - 499 # pumpkin carrying
+      - -1 # nothing
+  - name: Show Kina Option
+    type: flowadd
+    flow:
+      type: type1
+      next: Kina Quest Switch
+      param3: 82
+      param4: New Kina Text Option
 118-Town3:
   - name: Shorten Sparrot quest start text
     type: flowpatch


### PR DESCRIPTION
Adds a text option when you talk to Kina outside that lets you choose between carrying pumpkins and starting her crystal quest. Both can be done independent of each other.