### PR TITLE
Remove camera panning during Fledge's Gift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Shooting the bell during pumpkin archery ends the minigame immediately
 - Removed first time textboxes (by CovenEsme)
   - Removes rupee, heart, arrow, bomb, stamina fruit, silent realm tear and light fruit first time textboxes
+- Removed the panning cutscenes during the Fledge's Gift check (by CovenEsme)
 ### Bugfixes
 - Fixed a bug that prevented tricks from being properly reloaded when the randomizer restarted multiple times without changes to the list
 - Fixed a softlock caused by collecting the last 2 tears in a trial too close together

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -919,37 +919,7 @@
     type: flowpatch
     index: 16
     flow:
-      next: Show Fledge pre-dungeon text
-  - name: Fledge pre-dungeon text
-    type: textadd
-    text: "One more thing, <heroname>! Here are your\n<r<required dungeons>> for your adventure."
-  - name: Show Fledge pre-dungeon text
-    type: flowadd
-    flow:
-      type: type1
-      next: 21
-      param3: 0
-      param4: Fledge pre-dungeon text
-  # added during generation with correct text
-  # - name: Fledge Dungeon text
-  #   type: textpatch
-  #   index: 4
-  #   text: "Required dungeons:\nA\nB"
-  - name: Show more text after Fledge Dungeon text
-    type: flowpatch
-    index: 21
-    flow:
-      next: Show Fledge post-dungeon text
-  - name: Fledge post-dungeon text
-    type: textadd
-    text: "If you need to hear your <r<required\ndungeons>> again, just ask me! You can\nalso check them on the <b<bulletin board>>\nover there."
-  - name: Show Fledge post-dungeon text
-    type: flowadd
-    flow:
-      type: type1
-      next: 100
-      param3: 0
-      param4: Fledge post-dungeon text
+      next: -1
 115-Town2:
   - name: Shorten Karane letter text
     type: flowpatch

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -885,31 +885,71 @@
     flow:
       next: -1
 114-Friend:
-  - name: Fledge text # skips part about link's tunic and being a knight
+  - name: Skip Fledge camera panning 1
+    type: flowpatch
+    index: 15
+    flow:
+      next: 22
+  - name: Skip Fledge talking about the hero's tunic
     type: flowpatch
     index: 22
     flow:
-      next: 111
-  - name: Fledge pouch text skip # skips part explaining the adventure pouch
+      next: 51
+  - name: Skip Fledge wait frames
+    type: flowpatch
+    index: 51
+    flow:
+      next: 50
+  - name: tst4
+    type: flowpatch
+    index: 50
+    flow:
+      next: Show shorter Fledge pre-item text
+  - name: Shorter Fledge text
+    type: textadd
+    text: "I put a lot of work into making this!\nYou should take it with you."
+  - name: Show shorter Fledge pre-item text
+    type: flowadd
+    flow:
+      type: type1
+      next: 16
+      param3: 0
+      param4: Shorter Fledge text
+  - name: Skip Fledge talking about the Adventure Pouch # skips part explaining the adventure pouch
     type: flowpatch
     index: 16
     flow:
-      next: 24
-  - name: Fledge dungeon text
+      next: Show Fledge pre-dungeon text
+  - name: Fledge pre-dungeon text
     type: textadd
-    text: "By the way, your <r<required dungeons>>\nare on the <b<bulletin board>> over there."
-  - name: Show Fledge text
+    text: "One more thing, <heroname>! Here are your\n<r<required dungeons>> for your adventure."
+  - name: Show Fledge pre-dungeon text
+    type: flowadd
+    flow:
+      type: type1
+      next: 21
+      param3: 0
+      param4: Fledge pre-dungeon text
+  # added during generation with correct text
+  # - name: Fledge Dungeon text
+  #   type: textpatch
+  #   index: 4
+  #   text: "Required dungeons:\nA\nB"
+  - name: Show more text after Fledge Dungeon text
+    type: flowpatch
+    index: 21
+    flow:
+      next: Show Fledge post-dungeon text
+  - name: Fledge post-dungeon text
+    type: textadd
+    text: "If you need to hear your <r<required\ndungeons>> again, just ask me! You can\nalso check them on the <b<bulletin board>>\nover there."
+  - name: Show Fledge post-dungeon text
     type: flowadd
     flow:
       type: type1
       next: 100
-      param3: 115
-      param4: Fledge dungeon text
-  - name: Patch in text
-    type: flowpatch
-    index: 21
-    flow:
-      next: Show Fledge text
+      param3: 0
+      param4: Fledge post-dungeon text
 115-Town2:
   - name: Shorten Karane letter text
     type: flowpatch

--- a/gamepatches.py
+++ b/gamepatches.py
@@ -1635,9 +1635,18 @@ class GamePatcher:
                 self.placement_file.required_dungeons
             )
 
-            required_dungeons_text = self._format_required_dungeons_text(
-                required_dungeons_text, 27
-            )
+            # try to fit the text in as few lines as possible, breaking up at spaces if necessary
+            cur_line = ""
+            combined = ""
+
+            for part in required_dungeons_text.split(" "):
+                if len(cur_line + part) > 27:  # limit of one line
+                    combined += cur_line + "\n"
+                    cur_line = part + " "
+                else:
+                    cur_line += part + " "
+            combined += cur_line
+            required_dungeons_text = combined.strip()
 
         self.eventpatches["107-Kanban"].append(
             {
@@ -1647,45 +1656,6 @@ class GamePatcher:
                 "text": required_dungeons_text,
             }
         )
