### PR TITLE
Clearer could not place error msgs

### DIFF
--- a/asm/assemble.py
+++ b/asm/assemble.py
@@ -20,7 +20,7 @@ if sys.platform == "win32":
 else:
     if not "DEVKITPPC" in os.environ:
         raise Exception(
-            r"Could not find devkitPPC. Path to devkitPPC should be in the DEVKITPPC env var"
+            r"Could not find devkitPPC. Path to devkitPPC should be in the DEVKITPPC env var."
         )
     devkitbasepath = os.environ.get("DEVKITPPC") + "/bin"
 
@@ -33,7 +33,7 @@ def get_bin(name):
 
 if not os.path.isfile(get_bin("powerpc-eabi-as")):
     raise Exception(
-        r"Failed to assemble code: Could not find devkitPPC. devkitPPC should be installed to: C:\devkitPro\devkitPPC"
+        r"Failed to assemble code: Could not find devkitPPC. devkitPPC should be installed to: C:\devkitPro\devkitPPC."
     )
 
 # Allow yaml to dump OrderedDicts for the diffs.
@@ -183,7 +183,7 @@ def handle_sda_instr(line: str) -> str:
     address = original_symbols["main.dol"][lbl]
     if address < SDA_13_MIN or address > SDA_13_MAX:
         raise Exception(
-            f"Relocation failed, SDA for symbol {elf_symbol.name} out of range!"
+            f"Relocation failed, SDA for symbol {elf_symbol.name} out of range."
         )
     if instr == "la":
         return f"addi {reg}, r13, {address-SDA_13_BASE}"
@@ -241,7 +241,7 @@ try:
                 relative_file_path = open_file_match.group(1)
                 if most_recent_file_path or most_recent_org_offset is not None:
                     raise Exception(
-                        "File %s was not closed before opening new file %s"
+                        "File %s was not closed before opening new file %s."
                         % (most_recent_file_path, relative_file_path)
                     )
                 if relative_file_path not in code_chunks[patch_name]:
@@ -252,7 +252,7 @@ try:
                 continue
             elif org_match:
                 if not most_recent_file_path:
-                    raise Exception("Found .org directive when no file was open")
+                    raise Exception("Found .org directive when no file was open.")
 
                 org_offset = int(org_match.group(1), 16)
                 if org_offset >= free_space_start_offsets[most_recent_file_path]:
@@ -266,7 +266,7 @@ try:
                 continue
             elif org_symbol_match:
                 if not most_recent_file_path:
-                    raise Exception("Found .org directive when no file was open")
+                    raise Exception("Found .org directive when no file was open.")
 
                 org_symbol = org_symbol_match.group(1)
 
@@ -303,12 +303,12 @@ try:
                 if line[0] == ";":
                     # Comment
                     continue
-                raise Exception("Found code when no file was open")
+                raise Exception("Found code when no file was open.")
             if most_recent_org_offset is None:
                 if line[0] == ";":
                     # Comment
                     continue
-                raise Exception("Found code before any .org directive")
+                raise Exception("Found code before any .org directive.")
 
             if "@sda21" in line:
                 line = handle_sda_instr(line)
@@ -318,11 +318,11 @@ try:
             )
 
         if not code_chunks[patch_name]:
-            raise Exception("No code found")
+            raise Exception("No code found.")
 
         if most_recent_file_path or most_recent_org_offset is not None:
             raise Exception(
-                "File %s was not closed before the end of the file"
+                "File %s was not closed before the end of the file."
                 % most_recent_file_path
             )
 
@@ -378,7 +378,7 @@ try:
                     else:
                         if org_symbol not in custom_symbols_for_file:
                             raise Exception(
-                                ".org specified an invalid custom symbol: %s"
+                                ".org specified an invalid custom symbol: %s."
                                 % org_symbol
                             )
                         org_offset = custom_symbols_for_file[org_symbol]
@@ -412,7 +412,7 @@ try:
                 print()
                 result = call(command)
                 if result != 0:
-                    raise Exception("Assembler call failed")
+                    raise Exception("Assembler call failed.")
 
                 bin_name = os.path.join(
                     temp_dir, "tmp_" + patch_name + "_%08X.bin" % org_offset
@@ -436,7 +436,7 @@ try:
                         ["cargo", "build", "--release"], cwd="./custom-functions"
                     )
                     if result != 0:
-                        raise Exception("building rust functions failed")
+                        raise Exception("Building rust functions failed.")
                     command.append(
                         "./custom-functions/target/powerpc-unknown-eabi/release/libcustom_functions.a"
                     )
@@ -451,7 +451,7 @@ try:
                 print()
                 result = call(command)
                 if result != 0:
-                    raise Exception("Linker call failed")
+                    raise Exception("Linker call failed.")
 
                 # Keep track of custom symbols so they can be passed in the linker script to future assembler calls.
                 with open(map_name) as f:
@@ -488,7 +488,7 @@ try:
 
                 if org_offset in diffs[file_path]:
                     raise Exception(
-                        "Duplicate .org directive within a single asm patch: %X"
+                        "Duplicate .org directive within a single asm patch: %X."
                         % org_offset
                     )
 

