### PR TITLE
Fix Tricks not Reloading From Saved Settings Properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Dev
 ### Changes
-### Bugfixes 
+### Bugfixes
+- Fixed a bug that prevented tricks from being properly reloaded when the randomizer restarted multiple times without changes to the list
 
 ## 1.3.2
 ### Changes

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -208,6 +208,7 @@ class RandoGUI(QMainWindow):
         self.ui.progression_goddess.clicked.connect(self.goddess_cubes_toggled)
         self.ui.seed_button.clicked.connect(self.gen_new_seed)
         self.update_ui_for_settings()
+        self.update_settings()
         self.set_option_description(None)
 
         self.ui.tabWidget.setCurrentIndex(0)


### PR DESCRIPTION
This fix isn't elegant but it probably is the *correct* fix. This may also fix similar bugs that haven't been found yet, and should prevent similar bugs from appearing in the future.

## Root Cause Details
When the UI is initialized, default values are loaded in for all options before loading from the settings file (this ensures that even if the settings file is missing or incomplete from a previous version all options are properly initialized). However, because the tricks system is not a 1:1 relationship between the UI and the setting like every other implemented option, the additional processing done on it to populate the UI during loading caused the values stored in the settings file and in working memory to become desynced. Adding a call to synchronize all the settings after the UI has been fully initialized from defaults and the settings file should prevent this from ever happening