### PR TITLE
Add main node option for LMF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 - Temple of Time is always in post LMF finish state
 - Beating Skyview (even if it's in a different dungeon) rescues Machi
 - Beating Ancient Cistern (even if it's in a different dungeon) removes the void in the Great Tree
+- Added "Main Node" option to Open LMF (by YourAverageLink)
+  - When enabled, the fire, water, and lightning nodes will start out as active, but the player still needs to activate the main node (which requires an explosive to reveal the timeshift stone) to raise LMF.
 ### Bugfixes
 - always copy layer 0, this fixes various bugs, where changes from previous randomizations were not reverted
 - fix gorko sometimes asking to draw bombs even when you don't have them

--- a/SS Rando Logic - Glitched Requirements.yaml
+++ b/SS Rando Logic - Glitched Requirements.yaml
@@ -1887,7 +1887,10 @@ Can Activate Water Node:
 Can Raise Lanayru Mining Facility:
   (Can Activate Water Node & Can Activate Lightning Node & Can Activate Fire Node & Sword) |
   Option "open-lmf" Is "Open" |
+  (Option "open-lmf" Is "Main Node" & Can Access Second Part of Lanayru Desert & (Bomb Bag | Hook Beetle) & Sword) |
   (Can Access Lanayru Desert & Can RBM 2x40)
+  # TODO: add trick for whipping bomb flower near LMF being sufficient for Main Node only
+  # Need explosive for Main Node LMF so the timeshift stone can be activated
   # Scene Flag 2x40 is "LMF Rises up (+ Main Node is locked)"
 
 Can Access Dungeon Entrance in Lanayru Desert:

--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -1239,7 +1239,7 @@ Can Activate Water Node:
 Can Raise Lanayru Mining Facility:
   (Can Activate Water Node & Can Activate Lightning Node & Can Activate Fire Node & Sword) |
   Option "open-lmf" Is "Open" | 
-  (Option "open-lmf" Is "Main Node" & Can Access Second Part of Lanayru Desert & (Bomb Bag | Hook Beetle) & Sword) |
+  (Option "open-lmf" Is "Main Node" & Can Access Second Part of Lanayru Desert & (Bomb Bag | Hook Beetle) & Sword)
   # TODO: add trick for whipping bomb flower near LMF being sufficient for Main Node only
   # Need explosive for Main Node LMF so the timeshift stone can be activated 
 

--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -1238,8 +1238,10 @@ Can Activate Water Node:
 
 Can Raise Lanayru Mining Facility:
   (Can Activate Water Node & Can Activate Lightning Node & Can Activate Fire Node & Sword) |
-  Option "open-lmf" Is "Open"
-  # Scene Flag 2x40 is "LMF Rises up (+ Main Node is locked)"
+  Option "open-lmf" Is "Open" | 
+  (Option "open-lmf" Is "Main Node" & Can Access Second Part of Lanayru Desert & (Bomb Bag | Hook Beetle) & Sword) |
+  # TODO: add trick for whipping bomb flower near LMF being sufficient for Main Node only
+  # Need explosive for Main Node LMF so the timeshift stone can be activated 
 
 Can Access Dungeon Entrance in Lanayru Desert:
   Can Access Second Part of Lanayru Desert & Can Raise Lanayru Mining Facility

--- a/options.yaml
+++ b/options.yaml
@@ -268,9 +268,9 @@
   bits: 2
   choices:
     - Nodes
-    - Main Node
     # - Hook Beetle
     - Open
+    - Main Node
   default: Nodes
   help: Controls the conditions for opening LMF. Nodes requires activating the 3 nodes as in vanilla,
     Main Node will set the fire, water, and lightning nodes to be active but LMF still needs to be raised from the main node.

--- a/options.yaml
+++ b/options.yaml
@@ -268,11 +268,12 @@
   bits: 2
   choices:
     - Nodes
+    - Main Node
     # - Hook Beetle
     - Open
   default: Nodes
   help: Controls the conditions for opening LMF. Nodes requires activating the 3 nodes as in vanilla,
-    Hook Beetle will raise LMF once the Hook Beetle is obtained.
+    Main Node will set the fire, water, and lightning nodes to be active but LMF still needs to be raised from the main node.
   ui: option_open_lmf
 - name: Skip Horde
   command: skip-horde

--- a/patches.yaml
+++ b/patches.yaml
@@ -71,6 +71,12 @@ global:
         flag: 30 # LMF Rises CS
       - onlyif: Option "open-lmf" Is "Open"
         flag: 31 # LMF rising CS watched
+      - onlyif: Option "open-lmf" Is "Main Node"
+        flag: 100 # Lightning node active
+      - onlyif: Option "open-lmf" Is "Main Node"
+        flag: 101 # Fire node active
+      - onlyif: Option "open-lmf" Is "Main Node"
+        flag: 102 # Water node active
   objpackoarcadd: # Models to add to the global ObjectPack.arc.LZ file
     - GetSozaiL # Monster Horn (part of treasure)
     # - GetSozaiM # Evil Crystal (part of treasure), already part of objectpack


### PR DESCRIPTION
Adds option for starting with each of the three subnodes activated, but still needing to activate the main generator to actually raise LMF.