### PR TITLE
Remove now-nonexistent exit to Volcano East

### DIFF
--- a/logic/requirements/Eldin.yaml
+++ b/logic/requirements/Eldin.yaml
@@ -321,6 +321,5 @@ Bokoblin Base:
   Fire Dragon's Lair:
     exits:
       Bokoblin Base Summit: Nothing
-      Volcano - East: Fire Dragon's Reward
     locations:
       Fire Dragon's Reward: Bow | Beetle


### PR DESCRIPTION
This also removes an inlined requirement that depended on the Fire Dragon's Reward check (which caused issues when the location is banned).