### PR TITLE
Logic Tab Improvements - Tricks Dialog and Free Text Search

### DIFF
--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -475,9 +475,9 @@ class RandoGUI(QMainWindow):
             self.options.set_option("enabled-tricks-bitless", [])
             self.options.set_option("enabled-tricks-glitched", [])
 
-        # self.options.set_option(
-        #     "excluded-locations", self.get_option_value("excluded_locations")
-        # )
+        self.options.set_option(
+            "excluded-locations", self.get_option_value("excluded_locations")
+        )
 
         self.save_settings()
         self.ui.permalink.setText(self.options.get_permalink())
@@ -523,7 +523,12 @@ class RandoGUI(QMainWindow):
         elif isinstance(widget, QSpinBox):
             return widget.value()
         elif isinstance(widget, QListView):
-            return widget.model().stringList()
+            items = []
+            model = widget.model()
+            for int_index in range(0, model.rowCount()):
+                index = model.index(int_index, 0)
+                items.append(index.data())
+            return items
         else:
             print("Option widget is invalid: %s" % option_name)
 

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -543,14 +543,16 @@ class RandoGUI(QMainWindow):
         model.setData(new_row, value)
         model.sort(0)
 
-    def move_selected_rows(self, source, dest: QListView):
+    def move_selected_rows(self, source: QListView, dest: QListView):
         selection = source.selectionModel().selectedIndexes()
+        last_selection = source.currentIndex()
         # Remove starting from the last so the previous indices remain valid
         selection.sort(reverse=True, key=lambda x: x.row())
         for item in selection:
             value = item.data()
             source.model().removeRow(item.row())
             self.append_row(dest.model(), value)
+        source.selectionModel().setCurrentIndex(last_selection)
 
     def exclude_location(self):
         self.move_selected_rows(self.ui.included_locations, self.ui.excluded_locations)

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -123,21 +123,23 @@ class RandoGUI(QMainWindow):
 
         # setup exlcuded locations
         self.excluded_locations_model = QStringListModel()
-        self.excluded_locations_proxy = LocationsModel()
+        self.excluded_locations_proxy = LocationsModel(self)
         self.excluded_locations_proxy.setSourceModel(self.excluded_locations_model)
         self.excluded_locations_model.setStringList(
             OPTIONS["excluded-locations"]["default"]
         )
         self.included_locations_model = QStringListModel()
-        self.included_locations_proxy = LocationsModel()
+        self.included_locations_proxy = LocationsModel(self)
         self.included_locations_proxy.setSourceModel(self.included_locations_model)
         self.included_locations_model.setStringList(
             OPTIONS["excluded-locations"]["choices"]
         )
-        self.ui.excluded_locations.setModel(self.excluded_locations_model)
-        self.ui.included_locations.setModel(self.included_locations_model)
+        self.ui.excluded_locations.setModel(self.excluded_locations_proxy)
+        self.ui.included_locations.setModel(self.included_locations_proxy)
         self.ui.exclude_location.clicked.connect(self.exclude_location)
         self.ui.include_location.clicked.connect(self.include_location)
+        self.ui.excluded_free_search.textChanged.connect(self.update_excluded_free_filter)
+        self.ui.included_free_search.textChanged.connect(self.update_included_free_filter)
 
         # Starting Items ui.
         self.randomized_items_model = QStringListModel()
@@ -415,8 +417,8 @@ class RandoGUI(QMainWindow):
                 if choice not in current_settings["excluded-locations"]
             ]
         )
-        self.ui.excluded_locations.setModel(self.excluded_locations_model)
-        self.ui.included_locations.setModel(self.included_locations_model)
+        self.ui.excluded_locations.setModel(self.excluded_locations_proxy)
+        self.ui.included_locations.setModel(self.included_locations_proxy)
 
         # Update starting items.
         self.randomized_items_model = QStringListModel()
@@ -473,9 +475,9 @@ class RandoGUI(QMainWindow):
             self.options.set_option("enabled-tricks-bitless", [])
             self.options.set_option("enabled-tricks-glitched", [])
 
-        self.options.set_option(
-            "excluded-locations", self.get_option_value("excluded_locations")
-        )
+        # self.options.set_option(
+        #     "excluded-locations", self.get_option_value("excluded_locations")
+        # )
 
         self.save_settings()
         self.ui.permalink.setText(self.options.get_permalink())
@@ -547,6 +549,12 @@ class RandoGUI(QMainWindow):
     def include_location(self):
         self.move_selected_rows(self.ui.excluded_locations, self.ui.included_locations)
         self.update_settings()
+
+    def update_included_free_filter(self, new_text):
+        self.included_locations_proxy.filterRows(new_text)
+
+    def update_excluded_free_filter(self, new_text):
+        self.excluded_locations_proxy.filterRows(new_text)
 
     def remove_starting_item(self):
         self.move_selected_rows(self.ui.starting_items, self.ui.randomized_items)

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -644,7 +644,11 @@ class RandoGUI(QMainWindow):
 
     def launch_tricks_dialog(self):
         dialog = TricksDialog(self.enabled_tricks_model, self.disabled_tricks_model)
-        dialog.exec()
+        if dialog.exec():
+            results = dialog.getTrickValues()
+            self.disabled_tricks_model.setStringList(results[0])
+            self.enabled_tricks_model.setStringList(results[1])
+            self.update_settings()
 
     def eventFilter(self, target, event):
         if event.type() == QEvent.Enter:

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -552,7 +552,7 @@ class RandoGUI(QMainWindow):
             value = item.data()
             source.model().removeRow(item.row())
             self.append_row(dest.model(), value)
-        source.selectionModel().setCurrentIndex(last_selection)
+        # source.selectionModel().setCurrentIndex(last_selection)
 
     def exclude_location(self):
         self.move_selected_rows(self.ui.included_locations, self.ui.excluded_locations)

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -138,8 +138,12 @@ class RandoGUI(QMainWindow):
         self.ui.included_locations.setModel(self.included_locations_proxy)
         self.ui.exclude_location.clicked.connect(self.exclude_location)
         self.ui.include_location.clicked.connect(self.include_location)
-        self.ui.excluded_free_search.textChanged.connect(self.update_excluded_free_filter)
-        self.ui.included_free_search.textChanged.connect(self.update_included_free_filter)
+        self.ui.excluded_free_search.textChanged.connect(
+            self.update_excluded_free_filter
+        )
+        self.ui.included_free_search.textChanged.connect(
+            self.update_included_free_filter
+        )
 
         # Starting Items ui.
         self.randomized_items_model = QStringListModel()
@@ -469,7 +473,7 @@ class RandoGUI(QMainWindow):
         elif "Glitched" in logic_mode:
             self.options.set_option("enabled-tricks-bitless", [])
             self.options.set_option(
-                "enabled-tricks-glitched",  self.enabled_tricks_model.stringList()
+                "enabled-tricks-glitched", self.enabled_tricks_model.stringList()
             )
         else:  # this should only be no logic
             self.options.set_option("enabled-tricks-bitless", [])

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -661,11 +661,17 @@ class RandoGUI(QMainWindow):
             json.dump(self.user_presets, f)
 
     def launch_tricks_dialog(self):
+        old_en = self.enabled_tricks_model.stringList()
+        old_dis = self.disabled_tricks_model.stringList()
         dialog = TricksDialog(self.enabled_tricks_model, self.disabled_tricks_model)
         if dialog.exec():
             results = dialog.getTrickValues()
             self.disabled_tricks_model.setStringList(results[0])
             self.enabled_tricks_model.setStringList(results[1])
+            self.update_settings()
+        else:
+            self.disabled_tricks_model.setStringList(old_dis)
+            self.enabled_tricks_model.setStringList(old_en)
             self.update_settings()
 
     def eventFilter(self, target, event):

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -532,8 +532,9 @@ class RandoGUI(QMainWindow):
         model.insertRow(model.rowCount())
         new_row = model.index(model.rowCount() - 1, 0)
         model.setData(new_row, value)
+        model.sort(0)
 
-    def move_selected_rows(self, source, dest):
+    def move_selected_rows(self, source, dest: QListView):
         selection = source.selectionModel().selectedIndexes()
         # Remove starting from the last so the previous indices remain valid
         selection.sort(reverse=True, key=lambda x: x.row())

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -11,10 +11,16 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
+  </property>
+  <property name="sizeIncrement">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="font">
    <font>
@@ -44,6 +50,12 @@
       <height>41</height>
      </rect>
     </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
     <property name="text">
      <string/>
     </property>
@@ -59,6 +71,18 @@
       <width>1031</width>
       <height>541</height>
      </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <property name="sizeIncrement">
+     <size>
+      <width>0</width>
+      <height>0</height>
+     </size>
     </property>
     <property name="toolTip">
      <string/>
@@ -1367,12 +1391,54 @@
        </item>
        <item>
         <layout class="QVBoxLayout" name="vlay_exclude_locations">
