### PR TITLE
n hints per stone

### DIFF
--- a/hints/distributions/Balanced.json
+++ b/hints/distributions/Balanced.json
@@ -1,19 +1,20 @@
 {
-    "banned_stones": [],
-    "added_locations": [],
-    "removed_locations": [],
-    "added_items": [],
-    "removed_items": [],
-    "dungeon_sots_limit": 2,
-    "dungeon_barren_limit": 2,
-    "distribution": {
-      "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
-      "sometimes": {"order":  1, "weight":  1.00, "fixed":  5, "copies":  1},
-      "goal": {"order":  2, "weight":  0.00, "fixed":  1, "copies":  1},
-      "sots": {"order":  3, "weight":  1.30, "fixed":  2, "copies":  1},
-      "barren": {"order": 4, "weight":  1.50, "fixed":  1, "copies":  1},
-      "item": {"order":  5, "weight":  2.00, "fixed":  1, "copies":  1},
-      "random": {"order":  6, "weight":  0.40, "fixed":  0, "copies":  1},
-      "junk": {"order":  7, "weight":  0.30, "fixed":  0, "copies":  1}
-    }
+  "hints_per_stone": 2,
+  "banned_stones": [],
+  "added_locations": [],
+  "removed_locations": [],
+  "added_items": [],
+  "removed_items": [],
+  "dungeon_sots_limit": 2,
+  "dungeon_barren_limit": 2,
+  "distribution": {
+    "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
+    "sometimes": {"order":  1, "weight":  1.00, "fixed":  5, "copies":  1},
+    "goal": {"order":  2, "weight":  0.00, "fixed":  1, "copies":  1},
+    "sots": {"order":  3, "weight":  1.30, "fixed":  2, "copies":  1},
+    "barren": {"order": 4, "weight":  1.50, "fixed":  1, "copies":  1},
+    "item": {"order":  5, "weight":  2.00, "fixed":  1, "copies":  1},
+    "random": {"order":  6, "weight":  0.40, "fixed":  0, "copies":  1},
+    "junk": {"order":  7, "weight":  0.30, "fixed":  0, "copies":  1}
   }
+}

--- a/hints/distributions/Co-op S1.json
+++ b/hints/distributions/Co-op S1.json
@@ -1,20 +1,21 @@
 {
-    "banned_stones": [],
-    "added_locations": [],
-    "removed_locations": [],
-    "added_items": [],
-    "removed_items": [
-      "Key Piece #0", "Key Piece #1", "Key Piece #2", "Key Piece #3", "Key Piece #4"
-    ],
-    "dungeon_sots_limit": 2,
-    "dungeon_barren_limit": 2,
-    "distribution": {
-      "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
-      "sometimes": {"order":  1, "weight":  1.15, "fixed":  5, "copies":  1},
-      "sots": {"order":  2, "weight":  3.58, "fixed":  2, "copies":  1},
-      "barren": {"order": 3, "weight":  1.03, "fixed":  1, "copies":  1},
-      "item": {"order":  4, "weight":  1.94, "fixed":  1, "copies":  1},
-      "random": {"order":  5, "weight":  1.00, "fixed":  0, "copies":  1},
-      "junk": {"order":  6, "weight":  1.00, "fixed":  0, "copies":  1}
-    }
+  "hints_per_stone": 2,
+  "banned_stones": [],
+  "added_locations": [],
+  "removed_locations": [],
+  "added_items": [],
+  "removed_items": [
+    "Key Piece #0", "Key Piece #1", "Key Piece #2", "Key Piece #3", "Key Piece #4"
+  ],
+  "dungeon_sots_limit": 2,
+  "dungeon_barren_limit": 2,
+  "distribution": {
+    "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
+    "sometimes": {"order":  1, "weight":  1.15, "fixed":  5, "copies":  1},
+    "sots": {"order":  2, "weight":  3.58, "fixed":  2, "copies":  1},
+    "barren": {"order": 3, "weight":  1.03, "fixed":  1, "copies":  1},
+    "item": {"order":  4, "weight":  1.94, "fixed":  1, "copies":  1},
+    "random": {"order":  5, "weight":  1.00, "fixed":  0, "copies":  1},
+    "junk": {"order":  6, "weight":  1.00, "fixed":  0, "copies":  1}
   }
+}

