### PR TITLE
fix some hashnames

### DIFF
--- a/names.txt
+++ b/names.txt
@@ -3,7 +3,7 @@ Zelda
 Hylia
 Groose
 Cawlin
-Stritch
+Strich
 Impa
 Horwell
 Owlan
@@ -58,7 +58,7 @@ Tentalus
 Keese
 Bokoblin
 Moblin
-Archa
+Aracha
 Scervo
 Dreadfuse
 Slingshot


### PR DESCRIPTION
There are now only 4 names not in the textdump:

```
Tricycle
KolokChamp
Scrappa
FunFun
```