### PR TITLE
Fix bug with Fire Dragon's Lair loadzone

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -3305,6 +3305,13 @@ F201_1: # Inside Volcano
       anglez: 37379 # >> 9 = chest flag 73
       id: 0xFC26
       name: TBox
+  - name: Patch loadzone to Fire Dragon's Lair
+    type: objpatch
+    index: 3
+    room: 0
+    objtype: SCEN
+    object:
+      layer: 2
 F201_2: # Boko Base Volcano Summit
   - name: True Master Sword Chest
     type: objadd


### PR DESCRIPTION
Fixes an issue where re-entering the Fire Dragon's Lair from the post-boko base VS layer would put Link on F211 layer 0 without a loadzone to exit again. Resolves the issue that Fireworkspinner encountered in a co-op race on 2023-01-18.