+         <property name="spacing">
+          <number>6</number>
+         </property>
          <item>
           <widget class="QLabel" name="label_exclude_locations">
            <property name="text">
             <string>Exclude Locations</string>
            </property>
           </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <property name="sizeConstraint">
+            <enum>QLayout::SetDefaultConstraint</enum>
+           </property>
+           <item>
+            <widget class="QComboBox" name="comboBox"/>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="lineEdit">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Expanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="lineEdit_2"/>
+           </item>
+           <item>
+            <widget class="QComboBox" name="comboBox_2"/>
+           </item>
+          </layout>
          </item>
          <item>
           <layout class="QHBoxLayout" name="hlay_exclude_locations_body">
@@ -1390,9 +1456,38 @@
               </widget>
              </item>
              <item>
+              <widget class="QPushButton" name="pushButton">
+               <property name="text">
+                <string>Include All
+&lt;--</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacer">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
               <widget class="QPushButton" name="exclude_location">
                <property name="text">
                 <string>Exclude
+--&gt;</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="pushButton_2">
+               <property name="text">
+                <string>Exclude All
 --&gt;</string>
                </property>
               </widget>

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -1450,14 +1450,6 @@
               </widget>
              </item>
              <item>
-              <widget class="QPushButton" name="pushButton">
-               <property name="text">
-                <string>Include All
-&lt;--</string>
-               </property>
-              </widget>
-             </item>
-             <item>
               <spacer name="verticalSpacer">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>
@@ -1474,14 +1466,6 @@
               <widget class="QPushButton" name="exclude_location">
                <property name="text">
                 <string>Exclude
---&gt;</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="pushButton_2">
-               <property name="text">
-                <string>Exclude All
 --&gt;</string>
                </property>
               </widget>

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -1410,7 +1410,7 @@
             <widget class="QComboBox" name="comboBox"/>
            </item>
            <item>
-            <widget class="QLineEdit" name="lineEdit">
+            <widget class="QLineEdit" name="included_free_search">
              <property name="text">
               <string/>
              </property>
@@ -1433,7 +1433,7 @@
             </spacer>
            </item>
            <item>
-            <widget class="QLineEdit" name="lineEdit_2"/>
+            <widget class="QLineEdit" name="excluded_free_search"/>
            </item>
            <item>
             <widget class="QComboBox" name="comboBox_2"/>

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -39,9 +39,9 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>570</y>
+      <y>560</y>
       <width>1031</width>
-      <height>31</height>
+      <height>41</height>
      </rect>
     </property>
     <property name="text">
@@ -67,7 +67,7 @@
      <number>-6</number>
     </property>
     <property name="currentIndex">
-     <number>0</number>
+     <number>3</number>
     </property>
     <property name="usesScrollButtons">
      <bool>true</bool>
@@ -690,7 +690,7 @@
         <rect>
          <x>10</x>
          <y>20</y>
-         <width>179</width>
+         <width>178</width>
          <height>471</height>
         </rect>
        </property>
@@ -1337,6 +1337,13 @@
           <widget class="QComboBox" name="option_logic_mode"/>
          </item>
          <item>
+          <widget class="QPushButton" name="edit_tricks">
+           <property name="text">
+            <string>Tricks</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QCheckBox" name="option_hero_mode">
            <property name="text">
             <string>Hero Mode</string>
@@ -1394,51 +1401,6 @@
            </item>
            <item>
             <widget class="QListView" name="excluded_locations"/>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="vlay_tricks">
-         <item>
-          <widget class="QLabel" name="label_tricks">
-           <property name="text">
-            <string>Enable Tricks</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="hlay_tricks_body">
-           <item>
-            <widget class="QListView" name="disabled_tricks">
-             <property name="toolTip">
-              <string>test</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="vlay_tricks_controls">
-             <item>
-              <widget class="QPushButton" name="disable_trick">
-               <property name="text">
-                <string>Disable
-&lt;--</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="enable_trick">
-               <property name="text">
-                <string>Enable
---&gt;</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <widget class="QListView" name="enabled_tricks"/>
            </item>
           </layout>
          </item>

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -1407,9 +1407,6 @@
             <enum>QLayout::SetDefaultConstraint</enum>
            </property>
            <item>
-            <widget class="QComboBox" name="comboBox"/>
-           </item>
-           <item>
             <widget class="QLineEdit" name="included_free_search">
              <property name="text">
               <string/>
@@ -1434,9 +1431,6 @@
            </item>
            <item>
             <widget class="QLineEdit" name="excluded_free_search"/>
-           </item>
-           <item>
-            <widget class="QComboBox" name="comboBox_2"/>
            </item>
           </layout>
          </item>

--- a/gui/sort_model.py
+++ b/gui/sort_model.py
@@ -14,7 +14,7 @@ class LocationsModel(QSortFilterProxyModel):
     def lessThan(self, right, left):
         leftCheck = self.sourceModel().data(left)
         rightCheck = self.sourceModel().data(right)
-        if rightCheck == '':
+        if rightCheck == "":
             return False
         return check_order.index(leftCheck) > check_order.index(rightCheck)
 

--- a/gui/sort_model.py
+++ b/gui/sort_model.py
@@ -14,6 +14,8 @@ class LocationsModel(QSortFilterProxyModel):
     def lessThan(self, right, left):
         leftCheck = self.sourceModel().data(left)
         rightCheck = self.sourceModel().data(right)
