### PR TITLE
remove slingshot/top of lmf, add dodoh, balancing

### DIFF
--- a/checks.yaml
+++ b/checks.yaml
@@ -147,6 +147,7 @@ Knight Academy - Fledge's Crystals:
   Paths:
     - event/115-Town2/325
     - oarc/F001r/l0
+  text: <r<lending strength to a friend>> yields
 Skyloft Village - Bertie's Crystals:
   original item: Gratitude Crystal Pack
   type: skyloft, fetch, crystal quest
@@ -455,6 +456,7 @@ Sky - Dodoh's Crystals:
   Paths:
     - event/110-DivingGame/60
     - oarc/F020/l0
+  text: delivering a <r<colorful wheel>> is rewarded with
 Sky - Fun Fun Island Minigame - 500 Rupees:
   original item: Heart Piece
   type: sky, lanayru, minigame, long, scrapper

--- a/hints/distributions/S2 - 2D.json
+++ b/hints/distributions/S2 - 2D.json
@@ -1,18 +1,20 @@
 {
     "banned_stones": [],
-    "added_locations": [],
-    "removed_locations": [],
+    "added_locations": [
+      {"location": "Sky - Dodoh's Crystals", "type": "sometimes"}
+    ],
+    "removed_locations": ["Lanayru Desert - Chest on top of Lanayru Mining Facility","Faron Woods - Slingshot"],
     "added_items": [],
     "removed_items": [],
     "dungeon_sots_limit": 2,
     "dungeon_barren_limit": 2,
     "distribution": {
       "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
-      "sometimes": {"order":  1, "weight":  1.00, "fixed":  8, "copies":  1},
-      "sots": {"order":  2, "weight":  1.10, "fixed":  4, "copies":  1},
-      "barren": {"order": 3, "weight":  0.80, "fixed":  2, "copies":  1},
-      "item": {"order":  4, "weight":  1.20, "fixed":  3, "copies":  1},
-      "random": {"order":  5, "weight":  0.70, "fixed":  1, "copies":  1},
+      "sometimes": {"order":  1, "weight":  1.00, "fixed":  7, "copies":  1},
+      "sots": {"order":  2, "weight":  0.75, "fixed":  4, "copies":  1},
+      "barren": {"order": 3, "weight":  0.60, "fixed":  2, "copies":  1},
+      "item": {"order":  4, "weight":  0.70, "fixed":  2, "copies":  1},
+      "random": {"order":  5, "weight":  0.65, "fixed":  1, "copies":  1},
       "junk": {"order":  6, "weight":  0.50, "fixed":  1, "copies":  1}
     }
   }

--- a/hints/distributions/S2 - 3D EUD Off.json
+++ b/hints/distributions/S2 - 3D EUD Off.json
@@ -1,19 +1,21 @@
 {
     "banned_stones": [],
-    "added_locations": [],
-    "removed_locations": [],
+    "added_locations": [
+      {"location": "Sky - Dodoh's Crystals", "type": "sometimes"}
+    ],
+    "removed_locations": ["Lanayru Desert - Chest on top of Lanayru Mining Facility","Faron Woods - Slingshot"],
     "added_items": [],
     "removed_items": [],
     "dungeon_sots_limit": 2,
     "dungeon_barren_limit": 2,
     "distribution": {
       "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
-      "sometimes": {"order":  1, "weight":  1.00, "fixed":  8, "copies":  1},
+      "sometimes": {"order":  1, "weight":  1.00, "fixed":  7, "copies":  1},
       "goal": {"order":  2, "weight":  0.00, "fixed":  1, "copies":  1},
       "sots": {"order":  3, "weight":  1.00, "fixed":  4, "copies":  1},
       "barren": {"order": 4, "weight":  1.00, "fixed":  2, "copies":  1},
-      "item": {"order":  5, "weight":  1.10, "fixed":  3, "copies":  1},
-      "random": {"order":  6, "weight":  0.60, "fixed":  0, "copies":  1},
+      "item": {"order":  5, "weight":  0.90, "fixed":  2, "copies":  1},
+      "random": {"order":  6, "weight":  0.65, "fixed":  0, "copies":  1},
       "junk": {"order":  7, "weight":  0.40, "fixed":  0, "copies":  1}
     }
   }

--- a/hints/distributions/S2 - 3D.json
+++ b/hints/distributions/S2 - 3D.json
@@ -1,18 +1,20 @@
 {
     "banned_stones": [],
-    "added_locations": [],
-    "removed_locations": [],
+    "added_locations": [
+      {"location": "Sky - Dodoh's Crystals", "type": "sometimes"}
+    ],
+    "removed_locations": ["Lanayru Desert - Chest on top of Lanayru Mining Facility","Faron Woods - Slingshot"],
     "added_items": [],
     "removed_items": [],
     "dungeon_sots_limit": 2,
     "dungeon_barren_limit": 2,
     "distribution": {
       "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
-      "sometimes": {"order":  1, "weight":  1.00, "fixed":  8, "copies":  1},
+      "sometimes": {"order":  1, "weight":  1.00, "fixed":  7, "copies":  1},
       "goal": {"order":  2, "weight":  0.00, "fixed":  1, "copies":  1},
       "sots": {"order":  3, "weight":  0.90, "fixed":  3, "copies":  1},
       "barren": {"order": 4, "weight":  0.80, "fixed":  2, "copies":  1},
-      "item": {"order":  5, "weight":  1.10, "fixed":  3, "copies":  1},
+      "item": {"order":  5, "weight":  0.90, "fixed":  2, "copies":  1},
       "random": {"order":  6, "weight":  0.70, "fixed":  0, "copies":  1},
       "junk": {"order":  7, "weight":  0.50, "fixed":  0, "copies":  1}
     }


### PR DESCRIPTION
Final hint distro tweaks before season 2.

Dodoh Crystals has been added as a sometimes hint

Top of LMF hint has been removed for redundancy (all settings have open LMF)

Slingshot hint has been removed to avoid unhinted Owlan Crystals w/ barren slingshot situations.

Some tweaks made to distributions (removing one fixed item and sometimes from each, weakening slightly with weights)