--- a/hints/distributions/Junk.json
+++ b/hints/distributions/Junk.json
@@ -1,18 +1,19 @@
 {
-    "banned_stones": [],
-    "added_locations": [],
-    "removed_locations": [],
-    "added_items": [],
-    "removed_items": [],
-    "dungeon_sots_limit": 0,
-    "dungeon_barren_limit": 0,
-    "distribution": {
-      "junk": {"order":  0, "weight":  1.00, "fixed":  0, "copies":  1},
-      "always": {"order":  1, "weight":  0.00, "fixed":  0, "copies":  0},
-      "sometimes": {"order":  2, "weight":  0.00, "fixed":  0, "copies":  1},
-      "sots": {"order":  3, "weight":  0.00, "fixed":  0, "copies":  1},
-      "barren": {"order": 4, "weight":  0.00, "fixed":  0, "copies":  1},
-      "random": {"order":  5, "weight":  0.00, "fixed":  0, "copies":  1},
-      "item": {"order":  6, "weight":  0.00, "fixed":  0, "copies":  1}
-    }
+  "hints_per_stone": 2,
+  "banned_stones": [],
+  "added_locations": [],
+  "removed_locations": [],
+  "added_items": [],
+  "removed_items": [],
+  "dungeon_sots_limit": 0,
+  "dungeon_barren_limit": 0,
+  "distribution": {
+    "junk": {"order":  0, "weight":  1.00, "fixed":  0, "copies":  1},
+    "always": {"order":  1, "weight":  0.00, "fixed":  0, "copies":  0},
+    "sometimes": {"order":  2, "weight":  0.00, "fixed":  0, "copies":  1},
+    "sots": {"order":  3, "weight":  0.00, "fixed":  0, "copies":  1},
+    "barren": {"order": 4, "weight":  0.00, "fixed":  0, "copies":  1},
+    "random": {"order":  5, "weight":  0.00, "fixed":  0, "copies":  1},
+    "item": {"order":  6, "weight":  0.00, "fixed":  0, "copies":  1}
   }
+}

--- a/hints/distributions/S2 - 2D.json
+++ b/hints/distributions/S2 - 2D.json
@@ -1,23 +1,24 @@
 {
-    "banned_stones": [],
-    "added_locations": [
-      {"location": "Sky - Dodoh's Crystals", "type": "sometimes"}
-    ],
-    "removed_locations": [
-      "Lanayru Desert - Top of LMF - Chest",
-      "Faron Woods - Slingshot"
-    ],
-    "added_items": [],
-    "removed_items": [],
-    "dungeon_sots_limit": 2,
-    "dungeon_barren_limit": 2,
-    "distribution": {
-      "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
-      "sometimes": {"order":  1, "weight":  1.00, "fixed":  7, "copies":  1},
-      "sots": {"order":  2, "weight":  0.75, "fixed":  4, "copies":  1},
-      "barren": {"order": 3, "weight":  0.60, "fixed":  2, "copies":  1},
-      "item": {"order":  4, "weight":  0.70, "fixed":  2, "copies":  1},
-      "random": {"order":  5, "weight":  0.65, "fixed":  1, "copies":  1},
-      "junk": {"order":  6, "weight":  0.50, "fixed":  1, "copies":  1}
-    }
+  "hints_per_stone": 2,
+  "banned_stones": [],
+  "added_locations": [
+    {"location": "Sky - Dodoh's Crystals", "type": "sometimes"}
+  ],
+  "removed_locations": [
+    "Lanayru Desert - Chest on top of Lanayru Mining Facility",
+    "Faron Woods - Slingshot"
+  ],
+  "added_items": [],
+  "removed_items": [],
+  "dungeon_sots_limit": 2,
+  "dungeon_barren_limit": 2,
+  "distribution": {
+    "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
+    "sometimes": {"order":  1, "weight":  1.00, "fixed":  7, "copies":  1},
+    "sots": {"order":  2, "weight":  0.75, "fixed":  4, "copies":  1},
+    "barren": {"order": 3, "weight":  0.60, "fixed":  2, "copies":  1},
+    "item": {"order":  4, "weight":  0.70, "fixed":  2, "copies":  1},
+    "random": {"order":  5, "weight":  0.65, "fixed":  1, "copies":  1},
+    "junk": {"order":  6, "weight":  0.50, "fixed":  1, "copies":  1}
   }
+}