+        if rightCheck == '':
+            return False
         return check_order.index(leftCheck) > check_order.index(rightCheck)
 
     def filterAcceptsRow(

--- a/gui/sort_model.py
+++ b/gui/sort_model.py
@@ -4,6 +4,7 @@ from yaml_files import checks
 
 check_order = list(checks.keys())
 
+
 class LocationsModel(QSortFilterProxyModel):
     def __init__(self, parent):
         super().__init__(parent)
@@ -15,7 +16,9 @@ class LocationsModel(QSortFilterProxyModel):
         rightCheck = self.sourceModel().data(right)
         return check_order.index(leftCheck) > check_order.index(rightCheck)
 
-    def filterAcceptsRow(self, source_row: int, source_parent: Union[QModelIndex, QPersistentModelIndex]) -> bool:
+    def filterAcceptsRow(
+        self, source_row: int, source_parent: Union[QModelIndex, QPersistentModelIndex]
+    ) -> bool:
         index = self.sourceModel().index(source_row, 0, source_parent)
         return self.free_text_filter.lower() in self.sourceModel().data(index).lower()
 

--- a/gui/sort_model.py
+++ b/gui/sort_model.py
@@ -1,6 +1,20 @@
-from PySide6.QtCore import QSortFilterProxyModel
+from typing import Union
+from PySide6.QtCore import QSortFilterProxyModel, QModelIndex, QPersistentModelIndex, Qt
 
 
 class LocationsModel(QSortFilterProxyModel):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.free_text_filter = ""
+        self.setSortCaseSensitivity(Qt.CaseInsensitive)
+
     def lessThan(self, right, left):
         return False
+
+    def filterAcceptsRow(self, source_row: int, source_parent: Union[QModelIndex, QPersistentModelIndex]) -> bool:
+        index = self.sourceModel().index(source_row, 0, source_parent)
+        return self.free_text_filter.lower() in self.sourceModel().data(index).lower()
+
+    def filterRows(self, free_text_filter):
+        self.free_text_filter = free_text_filter
+        self.invalidateFilter()

--- a/gui/sort_model.py
+++ b/gui/sort_model.py
@@ -1,6 +1,8 @@
 from typing import Union
 from PySide6.QtCore import QSortFilterProxyModel, QModelIndex, QPersistentModelIndex, Qt
+from yaml_files import checks
 
+check_order = list(checks.keys())
 
 class LocationsModel(QSortFilterProxyModel):
     def __init__(self, parent):
@@ -9,7 +11,9 @@ class LocationsModel(QSortFilterProxyModel):
         self.setSortCaseSensitivity(Qt.CaseInsensitive)
 
     def lessThan(self, right, left):
-        return False
+        leftCheck = self.sourceModel().data(left)
+        rightCheck = self.sourceModel().data(right)
+        return check_order.index(leftCheck) > check_order.index(rightCheck)
 
     def filterAcceptsRow(self, source_row: int, source_parent: Union[QModelIndex, QPersistentModelIndex]) -> bool:
         index = self.sourceModel().index(source_row, 0, source_parent)

--- a/gui/tricks_dialog.py
+++ b/gui/tricks_dialog.py
@@ -29,12 +29,14 @@ class TricksDialog(QDialog):
 
     def move_selected_rows(self, source, dest):
         selection = source.selectionModel().selectedIndexes()
+        last_selection = source.currentIndex()
         # Remove starting from the last so the previous indices remain valid
         selection.sort(reverse=True, key=lambda x: x.row())
         for item in selection:
             value = item.data()
             source.model().removeRow(item.row())
             self.append_row(dest.model(), value)
+        source.selectionModel().setCurrentIndex(last_selection)
 
     def enable_trick(self):
         self.move_selected_rows(self.ui.disabled_tricks, self.ui.enabled_tricks)

--- a/gui/tricks_dialog.py
+++ b/gui/tricks_dialog.py
@@ -11,17 +11,14 @@ class TricksDialog(QDialog):
         self.ui.setupUi(self)
 
         self.enabled_tricks_model = enabled_model
-        self.enabled_tricks_model.setStringList(
-            OPTIONS["enabled-tricks-bitless"]["default"]
-        )
         self.disabled_tricks_model = disabled_model
-        self.disabled_tricks_model.setStringList(
-            OPTIONS["enabled-tricks-bitless"]["choices"]
-        )
         self.ui.enabled_tricks.setModel(self.enabled_tricks_model)
         self.ui.disabled_tricks.setModel(self.disabled_tricks_model)
         self.ui.enable_trick.clicked.connect(self.enable_trick)
         self.ui.disable_trick.clicked.connect(self.disable_trick)
+
+        self.ui.bbox_tricks.accepted.connect(self.accept)
+        self.ui.bbox_tricks.rejected.connect(self.reject)
 
     @staticmethod
     def append_row(model, value):
@@ -45,3 +42,6 @@ class TricksDialog(QDialog):
     def disable_trick(self):
         self.move_selected_rows(self.ui.enabled_tricks, self.ui.disabled_tricks)
         self.ui.disabled_tricks.model().sort(0)
+
+    def getTrickValues(self):
+        return self.disabled_tricks_model.stringList(), self.enabled_tricks_model.stringList()

--- a/gui/tricks_dialog.py
+++ b/gui/tricks_dialog.py
@@ -4,6 +4,7 @@ from gui.ui_tricks_dialog import Ui_TricksDialog
 
 from options import OPTIONS
 
+
 class TricksDialog(QDialog):
     def __init__(self, enabled_model, disabled_model):
         super().__init__()
@@ -44,4 +45,7 @@ class TricksDialog(QDialog):
         self.ui.disabled_tricks.model().sort(0)
 
     def getTrickValues(self):
-        return self.disabled_tricks_model.stringList(), self.enabled_tricks_model.stringList()
+        return (
+            self.disabled_tricks_model.stringList(),
+            self.enabled_tricks_model.stringList(),
+        )

--- a/gui/tricks_dialog.py
+++ b/gui/tricks_dialog.py
@@ -1,0 +1,49 @@
+from PySide6.QtCore import Qt, QTimer, QEvent, QStringListModel
+from PySide6.QtWidgets import QDialog
+from gui.ui_tricks_dialog import Ui_TricksDialog
+
+from options import OPTIONS
+
+class TricksDialog(QDialog):
+    def __init__(self, enabled_model, disabled_model):
+        super().__init__()
+        self.setWindowTitle("Enable Tricks")
+
+        self.ui = Ui_TricksDialog()
+        self.ui.setupUi(self)
+
+        self.enabled_tricks_model = enabled_model
+        self.enabled_tricks_model.setStringList(
+            OPTIONS["enabled-tricks-bitless"]["default"]
+        )
+        self.disabled_tricks_model = disabled_model
+        self.disabled_tricks_model.setStringList(
+            OPTIONS["enabled-tricks-bitless"]["choices"]
+        )
+        self.ui.enabled_tricks.setModel(self.enabled_tricks_model)
+        self.ui.disabled_tricks.setModel(self.disabled_tricks_model)
+        self.ui.enable_trick.clicked.connect(self.enable_trick)
+        self.ui.disable_trick.clicked.connect(self.disable_trick)
+
+    @staticmethod
+    def append_row(model, value):
+        model.insertRow(model.rowCount())
+        new_row = model.index(model.rowCount() - 1, 0)
+        model.setData(new_row, value)
+
+    def move_selected_rows(self, source, dest):
+        selection = source.selectionModel().selectedIndexes()
+        # Remove starting from the last so the previous indices remain valid
+        selection.sort(reverse=True, key=lambda x: x.row())
+        for item in selection:
+            value = item.data()
+            source.model().removeRow(item.row())
+            self.append_row(dest.model(), value)
+
+    def enable_trick(self):
+        self.move_selected_rows(self.ui.disabled_tricks, self.ui.enabled_tricks)
+        self.ui.enabled_tricks.model().sort(0)
+
+    def disable_trick(self):
+        self.move_selected_rows(self.ui.enabled_tricks, self.ui.disabled_tricks)
+        self.ui.disabled_tricks.model().sort(0)

--- a/gui/tricks_dialog.py
+++ b/gui/tricks_dialog.py
@@ -7,8 +7,6 @@ from options import OPTIONS
 class TricksDialog(QDialog):
     def __init__(self, enabled_model, disabled_model):
         super().__init__()
-        self.setWindowTitle("Enable Tricks")
-
         self.ui = Ui_TricksDialog()
         self.ui.setupUi(self)
 

--- a/gui/tricks_dialog.py
+++ b/gui/tricks_dialog.py
@@ -36,7 +36,7 @@ class TricksDialog(QDialog):
             value = item.data()
             source.model().removeRow(item.row())
             self.append_row(dest.model(), value)
-        source.selectionModel().setCurrentIndex(last_selection)
+        # source.selectionModel().setCurrentIndex(last_selection)
 
     def enable_trick(self):
         self.move_selected_rows(self.ui.disabled_tricks, self.ui.enabled_tricks)

--- a/gui/tricks_dialog.ui
+++ b/gui/tricks_dialog.ui
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TricksDialog</class>
+ <widget class="QDialog" name="TricksDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1005</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>240</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QWidget" name="layoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>999</width>
+     <height>229</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="vlay_tricks">
+    <item>
+     <widget class="QLabel" name="label_tricks">
+      <property name="text">
+       <string>Enable Tricks</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="hlay_tricks_body">
+      <item>
+       <widget class="QListView" name="disabled_tricks">
+        <property name="toolTip">
+         <string>test</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="vlay_tricks_controls">
+        <item>
+         <widget class="QPushButton" name="disable_trick">
+          <property name="text">
+           <string>Disable
+&lt;--</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="enable_trick">
+          <property name="text">
+           <string>Enable
+--&gt;</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QListView" name="enabled_tricks"/>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>TricksDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>TricksDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/gui/tricks_dialog.ui
+++ b/gui/tricks_dialog.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Enable Tricks</string>
   </property>
-  <widget class="QDialogButtonBox" name="buttonBox">
+  <widget class="QDialogButtonBox" name="bbox_tricks">
    <property name="geometry">
     <rect>
      <x>660</x>
@@ -79,7 +79,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>buttonBox</sender>
+   <sender>bbox_tricks</sender>
    <signal>accepted()</signal>
    <receiver>TricksDialog</receiver>
    <slot>accept()</slot>
@@ -95,7 +95,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>buttonBox</sender>
+   <sender>bbox_tricks</sender>
    <signal>rejected()</signal>
    <receiver>TricksDialog</receiver>
    <slot>reject()</slot>

--- a/gui/tricks_dialog.ui
+++ b/gui/tricks_dialog.ui
@@ -7,17 +7,17 @@
     <x>0</x>
     <y>0</y>
     <width>1005</width>
-    <height>300</height>
+    <height>309</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Enable Tricks</string>
   </property>
   <widget class="QDialogButtonBox" name="buttonBox">
    <property name="geometry">
     <rect>
-     <x>30</x>
-     <y>240</y>
+     <x>660</x>
+     <y>270</y>
      <width>341</width>
      <height>32</height>
     </rect>
@@ -32,20 +32,13 @@
   <widget class="QWidget" name="layoutWidget">
    <property name="geometry">
     <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>999</width>
-     <height>229</height>
+     <x>8</x>
+     <y>10</y>
+     <width>991</width>
+     <height>251</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="vlay_tricks">
-    <item>
-     <widget class="QLabel" name="label_tricks">
-      <property name="text">
-       <string>Enable Tricks</string>
-      </property>
-     </widget>
-    </item>
     <item>
      <layout class="QHBoxLayout" name="hlay_tricks_body">
       <item>

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -26,30 +26,39 @@ class Ui_MainWindow(object):
         if not MainWindow.objectName():
             MainWindow.setObjectName(u"MainWindow")
         MainWindow.resize(1051, 738)
-        sizePolicy = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(MainWindow.sizePolicy().hasHeightForWidth())
         MainWindow.setSizePolicy(sizePolicy)
+        MainWindow.setSizeIncrement(QSize(0, 0))
         font = QFont()
         font.setFamilies([u"Segoe UI"])
         font.setPointSize(9)
         MainWindow.setFont(font)
         self.centralwidget = QWidget(MainWindow)
         self.centralwidget.setObjectName(u"centralwidget")
-        sizePolicy1 = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
-        sizePolicy1.setHorizontalStretch(0)
-        sizePolicy1.setVerticalStretch(0)
-        sizePolicy1.setHeightForWidth(self.centralwidget.sizePolicy().hasHeightForWidth())
-        self.centralwidget.setSizePolicy(sizePolicy1)
+        sizePolicy.setHeightForWidth(self.centralwidget.sizePolicy().hasHeightForWidth())
+        self.centralwidget.setSizePolicy(sizePolicy)
         self.option_description = QLabel(self.centralwidget)
         self.option_description.setObjectName(u"option_description")
         self.option_description.setEnabled(True)
         self.option_description.setGeometry(QRect(10, 560, 1031, 41))
+        sizePolicy1 = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        sizePolicy1.setHorizontalStretch(0)
+        sizePolicy1.setVerticalStretch(0)
+        sizePolicy1.setHeightForWidth(self.option_description.sizePolicy().hasHeightForWidth())
+        self.option_description.setSizePolicy(sizePolicy1)
         self.option_description.setWordWrap(True)
         self.tabWidget = QTabWidget(self.centralwidget)
         self.tabWidget.setObjectName(u"tabWidget")
         self.tabWidget.setGeometry(QRect(10, 10, 1031, 541))
+        sizePolicy2 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        sizePolicy2.setHorizontalStretch(0)
+        sizePolicy2.setVerticalStretch(0)
+        sizePolicy2.setHeightForWidth(self.tabWidget.sizePolicy().hasHeightForWidth())
+        self.tabWidget.setSizePolicy(sizePolicy2)
+        self.tabWidget.setSizeIncrement(QSize(0, 0))
         self.tabWidget.setToolTipDuration(-6)
         self.tabWidget.setUsesScrollButtons(True)
         self.tabWidget.setDocumentMode(False)
@@ -180,22 +189,22 @@ class Ui_MainWindow(object):
         self.hlay_star_count.setObjectName(u"hlay_star_count")
         self.label_for_option_star_count = QLabel(self.verticalLayoutWidget_8)
         self.label_for_option_star_count.setObjectName(u"label_for_option_star_count")
-        sizePolicy2 = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Preferred)
-        sizePolicy2.setHorizontalStretch(0)
-        sizePolicy2.setVerticalStretch(0)
-        sizePolicy2.setHeightForWidth(self.label_for_option_star_count.sizePolicy().hasHeightForWidth())
-        self.label_for_option_star_count.setSizePolicy(sizePolicy2)
+        sizePolicy3 = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Preferred)
+        sizePolicy3.setHorizontalStretch(0)
+        sizePolicy3.setVerticalStretch(0)
+        sizePolicy3.setHeightForWidth(self.label_for_option_star_count.sizePolicy().hasHeightForWidth())
+        self.label_for_option_star_count.setSizePolicy(sizePolicy3)
 
         self.hlay_star_count.addWidget(self.label_for_option_star_count)
 
         self.option_star_count = QSpinBox(self.verticalLayoutWidget_8)
         self.option_star_count.setObjectName(u"option_star_count")
         self.option_star_count.setEnabled(True)
