### PR TITLE
Fix bug where sword didn't appear in the pedestal

### DIFF
--- a/asm/patch_diffs/ss_necessary_diff.txt
+++ b/asm/patch_diffs/ss_necessary_diff.txt
@@ -317,3 +317,6 @@ d_a_obj_light_lineNP.rel:
   0xDAC:
     Data: [0x48, 0x00, 0x00, 0x01]
     Relocations: [{SymbolName: check_activated_storyflag, Offset: 0x00, Type: R_PPC_REL24}]
+d_a_obj_seat_swordNP.rel:
+  0x10F4:
+    Data: [0x38, 0x80, 0x03, 0xB7]

--- a/asm/patches/ss_necessary.asm
+++ b/asm/patches/ss_necessary.asm
@@ -634,3 +634,9 @@ b try_end_pumpkin_archery
 .org 0xDAC
 bl check_activated_storyflag
 .close
+
+; Force Sword in pedestal
+.open "d_a_obj_seat_swordNP.rel"
+.org 0x10F4
+li r4, 951 ; story flag for raising sword
+.close


### PR DESCRIPTION
Fixes bug where the Goddess Sword wouldn't appear in the Sword Pedestal after getting the Goddess Sword from another check in the game first. This was due to the pedestal actor still having a check for the vanilla Goddess Sword story flag.