### PR TITLE
Remove first time textboxes 2: electric boogaloo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Machi is no longer rescued after beating Skyview
 - Added custom dowsing images for new chest dowsing functionality (by YourAverageLink)
 - Shooting the bell during pumpkin archery ends the minigame immediately
+- Removed first time textboxes (by CovenEsme)
+  - Removes rupee, heart, arrow, bomb, stamina fruit, silent realm tear and light fruit first time textboxes
 ### Bugfixes
 - Fixed a bug that prevented tricks from being properly reloaded when the randomizer restarted multiple times without changes to the list
 - Fixed a softlock caused by collecting the last 2 tears in a trial too close together

--- a/patches.yaml
+++ b/patches.yaml
@@ -42,7 +42,21 @@ global:
     - storyflag: 8 # LMF rising CS watched
       onlyif: Option "open-lmf" Is "Open"
   startitems: # careful, items are NOT progressive here (only set item flag, no text), storyflag for upgrade has to be set manually
+    - 2 # Green Rupee
+    - 3 # Blue Rupee
+    - 4 # Red Rupee
+    - 6 # Heart
+    - 7 # Single Arrow
+    - 8 # Bundle of Arrows
     - 15 # sailcloth
+    - 40 # 5 Bombs
+    - 41 # 10 Bombs
+    - 42 # Stamina Fruit
+    - 43 # Tear of Farore
+    - 44 # Tear of Din
+    - 45 # Tear of Nayru
+    - 46 # Sacred Tear
+    - 47 # Light Fruit
   startsceneflags: # currently only for skyloft
     Skyloft:
       - 95 # Fi Text for Ruby Tablet

--- a/patches.yaml
+++ b/patches.yaml
@@ -33,6 +33,7 @@ global:
     - 199 # talked to sword instructor after practice sword chest
     - 804 # eldin entrance statue
     - 386 # first part of bertie's text seen
+    - 70 # First time Light Fruit Cutscene
     - storyflag: 134 # Horde defeated
       onlyif: Option "skip-horde" Enabled
     - storyflag: 347 # Horde cutscene watched - must be set because the cutscene forces the horde fight


### PR DESCRIPTION
Removes first time textboxes for:
* Green, blue and red Rupees
* Heart flowers
* Arrow drops (singles and bundles)
* Bombs (5 and 10)
* Stamina Fruits
* Silent Realm Tears
* Silent Realm Light Fruits