--- a/hints/distributions/S2 - 3D EUD Off.json
+++ b/hints/distributions/S2 - 3D EUD Off.json
@@ -1,24 +1,25 @@
 {
-    "banned_stones": [],
-    "added_locations": [
-      {"location": "Sky - Dodoh's Crystals", "type": "sometimes"}
-    ],
-    "removed_locations": [
-      "Lanayru Desert - Top of LMF - Chest",
-      "Faron Woods - Slingshot"
-    ],
-    "added_items": [],
-    "removed_items": [],
-    "dungeon_sots_limit": 2,
-    "dungeon_barren_limit": 2,
-    "distribution": {
-      "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
-      "sometimes": {"order":  1, "weight":  1.00, "fixed":  7, "copies":  1},
-      "goal": {"order":  2, "weight":  0.00, "fixed":  1, "copies":  1},
-      "sots": {"order":  3, "weight":  1.00, "fixed":  4, "copies":  1},
-      "barren": {"order": 4, "weight":  1.00, "fixed":  2, "copies":  1},
-      "item": {"order":  5, "weight":  0.90, "fixed":  2, "copies":  1},
-      "random": {"order":  6, "weight":  0.65, "fixed":  0, "copies":  1},
-      "junk": {"order":  7, "weight":  0.40, "fixed":  0, "copies":  1}
-    }
+  "hints_per_stone": 2,
+  "banned_stones": [],
+  "added_locations": [
+    {"location": "Sky - Dodoh's Crystals", "type": "sometimes"}
+  ],
+  "removed_locations": [
+    "Lanayru Desert - Chest on top of Lanayru Mining Facility",
+    "Faron Woods - Slingshot"
+  ],
+  "added_items": [],
+  "removed_items": [],
+  "dungeon_sots_limit": 2,
+  "dungeon_barren_limit": 2,
+  "distribution": {
+    "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
+    "sometimes": {"order":  1, "weight":  1.00, "fixed":  7, "copies":  1},
+    "goal": {"order":  2, "weight":  0.00, "fixed":  1, "copies":  1},
+    "sots": {"order":  3, "weight":  1.00, "fixed":  4, "copies":  1},
+    "barren": {"order": 4, "weight":  1.00, "fixed":  2, "copies":  1},
+    "item": {"order":  5, "weight":  0.90, "fixed":  2, "copies":  1},
+    "random": {"order":  6, "weight":  0.65, "fixed":  0, "copies":  1},
+    "junk": {"order":  7, "weight":  0.40, "fixed":  0, "copies":  1}
   }
+}

--- a/hints/distributions/S2 - 3D.json
+++ b/hints/distributions/S2 - 3D.json
@@ -1,24 +1,25 @@
 {
-    "banned_stones": [],
-    "added_locations": [
-      {"location": "Sky - Dodoh's Crystals", "type": "sometimes"}
-    ],
-    "removed_locations": [
-      "Lanayru Desert - Top of LMF - Chest",
-      "Faron Woods - Slingshot"
-    ],
-    "added_items": [],
-    "removed_items": [],
-    "dungeon_sots_limit": 2,
-    "dungeon_barren_limit": 2,
-    "distribution": {
-      "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
-      "sometimes": {"order":  1, "weight":  1.00, "fixed":  7, "copies":  1},
-      "goal": {"order":  2, "weight":  0.00, "fixed":  1, "copies":  1},
-      "sots": {"order":  3, "weight":  0.90, "fixed":  3, "copies":  1},
-      "barren": {"order": 4, "weight":  0.80, "fixed":  2, "copies":  1},
-      "item": {"order":  5, "weight":  0.90, "fixed":  2, "copies":  1},
-      "random": {"order":  6, "weight":  0.70, "fixed":  0, "copies":  1},
-      "junk": {"order":  7, "weight":  0.50, "fixed":  0, "copies":  1}
-    }
+  "hints_per_stone": 2,
+  "banned_stones": [],
+  "added_locations": [
+    {"location": "Sky - Dodoh's Crystals", "type": "sometimes"}
+  ],
+  "removed_locations": [
+    "Lanayru Desert - Chest on top of Lanayru Mining Facility",
+    "Faron Woods - Slingshot"
+  ],
+  "added_items": [],
+  "removed_items": [],
+  "dungeon_sots_limit": 2,
+  "dungeon_barren_limit": 2,
+  "distribution": {
+    "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
+    "sometimes": {"order":  1, "weight":  1.00, "fixed":  7, "copies":  1},
+    "goal": {"order":  2, "weight":  0.00, "fixed":  1, "copies":  1},
+    "sots": {"order":  3, "weight":  0.90, "fixed":  3, "copies":  1},
+    "barren": {"order": 4, "weight":  0.80, "fixed":  2, "copies":  1},
+    "item": {"order":  5, "weight":  0.90, "fixed":  2, "copies":  1},
+    "random": {"order":  6, "weight":  0.70, "fixed":  0, "copies":  1},
+    "junk": {"order":  7, "weight":  0.50, "fixed":  0, "copies":  1}
   }
+}

