### PR TITLE
Deletes extra Parrow in Parrow's House

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -912,6 +912,12 @@ F005r: # Orielle and Parrow's House
     objtype: OBJ
     object:
       trigstoryfid: -1 # always Trigger
+  - name: Delete Parrow before Crystal Quest
+    type: objdelete
+    id: 0xFC13
+    layer: 2
+    room: 0
+    objtype: OBJ
 F008r: # Goddess Statue
   - name: Goddess Sword chest
     type: objadd


### PR DESCRIPTION
Because of the removeing of the wyrna requirement there are 2 parrow's at night now until you talk to wyrna for her check. To fix this the parrow before the wyrna's crystals has been removed