-
-        if required_dungeon_count >= 4:
-            required_dungeons_text = self._format_required_dungeons_text(
-                required_dungeons_text, 36
-            )
-
-        self.eventpatches["114-Friend"].append(
-            {
-                "name": "Fledge's Gift Dungeon text",
-                "type": "textpatch",
-                "index": 4,
-                "text": required_dungeons_text,
-            }
-        )
-
-        self.eventpatches["114-Friend"].append(
-            {
-                "name": "Fledge's Gift Dungeon text (repeat)",
-                "type": "textpatch",
-                "index": 15,
-                "text": required_dungeons_text,
-            }
-        )
-
-    def _format_required_dungeons_text(self, required_dungeons_text, max_line_length):
-        # try to fit the text in as few lines as possible, breaking up at spaces if necessary
-        cur_line = ""
-        combined = ""
-
-        required_dungeons_text = required_dungeons_text.replace("\n", "")
-
-        for part in required_dungeons_text.split(" "):
-            if len(cur_line + part) > max_line_length:  # limit of one line
-                combined += cur_line + "\n"
-                cur_line = part + " "
-            else:
-                cur_line += part + " "
-        combined += cur_line
-        return combined.strip()
 
     def add_trial_hint_patches(self):
         def find_event(filename, name):

--- a/gamepatches.py
+++ b/gamepatches.py
@@ -1635,18 +1635,9 @@ class GamePatcher:
                 self.placement_file.required_dungeons
             )
 
-            # try to fit the text in as few lines as possible, breaking up at spaces if necessary
-            cur_line = ""
-            combined = ""
-
-            for part in required_dungeons_text.split(" "):
-                if len(cur_line + part) > 27:  # limit of one line
-                    combined += cur_line + "\n"
-                    cur_line = part + " "
-                else:
-                    cur_line += part + " "
-            combined += cur_line
-            required_dungeons_text = combined.strip()
+            required_dungeons_text = self._format_required_dungeons_text(
+                required_dungeons_text, 27
+            )
 
         self.eventpatches["107-Kanban"].append(
             {
@@ -1656,6 +1647,45 @@ class GamePatcher:
                 "text": required_dungeons_text,
             }
         )
+
+        if required_dungeon_count >= 4:
+            required_dungeons_text = self._format_required_dungeons_text(
+                required_dungeons_text, 36
+            )
+
+        self.eventpatches["114-Friend"].append(
+            {
+                "name": "Fledge's Gift Dungeon text",
+                "type": "textpatch",
+                "index": 4,
+                "text": required_dungeons_text,
+            }
+        )
+
+        self.eventpatches["114-Friend"].append(
+            {
+                "name": "Fledge's Gift Dungeon text (repeat)",
+                "type": "textpatch",
+                "index": 15,
+                "text": required_dungeons_text,
+            }
+        )
+
+    def _format_required_dungeons_text(self, required_dungeons_text, max_line_length):
+        # try to fit the text in as few lines as possible, breaking up at spaces if necessary
+        cur_line = ""
+        combined = ""
+
+        required_dungeons_text = required_dungeons_text.replace("\n", "")
+
+        for part in required_dungeons_text.split(" "):
+            if len(cur_line + part) > max_line_length:  # limit of one line
+                combined += cur_line + "\n"
+                cur_line = part + " "
+            else:
+                cur_line += part + " "
+        combined += cur_line
+        return combined.strip()
 
     def add_trial_hint_patches(self):
         def find_event(filename, name):

--- a/patches.yaml
+++ b/patches.yaml
@@ -914,6 +914,15 @@ F001r: # Knight Academy
     layer: 4
     room: 0
     objtype: OBJ
+  - name: Move Fledge closer to Link's room
+    type: objpatch
+    id: 0xFC77
+    layer: 3
+    room: 0
+    objtype: OBJ
+    object:
+      posx: 850
+      posz: -1700
   - name: Fledge Pouch Check Storyflag at night
     type: objpatch
     id: 0xFC7E

--- a/patches.yaml
+++ b/patches.yaml
@@ -62,13 +62,15 @@ global:
     - 60 # 10 Deku Seeds
   startsceneflags: # currently only for skyloft
     Skyloft:
+      - 0  # Lower Academy gates opened
+      - 1  # UA Doors open
+      - 21 # Upper Academy gates opened
+      - 26 # Eye cs in Bazaar
+      - 66 # Batreaux Doors outside open
+      - 67 # Inside Doors open
       - 95 # Fi Text for Ruby Tablet
       - 96 # Fi Text for Amber Tablet
-      - 66 # Batreaux Doors outside open
       - 99 # Sheikah Stone cs played
-      - 67 # Inside Doors open
-      - 1 # UA Doors open
-      - 26 # Eye cs in Bazaar
     Faron Woods:
       - 15 # fi text after vine to deep woods
       - 14 # text in front of VP statue


### PR DESCRIPTION
Adds a text sequence onto Fledge's Gift to display the required dungeons for the seed. Additionally displays the same required dungeon text when talking to Fledge again in the Academy corridor.

Removes several panning camera changes during Fledge's Gift.