--- a/asm/patcher.py
+++ b/asm/patcher.py
@@ -244,7 +244,7 @@ def add_relocations_to_rel(
             rel_relocation.section_num_to_relocate_against = other_rel_section_index
             rel_relocation.symbol_address = relative_offset
         else:
-            raise Exception("Could not find symbol name: %s" % symbol_name)
+            raise Exception("Could not find symbol name: %s." % symbol_name)
 
         rel_relocation.relocation_offset = relocation_offset
         rel_relocation.curr_section_num = rel_section_index

--- a/gamepatches.py
+++ b/gamepatches.py
@@ -1228,7 +1228,9 @@ class GamePatcher:
         elif rupeesanity_option == "All":
             to_remove = []
         else:
-            raise ValueError(f"Wrong value {rupeesanity_option} for option rupeesanity.")
+            raise ValueError(
+                f"Wrong value {rupeesanity_option} for option rupeesanity."
+            )
 
         for rupee_check in to_remove:
             del filtered_item_locations[rupee_check]

--- a/gamepatches.py
+++ b/gamepatches.py
@@ -714,7 +714,7 @@ def make_progressive_item(
     if len(item_text_indexes) != len(storyflags) or len(item_text_indexes) != len(
         item_ids
     ):
-        raise Exception("item_text_indexes should be the same length as storyflags!")
+        raise Exception("item_text_indexes should be the same length as storyflags.")
     flow_idx = len(msbf["FLW3"]["flow"])
     msbf["FLW3"]["flow"][base_item_start]["next"] = flow_idx
     index = len(item_text_indexes) - 1  # start from the highest upgrade
@@ -1070,7 +1070,7 @@ def get_patches_from_location_item_list(all_checks, filled_checks, chest_dowsing
                     else:
                         stageoarcs[("F002r", 1)].add(oarc)
                 if modelname is None or arcname is None:
-                    raise Exception(f"no modelnames for {item}")
+                    raise Exception(f"No modelnames for {item}.")
                 shoppatches[index] = (item["id"], arcname, modelname)
             else:
                 print(f"ERROR: {path} didn't match any regex!")
@@ -1228,7 +1228,7 @@ class GamePatcher:
         elif rupeesanity_option == "All":
             to_remove = []
         else:
-            raise ValueError(f"Wrong value {rupeesanity_option} for option rupeesanity")
+            raise ValueError(f"Wrong value {rupeesanity_option} for option rupeesanity.")
 
         for rupee_check in to_remove:
             del filtered_item_locations[rupee_check]
@@ -1652,7 +1652,7 @@ class GamePatcher:
                 elif isinstance(entry, int):
                     self.startitemflags[entry] = 1
                 else:
-                    raise ValueError(f"expected list, tuple or int, got : {entry}")
+                    raise ValueError(f"Expected list, tuple or int, got : {entry}.")
             # story flags
             if (entry := ITEM_STORY_FLAGS.get(item)) is not None:
                 if isinstance(entry, tuple):
@@ -1662,7 +1662,7 @@ class GamePatcher:
                 elif isinstance(entry, int):
                     self.startstoryflags.append(entry)
                 else:
-                    raise ValueError(f"expected list, tuple or int, got : {entry}")
+                    raise ValueError(f"Expected list, tuple or int, got : {entry}.")
             if item == PROGRESSIVE_POUCH:
                 self.startstoryflags.append(30)  # Vanilla storyflag for pouch.
             if (ammo_flag_count := START_AMMO_COUNTS.get(item)) is not None:
@@ -2578,7 +2578,7 @@ class GamePatcher:
         startflag_byte_count = len(start_flags_write.getbuffer())
         if startflag_byte_count > 512:
             raise Exception(
-                f"not enough space to fit in all of the startflags, need {startflag_byte_count}, but only 512 bytes available"
+                f"Not enough space to fit in all of the startflags, need {startflag_byte_count}, but only 512 bytes available."
             )
         # print(f"total startflag byte count: {startflag_byte_count}")
         dol.write_data_bytes(0x804EE1B8, start_flags_write.getbuffer())

--- a/logic/assumed_fill.py
+++ b/logic/assumed_fill.py
@@ -55,7 +55,9 @@ class AssumedFill:
         for item in progress_list:
             self.useroutput.progress_callback("placing progress items...")
             if not self.place_item(item):
-                raise self.useroutput.GenerationFailed(f"could not place {item}")
+                raise self.useroutput.GenerationFailed(
+                    f"Could not find a valid location to place {item}. This may be because the settings are too restrictive. Try randomizing a new seed."
+                )
 
         # for i, (e, _) in enumerate(self.logic.pools):
         #     for _ in range(len(e)):
@@ -118,7 +120,7 @@ class AssumedFill:
             return False
         if not accessible_locations:
             raise self.useroutput.GenerationFailed(
-                f"no more location accessible for {item}"
+                f"No more locations accessible for {item}."
             )
 
         self.check_known_failures(item)
@@ -143,7 +145,7 @@ class AssumedFill:
             and not self.logic.full_inventory[EXTENDED_ITEM[number(PROGRESSIVE_BOW, 0)]]
         ):
             raise self.useroutput.GenerationFailed(
-                f"Known generation failure : Vanilla Bow"
+                f"Known generation failure: Vanilla Bow."
             )
 
         if (
@@ -152,7 +154,7 @@ class AssumedFill:
             and not self.logic.full_inventory[EXTENDED_ITEM[WHIP]]
         ):
             raise self.useroutput.GenerationFailed(
-                f"Known generation failure : Vanilla Whip"
+                f"Known generation failure: Vanilla Whip."
             )
 
     def link(self, pool: int, entrance=None, depth=0):
@@ -188,4 +190,4 @@ class AssumedFill:
             if result:
                 self.link(pool, result, depth + 1)
 
-        raise ValueError("No exit could be found for the entrance")
+        raise ValueError("No exit could be found for the entrance.")

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -83,7 +83,7 @@ def entrance_of_exit(exit):
         return exit.replace("Exit", "Entrance")
     if "Exit to " in exit:
         return exit.replace("Exit to", "Entrance from")
-    raise ValueError("No pattern")
+    raise ValueError("No pattern found for the entrance of exit {exit}.")
 
 
 SV = "Skyview"
@@ -148,7 +148,7 @@ ITEM_COUNTS: Dict[str, int] = defaultdict(lambda: 1)
 
 def number(name: str, index: int) -> EXTENDED_ITEM_NAME:
     if index >= ITEM_COUNTS[name]:
-        raise ValueError("Index too high")
+        raise ValueError("Constant index too high.")
     if ITEM_COUNTS[name] == 1:
         return EIN(name)
     return EIN(f"{name} #{index}")

--- a/logic/front_fill.py
+++ b/logic/front_fill.py
@@ -135,7 +135,7 @@ class FrontFill:
             return True
 
         raise self.useroutput.GenerationFailed(
-            f"no more location accessible for {item_name}"
+            f"No more locations accessible for {item_name}."
         )
 
     def randomize_progression_items(self):
@@ -146,7 +146,7 @@ class FrontFill:
         ]
         if len(accessible_undone_locations) == 0:
             raise Exception(
-                "No progress locations are accessible at the very start of the game!"
+                "No progress locations are accessible at the very start of the game."
             )
 
         unplaced_progress_items = list(self.progress_items)
@@ -162,7 +162,7 @@ class FrontFill:
             ]
 
             if not accessible_undone_locations:
