### PR TITLE
fix barbed wire not being gone after obtaining triforce of wisdom check

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -420,6 +420,12 @@ D003_2: # Sky Keep Power Room
     room: 0
     objtype: OBJ
 D003_3: # Sky Keep Wisdom Room
+  - name: Layer override
+    type: layeroverride
+    override:
+      - story_flag: -1
+        night: 0
+        layer: 1 # always use layer 1, 
   - name: Fi text
     type: objdelete
     id: 0xFC1B
@@ -509,6 +515,13 @@ D003_8: # this change is purely to make sure D003_8 gets patched, so a perviousl
       angley: 0
       anglez: 0xFFFF
       name: ScChang
+  - name: layer 2 in Wisdom room
+    type: objpatch
+    index: 1
+    room: 0
+    objtype: SCEN
+    object:
+      layer: 2 # force layer 2 so the barbed wire is gone
 F000: # Skyloft
   - name: Trial
     type: oarcadd


### PR DESCRIPTION
This slightly changes vanilla behaviour, because with this patch the barbed wire only stays gone until you reload via leaving the room, while in vanilla it's always gone after getting the triforce.

However, I don't think this is an issue.

Successfully tested it on console.