--- a/hints/distributions/Weak.json
+++ b/hints/distributions/Weak.json
@@ -1,23 +1,24 @@
 {
-    "banned_stones": [],
-    "added_locations": [],
-    "removed_locations": [],
-    "added_items": [
-        {"name": "Progressive Bug Net #0", "amount": 1},
-        {"name": "Progressive Mitts #0", "amount": 1},
-        {"name": "Progressive Mitts #1", "amount": 1},
-        {"name": "Tumbleweed", "amount": 1}
-    ],
-    "removed_items": [],
-    "dungeon_sots_limit": 1,
-    "dungeon_barren_limit": 1,
-    "distribution": {
-      "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
-      "sometimes": {"order":  1, "weight":  0.90, "fixed":  3, "copies":  1},
-      "sots": {"order":  2, "weight":  2.00, "fixed":  1, "copies":  1},
-      "barren": {"order": 3, "weight":  0.60, "fixed":  0, "copies":  1},
-      "item": {"order":  4, "weight":  1.50, "fixed":  0, "copies":  1},
-      "random": {"order":  5, "weight":  0.70, "fixed":  1, "copies":  1},
-      "junk": {"order":  6, "weight":  0.80, "fixed":  0, "copies":  1}
-    }
+  "hints_per_stone": 2,
+  "banned_stones": [],
+  "added_locations": [],
+  "removed_locations": [],
+  "added_items": [
+      {"name": "Progressive Bug Net #0", "amount": 1},
+      {"name": "Progressive Mitts #0", "amount": 1},
+      {"name": "Progressive Mitts #1", "amount": 1},
+      {"name": "Tumbleweed", "amount": 1}
+  ],
+  "removed_items": [],
+  "dungeon_sots_limit": 1,
+  "dungeon_barren_limit": 1,
+  "distribution": {
+    "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
+    "sometimes": {"order":  1, "weight":  0.90, "fixed":  3, "copies":  1},
+    "sots": {"order":  2, "weight":  2.00, "fixed":  1, "copies":  1},
+    "barren": {"order": 3, "weight":  0.60, "fixed":  0, "copies":  1},
+    "item": {"order":  4, "weight":  1.50, "fixed":  0, "copies":  1},
+    "random": {"order":  5, "weight":  0.70, "fixed":  1, "copies":  1},
+    "junk": {"order":  6, "weight":  0.80, "fixed":  0, "copies":  1}
   }
+}

