### PR TITLE
Fix stupid windows file encoding stuff

### DIFF
--- a/gamepatches.py
+++ b/gamepatches.py
@@ -25,6 +25,7 @@ from musicrando import music_rando
 from logic.bool_expression import check_static_option_req
 from logic.constants import *
 from logic.placement_file import PlacementFile
+from yaml_files import yaml_load
 
 from asm.patcher import apply_dol_patch, apply_rel_patch
 
@@ -987,8 +988,7 @@ RANDO_PATCH_FUNCS = {
 
 
 def get_patches_from_location_item_list(all_checks, filled_checks, chest_dowsing):
-    with (RANDO_ROOT_PATH / "items.yaml").open() as f:
-        items = yaml.safe_load(f)
+    items = yaml_load(RANDO_ROOT_PATH / "items.yaml")
     by_item_name = dict((x["name"], x) for x in items)
 
     # (stage, room) -> (object name, layer, id?, itemid)
@@ -1193,10 +1193,8 @@ class GamePatcher:
         self.eventpatches[eventfile].append(eventpatch)
 
     def load_base_patches(self):
-        with (RANDO_ROOT_PATH / "patches.yaml").open() as f:
-            self.patches = yaml.safe_load(f)
-        with (RANDO_ROOT_PATH / "eventpatches.yaml").open() as f:
-            self.eventpatches = yaml.safe_load(f)
+        self.patches = yaml_load(RANDO_ROOT_PATH / "patches.yaml")
+        self.eventpatches = yaml_load(RANDO_ROOT_PATH / "eventpatches.yaml")
 
         filtered_storyflags = []
         for storyflag in self.patches["global"]["startstoryflags"]:
@@ -1486,8 +1484,7 @@ class GamePatcher:
             )
 
     def shopsanity_patches(self):
-        with (Path(__file__).parent / "beedle_texts.yaml").open("r") as f:
-            beedle_texts = yaml.safe_load(f)
+        beedle_texts = yaml_load(Path(__file__).parent / "beedle_texts.yaml")
         # print(beedle_texts)
         for location in BEEDLE_TEXT_PATCHES:
             normal, discounted, normal_price, discount_price = BEEDLE_TEXT_PATCHES[
@@ -1550,8 +1547,7 @@ class GamePatcher:
     def do_build_arc_cache(self):
         self.progress_callback("building arc cache...")
 
-        with (RANDO_ROOT_PATH / "extracts.yaml").open() as f:
-            extracts = yaml.safe_load(f)
+        extracts = yaml_load(RANDO_ROOT_PATH / "extracts.yaml")
         self.patcher.create_oarc_cache(extracts)
 
     def add_startitem_patches(self):

--- a/musicrando.py
+++ b/musicrando.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 import struct
 from typing import List
 from paths import RANDO_ROOT_PATH
+from yaml_files import yaml_load
 
 
 def is_derangement(l: List[int]) -> bool:
@@ -30,8 +31,7 @@ def get_derangement(length: int, rng: random.Random) -> List[int]:
 
 
 def music_rando(placement_file, modified_extract_path):
-    with (RANDO_ROOT_PATH / "music.yaml").open() as f:
-        musiclist = yaml.safe_load(f)
+    musiclist = yaml_load(RANDO_ROOT_PATH / "music.yaml")
 
     NON_SHUFFLED_TYPES = [10, 11]
     TADTONES_FILE_NAME = "F63D5DB51DE748A3729628C659397A49"

--- a/options.py
+++ b/options.py
@@ -4,10 +4,10 @@ from pathlib import Path
 from util.file_accessor import read_yaml_file_cached
 
 import yaml
+from yaml_files import yaml_load
 from collections import OrderedDict
 
-with (RANDO_ROOT_PATH / "options.yaml").open("r") as f:
-    OPTIONS_LIST = yaml.safe_load(f)
+OPTIONS_LIST = yaml_load(RANDO_ROOT_PATH / "options.yaml")
 
 OPTIONS = OrderedDict((option["command"], option) for option in OPTIONS_LIST)
 OPTIONS["excluded-locations"]["choices"] = [

--- a/util/file_accessor.py
+++ b/util/file_accessor.py
@@ -8,7 +8,7 @@ def read_yaml_file_cached(filename: str):
     if filename in CACHE:
         return CACHE[filename]
     else:
-        with (RANDO_ROOT_PATH / filename).open() as f:
+        with (RANDO_ROOT_PATH / filename).open("r", encoding="utf-8") as f:
             yaml_file = yaml.safe_load(f)
         CACHE[filename] = yaml_file
         return yaml_file

--- a/yaml_files.py
+++ b/yaml_files.py
@@ -5,7 +5,7 @@ import yaml
 
 
 def yaml_load(file_path: Path):
-    with file_path.open("r") as f:
+    with file_path.open("r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 


### PR DESCRIPTION
Fixes an issue when running the randomizer on Windows with a system character set that's not UTF-8 (or other anglocentric character set) that meant the yaml files couldn't be read correctly.