### PR TITLE
fix broken banned locations, rename slingshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,7 +195,7 @@
     - Sealed Grounds - Zelda's Blessing
     - Sand Sea - Skipper's Retreat - Chest in Shack
     - Volcano Summit - Item behind Digging
-    - Faron Woods - Slingshot
+    - Faron Woods - Kikwi Elder's Reward
     - Sky - Beedle's Crystals
     - Sealed Grounds - Gorko's Goddess Wall Reward
   - The Sea Chart can now be hinted when Sandship is a required dungeon

--- a/SS Rando Logic - Glitched Requirements.yaml
+++ b/SS Rando Logic - Glitched Requirements.yaml
@@ -1443,7 +1443,7 @@ Can Open Door to Lake Floria:
 Faron Woods - Item on Tree:
   Can Access Most of Faron Woods
 
-Faron Woods - Slingshot:
+Faron Woods - Kikwi Elder's Reward:
   Can Access Most of Faron Woods & Can Defeat Bokoblins
 
 Faron Woods - Item behind Bombable Rock:

--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -765,7 +765,7 @@ Can Open Door to Lake Floria:
 Faron Woods - Item on Tree:
   Can Access Most of Faron Woods
 
-Faron Woods - Slingshot:
+Faron Woods - Kikwi Elder's Reward:
   Can Access Most of Faron Woods & Can Defeat Bokoblins
 
 Faron Woods - Item behind Bombable Rock:

--- a/checks.yaml
+++ b/checks.yaml
@@ -640,7 +640,7 @@ Faron Woods - Item on Tree:
   type: faron, freestanding
   Paths:
     - stage/F100/r0/l0/Item/68
-Faron Woods - Slingshot:
+Faron Woods - Kikwi Elder's Reward:
   original item: Progressive Slingshot
   type: faron, long, combat #because of the Lopsa Bokoblin fight, this is a combat reward
   Paths:

--- a/hints/distributions/S2 - 2D.json
+++ b/hints/distributions/S2 - 2D.json
@@ -6,7 +6,7 @@
   ],
   "removed_locations": [
     "Lanayru Desert - Chest on top of Lanayru Mining Facility",
-    "Faron Woods - Slingshot"
+    "Faron Woods - Kikwi Elder's Reward"
   ],
   "added_items": [],
   "removed_items": [],

--- a/hints/distributions/S2 - 3D EUD Off.json
+++ b/hints/distributions/S2 - 3D EUD Off.json
@@ -6,7 +6,7 @@
   ],
   "removed_locations": [
     "Lanayru Desert - Chest on top of Lanayru Mining Facility",
-    "Faron Woods - Slingshot"
+    "Faron Woods - Kikwi Elder's Reward"
   ],
   "added_items": [],
   "removed_items": [],

--- a/hints/distributions/S2 - 3D.json
+++ b/hints/distributions/S2 - 3D.json
@@ -6,7 +6,7 @@
   ],
   "removed_locations": [
     "Lanayru Desert - Chest on top of Lanayru Mining Facility",
-    "Faron Woods - Slingshot"
+    "Faron Woods - Kikwi Elder's Reward"
   ],
   "added_items": [],
   "removed_items": [],

--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -106,11 +106,6 @@ class Rando:
 
         logic = Logic(areas, logic_settings, self.placement)
 
-        for loc in self.options["excluded-locations"]:
-            logic.requirements[EXTENDED_ITEM[self.norm(loc)]] &= DNFInventory(
-                BANNED_BIT
-            )
-
         self.rando_algo = FillAlgorithm(logic, self.rng, self.randosettings)
 
         self.randomised = False
@@ -245,6 +240,7 @@ class Rando:
         }
 
         self.banned: List[EIN] = []
+        self.banned.extend(map(self.norm, self.options["excluded-locations"]))
 
         if self.options["empty-unrequired-dungeons"]:
             self.banned.extend(

--- a/logic/requirements/Faron.yaml
+++ b/logic/requirements/Faron.yaml
@@ -83,7 +83,7 @@ Faron Woods:
     Rupee on Hollow Tree Branch: Beetle
     Rupee on Platform near Floria Door: Beetle
     All Kikwis Saved: (Sword | Beetle) & Can Defeat Bokoblins
-    Slingshot: All Kikwis Saved
+    Kikwi Elder's Reward: All Kikwis Saved
     Item on Tree: Nothing
     Item behind Bombable Rock: Bomb Bag
     Chest behind Bombable Rocks near Erla: Bomb Bag

--- a/logic/requirements/Sky.yaml
+++ b/logic/requirements/Sky.yaml
@@ -192,7 +192,7 @@ South West:
       Fun Fun Island Minigame -- 500 Rupees: Fun Fun Island Minigame
       Goddess Chest under Fun Fun Island: Faron - Goddess Cube in Floria Waterfall
       Fun Fun Island Minigame:
-        Dodoh's Crystals
+        Lanayru - Retrieve Party Wheel
 
   Triple Island:
     entrance: Nothing


### PR DESCRIPTION
Essentially reverts #317 in favor of removing the inlined requirement for Dodoh. Slingshot seemed to be unrelated, and more related to its name, so it was renamed to Kikwi Elder's Reward. Should also fix nonprogress item calculation and the excluded locations sometimes having progress bug.