### PR TITLE
Add dowsing hint distro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   - Progress Items: Main quest dowsing will point to chests that contain progress items
   - Currently does not work on goddess chests
 - Added option to enable dowsing in dungeons (by YourAverageLink, but shoutouts to Zeldex)
+- Added hint distribution designed for use with the new chest dowsing feature 
+  - Removes hints for easily dowsable chests and adds some for non-dowsable checks
+  - Only shows one hint per Gossip Stone
 - Added option to start with various items (by CovenEsme)
   - Includes: b-wheel items, pouches, quest items, songs, triforces, wallets, harp, water scale, earrings, mitts, life tree seedling, sea chart, spiral charge, stone of trials and Earth Temple key pieces.
 - Added option to start with extra health (by CovenEsme)

--- a/hints/distributions/CDMC.json
+++ b/hints/distributions/CDMC.json
@@ -1,0 +1,47 @@
+{
+  "hints_per_stone": 1,
+  "banned_stones": [
+    "Lanayru Sand Sea - Gossip Stone in Shipyard",
+    "Temple of Time - Gossip Stone in Temple of Time Area"
+  ],
+  "added_locations": [
+    {"location": "Upper Skyloft - Cawlin's Letter", "type": "sometimes"},
+    {"location": "Upper Skyloft - Fledge's Crystals", "type": "always"},
+    {"location": "Central Skyloft - Item in Bird Nest", "type": "sometimes"},
+    {"location": "Faron Woods - Item behind Bombable Rock", "type": "sometimes"},
+    {"location": "Lanayru Sand Sea - Skipper's Retreat - Chest in Shack", "type": "always"},
+    {"location": "Skyview - Rupee on Spring Pillar", "type": "sometimes"},
+    {"location": "Earth Temple - Rupee in Lava Tunnel", "type": "sometimes"},
+    {"location": "Ancient Cistern - Bokoblin", "type": "sometimes"},
+    {"location": "Fire Sanctuary - Mogma Mitts", "type": "sometimes"}
+  ],
+  "removed_locations": [
+    "Thunderhead - Isle of Songs - Din's Power",
+    "Faron Woods - Chest inside Great Tree",
+    "Lake Floria - Lake Floria Chest",
+    "Eldin Volcano - Digging Spot behind Boulder on Sandy Slope",
+    "Lanayru Desert - Secret Passageway Chest",
+    "Lanayru Desert - Fire Node - Shortcut Chest",
+    "Skyview - Chest behind Three Eyes",
+    "Earth Temple - Chest in West Room",
+    "Ancient Cistern - Chest in East Part",
+    "Sandship - Boss Key Chest",
+    "Lanayru Gorge - Lanayru Soth",
+    "Lanayru Mining Facility - Boss Key Chest",
+    "Fire Sanctuary - Chest after Bombable Wall"
+  ],
+  "added_items": [],
+  "removed_items": [],
+  "dungeon_sots_limit": 0,
+  "dungeon_barren_limit": 1,
+  "distribution": {
+    "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
+    "sometimes": {"order":  1, "weight":  1.00, "fixed":  2, "copies":  1},
+    "goal": {"order":  2, "weight":  0.00, "fixed":  1, "copies":  1},
+    "sots": {"order":  3, "weight":  0.00, "fixed":  1, "copies":  1},
+    "barren": {"order": 4, "weight":  0.00, "fixed":  2, "copies":  1},
+    "item": {"order":  5, "weight":  0.00, "fixed":  0, "copies":  1},
+    "random": {"order":  6, "weight":  0.50, "fixed":  0, "copies":  1},
+    "junk": {"order":  7, "weight":  0.00, "fixed":  0, "copies":  1}
+  }
+}

--- a/hints/distributions/CDMC.json
+++ b/hints/distributions/CDMC.json
@@ -26,7 +26,7 @@
     "Earth Temple - Chest in West Room",
     "Ancient Cistern - Chest in East Part",
     "Sandship - Boss Key Chest",
-    "Lanayru Gorge - Lanayru Soth",
+    "Lanayru Gorge - Thunder Dragon's Reward",
     "Lanayru Mining Facility - Boss Key Chest",
     "Fire Sanctuary - Chest after Bombable Wall"
   ],

--- a/options.yaml
+++ b/options.yaml
@@ -648,7 +648,7 @@
 - name: Hint Distribution
   command: hint-distribution
   type: singlechoice
-  bits: 3
+  bits: 4
   choices:
     - Weak
     - Balanced
@@ -661,6 +661,7 @@
     - S2 - 2D
     - S2 - 3D
     - S2 - 3D EUD Off
+    - CDMC
   default: Balanced
   help: Sets the distribution of hints. Distributions describe how many hints are placed and in what order, as well
     as specifics about what additional items and locations can and cannot be hinted


### PR DESCRIPTION
Uses the new n hints per stone stuff to only have one hint per stone. Removes a bunch of always and sometimes hints that are easily dowsable and adds a few that aren't.