-                raise Exception("No locations left to place progress items!")
+                raise Exception("No locations left to place progress items.")
 
             for location in accessible_undone_locations:
                 if location not in location_weights:
@@ -220,7 +220,7 @@ class FrontFill:
                 if item_name is None:
                     # This means that no item can unlock a new location
                     if must_place_useful_item:
-                        raise Exception("No useful progress items to place!")
+                        raise Exception("No useful progress items to place.")
                     else:
                         assert False
                         # I didn't want to adapt this part because it's too obscure and apparently useless
@@ -271,7 +271,7 @@ class FrontFill:
             item_name = self.rng.choice(to_place)
 
             if not accessible_undone_locations:
-                raise Exception("No valid locations left to place non-progress items!")
+                raise Exception("No valid locations left to place non-progress items.")
 
             location_name = self.rng.choice(accessible_undone_locations)
             self.logic.place_item(location_name, item_name)

--- a/logic/hints.py
+++ b/logic/hints.py
@@ -71,7 +71,7 @@ class Hints:
                 STATUS.useless: HINT_MODES.Useless,
             }
         else:
-            raise ValueError(f'Unknown value for setting "song-hints": "{hint_mode}"')
+            raise ValueError(f'Unknown value for setting "song-hints": "{hint_mode}".')
 
         does_hint = hint_mode != "None"
         get_check = lambda trial_gate: self.norm(
@@ -145,7 +145,9 @@ class Hints:
 
         for hintname in hints:
             if not self.place_hint(hintname):
-                raise self.useroutput.GenerationFailed(f"could not place {hintname}")
+                raise self.useroutput.GenerationFailed(
+                    f"Could not find a valid location to place {hintname}. This may be because the settings are too restrictive. Try randomizing a new seed."
+                )
 
     def place_hint(self, hintname: EXTENDED_ITEM_NAME, depth=0) -> bool:
         hint_bit = EXTENDED_ITEM[hintname]
@@ -173,7 +175,7 @@ class Hints:
             return False
         if not accessible_stones:
             raise self.useroutput.GenerationFailed(
-                f"no more location accessible for {hintname}"
+                f"No more locations accessible for {hintname}."
             )
 
         spots = [

--- a/logic/inventory.py
+++ b/logic/inventory.py
@@ -192,7 +192,7 @@ class Inventory:
                         )
                     )
             else:
-                raise ValueError(f"{item} not in inventory")
+                raise ValueError(f"{item} not in inventory.")
         raise ValueError(item)
 
     @staticmethod

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -466,7 +466,7 @@ class Logic:
             and location in self.placement.locations
             and self.placement.locations[location] != item
         ):