-        sizePolicy3 = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
-        sizePolicy3.setHorizontalStretch(0)
-        sizePolicy3.setVerticalStretch(0)
-        sizePolicy3.setHeightForWidth(self.option_star_count.sizePolicy().hasHeightForWidth())
-        self.option_star_count.setSizePolicy(sizePolicy3)
+        sizePolicy4 = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
+        sizePolicy4.setHorizontalStretch(0)
+        sizePolicy4.setVerticalStretch(0)
+        sizePolicy4.setHeightForWidth(self.option_star_count.sizePolicy().hasHeightForWidth())
+        self.option_star_count.setSizePolicy(sizePolicy4)
         self.option_star_count.setMaximum(32767)
         self.option_star_count.setSingleStep(100)
 
@@ -357,11 +366,11 @@ class Ui_MainWindow(object):
         self.option_required_dungeon_count = QSpinBox(self.verticalLayoutWidget)
         self.option_required_dungeon_count.setObjectName(u"option_required_dungeon_count")
         self.option_required_dungeon_count.setEnabled(True)
-        sizePolicy4 = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
-        sizePolicy4.setHorizontalStretch(0)
-        sizePolicy4.setVerticalStretch(0)
-        sizePolicy4.setHeightForWidth(self.option_required_dungeon_count.sizePolicy().hasHeightForWidth())
-        self.option_required_dungeon_count.setSizePolicy(sizePolicy4)
+        sizePolicy5 = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        sizePolicy5.setHorizontalStretch(0)
+        sizePolicy5.setVerticalStretch(0)
+        sizePolicy5.setHeightForWidth(self.option_required_dungeon_count.sizePolicy().hasHeightForWidth())
+        self.option_required_dungeon_count.setSizePolicy(sizePolicy5)
         self.option_required_dungeon_count.setMaximumSize(QSize(41, 16777215))
 
         self.hlay_req_dungeons.addWidget(self.option_required_dungeon_count)
@@ -847,11 +856,42 @@ class Ui_MainWindow(object):
         self.vlay_logic_settings.addLayout(self.hlay_misc_logic_settings)
 
         self.vlay_exclude_locations = QVBoxLayout()
+        self.vlay_exclude_locations.setSpacing(6)
         self.vlay_exclude_locations.setObjectName(u"vlay_exclude_locations")
         self.label_exclude_locations = QLabel(self.layoutWidget)
         self.label_exclude_locations.setObjectName(u"label_exclude_locations")
 
         self.vlay_exclude_locations.addWidget(self.label_exclude_locations)
+
+        self.horizontalLayout = QHBoxLayout()
+        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.horizontalLayout.setSizeConstraint(QLayout.SetDefaultConstraint)
+        self.comboBox = QComboBox(self.layoutWidget)
+        self.comboBox.setObjectName(u"comboBox")
+
+        self.horizontalLayout.addWidget(self.comboBox)
+
+        self.lineEdit = QLineEdit(self.layoutWidget)
+        self.lineEdit.setObjectName(u"lineEdit")
+
+        self.horizontalLayout.addWidget(self.lineEdit)
+
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+
+        self.horizontalLayout.addItem(self.horizontalSpacer)
+
+        self.lineEdit_2 = QLineEdit(self.layoutWidget)
+        self.lineEdit_2.setObjectName(u"lineEdit_2")
+
+        self.horizontalLayout.addWidget(self.lineEdit_2)
+
+        self.comboBox_2 = QComboBox(self.layoutWidget)
+        self.comboBox_2.setObjectName(u"comboBox_2")
+
+        self.horizontalLayout.addWidget(self.comboBox_2)
+
+
+        self.vlay_exclude_locations.addLayout(self.horizontalLayout)
 
         self.hlay_exclude_locations_body = QHBoxLayout()
         self.hlay_exclude_locations_body.setObjectName(u"hlay_exclude_locations_body")
@@ -867,10 +907,24 @@ class Ui_MainWindow(object):
 
         self.vlay_exclude_locations_controls.addWidget(self.include_location)
 
+        self.pushButton = QPushButton(self.layoutWidget)
+        self.pushButton.setObjectName(u"pushButton")
+
+        self.vlay_exclude_locations_controls.addWidget(self.pushButton)
+
+        self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+
+        self.vlay_exclude_locations_controls.addItem(self.verticalSpacer)
+
         self.exclude_location = QPushButton(self.layoutWidget)
         self.exclude_location.setObjectName(u"exclude_location")
 
         self.vlay_exclude_locations_controls.addWidget(self.exclude_location)
+
+        self.pushButton_2 = QPushButton(self.layoutWidget)
+        self.pushButton_2.setObjectName(u"pushButton_2")
+
+        self.vlay_exclude_locations_controls.addWidget(self.pushButton_2)
 
 
         self.hlay_exclude_locations_body.addLayout(self.vlay_exclude_locations_controls)
@@ -1000,11 +1054,8 @@ class Ui_MainWindow(object):
 
         self.randomized_items = QListView(self.verticalLayoutWidget_201)
         self.randomized_items.setObjectName(u"randomized_items")
-        sizePolicy5 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        sizePolicy5.setHorizontalStretch(0)
-        sizePolicy5.setVerticalStretch(0)
-        sizePolicy5.setHeightForWidth(self.randomized_items.sizePolicy().hasHeightForWidth())
-        self.randomized_items.setSizePolicy(sizePolicy5)
+        sizePolicy2.setHeightForWidth(self.randomized_items.sizePolicy().hasHeightForWidth())
+        self.randomized_items.setSizePolicy(sizePolicy2)
 
         self.vlay_randomized_items_section.addWidget(self.randomized_items)
 
@@ -1051,8 +1102,8 @@ class Ui_MainWindow(object):
 
         self.starting_items = QListView(self.verticalLayoutWidget_201)
         self.starting_items.setObjectName(u"starting_items")
-        sizePolicy5.setHeightForWidth(self.starting_items.sizePolicy().hasHeightForWidth())
-        self.starting_items.setSizePolicy(sizePolicy5)
+        sizePolicy2.setHeightForWidth(self.starting_items.sizePolicy().hasHeightForWidth())
+        self.starting_items.setSizePolicy(sizePolicy2)
 
         self.vlay_starting_items_section.addWidget(self.starting_items)
 
