### PR TITLE
Expand arc replacements to work with all arcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,16 @@
   - The 2 small chests previously found within the Goddess Statue have been removed
 - Removed all skippable cutscenes except boss intro cutscenes (by CovenEsme)
   - When starting a new file, Link will now spawn directly in his room
+- Expanded arc replacements to cover the remaining unpatched arcs (by Muzu)
+  - Previously unpatched arcs (such as DoButton.arc) are now picked up from the arc replacements folder and patched
+  - The arc replacements folder now supports sub folders so people can organise arcs freely
+  - Existing Title2D and DoButton patches to add custom title screen and dowsing icons now pull from modified_extract instead of actual_extract so they don't overwrite replaced arcs
+  - Due to duplicate arc names, the text arcs found in DATA/files/US/Object and the cursor arcs found in DATA/files/Layout and DATA/files/sys/mpls_movie/layout require specific names in the arc replacements folder
+    - Text arcs intended for the en_US folder support the default names (e.g. 0-Common.arc) but also support being prefixed with "en" for consistency (e.g. en0-Common.arc)
+    - Text arcs intended for the es_US folder must be prefixed with "es" (e.g. es0-Common.arc)
+    - Text arcs intended for the fr_US folder must be prefixed with "fr" (e.g. fr0-Common.arc) 
+    - The cursor arc intended for the regular layout folder supports the default name (i.e. cursor.arc)
+    - The cursor arc intended for the mpls_movie/layout folder (motion plus tutorial cursor) must be prefixed with "mpls" (i.e. mplscursor.arc)
 ### Bugfixes
 - Fixed a bug that prevented tricks from being properly reloaded when the randomizer restarted multiple times without changes to the list
 - Fixed a softlock caused by collecting the last 2 tears in a trial too close together

--- a/gamepatches.py
+++ b/gamepatches.py
@@ -2698,48 +2698,36 @@ class GamePatcher:
 
     def do_patch_title_screen_logo(self):
         # patch title screen logo
-        actual_data = (
-            self.actual_extract_path
-            / "DATA"
-            / "files"
-            / "US"
-            / "Layout"
-            / "Title2D.arc"
-        ).read_bytes()
-        actual_arc = U8File.parse_u8(BytesIO(actual_data))
-        logodata = (self.rando_root_path / "assets" / "logo.tpl").read_bytes()
-        actual_arc.set_file_data("timg/tr_wiiKing2Logo_00.tpl", logodata)
-        (
+        title_2D_path = (
             self.modified_extract_path
             / "DATA"
             / "files"
             / "US"
             / "Layout"
             / "Title2D.arc"
-        ).write_bytes(actual_arc.to_buffer())
+        )
+        data = title_2D_path.read_bytes()
+        arc = U8File.parse_u8(BytesIO(data))
+        logodata = (self.rando_root_path / "assets" / "logo.tpl").read_bytes()
+        arc.set_file_data("timg/tr_wiiKing2Logo_00.tpl", logodata)
+        title_2D_path.write_bytes(arc.to_buffer())
 
     def do_patch_custom_dowsing_images(self):
         # patch propeller dowsing image; used for chest dowsing
-        actual_data = (
-            self.actual_extract_path
-            / "DATA"
-            / "files"
-            / "US"
-            / "Layout"
-            / "DoButton.arc"
-        ).read_bytes()
-        actual_arc = U8File.parse_u8(BytesIO(actual_data))
-        chestdata = (self.rando_root_path / "assets" / "chest_image.tpl").read_bytes()
-        actual_arc.set_file_data("timg/tr_dauzTarget_10.tpl", chestdata)
-        sandshipdata = (
-            self.rando_root_path / "assets" / "sandship_image.tpl"
-        ).read_bytes()
-        actual_arc.set_file_data("timg/tr_dauzTarget_18.tpl", sandshipdata)
-        (
+        do_button_path = (
             self.modified_extract_path
             / "DATA"
             / "files"
             / "US"
             / "Layout"
             / "DoButton.arc"
-        ).write_bytes(actual_arc.to_buffer())
+        )
+        data = do_button_path.read_bytes()
+        arc = U8File.parse_u8(BytesIO(data))
+        chestdata = (self.rando_root_path / "assets" / "chest_image.tpl").read_bytes()
+        arc.set_file_data("timg/tr_dauzTarget_10.tpl", chestdata)
+        sandshipdata = (
+            self.rando_root_path / "assets" / "sandship_image.tpl"
+        ).read_bytes()
+        arc.set_file_data("timg/tr_dauzTarget_18.tpl", sandshipdata)
+        do_button_path.write_bytes(arc.to_buffer())