--- a/hints/distributions/sample.json
+++ b/hints/distributions/sample.json
@@ -1,7 +1,8 @@
 {
+  "hints_per_stone": 2,
   "banned_stones": [
-    "Shipyard - Gossip Stone",
-    "Lanayru - Temple of Time - Gossip Stone:"
+    "Lanayru Sand Sea - Gossip Stone in Shipyard",
+    "Temple of Time - Gossip Stone in Temple of Time Area:"
   ],
   "added_locations": [
     {"location": "Batreaux's House - 10 Crystals", "type": "always"}

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -486,7 +486,7 @@ class HintDistribution:
         return BarrenGossipStoneHint(area)
 
     def _create_junk_hint(self):
-        return EmptyGossipStoneHint(self.junk_hints.pop())
+        return EmptyGossipStoneHint(self.rng.choice(self.junk_hints)
 
     def get_junk_text(self):
         return self.junk_hints.pop()

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -121,9 +121,15 @@ class HintDistribution:
     def _read_from_json(self, jsn):
         self.hints_per_stone = jsn["hints_per_stone"]
         # Limit number of hints per stone as there appears to be ~600 character limit to the hintstone text.
-        if self.hints_per_stone <= 0 or self.hints_per_stone >= 9:
+        if self.hints_per_stone >= 9:
             raise ValueError(
-                "Selected hint distribution must have no less than one hint per stone and no more than 8."
+                "Selected hint distribution must have no more than 8 hints per stone. "
+                + "Having more than 8 risks hint text being cut off when shown in game."
+            )
+        elif self.hints_per_stone <= 0:
+            raise ValueError(
+                "Selected hint distribution must have at least 1 hint per stone. "
+                + "Instead, the 'Junk' hint distribution should be used if hints are not required."
             )
         self.banned_stones = jsn["banned_stones"]
         self.added_locations = jsn["added_locations"]

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -120,6 +120,12 @@ class HintDistribution:
         self._read_from_json(json.loads(s))
 
     def _read_from_json(self, jsn):
+        self.hints_per_stone = jsn["hints_per_stone"]
+        # Limit number of hints per stone as there appears to be ~600 character limit to the hintstone text.
+        if self.hints_per_stone <= 0 or self.hints_per_stone >= 9:
+            raise ValueError(
+                "Selected hint distribution must have no less than one hint per stone and no more than 8."
+            )
         self.banned_stones = jsn["banned_stones"]
         self.added_locations = jsn["added_locations"]
         self.removed_locations = jsn["removed_locations"]

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -11,8 +11,6 @@ from hints.hint_types import *
 from options import Options
 from logic.randomize import LogicUtils
 
-MAX_HINTS_PER_STONE = 2
-
 HINTABLE_ITEMS = (
     dict.fromkeys(
         [
@@ -83,6 +81,7 @@ class InvalidHintDistribution(Exception):
 
 class HintDistribution:
     def __init__(self):
+        self.hints_per_stone = 0
         self.banned_stones = []
         self.added_locations = []
         self.removed_locations = []
@@ -158,7 +157,7 @@ class HintDistribution:
 
         self.banned_stones = list(map(areas.short_to_full, self.banned_stones))
         self.max_hints_per_stone = {
-            stone: 0 if stone in self.banned_stones else MAX_HINTS_PER_STONE
+            stone: 0 if stone in self.banned_stones else self.hints_per_stone
             for stone in self.areas.gossip_stones
         }
         self.nb_hints = sum(self.max_hints_per_stone.values())
@@ -486,7 +485,7 @@ class HintDistribution:
         return BarrenGossipStoneHint(area)
 
     def _create_junk_hint(self):
-        return EmptyGossipStoneHint(self.rng.choice(self.junk_hints)
+        return EmptyGossipStoneHint(self.rng.choice(self.junk_hints))
 
     def get_junk_text(self):
         return self.junk_hints.pop()

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -162,11 +162,11 @@ class HintDistribution:
         self.hinted_locations = unhintable
 
         self.banned_stones = list(map(areas.short_to_full, self.banned_stones))
-        self.max_hints_per_stone = {
+        self.hints_per_stone = {
             stone: 0 if stone in self.banned_stones else self.hints_per_stone
             for stone in self.areas.gossip_stones
         }
-        self.nb_hints = sum(self.max_hints_per_stone.values())
+        self.nb_hints = sum(self.hints_per_stone.values())
         assert self.nb_hints <= MAX_HINTS
 
         check_hint_status2 = (

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -1,4 +1,7 @@
 from collections import defaultdict
+import json
+from os import listdir
+from paths import RANDO_ROOT_PATH
 from typing import NewType, Dict, Callable
 
 EXTENDED_ITEM_NAME = NewType("EXTENDED_ITEM_NAME", str)
@@ -8,7 +11,18 @@ sep = " - "
 
 EVERYTHING = EIN("Everything")
 
-MAX_HINTS = 32
+NUMBER_OF_HINT_STONES = 16
+HINT_DISTROS_DIRECTORY = RANDO_ROOT_PATH / f"hints/distributions"
+
+hint_distros = [f for f in listdir(HINT_DISTROS_DIRECTORY) if f.endswith("json")]
+max_hints_per_stone = 0
+for distro_filename in hint_distros:
+    with open(HINT_DISTROS_DIRECTORY / distro_filename) as f:
+        hints_per_stone = json.load(f)["hints_per_stone"]
+        if hints_per_stone > max_hints_per_stone:
+            max_hints_per_stone = hints_per_stone
+
+MAX_HINTS = max_hints_per_stone * NUMBER_OF_HINT_STONES
 
 # Logic options, runtime requirements
 

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -1,7 +1,4 @@
 from collections import defaultdict
-import json
-from os import listdir
-from paths import RANDO_ROOT_PATH
 from typing import NewType, Dict, Callable
 
 EXTENDED_ITEM_NAME = NewType("EXTENDED_ITEM_NAME", str)
@@ -12,17 +9,9 @@ sep = " - "
 EVERYTHING = EIN("Everything")
 
 NUMBER_OF_HINT_STONES = 16
-HINT_DISTROS_DIRECTORY = RANDO_ROOT_PATH / f"hints/distributions"
 
-hint_distros = [f for f in listdir(HINT_DISTROS_DIRECTORY) if f.endswith("json")]
-max_hints_per_stone = 0
-for distro_filename in hint_distros:
-    with open(HINT_DISTROS_DIRECTORY / distro_filename) as f:
-        hints_per_stone = json.load(f)["hints_per_stone"]
-        if hints_per_stone > max_hints_per_stone:
-            max_hints_per_stone = hints_per_stone
-
-MAX_HINTS = max_hints_per_stone * NUMBER_OF_HINT_STONES
+MAX_HINTS_PER_STONE = 8
+MAX_HINTS = MAX_HINTS_PER_STONE * NUMBER_OF_HINT_STONES
 
 # Logic options, runtime requirements
 

--- a/logic/hints.py
+++ b/logic/hints.py
@@ -157,7 +157,7 @@ class Hints:
             stone
             for stone in accessible_stones
             for spot in range(
-                self.dist.max_hints_per_stone[stone]
+                self.dist.hints_per_stone[stone]
                 - len(self.logic.placement.stones[stone])
             )
         ]

--- a/logic/hints.py
+++ b/logic/hints.py
@@ -3,7 +3,7 @@ from logic.constants import *
 from logic.inventory import EXTENDED_ITEM
 from logic.logic import DNFInventory
 from logic.logic_input import Areas
-from hints.hint_distribution import MAX_HINTS_PER_STONE, HintDistribution
+from hints.hint_distribution import HintDistribution
 from hints.hint_types import *
 from .randomize import LogicUtils, UserOutput
 from options import Options
@@ -115,7 +115,7 @@ class Hints:
         hintstone_hints = {
             hintname: hint for hint, hintname in zip(hintstone_hints, HINTS)
         }
-        self.max_hints_per_stone = self.dist.max_hints_per_stone
+        self.hints_per_stone = self.dist.hints_per_stone
         self.randomize(hintstone_hints)
 
         placed_hintstone_hints = {
@@ -157,7 +157,7 @@ class Hints:
             stone
             for stone in accessible_stones
             for spot in range(
-                self.max_hints_per_stone[stone]
+                self.dist.max_hints_per_stone[stone]
                 - len(self.logic.placement.stones[stone])
             )
         ]


### PR DESCRIPTION
Allows hint distributions to specify how many hints should appear on each Gossip Stone. This ranges from 1-8 hints per stone.

Fewer than 1 doesn't make any sense since, if no hints are desired, one can simply use the 'Junk' hint distribution.

More than 8 can result in hints getting cut off from the end of the list when viewed in-game. I suspect that this is due to a character limit but I haven't confirmed this. 8 hints per stone is likely excessive but does provide room to experiment should anyone wish to do so (e.g. having fewer but more valuable hint stones).