@@ -1089,8 +1140,8 @@ class Ui_MainWindow(object):
 
         self.option_random_starting_item = QCheckBox(self.verticalLayoutWidget_201)
         self.option_random_starting_item.setObjectName(u"option_random_starting_item")
-        sizePolicy4.setHeightForWidth(self.option_random_starting_item.sizePolicy().hasHeightForWidth())
-        self.option_random_starting_item.setSizePolicy(sizePolicy4)
+        sizePolicy5.setHeightForWidth(self.option_random_starting_item.sizePolicy().hasHeightForWidth())
+        self.option_random_starting_item.setSizePolicy(sizePolicy5)
 
         self.hlay_starting_items_misc_options.addWidget(self.option_random_starting_item)
 
@@ -1108,8 +1159,8 @@ class Ui_MainWindow(object):
 
         self.option_starting_heart_containers = QSpinBox(self.verticalLayoutWidget_201)
         self.option_starting_heart_containers.setObjectName(u"option_starting_heart_containers")
-        sizePolicy4.setHeightForWidth(self.option_starting_heart_containers.sizePolicy().hasHeightForWidth())
-        self.option_starting_heart_containers.setSizePolicy(sizePolicy4)
+        sizePolicy5.setHeightForWidth(self.option_starting_heart_containers.sizePolicy().hasHeightForWidth())
+        self.option_starting_heart_containers.setSizePolicy(sizePolicy5)
         self.option_starting_heart_containers.setMaximumSize(QSize(41, 16777215))
 
         self.hlay_heart_containters.addWidget(self.option_starting_heart_containers)
@@ -1128,8 +1179,8 @@ class Ui_MainWindow(object):
 
         self.option_starting_heart_pieces = QSpinBox(self.verticalLayoutWidget_201)
         self.option_starting_heart_pieces.setObjectName(u"option_starting_heart_pieces")
-        sizePolicy4.setHeightForWidth(self.option_starting_heart_pieces.sizePolicy().hasHeightForWidth())
-        self.option_starting_heart_pieces.setSizePolicy(sizePolicy4)
+        sizePolicy5.setHeightForWidth(self.option_starting_heart_pieces.sizePolicy().hasHeightForWidth())
+        self.option_starting_heart_pieces.setSizePolicy(sizePolicy5)
         self.option_starting_heart_pieces.setMaximumSize(QSize(41, 16777215))
 
         self.hlay_heart_pieces.addWidget(self.option_starting_heart_pieces)
@@ -1309,9 +1360,14 @@ class Ui_MainWindow(object):
         self.edit_tricks.setText(QCoreApplication.translate("MainWindow", u"Tricks", None))
         self.option_hero_mode.setText(QCoreApplication.translate("MainWindow", u"Hero Mode", None))
         self.label_exclude_locations.setText(QCoreApplication.translate("MainWindow", u"Exclude Locations", None))
+        self.lineEdit.setText("")
         self.include_location.setText(QCoreApplication.translate("MainWindow", u"Include\n"
 "<--", None))
+        self.pushButton.setText(QCoreApplication.translate("MainWindow", u"Include All\n"
+"<--", None))
         self.exclude_location.setText(QCoreApplication.translate("MainWindow", u"Exclude\n"
+"-->", None))
+        self.pushButton_2.setText(QCoreApplication.translate("MainWindow", u"Exclude All\n"
 "-->", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_logic_settings), QCoreApplication.translate("MainWindow", u"Logic Settings", None))
         self.box_stone_hints.setTitle(QCoreApplication.translate("MainWindow", u"Gossip Stone Hints", None))

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -897,11 +897,6 @@ class Ui_MainWindow(object):
 
         self.vlay_exclude_locations_controls.addWidget(self.include_location)
 
-        self.pushButton = QPushButton(self.layoutWidget)
-        self.pushButton.setObjectName(u"pushButton")
-
-        self.vlay_exclude_locations_controls.addWidget(self.pushButton)
-
         self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
 
         self.vlay_exclude_locations_controls.addItem(self.verticalSpacer)
@@ -910,11 +905,6 @@ class Ui_MainWindow(object):
         self.exclude_location.setObjectName(u"exclude_location")
 
         self.vlay_exclude_locations_controls.addWidget(self.exclude_location)
-
-        self.pushButton_2 = QPushButton(self.layoutWidget)
-        self.pushButton_2.setObjectName(u"pushButton_2")
-
-        self.vlay_exclude_locations_controls.addWidget(self.pushButton_2)
 
 
         self.hlay_exclude_locations_body.addLayout(self.vlay_exclude_locations_controls)
@@ -1353,11 +1343,7 @@ class Ui_MainWindow(object):
         self.included_free_search.setText("")
         self.include_location.setText(QCoreApplication.translate("MainWindow", u"Include\n"
 "<--", None))
-        self.pushButton.setText(QCoreApplication.translate("MainWindow", u"Include All\n"
-"<--", None))
         self.exclude_location.setText(QCoreApplication.translate("MainWindow", u"Exclude\n"
-"-->", None))
-        self.pushButton_2.setText(QCoreApplication.translate("MainWindow", u"Exclude All\n"
 "-->", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_logic_settings), QCoreApplication.translate("MainWindow", u"Logic Settings", None))
         self.box_stone_hints.setTitle(QCoreApplication.translate("MainWindow", u"Gossip Stone Hints", None))

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -871,19 +871,19 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout.addWidget(self.comboBox)
 
-        self.lineEdit = QLineEdit(self.layoutWidget)
-        self.lineEdit.setObjectName(u"lineEdit")
+        self.included_free_search = QLineEdit(self.layoutWidget)
+        self.included_free_search.setObjectName(u"included_free_search")
 
-        self.horizontalLayout.addWidget(self.lineEdit)
+        self.horizontalLayout.addWidget(self.included_free_search)
 
         self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout.addItem(self.horizontalSpacer)
 
-        self.lineEdit_2 = QLineEdit(self.layoutWidget)
-        self.lineEdit_2.setObjectName(u"lineEdit_2")
+        self.excluded_free_search = QLineEdit(self.layoutWidget)
+        self.excluded_free_search.setObjectName(u"excluded_free_search")
 
-        self.horizontalLayout.addWidget(self.lineEdit_2)
+        self.horizontalLayout.addWidget(self.excluded_free_search)
 
         self.comboBox_2 = QComboBox(self.layoutWidget)
         self.comboBox_2.setObjectName(u"comboBox_2")
@@ -1360,7 +1360,7 @@ class Ui_MainWindow(object):
         self.edit_tricks.setText(QCoreApplication.translate("MainWindow", u"Tricks", None))
         self.option_hero_mode.setText(QCoreApplication.translate("MainWindow", u"Hero Mode", None))
         self.label_exclude_locations.setText(QCoreApplication.translate("MainWindow", u"Exclude Locations", None))