--- a/sslib/allpatch.py
+++ b/sslib/allpatch.py
@@ -15,6 +15,9 @@ STAGE_REGEX = re.compile("(.+)_stg_l([0-9]+).arc.LZ")
 EVENT_REGEX = re.compile("([0-9])-[A-Za-z]+.arc")
 ROOM_REGEX = re.compile(r"/rarc/(?P<stage>.+)_r(?P<roomid>[0-9]+).arc")
 OARC_ARC_REGEX = re.compile(r"/oarc/(?P<name>.+\.arc)")
+TEXT_ARC_REGEX = re.compile(
+    r"(.+(/|\\))*(?P<lang>(en|es|fr))_US(/|\\)(?P<name>.+\.arc)"
+)
 LANGUAGES = {"EU": "en_GB", "US": "en_US", "JP": "ja_JP"}
 
 
@@ -41,10 +44,9 @@ class AllPatcher:
         self.copy_unmodified = copy_unmodified
         self.arc_replacements = {}
         if arc_replacement_path.is_dir():
-            for replace_path in arc_replacement_path.iterdir():
+            for replace_path in arc_replacement_path.rglob("*.arc"):
                 arcname = replace_path.parts[-1]
-                if arcname.endswith(".arc"):
-                    self.arc_replacements[arcname] = replace_path
+                self.arc_replacements[arcname] = replace_path
         self.objpackoarcadd = []
         self.stage_oarc_add = {}
         self.stage_oarc_delete = {}
@@ -331,6 +333,7 @@ class AllPatcher:
             object_arc.add_file_data(f"oarc/{arcname}", oarc_path.read_bytes())
             patched_arcs.add(arcname)
             objpack_modified = True
+
         if self.arc_replacements:
             for path in object_arc.get_all_paths():
                 if match := OARC_ARC_REGEX.match(path):
@@ -341,6 +344,7 @@ class AllPatcher:
                         object_arc.set_file_data(path, replacement.read_bytes())
                         patched_arcs.add(arc)
                         objpack_modified = True
+
         if objpack_modified:
             objpack_data = object_arc.to_buffer()
             write_bytes_create_dirs(
@@ -351,3 +355,51 @@ class AllPatcher:
                 / "ObjectPack.arc.LZ",
                 nlzss11.compress(objpack_data),
             )
+
+        # handles arc replacement for all other arcs
+        for path in self.actual_extract_path.glob("**/*.arc"):
+
+            modified = False
+            modified_path = str(path).replace(
+                str(self.actual_extract_path), str(self.modified_extract_path)
+            )
+            replacement = Path()
+
+            # replaces arc with actual arc if deleted
+            if not Path(modified_path).exists():
+                shutil.copy(path, modified_path)
+
+            # handles stage text arcs as they have duplicate names for each language
+            if match := TEXT_ARC_REGEX.match(str(path)):
+                if match.group("lang") == "en":
+                    if replacement := (
+                        self.arc_replacements.get(match.group("name"))
+                        or self.arc_replacements.get(
+                            match.group("lang") + match.group("name")
+                        )
+                    ):
+                        modified = True
+                elif match.group("lang") == "es" or match.group("lang") == "fr":
+                    if replacement := self.arc_replacements.get(
+                        match.group("lang") + match.group("name")
+                    ):
+                        modified = True
+
+            # handles motion plus movie cursor and regular cursor arcs separately as they have duplicate names
+            elif path.parts[-1] == "cursor.arc":
+                if path.parts[-3] == "mpls_movie":
+                    if replacement := self.arc_replacements.get(f"mplscursor.arc"):
+                        modified = True
+                else:
+                    if replacement := self.arc_replacements.get("cursor.arc"):
+                        modified = True
+
+            # handles all other non-duplicate named arcs
+            elif replacement := self.arc_replacements.get(path.parts[-1]):
+                modified = True
+
+            if modified:
+                shutil.copy(replacement, modified_path)
+            else:
+                # replaces arc with actual arc if unchanged
+                shutil.copy(path, modified_path)


### PR DESCRIPTION
-The remaining unpatched arcs are now supported by arc_replacements
-Due to some duplicate arc names, there are specific names filenames required for some of the arcs to get around this- fortunately they're for arcs that aren't commonly modified anyway (motion plus tutorial cursor arc and the Spanish and French stage text arcs), see changelog for specifics
-The arc replacements folder now supports sub folders so people can organise their arcs freely
-The existing patches to DoButton.arc and Title2D.arc that handle the custom textures for the title screen and dowsing icons now pull from modified_extract instead of actual_extract so they don't fully overwrite replaced arcs
