### PR TITLE
Fix random starting item not same for all players

### DIFF
--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -200,9 +200,11 @@ class Rando:
 
         if self.options["random-starting-item"]:
 
-            possible_random_starting_items = RANDOM_STARTING_ITEMS
-            for starting_item in self.options["starting-items"]:
-                possible_random_starting_items.remove(starting_item)
+            possible_random_starting_items = [
+                item
+                for item in RANDOM_STARTING_ITEMS
+                if item not in self.options["starting-items"]
+            ]
             if len(possible_random_starting_items) == 0:
                 raise ValueError(
                     "All valid progress items have already been added as starting items."

--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -199,9 +199,10 @@ class Rando:
                 starting_items.add(item)
 
         if self.options["random-starting-item"]:
-            possible_random_starting_items = tuple(
-                set(RANDOM_STARTING_ITEMS) - set(self.options["starting-items"])
-            )
+
+            possible_random_starting_items = RANDOM_STARTING_ITEMS
+            for starting_item in self.options["starting-items"]:
+                possible_random_starting_items.remove(starting_item)
             if len(possible_random_starting_items) == 0:
                 raise ValueError(
                     "All valid progress items have already been added as starting items."


### PR DESCRIPTION
Fixes a bug where the players using the same seed that has the `random-starting-item` option enabled may not get the same item. This is due to a use of set comprehension making the random choice result in a potentially different starting item for the same seed.