-        self.lineEdit.setText("")
+        self.included_free_search.setText("")
         self.include_location.setText(QCoreApplication.translate("MainWindow", u"Include\n"
 "<--", None))
         self.pushButton.setText(QCoreApplication.translate("MainWindow", u"Include All\n"

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -45,7 +45,7 @@ class Ui_MainWindow(object):
         self.option_description = QLabel(self.centralwidget)
         self.option_description.setObjectName(u"option_description")
         self.option_description.setEnabled(True)
-        self.option_description.setGeometry(QRect(10, 570, 1031, 31))
+        self.option_description.setGeometry(QRect(10, 560, 1031, 41))
         self.option_description.setWordWrap(True)
         self.tabWidget = QTabWidget(self.centralwidget)
         self.tabWidget.setObjectName(u"tabWidget")
@@ -434,7 +434,7 @@ class Ui_MainWindow(object):
         self.box_dungeons.setGeometry(QRect(820, 0, 191, 501))
         self.verticalLayoutWidget_7 = QWidget(self.box_dungeons)
         self.verticalLayoutWidget_7.setObjectName(u"verticalLayoutWidget_7")
-        self.verticalLayoutWidget_7.setGeometry(QRect(10, 20, 179, 471))
+        self.verticalLayoutWidget_7.setGeometry(QRect(10, 20, 178, 471))
         self.vlay_dungeons = QVBoxLayout(self.verticalLayoutWidget_7)
         self.vlay_dungeons.setObjectName(u"vlay_dungeons")
         self.vlay_dungeons.setContentsMargins(0, 0, 0, 0)
@@ -829,6 +829,11 @@ class Ui_MainWindow(object):
 
         self.hlay_misc_logic_settings.addWidget(self.option_logic_mode)
 
+        self.edit_tricks = QPushButton(self.layoutWidget)
+        self.edit_tricks.setObjectName(u"edit_tricks")
+
+        self.hlay_misc_logic_settings.addWidget(self.edit_tricks)
+
         self.option_hero_mode = QCheckBox(self.layoutWidget)
         self.option_hero_mode.setObjectName(u"option_hero_mode")
 
@@ -880,46 +885,6 @@ class Ui_MainWindow(object):
 
 
         self.vlay_logic_settings.addLayout(self.vlay_exclude_locations)
-
-        self.vlay_tricks = QVBoxLayout()
-        self.vlay_tricks.setObjectName(u"vlay_tricks")
-        self.label_tricks = QLabel(self.layoutWidget)
-        self.label_tricks.setObjectName(u"label_tricks")
-
-        self.vlay_tricks.addWidget(self.label_tricks)
-
-        self.hlay_tricks_body = QHBoxLayout()
-        self.hlay_tricks_body.setObjectName(u"hlay_tricks_body")
-        self.disabled_tricks = QListView(self.layoutWidget)
-        self.disabled_tricks.setObjectName(u"disabled_tricks")
-
-        self.hlay_tricks_body.addWidget(self.disabled_tricks)
-
-        self.vlay_tricks_controls = QVBoxLayout()
-        self.vlay_tricks_controls.setObjectName(u"vlay_tricks_controls")
-        self.disable_trick = QPushButton(self.layoutWidget)
-        self.disable_trick.setObjectName(u"disable_trick")
-
-        self.vlay_tricks_controls.addWidget(self.disable_trick)
-
-        self.enable_trick = QPushButton(self.layoutWidget)
-        self.enable_trick.setObjectName(u"enable_trick")
-
-        self.vlay_tricks_controls.addWidget(self.enable_trick)
-
-
-        self.hlay_tricks_body.addLayout(self.vlay_tricks_controls)
-
-        self.enabled_tricks = QListView(self.layoutWidget)
-        self.enabled_tricks.setObjectName(u"enabled_tricks")
-
-        self.hlay_tricks_body.addWidget(self.enabled_tricks)
-
-
-        self.vlay_tricks.addLayout(self.hlay_tricks_body)
-
-
-        self.vlay_logic_settings.addLayout(self.vlay_tricks)
 
         self.tabWidget.addTab(self.tab_logic_settings, "")
         self.tab_hints = QWidget()
@@ -1249,7 +1214,7 @@ class Ui_MainWindow(object):
 
         self.retranslateUi(MainWindow)
 
-        self.tabWidget.setCurrentIndex(0)
+        self.tabWidget.setCurrentIndex(3)
         self.option_triforce_shuffle.setCurrentIndex(-1)
         self.option_randomize_entrances.setCurrentIndex(-1)
         self.option_chest_dowsing.setCurrentIndex(-1)
@@ -1341,19 +1306,12 @@ class Ui_MainWindow(object):
         self.label_for_option_damage_multiplier.setText(QCoreApplication.translate("MainWindow", u"Damage Taken Multiplier", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_additional_settings), QCoreApplication.translate("MainWindow", u"Additional Settings", None))
         self.label_for_option_logic_mode.setText(QCoreApplication.translate("MainWindow", u"Logic Mode", None))
+        self.edit_tricks.setText(QCoreApplication.translate("MainWindow", u"Tricks", None))
         self.option_hero_mode.setText(QCoreApplication.translate("MainWindow", u"Hero Mode", None))
         self.label_exclude_locations.setText(QCoreApplication.translate("MainWindow", u"Exclude Locations", None))
         self.include_location.setText(QCoreApplication.translate("MainWindow", u"Include\n"
 "<--", None))
         self.exclude_location.setText(QCoreApplication.translate("MainWindow", u"Exclude\n"
-"-->", None))
-        self.label_tricks.setText(QCoreApplication.translate("MainWindow", u"Enable Tricks", None))
-#if QT_CONFIG(tooltip)
-        self.disabled_tricks.setToolTip(QCoreApplication.translate("MainWindow", u"test", None))
-#endif // QT_CONFIG(tooltip)
-        self.disable_trick.setText(QCoreApplication.translate("MainWindow", u"Disable\n"
-"<--", None))
-        self.enable_trick.setText(QCoreApplication.translate("MainWindow", u"Enable\n"
 "-->", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_logic_settings), QCoreApplication.translate("MainWindow", u"Logic Settings", None))
         self.box_stone_hints.setTitle(QCoreApplication.translate("MainWindow", u"Gossip Stone Hints", None))

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -866,11 +866,6 @@ class Ui_MainWindow(object):
         self.horizontalLayout = QHBoxLayout()
         self.horizontalLayout.setObjectName(u"horizontalLayout")
         self.horizontalLayout.setSizeConstraint(QLayout.SetDefaultConstraint)
-        self.comboBox = QComboBox(self.layoutWidget)
-        self.comboBox.setObjectName(u"comboBox")
-
-        self.horizontalLayout.addWidget(self.comboBox)
-
         self.included_free_search = QLineEdit(self.layoutWidget)
         self.included_free_search.setObjectName(u"included_free_search")
 
@@ -884,11 +879,6 @@ class Ui_MainWindow(object):
         self.excluded_free_search.setObjectName(u"excluded_free_search")
 
         self.horizontalLayout.addWidget(self.excluded_free_search)
-
-        self.comboBox_2 = QComboBox(self.layoutWidget)
-        self.comboBox_2.setObjectName(u"comboBox_2")
-
-        self.horizontalLayout.addWidget(self.comboBox_2)
 
 
         self.vlay_exclude_locations.addLayout(self.horizontalLayout)

--- a/gui/ui_tricks_dialog.py
+++ b/gui/ui_tricks_dialog.py
@@ -24,11 +24,11 @@ class Ui_TricksDialog(object):
         if not TricksDialog.objectName():
             TricksDialog.setObjectName(u"TricksDialog")
         TricksDialog.resize(1005, 309)
-        self.buttonBox = QDialogButtonBox(TricksDialog)
-        self.buttonBox.setObjectName(u"buttonBox")
-        self.buttonBox.setGeometry(QRect(660, 270, 341, 32))
-        self.buttonBox.setOrientation(Qt.Horizontal)
-        self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
+        self.bbox_tricks = QDialogButtonBox(TricksDialog)
+        self.bbox_tricks.setObjectName(u"bbox_tricks")
+        self.bbox_tricks.setGeometry(QRect(660, 270, 341, 32))
+        self.bbox_tricks.setOrientation(Qt.Horizontal)
+        self.bbox_tricks.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
         self.layoutWidget = QWidget(TricksDialog)
         self.layoutWidget.setObjectName(u"layoutWidget")
         self.layoutWidget.setGeometry(QRect(8, 10, 991, 251))
@@ -67,8 +67,8 @@ class Ui_TricksDialog(object):
 
 
         self.retranslateUi(TricksDialog)
-        self.buttonBox.accepted.connect(TricksDialog.accept)
-        self.buttonBox.rejected.connect(TricksDialog.reject)
+        self.bbox_tricks.accepted.connect(TricksDialog.accept)
+        self.bbox_tricks.rejected.connect(TricksDialog.reject)
 
         QMetaObject.connectSlotsByName(TricksDialog)
     # setupUi

--- a/gui/ui_tricks_dialog.py
+++ b/gui/ui_tricks_dialog.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'tricks_dialog.ui'
+##
+## Created by: Qt User Interface Compiler version 6.2.4
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractButton, QApplication, QDialog, QDialogButtonBox,
+    QHBoxLayout, QLabel, QListView, QPushButton,
+    QSizePolicy, QVBoxLayout, QWidget)
+
+class Ui_TricksDialog(object):
+    def setupUi(self, TricksDialog):
+        if not TricksDialog.objectName():
+            TricksDialog.setObjectName(u"TricksDialog")
+        TricksDialog.resize(1005, 300)
+        self.buttonBox = QDialogButtonBox(TricksDialog)
+        self.buttonBox.setObjectName(u"buttonBox")
+        self.buttonBox.setGeometry(QRect(30, 240, 341, 32))
+        self.buttonBox.setOrientation(Qt.Horizontal)
+        self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
+        self.layoutWidget = QWidget(TricksDialog)
+        self.layoutWidget.setObjectName(u"layoutWidget")
+        self.layoutWidget.setGeometry(QRect(0, 0, 999, 229))
+        self.vlay_tricks = QVBoxLayout(self.layoutWidget)
+        self.vlay_tricks.setObjectName(u"vlay_tricks")
+        self.vlay_tricks.setContentsMargins(0, 0, 0, 0)
+        self.label_tricks = QLabel(self.layoutWidget)
+        self.label_tricks.setObjectName(u"label_tricks")
+
+        self.vlay_tricks.addWidget(self.label_tricks)
+
+        self.hlay_tricks_body = QHBoxLayout()
+        self.hlay_tricks_body.setObjectName(u"hlay_tricks_body")
+        self.disabled_tricks = QListView(self.layoutWidget)
+        self.disabled_tricks.setObjectName(u"disabled_tricks")
+
+        self.hlay_tricks_body.addWidget(self.disabled_tricks)
+
+        self.vlay_tricks_controls = QVBoxLayout()
+        self.vlay_tricks_controls.setObjectName(u"vlay_tricks_controls")
+        self.disable_trick = QPushButton(self.layoutWidget)
+        self.disable_trick.setObjectName(u"disable_trick")
+
+        self.vlay_tricks_controls.addWidget(self.disable_trick)
+
+        self.enable_trick = QPushButton(self.layoutWidget)
+        self.enable_trick.setObjectName(u"enable_trick")
+
+        self.vlay_tricks_controls.addWidget(self.enable_trick)
+
+
+        self.hlay_tricks_body.addLayout(self.vlay_tricks_controls)
+
+        self.enabled_tricks = QListView(self.layoutWidget)
+        self.enabled_tricks.setObjectName(u"enabled_tricks")
+
+        self.hlay_tricks_body.addWidget(self.enabled_tricks)
+
+
+        self.vlay_tricks.addLayout(self.hlay_tricks_body)
+
+
+        self.retranslateUi(TricksDialog)
+        self.buttonBox.accepted.connect(TricksDialog.accept)
+        self.buttonBox.rejected.connect(TricksDialog.reject)
+
+        QMetaObject.connectSlotsByName(TricksDialog)
+    # setupUi
+
+    def retranslateUi(self, TricksDialog):
+        TricksDialog.setWindowTitle(QCoreApplication.translate("TricksDialog", u"Dialog", None))
+        self.label_tricks.setText(QCoreApplication.translate("TricksDialog", u"Enable Tricks", None))
+#if QT_CONFIG(tooltip)
+        self.disabled_tricks.setToolTip(QCoreApplication.translate("TricksDialog", u"test", None))
+#endif // QT_CONFIG(tooltip)
+        self.disable_trick.setText(QCoreApplication.translate("TricksDialog", u"Disable\n"
+"<--", None))
+        self.enable_trick.setText(QCoreApplication.translate("TricksDialog", u"Enable\n"
+"-->", None))
+    # retranslateUi
+

--- a/gui/ui_tricks_dialog.py
+++ b/gui/ui_tricks_dialog.py
@@ -8,79 +8,120 @@
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
-    QMetaObject, QObject, QPoint, QRect,
-    QSize, QTime, QUrl, Qt)
-from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
-    QFont, QFontDatabase, QGradient, QIcon,
-    QImage, QKeySequence, QLinearGradient, QPainter,
-    QPalette, QPixmap, QRadialGradient, QTransform)
-from PySide6.QtWidgets import (QAbstractButton, QApplication, QDialog, QDialogButtonBox,
-    QHBoxLayout, QListView, QPushButton, QSizePolicy,
-    QVBoxLayout, QWidget)
+from PySide6.QtCore import (
+    QCoreApplication,
+    QDate,
+    QDateTime,
+    QLocale,
+    QMetaObject,
+    QObject,
+    QPoint,
+    QRect,
+    QSize,
+    QTime,
+    QUrl,
+    Qt,
+)
+from PySide6.QtGui import (
+    QBrush,
+    QColor,
+    QConicalGradient,
+    QCursor,
+    QFont,
+    QFontDatabase,
+    QGradient,
+    QIcon,
+    QImage,
+    QKeySequence,
+    QLinearGradient,
+    QPainter,
+    QPalette,
+    QPixmap,
+    QRadialGradient,
+    QTransform,
+)
+from PySide6.QtWidgets import (
+    QAbstractButton,
+    QApplication,
+    QDialog,
+    QDialogButtonBox,
+    QHBoxLayout,
+    QListView,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
 
 class Ui_TricksDialog(object):
     def setupUi(self, TricksDialog):
         if not TricksDialog.objectName():
-            TricksDialog.setObjectName(u"TricksDialog")
+            TricksDialog.setObjectName("TricksDialog")
         TricksDialog.resize(1005, 309)
         self.bbox_tricks = QDialogButtonBox(TricksDialog)
-        self.bbox_tricks.setObjectName(u"bbox_tricks")
+        self.bbox_tricks.setObjectName("bbox_tricks")
         self.bbox_tricks.setGeometry(QRect(660, 270, 341, 32))
         self.bbox_tricks.setOrientation(Qt.Horizontal)
-        self.bbox_tricks.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
+        self.bbox_tricks.setStandardButtons(
+            QDialogButtonBox.Cancel | QDialogButtonBox.Ok
+        )
         self.layoutWidget = QWidget(TricksDialog)
-        self.layoutWidget.setObjectName(u"layoutWidget")
+        self.layoutWidget.setObjectName("layoutWidget")
         self.layoutWidget.setGeometry(QRect(8, 10, 991, 251))
         self.vlay_tricks = QVBoxLayout(self.layoutWidget)
-        self.vlay_tricks.setObjectName(u"vlay_tricks")
+        self.vlay_tricks.setObjectName("vlay_tricks")
         self.vlay_tricks.setContentsMargins(0, 0, 0, 0)
         self.hlay_tricks_body = QHBoxLayout()
-        self.hlay_tricks_body.setObjectName(u"hlay_tricks_body")
+        self.hlay_tricks_body.setObjectName("hlay_tricks_body")
         self.disabled_tricks = QListView(self.layoutWidget)
-        self.disabled_tricks.setObjectName(u"disabled_tricks")
+        self.disabled_tricks.setObjectName("disabled_tricks")
 
         self.hlay_tricks_body.addWidget(self.disabled_tricks)
 
         self.vlay_tricks_controls = QVBoxLayout()
-        self.vlay_tricks_controls.setObjectName(u"vlay_tricks_controls")
+        self.vlay_tricks_controls.setObjectName("vlay_tricks_controls")
         self.disable_trick = QPushButton(self.layoutWidget)
-        self.disable_trick.setObjectName(u"disable_trick")
+        self.disable_trick.setObjectName("disable_trick")
 
         self.vlay_tricks_controls.addWidget(self.disable_trick)
 
         self.enable_trick = QPushButton(self.layoutWidget)
-        self.enable_trick.setObjectName(u"enable_trick")
+        self.enable_trick.setObjectName("enable_trick")
 
         self.vlay_tricks_controls.addWidget(self.enable_trick)
-
 
         self.hlay_tricks_body.addLayout(self.vlay_tricks_controls)
 
         self.enabled_tricks = QListView(self.layoutWidget)
-        self.enabled_tricks.setObjectName(u"enabled_tricks")
+        self.enabled_tricks.setObjectName("enabled_tricks")
 
         self.hlay_tricks_body.addWidget(self.enabled_tricks)
 
-
         self.vlay_tricks.addLayout(self.hlay_tricks_body)
-
 
         self.retranslateUi(TricksDialog)
         self.bbox_tricks.accepted.connect(TricksDialog.accept)
         self.bbox_tricks.rejected.connect(TricksDialog.reject)
 
         QMetaObject.connectSlotsByName(TricksDialog)
+
     # setupUi
 
     def retranslateUi(self, TricksDialog):
-        TricksDialog.setWindowTitle(QCoreApplication.translate("TricksDialog", u"Enable Tricks", None))
-#if QT_CONFIG(tooltip)
-        self.disabled_tricks.setToolTip(QCoreApplication.translate("TricksDialog", u"test", None))
-#endif // QT_CONFIG(tooltip)
-        self.disable_trick.setText(QCoreApplication.translate("TricksDialog", u"Disable\n"
-"<--", None))
-        self.enable_trick.setText(QCoreApplication.translate("TricksDialog", u"Enable\n"
-"-->", None))
-    # retranslateUi
+        TricksDialog.setWindowTitle(
+            QCoreApplication.translate("TricksDialog", "Enable Tricks", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.disabled_tricks.setToolTip(
+            QCoreApplication.translate("TricksDialog", "test", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.disable_trick.setText(
+            QCoreApplication.translate("TricksDialog", "Disable\n" "<--", None)
+        )
+        self.enable_trick.setText(
+            QCoreApplication.translate("TricksDialog", "Enable\n" "-->", None)
+        )
 
+    # retranslateUi

--- a/gui/ui_tricks_dialog.py
+++ b/gui/ui_tricks_dialog.py
@@ -16,30 +16,25 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QAbstractButton, QApplication, QDialog, QDialogButtonBox,
-    QHBoxLayout, QLabel, QListView, QPushButton,
-    QSizePolicy, QVBoxLayout, QWidget)
+    QHBoxLayout, QListView, QPushButton, QSizePolicy,
+    QVBoxLayout, QWidget)
 
 class Ui_TricksDialog(object):
     def setupUi(self, TricksDialog):
         if not TricksDialog.objectName():
             TricksDialog.setObjectName(u"TricksDialog")
-        TricksDialog.resize(1005, 300)
+        TricksDialog.resize(1005, 309)
         self.buttonBox = QDialogButtonBox(TricksDialog)
         self.buttonBox.setObjectName(u"buttonBox")
-        self.buttonBox.setGeometry(QRect(30, 240, 341, 32))
+        self.buttonBox.setGeometry(QRect(660, 270, 341, 32))
         self.buttonBox.setOrientation(Qt.Horizontal)
         self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
         self.layoutWidget = QWidget(TricksDialog)
         self.layoutWidget.setObjectName(u"layoutWidget")
-        self.layoutWidget.setGeometry(QRect(0, 0, 999, 229))
+        self.layoutWidget.setGeometry(QRect(8, 10, 991, 251))
         self.vlay_tricks = QVBoxLayout(self.layoutWidget)
         self.vlay_tricks.setObjectName(u"vlay_tricks")
         self.vlay_tricks.setContentsMargins(0, 0, 0, 0)
-        self.label_tricks = QLabel(self.layoutWidget)
-        self.label_tricks.setObjectName(u"label_tricks")
-
-        self.vlay_tricks.addWidget(self.label_tricks)
-
         self.hlay_tricks_body = QHBoxLayout()
         self.hlay_tricks_body.setObjectName(u"hlay_tricks_body")
         self.disabled_tricks = QListView(self.layoutWidget)
@@ -79,8 +74,7 @@ class Ui_TricksDialog(object):
     # setupUi
 
     def retranslateUi(self, TricksDialog):
-        TricksDialog.setWindowTitle(QCoreApplication.translate("TricksDialog", u"Dialog", None))
-        self.label_tricks.setText(QCoreApplication.translate("TricksDialog", u"Enable Tricks", None))
+        TricksDialog.setWindowTitle(QCoreApplication.translate("TricksDialog", u"Enable Tricks", None))
 #if QT_CONFIG(tooltip)
         self.disabled_tricks.setToolTip(QCoreApplication.translate("TricksDialog", u"test", None))
 #endif // QT_CONFIG(tooltip)

--- a/gui/ui_tricks_dialog.py
+++ b/gui/ui_tricks_dialog.py
@@ -8,120 +8,79 @@
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide6.QtCore import (
-    QCoreApplication,
-    QDate,
-    QDateTime,
-    QLocale,
-    QMetaObject,
-    QObject,
-    QPoint,
-    QRect,
-    QSize,
-    QTime,
-    QUrl,
-    Qt,
-)
-from PySide6.QtGui import (
-    QBrush,
-    QColor,
-    QConicalGradient,
-    QCursor,
-    QFont,
-    QFontDatabase,
-    QGradient,
-    QIcon,
-    QImage,
-    QKeySequence,
-    QLinearGradient,
-    QPainter,
-    QPalette,
-    QPixmap,
-    QRadialGradient,
-    QTransform,
-)
-from PySide6.QtWidgets import (
-    QAbstractButton,
-    QApplication,
-    QDialog,
-    QDialogButtonBox,
-    QHBoxLayout,
-    QListView,
-    QPushButton,
-    QSizePolicy,
-    QVBoxLayout,
-    QWidget,
-)
-
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractButton, QApplication, QDialog, QDialogButtonBox,
+    QHBoxLayout, QListView, QPushButton, QSizePolicy,
+    QVBoxLayout, QWidget)
 
 class Ui_TricksDialog(object):
     def setupUi(self, TricksDialog):
         if not TricksDialog.objectName():
-            TricksDialog.setObjectName("TricksDialog")
+            TricksDialog.setObjectName(u"TricksDialog")
         TricksDialog.resize(1005, 309)
         self.bbox_tricks = QDialogButtonBox(TricksDialog)
-        self.bbox_tricks.setObjectName("bbox_tricks")
+        self.bbox_tricks.setObjectName(u"bbox_tricks")
         self.bbox_tricks.setGeometry(QRect(660, 270, 341, 32))
         self.bbox_tricks.setOrientation(Qt.Horizontal)
-        self.bbox_tricks.setStandardButtons(
-            QDialogButtonBox.Cancel | QDialogButtonBox.Ok
-        )
+        self.bbox_tricks.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
         self.layoutWidget = QWidget(TricksDialog)
-        self.layoutWidget.setObjectName("layoutWidget")
+        self.layoutWidget.setObjectName(u"layoutWidget")
         self.layoutWidget.setGeometry(QRect(8, 10, 991, 251))
         self.vlay_tricks = QVBoxLayout(self.layoutWidget)
-        self.vlay_tricks.setObjectName("vlay_tricks")
+        self.vlay_tricks.setObjectName(u"vlay_tricks")
         self.vlay_tricks.setContentsMargins(0, 0, 0, 0)
         self.hlay_tricks_body = QHBoxLayout()
-        self.hlay_tricks_body.setObjectName("hlay_tricks_body")
+        self.hlay_tricks_body.setObjectName(u"hlay_tricks_body")
         self.disabled_tricks = QListView(self.layoutWidget)
-        self.disabled_tricks.setObjectName("disabled_tricks")
+        self.disabled_tricks.setObjectName(u"disabled_tricks")
 
         self.hlay_tricks_body.addWidget(self.disabled_tricks)
 
         self.vlay_tricks_controls = QVBoxLayout()
-        self.vlay_tricks_controls.setObjectName("vlay_tricks_controls")
+        self.vlay_tricks_controls.setObjectName(u"vlay_tricks_controls")
         self.disable_trick = QPushButton(self.layoutWidget)
-        self.disable_trick.setObjectName("disable_trick")
+        self.disable_trick.setObjectName(u"disable_trick")
 
         self.vlay_tricks_controls.addWidget(self.disable_trick)
 
         self.enable_trick = QPushButton(self.layoutWidget)
-        self.enable_trick.setObjectName("enable_trick")
+        self.enable_trick.setObjectName(u"enable_trick")
 
         self.vlay_tricks_controls.addWidget(self.enable_trick)
+
 
         self.hlay_tricks_body.addLayout(self.vlay_tricks_controls)
 
         self.enabled_tricks = QListView(self.layoutWidget)
-        self.enabled_tricks.setObjectName("enabled_tricks")
+        self.enabled_tricks.setObjectName(u"enabled_tricks")
 
         self.hlay_tricks_body.addWidget(self.enabled_tricks)
 
+
         self.vlay_tricks.addLayout(self.hlay_tricks_body)
+
 
         self.retranslateUi(TricksDialog)
         self.bbox_tricks.accepted.connect(TricksDialog.accept)
         self.bbox_tricks.rejected.connect(TricksDialog.reject)
 
         QMetaObject.connectSlotsByName(TricksDialog)
-
     # setupUi
 
     def retranslateUi(self, TricksDialog):
-        TricksDialog.setWindowTitle(
-            QCoreApplication.translate("TricksDialog", "Enable Tricks", None)
-        )
-        # if QT_CONFIG(tooltip)
-        self.disabled_tricks.setToolTip(
-            QCoreApplication.translate("TricksDialog", "test", None)
-        )
-        # endif // QT_CONFIG(tooltip)
-        self.disable_trick.setText(
-            QCoreApplication.translate("TricksDialog", "Disable\n" "<--", None)
-        )
-        self.enable_trick.setText(
-            QCoreApplication.translate("TricksDialog", "Enable\n" "-->", None)
-        )
-
+        TricksDialog.setWindowTitle(QCoreApplication.translate("TricksDialog", u"Enable Tricks", None))
+#if QT_CONFIG(tooltip)
+        self.disabled_tricks.setToolTip(QCoreApplication.translate("TricksDialog", u"test", None))
+#endif // QT_CONFIG(tooltip)
+        self.disable_trick.setText(QCoreApplication.translate("TricksDialog", u"Disable\n"
+"<--", None))
+        self.enable_trick.setText(QCoreApplication.translate("TricksDialog", u"Enable\n"
+"-->", None))
     # retranslateUi
+

--- a/options.yaml
+++ b/options.yaml
@@ -406,7 +406,6 @@
     - Sky Keep - FS Room Clawshots Vine Clip
   default: []
   help: Enable specific tricks to be considered in logic
-  ui: enabled_tricks
 - name: Enabled Tricks Glitched
   command: enabled-tricks-glitched
   type: multichoice
@@ -421,7 +420,6 @@
 
   default: []
   help: Enable specific tricks to be considered in logic
-  ui: enabled_tricks
 - name: Song Hints
   command: song-hints
   type: singlechoice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 include = '\.pyi?$'
-exclude = 'gui/ui_randogui.py'
+exclude = 'gui/ui_.*.py'


### PR DESCRIPTION
Improves the Logic tab of the randomizer. Makes the following changes
- Tricks are migrated to a popup window and removed from the rest of the tab
- Include/Exclude locations have been expanded to fill the vacated space
- Adds a free text search to both the included and excluded locations lists
  - Text searches can be done independently on both views and do not impact each other
  - Moving an item from to a destination view where the search would hide it is supported (item will be hidden by default)
  - Searches are case insensitive, and will match any check name containing the string. It is not limited to word boundaries or any other related limitation

## Technical Notes
- The serialization process for **all** ListViews has been altered
- Sorting is correctly applied to all ListViews whenever they have an item added to it

## Future Notes
- Dropdown/text->category filtering is still planned for the future, but did not make the cut for this PR in the interest of getting this important first usability improvement rolled out
- Include/Exclude All is still planned, but remains unimplemented here