### PR TITLE
Fix missing old logic emmy requirement for Floria

### DIFF
--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -761,9 +761,9 @@ Can Reach Oolo in Faron 2:
 
 Can Open Door to Lake Floria:
   Can Access Most of Faron Woods &
-  (Can Talk to Yerbal & Goddess Sword) |
+  ((Can Talk to Yerbal & Goddess Sword) |
   (Can Talk to Yerbal & Option "open-lake-floria" Is "Talk to Yerbal") |
-  (Water Scale & Option "open-lake-floria" Is "Open")
+  (Water Scale & Option "open-lake-floria" Is "Open"))
   # You need to charge a skyward strike to open the door to Lake Floria
   # Scene Flag 7x02 is "Cutscene of the Doors to Lake Floria opening"
   # Scene Flag 7x04 is "Doors to Lake Floria opened"

--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -760,6 +760,7 @@ Can Reach Oolo in Faron 2:
   # Scene Flag 2x01 is "Log after Lopsa is pushed down"
 
 Can Open Door to Lake Floria:
+  Can Access Most of Faron Woods &
   (Can Talk to Yerbal & Goddess Sword) |
   (Can Talk to Yerbal & Option "open-lake-floria" Is "Talk to Yerbal") |
   (Water Scale & Option "open-lake-floria" Is "Open")


### PR DESCRIPTION
Fixes a bug where the tracker will show Lake Floria as being accessible without Emerald Tablet. This is due to a missing requirement in the old logic files and doesn't impact the actual game logic.