### PR TITLE
Fix no fi text before Lopsa roll, remove BK chest cs in FS

### DIFF
--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -1315,6 +1315,12 @@
     index: 165
     flow:
       next: -1
+  - name: change Flag to skip over Fi telling you that you can roll
+    type: flowpatch
+    index: 119
+    flow:
+      param1: 13
+      param3: 2
 
 201-ForestD1:
   - name: give item after beating skyview

--- a/patches.yaml
+++ b/patches.yaml
@@ -2333,6 +2333,12 @@ D201: # FS A
     layer: 0
     room: 0
     objtype: OBJ
+  - name: BK chest intro cs deleted
+    type: objdelete
+    id: 0xFC44
+    layer: 0
+    room: 4
+    objtype: STAG
 D201_1: # FS B
   - name: Clawshot Target for 2nd small Key
     type: objadd


### PR DESCRIPTION
Sets now the correct flag after finishing the bokoblins and thus allos to remove the fi text for real this time.
cs showing off the BK chest in FS has been removed