-            raise ValueError(f"Location {location} is already taken")
+            raise ValueError(f"Location {location} is already taken.")
 
         items = self.placement.stone_hints if hint_mode else self.placement.items
         if (
@@ -479,14 +479,14 @@ class Logic:
                 name = ""
             else:
                 name = "Item "
-            raise ValueError(f"{name}{item} is already placed")
+            raise ValueError(f"{name}{item} is already placed.")
 
         if item in self.placement.item_placement_limit and not location.startswith(
             self.placement.item_placement_limit[item]
         ):
             raise ValueError(
                 "This item cannot be placed in this area, "
-                f"it must be placed in {self.placement.item_placement_limit[item]}"
+                f"it must be placed in {self.placement.item_placement_limit[item]}."
             )
 
         if hint_mode:
@@ -515,19 +515,19 @@ class Logic:
 
         if hint_mode := old_hint is not None:
             if location not in self.placement.stones:
-                raise ValueError(f"Hint stone {location} is empty")
+                raise ValueError(f"Hint stone {location} is empty.")
             if old_hint not in self.placement.stones[location]:
-                raise ValueError(f"Hint stone {location} does not contain {old_hint}")
+                raise ValueError(f"Hint stone {location} does not contain {old_hint}.")
             if item in self.placement.stone_hints:
-                raise ValueError(f"{item} is already placed")
+                raise ValueError(f"{item} is already placed.")
             self.placement.stones[location].remove(old_hint)
             del self.placement.stone_hints[old_hint]
             old_item = old_hint
         else:
             if location not in self.placement.locations:
-                raise ValueError(f"Location {location} is not taken")
+                raise ValueError(f"Location {location} is not taken.")
             if item in self.placement.items:
-                raise ValueError(f"Item {item} is already placed")
+                raise ValueError(f"Item {item} is already placed.")
             old_item = self.placement.locations[location]
             del self.placement.locations[location]
             del self.placement.items[old_item]

--- a/logic/logic_expression.py
+++ b/logic/logic_expression.py
@@ -137,11 +137,11 @@ class BasicTextAtom(LogicExpression):
     text: str
 
     def eval(self, *args):
-        raise TypeError("Text must be localized to be evaluated")
+        raise TypeError("Text must be localized to be evaluated.")
 
     def localize(self, localizer: Callable[[str], EXTENDED_ITEM_NAME | None]):
         if (v := localizer(self.text)) is None:
-            raise ValueError(f"Unknown event {self.text}")
+            raise ValueError(f"Unknown event {self.text}.")
         else:
             ret = EventAtom(v)
             ret.opaque = self.opaque
@@ -184,7 +184,7 @@ class AndCombination(LogicExpression):
 
     def eval(self, *args):
         raise TypeError(
-            f"Some argument of this {type(self).__name__} cannot be evaluated, or something has gone wrong"
+            f"Some argument of this {type(self).__name__} cannot be evaluated, or something has gone wrong."
         )
 
 
@@ -214,7 +214,7 @@ class OrCombination(LogicExpression):
 
     def eval(self, *args):
         raise TypeError(
-            f"Some argument of this {type(self).__name__} cannot be evaluated, or something has gone wrong"
+            f"Some argument of this {type(self).__name__} cannot be evaluated, or something has gone wrong."
         )
 
 
@@ -272,7 +272,7 @@ class MakeExpression(Transformer):
         if match := item_with_count_re.search(text):
             item_name = match.group(1)
             if item_name not in RAW_ITEM_NAMES:
-                raise ValueError(f"Unknown item {item_name}")
+                raise ValueError(f"Unknown item {item_name}.")
             return InventoryAtom(item_name, int(match.group(2)))
 
         elif text in RAW_ITEM_NAMES or text in EXTENDED_ITEM:

--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -60,7 +60,7 @@ class Area(Generic[LE]):
             area.allowed_time_of_day = parent.allowed_time_of_day
         if (v := raw_dict.get("hint-region")) is not None:
             if v not in ALL_HINT_REGIONS:
-                raise ValueError(f"Unknown hint region {v}")
+                raise ValueError(f"Unknown hint region {v}.")
             area.hint_region = v
         elif parent is not None:
             area.hint_region = parent.hint_region
@@ -92,7 +92,7 @@ class Area(Generic[LE]):
 
         if (v := raw_dict.get("entrance")) is not None:
             if parent is None:
-                raise ValueError("An entrance was given but no parent to give it to")
+                raise ValueError("An entrance was given but no parent to give it to.")
             parent.exits[name.rsplit("\\", 1)[-1]] = LogicExpression.parse(v)
 
         area.sub_areas = {
@@ -183,7 +183,7 @@ class Areas:
             queue.extend(area.sub_areas.values())
         else:
             raise ValueError(
-                f"Could not find '{partial_address_str}' from '{base_address_str}'"
+                f"Could not find '{partial_address_str}' from '{base_address_str}'."
             )
 
     def prettify(self, s, *, custom=False):
@@ -198,7 +198,7 @@ class Areas:
             return self.gossip_stones[s]["short_name"]
         if "\\" not in s and "#" not in s:
             return s
-        raise ValueError(f"Can't find a shortname for {s}")
+        raise ValueError(f"Can't find a shortname for {s}.")
 
     def __init__(
         self,
@@ -376,7 +376,7 @@ class Areas:
             for (a, b) in self.short_full:
                 if b == elt:
                     return a
-            raise ValueError(f"Error: association list, cannot find {elt}")
+            raise ValueError(f"Error: association list, cannot find {elt}.")
 
         self.short_to_full = short_to_full
         self.full_to_short = full_to_short
@@ -451,7 +451,7 @@ class Areas:
                         elif area.allowed_time_of_day == area_dest.allowed_time_of_day:
                             reqs[area_bit] |= timed_req & DNFInv(EIN(area_name))
                         else:
-                            raise ValueError("Time makes this exit impossible")
+                            raise ValueError("Time makes this exit impossible.")
 
                 else:  # Map exit
                     exit_full = with_sep_full(area_name, exit)

--- a/logic/logic_utils.py
+++ b/logic/logic_utils.py
@@ -58,7 +58,7 @@ class LogicUtils(Logic):
         full_inventory = Logic.fill_inventory(self.requirements, EMPTY_INV)
         DEMISE_BIT = EXTENDED_ITEM[self.short_to_full(DEMISE)]
         if not full_inventory[DEMISE_BIT]:
-            raise useroutput.GenerationFailed(f"Could not reach Demise")
+            raise useroutput.GenerationFailed(f"Could not reach Demise.")
 
         full_inventory = Logic.fill_inventory(self.requirements, Inventory(BANNED_BIT))
 
@@ -66,19 +66,19 @@ class LogicUtils(Logic):
             (everything_req,) = self.requirements[EVERYTHING_BIT].disjunction
             i = next(iter(everything_req.intset - full_inventory.intset))
             check = self.areas.full_to_short(EXTENDED_ITEM.get_item_name(i))
-            raise useroutput.GenerationFailed(f"Could not reach check {check}")
+            raise useroutput.GenerationFailed(f"Could not reach check {check}.")
 
         if not all(item in self.placement.locations for item in self.areas.checks):
             check = next(iter(set(self.areas.checks) - set(self.placement.locations)))
             check_name = self.areas.full_to_short(check)
             raise useroutput.GenerationFailed(
-                f"Check {check_name} has not been assigned an item"
+                f"Check {check_name} has not been assigned an item."
             )
 
         if not all(item in self.placement.items for item in INVENTORY_ITEMS):
             item = next(iter(set(INVENTORY_ITEMS) - set(self.placement.items)))
             raise useroutput.GenerationFailed(
-                f"Item {item} has not been handled by the randomizer"
+                f"Item {item} has not been handled by the randomizer."
             )
 
     @cache

--- a/logic/placement_file.py
+++ b/logic/placement_file.py
@@ -68,38 +68,38 @@ class PlacementFile:
         This does not check consistency with all the settings"""
         if VERSION != self.version:
             raise InvalidPlacementFile(
-                f"Version did not match, requires {self.version} but found {VERSION}"
+                f"Version did not match, requires {self.version} but found {VERSION}."
             )
 
         for item in self.starting_items:
             if item not in ALLOWED_STARTING_ITEMS:
-                raise InvalidPlacementFile(f"Invalid starting item {item} !")
+                raise InvalidPlacementFile(f"Invalid starting item {item}.")
 
         for req_dungeon in self.required_dungeons:
             if req_dungeon not in REGULAR_DUNGEONS:
                 raise InvalidPlacementFile(
-                    f"{req_dungeon} is not a valid required dungeon!"
+                    f"{req_dungeon} is not a valid required dungeon."
                 )
 
         if sorted(self.dungeon_connections.keys()) != sorted(
             DUNGEON_OVERWORLD_ENTRANCES.values()
         ):
-            raise InvalidPlacementFile("dungeon dungeon_connections are wrong!")
+            raise InvalidPlacementFile("Dungeon dungeon_connections are wrong.")
 
         if sorted(self.dungeon_connections.values()) != sorted(
             DUNGEON_OVERWORLD_ENTRANCES.keys()
         ):
-            raise InvalidPlacementFile("dungeon entries are wrong!")
+            raise InvalidPlacementFile("Dungeon entries are wrong.")
 
         if sorted(self.trial_connections.keys()) != sorted(SILENT_REALM_GATES.values()):
-            raise InvalidPlacementFile("trial trial_connections are wrong!")
+            raise InvalidPlacementFile("Trial trial_connections are wrong.")
 
         if sorted(self.trial_connections.values()) != sorted(SILENT_REALM_GATES.keys()):
-            raise InvalidPlacementFile("trial entries are wrong!")
+            raise InvalidPlacementFile("Trial entries are wrong.")
 
         for item in self.item_locations.values():
             if item not in ALL_ITEM_NAMES:
-                raise InvalidPlacementFile(f'invalid item "{item}"')
+                raise InvalidPlacementFile(f'Invalid item "{item}".')
 
         check_sets_equal(
             set(areas.checks.keys()),
@@ -116,12 +116,12 @@ class PlacementFile:
         for hintlist in self.hints.values():
             if not isinstance(hintlist, list):
                 raise InvalidPlacementFile(
-                    "gossip stone hints need to be LISTS of strings!"
+                    "Gossip stone hints need to be LISTS of strings."
                 )
             for hint in hintlist:
                 if not isinstance(hint, str):
                     raise InvalidPlacementFile(
-                        "gossip stone hints need to be lists of STRINGS!"
+                        "Gossip stone hints need to be lists of STRINGS."
                     )
 
 

--- a/logic/random_fill.py
+++ b/logic/random_fill.py
@@ -71,5 +71,5 @@ class RandomFill:
             return True
 
         raise self.useroutput.GenerationFailed(
-            f"no more location accessible for {item}"
+            f"No more locations accessible for {item}."
         )

--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -79,7 +79,7 @@ class Rando:
             FillAlgorithm = RandomFill
         else:
             raise ValueError(
-                f"Wrong value for option 'fill-algorithm: f'{fill_algorithm}'"
+                f"Wrong value for option 'fill-algorithm: f'{fill_algorithm}'."
             )
 
         runtime_requirements = (
@@ -112,7 +112,7 @@ class Rando:
 
         def fun():
             if not self.randomised:
-                raise ValueError("Cannot extract hint logic before randomisation")
+                raise ValueError("Cannot extract hint logic before randomisation.")
             return LogicUtils(
                 areas,
                 logic.placement,
@@ -311,7 +311,7 @@ class Rando:
             elif rupoor_mode == "Rupoor Insanity":
                 unplaced = may_be_placed_list
             else:
-                raise ValueError(f"Option rupoor-mode has unknown value {rupoor_mode}")
+                raise ValueError(f"Option rupoor-mode has unknown value {rupoor_mode}.")
             self.placement.add_unplaced_items(set(unplaced))
 
         must_be_placed_items = (
@@ -406,7 +406,7 @@ class Rando:
                 checks_to_use = DUNGEON_FINAL_CHECK
             else:
                 raise ValueError(
-                    f"Option sword-dungeon-reward has unknown value {sword_reward_mode}"
+                    f"Option sword-dungeon-reward has unknown value {sword_reward_mode}."
                 )
 
             dungeons = self.required_dungeons.copy()

--- a/musicrando.py
+++ b/musicrando.py
@@ -22,7 +22,7 @@ def get_derangement(length: int, rng: random.Random) -> List[int]:
     shuffled such that no number is at its index
     """
     if length <= 1:
-        raise ValueError("length needs to be at least 2")
+        raise ValueError("Length needs to be at least 2.")
     lst = list(range(length))
     rng.shuffle(lst)
     while not is_derangement(lst):

--- a/options.py
+++ b/options.py
@@ -79,7 +79,7 @@ class Options:
                 validation_errors.append(f"path {value_str} is not a directory!")
             value = path
         else:
-            raise Exception(f'unknown type: {option["type"]}')
+            raise Exception(f'Unknown type: {option["type"]}.')
         return value, validation_errors
 
     def update_from_cmd_args(self, raw_options):
@@ -131,7 +131,7 @@ class Options:
                 # needs information, how many bits this number is, then it's just the index to the choices
                 writer.write(option["choices"].index(value), option["bits"])
             else:
-                raise Exception(f'unknown type: {option["type"]}')
+                raise Exception(f'Unknown type: {option["type"]}.')
         writer.flush()
         permalink = writer.to_base64()
         if self["seed"] != -1 and not exclude_seed:
@@ -143,56 +143,56 @@ class Options:
         Sets the option to a value, this function checks if the value is valid, and throws an exception if it isn't
         """
         if not option_name in OPTIONS:
-            raise ValueError(f"not a valid option: {option_name}!")
+            raise ValueError(f"Not a valid option: {option_name}.")
         option = OPTIONS[option_name]
         if option["type"] == "boolean":
             if not isinstance(option_value, bool):
                 raise TypeError(
-                    f"value for option {option_name} has to be a boolean, got {type(option_value)}!"
+                    f"Value for option {option_name} has to be a boolean, got {type(option_value)}."
                 )
         elif option["type"] == "int":
             if not isinstance(option_value, int):
                 raise TypeError(
-                    f"value for option {option_name} has to be a number, got {type(option_value)}!"
+                    f"Value for option {option_name} has to be a number, got {type(option_value)}."
                 )
             if "max" in option and option_value > option["max"]:
                 raise ValueError(
-                    f'{option_value} is greater than the maximum of {option["max"]} for {option["command"]}'
+                    f'{option_value} is greater than the maximum of {option["max"]} for {option["command"]}.'
                 )
             if "min" in option and option_value < option["min"]:
                 raise ValueError(
-                    f'{option_value} is smaller than the minimum of {option["min"]} for {option["command"]}'
+                    f'{option_value} is smaller than the minimum of {option["min"]} for {option["command"]}.'
                 )
         elif option["type"] == "multichoice":
             if not isinstance(option_value, list):
                 raise TypeError(
-                    f"value for option {option_name} has to be a list, got {type(option_value)}!"
+                    f"Value for option {option_name} has to be a list, got {type(option_value)}."
                 )
             unknown_values = [v for v in option_value if not v in option["choices"]]
             if unknown_values:
                 raise ValueError(
-                    f"Unknown choice(s) for {option_name}: {unknown_values}"
+                    f"Unknown choice(s) for {option_name}: {unknown_values}."
                 )
         elif option["type"] == "singlechoice":
             if isinstance(option["default"], int) and not isinstance(option_value, int):
                 option_value = int(option_value)
             if not option_value in option["choices"]:
-                raise ValueError(f"Unknown choice for {option_name}: {option_value}")
+                raise ValueError(f"Unknown choice for {option_name}: {option_value}.")
         elif option["type"] == "dirpath":
             path = Path(option_value).expanduser()
             if not path.is_dir():
-                raise ValueError(f"path {option_value} is not a directory!")
+                raise ValueError(f"Path {option_value} is not a directory.")
             option_value = path
         self.options[option_name] = option_value
 
     def set_option_str(self, option_name, option_value):
         if not option_name in OPTIONS:
-            raise ValueError(f"not a valid option: {option_name}!")
+            raise ValueError(f"Not a valid option: {option_name}.")
         value, vaidation_errors = Options.parse_and_validate_option(
             option_value, OPTIONS[option_name]
         )
         if vaidation_errors:
-            raise ValueError(f"validation errors: {vaidation_errors}")
+            raise ValueError(f"Validation errors: {vaidation_errors}.")
         self.options[option_name] = value
 
     def validate_options(self):
@@ -221,7 +221,7 @@ class Options:
             elif option["type"] == "singlechoice":
                 value = option["choices"][reader.read(option["bits"])]
             else:
-                raise Exception(f'unknown type: {option["type"]}')
+                raise Exception(f'Unknown type: {option["type"]}.')
             self.set_option(option_name, value)
 
     def to_dict(self, exclude_nonperma=False, exclude=[]):

--- a/sslib/allpatch.py
+++ b/sslib/allpatch.py
@@ -58,7 +58,7 @@ class AllPatcher:
         self.progress_callback = dummy_progress_callback
         if not (self.actual_extract_path / "DATA").exists():
             raise Exception(
-                "actual extract path should have a DATA subdir, make sure the directory structure is properly set up!"
+                "actual_extract path should have a DATA subdir, make sure the directory structure is properly set up."
             )
 
     def add_stage_oarc(self, stage: str, layer: int, oarcs: Iterable[str]):
@@ -277,7 +277,7 @@ class AllPatcher:
                 )
 
         if eventrootpath == None:
-            raise Exception("Event files not found")
+            raise Exception("Event files not found.")
         for eventpath in eventrootpath.glob("*.arc"):
             modified = False
             filename = eventpath.parts[-1]

--- a/sslib/dol.py
+++ b/sslib/dol.py
@@ -63,7 +63,7 @@ class DOL:
 
         if offset is None:
             raise Exception(
-                "Address %08X is not in the data for any of the DOL sections" % address
+                "Address %08X is not in the data for any of the DOL sections." % address
             )
 
         return read_callback(self.data, offset, *args)
@@ -75,7 +75,7 @@ class DOL:
 
         if offset is None:
             raise Exception(
-                "Address %08X is not in the data for any of the DOL sections" % address
+                "Address %08X is not in the data for any of the DOL sections." % address
             )
 
         write_callback(self.data, offset, *args)

--- a/sslib/fs_helpers.py
+++ b/sslib/fs_helpers.py
@@ -100,7 +100,7 @@ def write_str(data, offset, new_string, max_length):
     str_len = len(new_string)
     if str_len >= max_length:
         raise Exception(
-            'String "%s" is too long (max length including null byte: 0x%X)'
+            'String "%s" is too long (max length including null byte: 0x%X).'
             % (new_string, max_length)
         )
 
@@ -119,7 +119,7 @@ def write_magic_str(data, offset, new_string, max_length):
     str_len = len(new_string)
     if str_len > max_length:
         raise Exception(
-            "String %s is too long (max length 0x%X)" % (new_string, max_length)
+            "String %s is too long (max length 0x%X)." % (new_string, max_length)
         )
 
     padding_length = max_length - str_len

--- a/sslib/msb.py
+++ b/sslib/msb.py
@@ -58,7 +58,7 @@ def parseMSB(data: bytes) -> ParsedMsb:
         parsed["type"] = "MsgStdBn"
         assert data[10:16] == b"\x00\x00\x01\x03\x00\x03"
     else:
-        raise Exception("unsupported filetype!")
+        raise Exception("Unsupported filetype.")
     assert struct.unpack(">i", data[0x12:0x16])[0] == len(data)
     pos = 0x20
     while pos < len(data):
@@ -133,7 +133,7 @@ def parseMSB(data: bytes) -> ParsedMsb:
                 ]
                 parsed["TXT2"].append(bytestring)
         else:
-            raise Exception(f"unsupported seg_id: {seg_id}")
+            raise Exception(f"Unsupported seg_id: {seg_id}.")
     return parsed
 
 
@@ -145,7 +145,7 @@ def buildMSB(msb: ParsedMsb) -> bytes:
         header = b"MsgStdBn\xFE\xFF"
         header += b"\x00\x00\x01\x03\x00\x03"
     else:
-        raise Exception(f'unsupported filetype: {msb["type"]}')
+        raise Exception(f'Unsupported filetype: {msb["type"]}.')
     header = bytearray(header + b"\x00" * 16)
     total_body = b""
     for seg_id, seg_data in msb.items():
@@ -207,7 +207,7 @@ def buildMSB(msb: ParsedMsb) -> bytes:
             body += seg_header
             body += seg_body
         else:
-            raise Exception(f"unsupported seg_id: {seg_id}")
+            raise Exception(f"Unsupported seg_id: {seg_id}.")
         total_body += seg_id.encode("ascii")
         total_body += struct.pack(">i", len(body)) + 8 * b"\x00"
         total_body += body

--- a/sslib/rel.py
+++ b/sslib/rel.py
@@ -148,7 +148,7 @@ class REL:
 
         if section_index is None:
             raise Exception(
-                "Offset %04X is not in the data for any of the REL sections" % offset
+                "Offset %04X is not in the data for any of the REL sections." % offset
             )
 
         return (section_index, relative_offset)
@@ -178,7 +178,7 @@ class REL:
 
         if data is None:
             raise Exception(
-                "Offset %04X is not in the data for any of the REL sections" % offset
+                "Offset %04X is not in the data for any of the REL sections." % offset
             )
 
         return read_callback(data, relative_offset, *args)
@@ -193,7 +193,7 @@ class REL:
 
         if data is None:
             raise Exception(
-                "Offset %04X is not in the data for any of the REL sections" % offset
+                "Offset %04X is not in the data for any of the REL sections." % offset
             )
 
         write_callback(data, relative_offset, *args)

--- a/sslib/u8file.py
+++ b/sslib/u8file.py
@@ -104,10 +104,10 @@ class U8File:
         nodes = []
         data.seek(0)
         if data.read(4) != MAGIC_HEADER:
-            raise InvalidU8File("Invalid magic header")
+            raise InvalidU8File("Invalid magic header.")
         first_node_offset = struct.unpack(">I", data.read(4))[0]
         if first_node_offset != U8File.FIRST_NODE_OFFSET:
-            raise InvalidU8File("Invalid first node offset")
+            raise InvalidU8File("Invalid first node offset.")
         _all_node_size = struct.unpack(">I", data.read(4))[0]
         _start_data_offset = struct.unpack(">I", data.read(4))[0]
         # read the first node, to figure out where the filenames start
@@ -153,7 +153,7 @@ class U8File:
                 )
                 nodes.append(node)
             else:
-                raise InvalidU8File(f"Unknown nodetype {nodetype}")
+                raise InvalidU8File(f"Unknown nodetype {nodetype}.")
         return U8File(data, nodes)
 
     def writeto(self, buffer: BufferedIOBase):
@@ -249,7 +249,7 @@ class U8File:
     def set_file_data(self, path: str, data: bytes):
         file = self.get_file(path)
         if not file:
-            raise Exception("file not found!")
+            raise Exception("File not found.")
         file.set_data(data)
 
     def add_file_data(self, path: str, data: bytes):

--- a/ssrando.py
+++ b/ssrando.py
@@ -123,7 +123,9 @@ class Randomizer(BaseRandomizer):
             / "files"
             / "COPYDATE_CODE_2011-09-28_153155"
         ).exists():
-            raise StartupException("ERROR: the randomizer only supports NTSC-U 1.00 (North American).")
+            raise StartupException(
+                "ERROR: the randomizer only supports NTSC-U 1.00 (North American)."
+            )
 
     @cached_property
     def get_total_progress_steps(self):

--- a/ssrando.py
+++ b/ssrando.py
@@ -103,19 +103,19 @@ class Randomizer(BaseRandomizer):
         # catch common errors with directory setup
         if not self.actual_extract_path.is_dir():
             raise StartupException(
-                "ERROR: directory actual-extract doesn't exist! Make sure you have the ISO extracted into that directory"
+                "ERROR: directory actual-extract doesn't exist! Make sure you have the ISO extracted into that directory."
             )
         if not self.modified_extract_path.is_dir():
             raise StartupException(
-                "ERROR: directory modified-extract doesn't exist! Make sure you have the contents of actual-extract copied over to modified-extract"
+                "ERROR: directory modified-extract doesn't exist! Make sure you have the contents of actual-extract copied over to modified-extract."
             )
         if not (self.actual_extract_path / "DATA").is_dir():
             raise StartupException(
-                "ERROR: directory actual-extract doesn't contain a DATA directory! Make sure you have the ISO properly extracted into actual-extract"
+                "ERROR: directory actual-extract doesn't contain a DATA directory! Make sure you have the ISO properly extracted into actual-extract."
             )
         if not (self.modified_extract_path / "DATA").is_dir():
             raise StartupException(
-                "ERROR: directory 'DATA' in modified-extract doesn't exist! Make sure you have the contents of actual-extract copied over to modified-extract"
+                "ERROR: directory 'DATA' in modified-extract doesn't exist! Make sure you have the contents of actual-extract copied over to modified-extract."
             )
         if not (
             self.modified_extract_path
@@ -123,7 +123,7 @@ class Randomizer(BaseRandomizer):
             / "files"
             / "COPYDATE_CODE_2011-09-28_153155"
         ).exists():
-            raise StartupException("ERROR: the randomizer only supports NTSC-U 1.00")
+            raise StartupException("ERROR: the randomizer only supports NTSC-U 1.00 (North American).")
 
     @cached_property
     def get_total_progress_steps(self):

--- a/witmanager.py
+++ b/witmanager.py
@@ -108,10 +108,10 @@ class WitManager:
             if not digest == CLEAN_NTSC_U_1_00_ISO_HASH:
                 if digest in WRONG_VERSION_HASHES:
                     raise WrongChecksumException(
-                        f"This ISO is {WRONG_VERSION_HASHES[digest]}, but the rando only support NTSC-U 1.00 (North American)"
+                        f"This ISO is {WRONG_VERSION_HASHES[digest]}, but the rando only support NTSC-U 1.00 (North American)."
                     )
                 raise WrongChecksumException(
-                    f"Unrecognized wrong hash {digest}, make sure you got a clean dump of NTSC-U 1.00 (North American)"
+                    f"Unrecognized wrong hash {digest}, make sure you got a clean dump of NTSC-U 1.00 (North American)."
                 )
 
     def actual_extract_already_exists(self):
@@ -153,7 +153,7 @@ class WitManager:
                 if not return_code is None:
                     if return_code != 0:
                         raise WitException(
-                            f'ERROR: {extract_process.stderr.read().decode("UTF-8")}'
+                            f'ERROR: {extract_process.stderr.read().decode("UTF-8")}.'
                         )
                     break
             # delete all videos, they take up way too much space
@@ -229,7 +229,7 @@ class WitManager:
             if not return_code is None:
                 if return_code != 0:
                     raise WitException(
-                        f'ERROR: {extract_process.stderr.read().decode("UTF-8")}'
+                        f'ERROR: {extract_process.stderr.read().decode("UTF-8")}.'
                     )
                 break
         assert return_code == 0


### PR DESCRIPTION
Updates some error messages to more clearly describe what went wrong. In particular, the text for not being able to place an item or a hint has been updated to indicate that this might be because the settings are too restrictive and to try randomizing a new seed.

Also standardizes the error messages to start with a capital letter (unless the msg starts with a variable name or similar) and end with a full stop.