### PR TITLE
Select Filters

### DIFF
--- a/checks.yaml
+++ b/checks.yaml
@@ -103,7 +103,7 @@ Central Skyloft - Waterfall Cave Second Chest:
     - stage/D000/r0/l0/TBox/68
 Central Skyloft - Rupee Waterfall Cave Crawlspace:
   original item: "Red Rupee #25"
-  type:
+  type: Rupees
   Paths:
     - stage/D000/r0/l0/Item/88
 Central Skyloft - Parrow's Gift:
@@ -671,17 +671,17 @@ Faron Woods - Kikwi Elder's Reward:
   text: the <r<Kikwi relic>> is
 Faron Woods - Rupee on Hollow Tree Root:
   original item: "Blue Rupee #6"
-  type:
+  type: Rupees
   Paths:
     - stage/F100/r0/l0/Item/42
 Faron Woods - Rupee on Hollow Tree Branch:
   original item: "Red Rupee #27"
-  type:
+  type: Rupees
   Paths:
     - stage/F100/r0/l0/Item/41
 Faron Woods - Rupee on Platform near Floria Door:
   original item: "Red Rupee #26"
-  type:
+  type: Rupees
   Paths:
     - stage/F100/r0/l0/Item/40
 Faron Woods - Deep Woods Chest:
@@ -703,34 +703,34 @@ Faron Woods - Chest inside Great Tree:
   text: climbing inside an <r<old hermit's home>> rewards
 Faron Woods - Rupee on Great Tree North Branch:
   original item: "Blue Rupee #4"
-  type:
+  type: Rupees
   Paths:
     - stage/F100/r0/l0/Item/43
 Faron Woods - Rupee on Great Tree West Branch:
   original item: "Blue Rupee #5"
-  type:
+  type: Rupees
   Paths:
     - stage/F100/r0/l0/Item/44
 
 # Lake Floria:
 Lake Floria - Rupee under Central Boulder:
  original item: "Silver Rupee #12"
- type:
+ type: Rupees
  Paths:
   - stage/F102/r2/l0/Item/60
 Lake Floria - Rupee behind Southwest Boulder:
  original item: "Blue Rupee #7"
- type:
+ type: Rupees
  Paths:
   - stage/F102/r2/l0/Item/63
 Lake Floria - Left Rupee behind Northwest Boulder:
  original item: "Red Rupee #29"
- type:
+ type: Rupees
  Paths:
   - stage/F102/r2/l0/Item/62
 Lake Floria - Right Rupee behind Northwest Boulder:
  original item: "Red Rupee #28"
- type:
+ type: Rupees
  Paths:
   - stage/F102/r2/l0/Item/61
 Lake Floria - Lake Floria Chest:
@@ -752,7 +752,7 @@ Lake Floria - Dragon Lair East Chest:
     - stage/F102_2/r0/l0/TBox/85
 Lake Floria - Rupee on High Ledge outside Ancient Cistern Entrance:
   original item: "Gold Rupee #10"
-  type:
+  type: Rupees
   Paths:
    - stage/F102_1/r0/l0/Item/64
 
@@ -769,7 +769,7 @@ Flooded Faron Woods - Water Dragon's Reward:
 # Eldin Volcano:
 Eldin Volcano - Rupee on Ledge before First Room:
   original item: "Red Rupee #30"
-  type:
+  type: Rupees
   Paths:
     - stage/F200/r0/l0/Item/41
 Eldin Volcano - Chest behind Bombable Wall in First Room:
@@ -779,12 +779,12 @@ Eldin Volcano - Chest behind Bombable Wall in First Room:
     - stage/F200/r1/l0/TBox/72
 Eldin Volcano - Rupee behind Bombable Wall in First Room:
   original item: "Blue Rupee #8"
-  type:
+  type: Rupees
   Paths:
     - stage/F200/r1/l0/Item/13
 Eldin Volcano - Rupee in Crawlspace in First Room:
   original item: "Blue Rupee #9"
-  type:
+  type: Rupees
   Paths:
     - stage/F200/r1/l0/Item/19
 Eldin Volcano - Chest after Crawlspace:
@@ -794,12 +794,12 @@ Eldin Volcano - Chest after Crawlspace:
     - stage/F200/r2/l0/TBox/66
 Eldin Volcano - Southeast Rupee above Mogma Turf Entrance:
   original item: "Blue Rupee #10"
-  type:
+  type: Rupees
   Paths:
     - stage/F200/r2/l0/Item/125
 Eldin Volcano - North Rupee above Mogma Turf Entrance:
   original item: "Red Rupee #31"
-  type:
+  type: Rupees
   Paths:
     - stage/F200/r2/l0/Item/123
 Eldin Volcano - Chest behind Bombable Wall near Cliff:
@@ -819,12 +819,12 @@ Eldin Volcano - Chest behind Bombable Wall near Volcano Ascent:
     - stage/F200/r2/l0/TBox/71
 Eldin Volcano - Left Rupee behind Bombable Wall on First Slope:
   original item: "Red Rupee #32"
-  type:
+  type: Rupees
   Paths:
     - stage/F200/r4/l0/Item/45
 Eldin Volcano - Right Rupee behind Bombable Wall on First Slope:
   original item: "Red Rupee #33"
-  type:
+  type: Rupees
   Paths:
     - stage/F200/r4/l0/Item/11
 
@@ -1113,17 +1113,17 @@ Lanayru Gorge - Life Tree Seedling:
 ## Ancient Harbour
 Lanayru Sand Sea - Ancient Harbour - Rupee on First Pillar:
   original item: "Red Rupee #34"
-  type:
+  type: Rupees
   Paths:
     - stage/F301/r0/l0/Item/92
 Lanayru Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown:
   original item: "Silver Rupee #13"
-  type:
+  type: Rupees
   Paths:
     - stage/F301/r0/l0/Item/91
 Lanayru Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown:
   original item: "Silver Rupee #14"
-  type:
+  type: Rupees
   Paths:
     - stage/F301/r0/l0/Item/93
 
@@ -1165,17 +1165,17 @@ Lanayru Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05:
 ## Pirate Stronghold
 Lanayru Sand Sea - Pirate Stronghold - Rupee on East Sea Pillar:
   original item: "Silver Rupee #16"
-  type:
+  type: Rupees
   Paths:
     - stage/F301_6/r0/l0/Item/12
 Lanayru Sand Sea - Pirate Stronghold - Rupee on West Sea Pillar:
   original item: "Silver Rupee #15"
-  type:
+  type: Rupees
   Paths:
     - stage/F301_6/r0/l0/Item/11
 Lanayru Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar or Nose:
   original item: "Silver Rupee #17"
-  type:
+  type: Rupees
   Paths:
     - stage/F301_6/r0/l1/Item/13
     - stage/F301_6/r0/l2/Item/13
@@ -1227,17 +1227,17 @@ Skyview - Item behind Bars:
     - stage/D100/r5/l0/Item/103
 Skyview - Rupee in Southeast Tunnel:
   original item: "Red Rupee #35"
-  type:
+  type: Rupees
   Paths:
     - stage/D100/r5/l0/Item/65
 Skyview - Rupee in Southwest Tunnel:
   original item: "Red Rupee #36"
-  type:
+  type: Rupees
   Paths:
     - stage/D100/r5/l0/Item/67
 Skyview - Rupee in East Tunnel:
   original item: "Red Rupee #37"
-  type:
+  type: Rupees
   Paths:
     - stage/D100/r5/l0/Item/66
 Skyview - Chest behind Three Eyes:
@@ -1267,7 +1267,7 @@ Skyview - Heart Container:
     - stage/B100/r0/l4/HeartCo
 Skyview - Rupee on Spring Pillar:
   original item: "Red Rupee #38"
-  type:
+  type: Rupees
   Paths:
     - stage/B100_1/r0/l0/Item/109
 Skyview - Ruby Tablet:
@@ -1285,7 +1285,7 @@ Earth Temple - Vent Chest:
     - stage/D200/r1/l0/TBox/66
 Earth Temple - Rupee above Drawbridge:
   original item: "Red Rupee #39"
-  type:
+  type: Rupees
   Paths:
     - stage/D200/r1/l0/Item/25
 Earth Temple - Chest behind Bombable Rock:
@@ -1319,7 +1319,7 @@ Earth Temple - Ledd's Gift:
     - oarc/D200/l0
 Earth Temple - Rupee in Lava Tunnel:
   original item: "Silver Rupee #18"
-  type:
+  type: Rupees
   Paths:
     - stage/D200/r2/l0/Item/21
   text: hidden within the <r<neck of a dragon>> rests
@@ -1422,37 +1422,37 @@ Lanayru Mining Facility - Goddess Harp:
 # Ancient Cistern (AC):
 Ancient Cistern - Rupee in West Hand:
   original item: "Silver Rupee #20"
-  type:
+  type: Rupees
   Paths:
     - stage/D101/r0/l0/Item/93
 Ancient Cistern - Rupee in East Hand:
   original item: "Silver Rupee #19"
-  type:
+  type: Rupees
   Paths:
     - stage/D101/r0/l0/Item/92
 Ancient Cistern - First Rupee in East Part in Short Tunnel:
   original item: "Green Rupee #0"
-  type:
+  type: Rupees
   Paths:
     - stage/D101/r2/l0/Item/65
 Ancient Cistern - Second Rupee in East Part in Short Tunnel:
   original item: "Green Rupee #1"
-  type:
+  type: Rupees
   Paths:
     - stage/D101/r2/l0/Item/66
 Ancient Cistern - Third Rupee in East Part in Short Tunnel:
   original item: "Green Rupee #2"
-  type:
+  type: Rupees
   Paths:
     - stage/D101/r2/l0/Item/67
 Ancient Cistern - Rupee in East Part in Cubby:
   original item: "Red Rupee #41"
-  type:
+  type: Rupees
   Paths:
     - stage/D101/r2/l0/Item/68
 Ancient Cistern - Rupee in East Part in Main Tunnel:
   original item: "Red Rupee #40"
-  type:
+  type: Rupees
   Paths:
     - stage/D101/r2/l0/Item/34
 Ancient Cistern - Chest in East Part:
@@ -1465,7 +1465,7 @@ Ancient Cistern - Chest in East Part:
 # # Can Be Locked Out Of if activating water pillar before collecting
 # Ancient Cistern - Rupee under Lilypad:
 #   original item: Red Rupee
-#   type:
+#   type: Rupees
 #   Paths:
 #     - stage/D101/r5/l0/Item/13
 Ancient Cistern - Chest after Whip Hooks:
@@ -1684,7 +1684,7 @@ Sky Keep - Chest after Dreadfuse:
     - stage/D003_6/r0/l0/TBox/65
 Sky Keep - Rupee in Fire Sanctuary Room in Alcove:
   original item: "Silver Rupee #21"
-  type:
+  type: Rupees
   Paths:
     - stage/D003_2/r0/l0/Item/36
 Sky Keep - Triforce of Power:

--- a/checks.yaml
+++ b/checks.yaml
@@ -42,7 +42,7 @@ Upper Skyloft - In Zelda's Closet:
     - stage/F001r/r6/l0/chest/32 #sceneflag
 Upper Skyloft - Owlan's Crystals:
   original item: Gratitude Crystal Pack
-  type: scrapper, crystal quest, combat
+  type: Scrapper Deliveries, Gratitiude Crystal Sidequests, Combat
   Paths:
     - event/118-Town3/157
     - oarc/F001r/l0
@@ -50,7 +50,7 @@ Upper Skyloft - Owlan's Crystals:
   text: delivering a <r<Kikwi>> reveals
 Upper Skyloft - Fledge's Crystals:
   original item: Gratitude Crystal Pack
-  type: crystal quest
+  type: Gratitiude Crystal Sidequests
   Paths:
     - event/115-Town2/325
     - oarc/F001r/l0
@@ -63,14 +63,14 @@ Upper Skyloft - Cawlin's Letter:
     - oarc/F001r/l0
 Upper Skyloft - Ghost/Pipit's Crystals:
   original item: Gratitude Crystal Pack
-  type: crystal quest
+  type: Gratitiude Crystal Sidequests
   Paths:
     - event/115-Town2/522
     - event/115-Town2/641
     - oarc/F001r/l0
 Upper Skyloft - Pumpkin Archery -- 600 Points:
   original item: Heart Piece
-  type: minigame
+  type: Minigames
   Paths:
     - event/114-Friend/99
     - oarc/F000/l4
@@ -87,7 +87,7 @@ Central Skyloft - Potion Lady's Gift:
     - oarc/F004r/l0
 Central Skyloft - Wryna's Crystals:
   original item: Gratitude Crystal Pack
-  type: crystal quest
+  type: Gratitiude Crystal Sidequests
   Paths:
     - event/118-Town3/144
     - oarc/F006r/l0
@@ -117,7 +117,7 @@ Central Skyloft - Parrow's Gift:
     - oarc/F005r/l0
 Central Skyloft - Parrow's Crystals:
   original item: Gratitude Crystal Pack
-  type: crystal quest
+  type: Gratitiude Crystal Sidequests
   Paths:
     - event/115-Town2/814
     - oarc/F000/l4
@@ -125,7 +125,7 @@ Central Skyloft - Parrow's Crystals:
     - oarc/F005r/l0
 Central Skyloft - Peater/Peatrice's Crystals:
   original item: Gratitude Crystal Pack
-  type: crystal quest
+  type: Gratitiude Crystal Sidequests
   Paths:
     - event/109-TakeGoron/79
     - event/123-Town5/316
@@ -147,31 +147,31 @@ Central Skyloft - Shed Chest:
 ## Goddess Chests
 Central Skyloft - West Cliff Goddess Chest:
   original item: Silver Rupee
-  type: goddess, faron goddess
+  type: goddess, Faron Woods Goddess Chests
   Paths:
     - stage/F000/r0/l0/TBox/78
   cube_region: Faron Woods
 Central Skyloft - Bazaar Goddess Chest:
   original item: Gold Rupee
-  type: goddess, sand sea goddess
+  type: goddess, Sand Sea Goddess Chests
   Paths:
     - stage/F004r/r0/l0/TBox/93
   cube_region: Lanayru Sand Sea
 Central Skyloft - Shed Goddess Chest:
   original item: Heart Piece
-  type: goddess, eldin goddess
+  type: goddess, Eldin Volcano Goddess Chests
   Paths:
     - stage/F000/r0/l0/TBox/79
   cube_region: Eldin Volcano
 Central Skyloft - Floating Island Goddess Chest:
   original item: Gold Rupee
-  type: goddess, floria goddess
+  type: goddess, Lake Floria Goddess Chests
   Paths:
     - stage/F000/r0/l0/TBox/91
   cube_region: Lake Floria
 Central Skyloft - Waterfall Goddess Chest:
   original item: Heart Piece
-  type: goddess, sand sea goddess
+  type: goddess, Sand Sea Goddess Chests
   Paths:
     - stage/F000/r0/l0/TBox/80
   hint: sometimes
@@ -181,20 +181,20 @@ Central Skyloft - Waterfall Goddess Chest:
 # Skyloft Village checks:
 Skyloft Village - Mallara's Crystals:
   original item: Gratitude Crystal Pack
-  type: crystal quest
+  type: Gratitiude Crystal Sidequests
   Paths:
     - event/123-Town5/186
     - oarc/F016r/l0
 Skyloft Village - Bertie's Crystals:
   original item: Gratitude Crystal Pack
-  type: crystal quest
+  type: Gratitiude Crystal Sidequests
   Paths:
     - event/115-Town2/125
     - oarc/F014r/l0
   text: helping an <r<exhausted parent>> rewards
 Skyloft Village - Sparrot's Crystals:
   original item: Gratitude Crystal Pack
-  type: scrapper, crystal quest
+  type: Scrapper Deliveries, Gratitiude Crystal Sidequests
   Paths:
     - event/118-Town3/141
     - oarc/F013r/l0
@@ -267,56 +267,56 @@ Batreaux's House - 80 Crystals:
 # Beedle's Shop:
 Beedle's Shop - 300 Rupee Item:
   original item: "Progressive Pouch #1"
-  type: beedle
+  type: Beedle's Shop Purchases
   Paths:
     - ShpSmpl/20
 Beedle's Shop - 600 Rupee Item:
   original item: "Progressive Pouch #2"
-  type: beedle
+  type: Beedle's Shop Purchases
   Paths:
     - ShpSmpl/21
 Beedle's Shop - 1200 Rupee Item:
   original item: "Progressive Pouch #3"
-  type: beedle
+  type: Beedle's Shop Purchases
   hint: always
   Paths:
     - ShpSmpl/22
   text: for <g+<1200 rupees>> <r<Beedle>> sells
 Beedle's Shop - 800 Rupee Item:
   original item: "Life Medal #0"
-  type: beedle
+  type: Beedle's Shop Purchases
   Paths:
     - ShpSmpl/26
 Beedle's Shop - 1600 Rupee Item:
   original item: "Heart Piece #0"
-  type: beedle
+  type: Beedle's Shop Purchases
   hint: always
   Paths:
     - ShpSmpl/23
   text: for <g+<1600 rupees>> <r<Beedle>> sells
 Beedle's Shop - First 100 Rupee Item:
   original item: "Extra Wallet #0"
-  type: beedle
+  type: Beedle's Shop Purchases
   Paths:
     - ShpSmpl/24
 Beedle's Shop - Second 100 Rupee Item:
   original item: "Extra Wallet #1"
-  type: beedle
+  type: Beedle's Shop Purchases
   Paths:
     - ShpSmpl/17
 Beedle's Shop - Third 100 Rupee Item:
   original item: "Extra Wallet #2"
-  type: beedle
+  type: Beedle's Shop Purchases
   Paths:
     - ShpSmpl/18
 Beedle's Shop - 50 Rupee Item:
   original item: "Progressive Bug Net #0"
-  type: beedle
+  type: Beedle's Shop Purchases
   Paths:
     - ShpSmpl/25
 Beedle's Shop - 1000 Rupee Item:
   original item: Bug Medal
-  type: beedle
+  type: Beedle's Shop Purchases
   Paths:
     - ShpSmpl/27
 
@@ -324,52 +324,52 @@ Beedle's Shop - 1000 Rupee Item:
 ## Aren't randomized, but still need logic, because some of them need items
 Upper Skyloft - Crystal in Link's Room:
   original item: "Gratitude Crystal #0"
-  type: crystal
+  type: Loose Crystals
 Upper Skyloft - Crystal in Knight Academy Plant:
   original item: "Gratitude Crystal #5"
-  type: crystal
+  type: Loose Crystals
 Upper Skyloft - Crystal in Zelda's Room:
   original item: "Gratitude Crystal #11"
-  type: crystal
+  type: Loose Crystals
 Upper Skyloft - Crystal in Sparring Hall:
   original item: "Gratitude Crystal #9"
-  type: crystal
+  type: Loose Crystals
 
 Central Skyloft - Crystal in Orielle and Parrow's House:
   original item: "Gratitude Crystal #3"
-  type: crystal
+  type: Loose Crystals
 Central Skyloft - Crystal on West Cliff:
   original item: "Gratitude Crystal #6"
-  type: crystal
+  type: Loose Crystals
 Central Skyloft - Crystal between Wooden Planks:
   original item: "Gratitude Crystal #4"
-  type: crystal
+  type: Loose Crystals
 Central Skyloft - Crystal after Waterfall Cave:
   original item: "Gratitude Crystal #7"
-  type: crystal
+  type: Loose Crystals
 Central Skyloft - Crystal in Loftwing Prison:
   original item: "Gratitude Crystal #8"
-  type: crystal
+  type: Loose Crystals
 Central Skyloft - Crystal on Waterfall Island:
   original item: "Gratitude Crystal #10"
-  type: crystal
+  type: Loose Crystals
 Central Skyloft - Crystal on Light Tower:
   original item: "Gratitude Crystal #1"
-  type: crystal
+  type: Loose Crystals
 
 Skyloft Village - Crystal near Pumpkin Patch:
   original item: "Gratitude Crystal #2"
-  type: crystal
+  type: Loose Crystals
 
 Sky - Crystal outside Lumpy Pumpkin:
   original item: "Gratitude Crystal #12"
-  type: crystal
+  type: Loose Crystals
 Sky - Crystal inside Lumpy Pumpkin:
   original item: "Gratitude Crystal #13"
-  type: crystal
+  type: Loose Crystals
 Sky - Crystal on Beedle's Ship:
   original item: "Gratitude Crystal #14"
-  type: crystal
+  type: Loose Crystals
 
 # Sky:
 Sky - Lumpy Pumpkin - Chandelier:
@@ -380,7 +380,7 @@ Sky - Lumpy Pumpkin - Chandelier:
   text: <r<angering a bartender>> dislodges
 Sky - Lumpy Pumpkin - Harp Minigame:
   original item: Heart Piece
-  type: minigame
+  type: Minigames
   Paths:
     - event/117-Pumpkin/305
     - oarc/F011r/l0
@@ -388,7 +388,7 @@ Sky - Lumpy Pumpkin - Harp Minigame:
   text: the <r<bartender>> holds
 Sky - Kina's Crystals:
   original item: Gratitude Crystal Pack
-  type: scrapper, crystal quest
+  type: Scrapper Deliveries, Gratitiude Crystal Sidequests
   Paths:
     - event/117-Pumpkin/386
     - oarc/F020/l0
@@ -396,14 +396,14 @@ Sky - Kina's Crystals:
   text: <r<delivering a mogma to the sky>> is rewarded with
 Sky - Orielle's Crystals:
   original item: Gratitude Crystal Pack
-  type: crystal quest
+  type: Gratitiude Crystal Sidequests
   Paths:
     - event/115-Town2/225
     - oarc/F020/l0
   text: saving a <r<sick loftwing>> is rewardede with
 Sky - Beedle's Crystals:
   original item: Gratitude Crystal Pack
-  type: crystal quest
+  type: Gratitiude Crystal Sidequests
   Paths:
     - event/105-Terry/115
     - oarc/F020/l0
@@ -411,14 +411,14 @@ Sky - Beedle's Crystals:
   text: <r<reuniting two Beedles>> is rewarded with
 Sky - Dodoh's Crystals:
   original item: Gratitude Crystal Pack
-  type: scrapper
+  type: Scrapper Deliveries
   Paths:
     - event/110-DivingGame/60
     - oarc/F020/l0
   text: delivering a <r<colorful wheel>> is rewarded with
 Sky - Fun Fun Island Minigame -- 500 Rupees:
   original item: Heart Piece
-  type: minigame, scrapper
+  type: Minigames, Scrapper Deliveries
   Paths:
     - event/110-DivingGame/19
     - oarc/F020/l2
@@ -438,25 +438,25 @@ Sky - Chest in Breakable Boulder near Lumpy Pumpkin:
 ## Goddess Chests
 Sky - Bamboo Island Goddess Chest:
   original item: Gold Rupee
-  type: goddess, eldin goddess
+  type: goddess, Eldin Volcano Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/82
   cube_region: Eldin Volcano
 Sky - Goddess Chest on Island next to Bamboo Island:
   original item: Silver Rupee
-  type: goddess, eldin goddess
+  type: goddess, Eldin Volcano Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/71
   cube_region: Eldin Volcano
 Sky - Goddess Chest in Cave on Island next to Bamboo Island:
   original item: Heart Medal
-  type: goddess, lanayru goddess
+  type: goddess, Lanayru Desert Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/83
   cube_region: Lanayru Desert
 Sky - Beedle's Island Goddess Chest:
   original item: Heart Piece
-  type: goddess, lanayru goddess, combat
+  type: goddess, Lanayru Desert Goddess Chests, Combat
   Paths:
     - stage/F020/r0/l0/TBox/89
   hint: sometimes
@@ -464,73 +464,73 @@ Sky - Beedle's Island Goddess Chest:
   cube_region: Lanayru Desert
 Sky - Beedle's Island Cage Goddess Chest:
   original item: Rupee Medal
-  type: goddess, faron goddess
+  type: goddess, Faron Woods Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/81
   cube_region: Faron Woods
 Sky - Northeast Island Goddess Chest behind Bombable Rocks:
   original item: Silver Rupee
-  type: goddess, lanayru goddess
+  type: goddess, Lanayru Desert Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/72
   cube_region: Lanayru Mine
 Sky - Northeast Island Cage Goddess Chest:
   original item: Treasure Medal
-  type: goddess, eldin goddess
+  type: goddess, Eldin Volcano Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/74
   cube_region: Eldin Volcano
 Sky - Lumpy Pumpkin - Goddess Chest on the Roof:
   original item: Gold Rupee
-  type: goddess, faron goddess
+  type: goddess, Faron Woods Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/87
   cube_region: Skyview
 Sky - Lumpy Pumpkin - Outside Goddess Chest:
   original item: Progressive Pouch
-  type: goddess, faron goddess
+  type: goddess, Faron Woods Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/64
   cube_region: Faron Woods
 Sky - Goddess Chest on Island Closest to Faron Pillar:
   original item: Heart Piece
-  type: goddess, faron goddess
+  type: goddess, Faron Woods Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/65
   cube_region: Faron Woods
 Sky - Goddess Chest outside Volcanic Island:
   original item: Heart Medal
-  type: goddess, lanayru goddess
+  type: goddess, Lanayru Desert Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/67
   cube_region: Lanayru Desert
 Sky - Goddess Chest inside Volcanic Island:
   original item: Heart Piece
-  type: goddess, faron goddess
+  type: goddess, Faron Woods Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/68
   cube_region: Faron Woods
 Sky - Goddess Chest under Fun Fun Island:
   original item: Gold Rupee
-  type: goddess, floria goddess
+  type: goddess, Lake Floria Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/86
   cube_region: Lake Floria
 Sky - Southwest Triple Island Upper Goddess Chest:
   original item: Small Seed Satchel
-  type: goddess, eldin goddess
+  type: goddess, Eldin Volcano Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/66
   cube_region: Eldin Volcano
 Sky - Southwest Triple Island Lower Goddess Chest:
   original item: Life Medal
-  type: goddess, lanayru goddess
+  type: goddess, Lanayru Desert Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/84
   cube_region: Lanayru Desert
 Sky - Southwest Triple Island Cage Goddess Chest:
   original item: Potion Medal
-  type: goddess, sand sea goddess
+  type: goddess, Sand Sea Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/75
   cube_region: Lanayru Sand Sea
@@ -557,7 +557,7 @@ Thunderhead - Isle of Songs - Din's Power:
   text: a <r<blade of white>> reveals
 Thunderhead - Song from Levias:
   original item: Song of the Hero
-  type: scrapper, combat
+  type: Scrapper Deliveries, Combat
   Paths:
     - event/120-Nushi/give item after levias
     - oarc/F023/l0
@@ -565,7 +565,7 @@ Thunderhead - Song from Levias:
   text: the <r<ancient whale within a raging storm>> bellows out
 Thunderhead - Bug Heaven -- 10 Bugs in 3 Minutes:
   original item: Horned Colossus Beetle
-  type: minigame
+  type: Minigames
   Paths:
     - event/116-InsectGame/69
     - oarc/F023/l0
@@ -580,37 +580,37 @@ Thunderhead - East Island Chest:
 ## Goddess Cubes
 Thunderhead - East Island Goddess Chest:
   original item: Rupee Medal
-  type: goddess, faron goddess
+  type: goddess, Faron Woods Goddess Chests
   Paths:
     - stage/F023/r0/l0/TBox/73
   cube_region: Faron Woods
 Thunderhead - Goddess Chest on top of Isle of Songs:
   original item: Small Bomb Bag
-  type: goddess, summit goddess
+  type: goddess, Volcano Summit Goddess Chests
   Paths:
     - stage/F023/r0/l0/TBox/85
   cube_region: Volcano Summit
 Thunderhead - Goddess Chest outside Isle of Songs:
   original item: Gold Rupee
-  type: goddess, eldin goddess
+  type: goddess, Eldin Volcano Goddess Chests
   Paths:
     - stage/F023/r0/l0/TBox/92
   cube_region: Mogma Turf
 Thunderhead - First Goddess Chest on Mogma Mitts Island:
   original item: Bottle
-  type: goddess, summit goddess
+  type: goddess, Volcano Summit Goddess Chests
   Paths:
     - stage/F023/r0/l0/TBox/77
   cube_region: Volcano Summit
 Thunderhead - Second Goddess Chest on Mogma Mitts Island:
   original item: Small Quiver
-  type: goddess, sand sea goddess
+  type: goddess, Sand Sea Goddess Chests
   Paths:
    - stage/F023/r0/l0/TBox/76
   cube_region: Lanayru Gorge
 Thunderhead - Bug Heaven Goddess Chest:
   original item: Heart Piece
-  type: goddess, summit goddess
+  type: goddess, Volcano Summit Goddess Chests
   Paths:
     - stage/F023/r0/l0/TBox/88
   cube_region: Volcano Summit
@@ -663,7 +663,7 @@ Faron Woods - Item on Tree:
     - stage/F100/r0/l0/Item/68
 Faron Woods - Kikwi Elder's Reward:
   original item: Progressive Slingshot
-  type: combat #because of the Lopsa Bokoblin fight, this is a combat reward
+  type: Combat #because of the Lopsa Bokoblin fight, this is a Combat reward
   Paths:
     - event/200-Forest/595
     - oarc/F100/l0
@@ -870,7 +870,7 @@ Mogma Turf - Chest behind Bombable Wall at Entrance:
     - stage/F210/r0/l0/TBox/65
 Mogma Turf - Digging Mitts Fight:
   original item: Progressive Mitts
-  type: combat
+  type: Combat
   Paths:
     - event/300-Mountain/6
     - event/300-Mountain/135
@@ -997,7 +997,7 @@ Lanayru Desert - Chest near Hook Beetle Fight:
     - stage/F300/r0/l0/TBox/84
 Lanayru Desert - Hook Beetle Fight:
   original item: Progressive Beetle
-  type: combat
+  type: Combat
   Paths:
     - event/400-Desert/8
     - oarc/F300/l0
@@ -1155,7 +1155,7 @@ Lanayru Sand Sea - Skipper's Retreat - Skydive Chest:
 ## Shipyard
 Lanayru Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05:
   original item: Heart Piece
-  type: minigame, combat #Moldarach 2 makes this a combat check
+  type: Minigames, Combat #Moldarach 2 makes this a Combat check
   Paths:
     - event/406-TrolleyRace/77
     - oarc/F301_4/l0

--- a/checks.yaml
+++ b/checks.yaml
@@ -1,48 +1,48 @@
 # Upper Skyloft checks:
 Upper Skyloft - Fledge's Gift:
   original item: Progressive Pouch
-  type: skyloft, free gift
+  type:
   Paths:
     - event/114-Friend/16
     - oarc/F001r/l3
     - oarc/F001r/l4
 Upper Skyloft - Owlan's Gift:
   original item: Wooden Shield
-  type: skyloft, free gift
+  type:
   Paths:
     - event/108-ShinkanA/169
     - oarc/F000/l4
     - oarc/F000/l6
 Upper Skyloft - Sparring Hall Chest:
   original item: Progressive Sword
-  type: skyloft, miscellaneous
+  type:
   Paths:
     - stage/F009r/r0/l0/TBox/66
 Upper Skyloft - Chest near Goddess Statue:
   original item: Red Rupee
-  type: skyloft, miscellaneous
+  type:
   Paths:
     - stage/F000/r0/l0/TBox/71
 Upper Skyloft - First Goddess Sword Item in Goddess Statue:
   original item: Progressive Sword
-  type: skyloft, miscellaneous
+  type:
   Paths:
     - event/107-Kanban/Fi give Goddess Statue item 1
     - oarc/F008r/l1
 Upper Skyloft - Second Goddess Sword Item in Goddess Statue:
   original item: Emerald Tablet
-  type: skyloft, miscellaneous
+  type:
   Paths:
     - event/107-Kanban/Fi give Goddess Statue item 2
     - oarc/F008r/l1
 Upper Skyloft - In Zelda's Closet:
   original item: Heart Piece
-  type: skyloft, miscellaneous
+  type:
   Paths:
     - stage/F001r/r6/l0/chest/32 #sceneflag
 Upper Skyloft - Owlan's Crystals:
   original item: Gratitude Crystal Pack
-  type: skyloft, faron, long, scrapper, crystal quest, combat
+  type: scrapper, crystal quest, combat
   Paths:
     - event/118-Town3/157
     - oarc/F001r/l0
@@ -50,27 +50,27 @@ Upper Skyloft - Owlan's Crystals:
   text: delivering a <r<Kikwi>> reveals
 Upper Skyloft - Fledge's Crystals:
   original item: Gratitude Crystal Pack
-  type: skyloft, lanayru, short, crystal quest, dungeon
+  type: crystal quest
   Paths:
     - event/115-Town2/325
     - oarc/F001r/l0
   text: <r<lending strength to a friend>> yields
 Upper Skyloft - Cawlin's Letter:
   original item: Cawlin's Letter
-  type: skyloft, short
+  type:
   Paths:
     - event/115-Town2/166
     - oarc/F001r/l0
 Upper Skyloft - Ghost/Pipit's Crystals:
   original item: Gratitude Crystal Pack
-  type: skyloft, fetch, crystal quest
+  type: crystal quest
   Paths:
     - event/115-Town2/522
     - event/115-Town2/641
     - oarc/F001r/l0
 Upper Skyloft - Pumpkin Archery -- 600 Points:
   original item: Heart Piece
-  type: skyloft, minigame
+  type: minigame
   Paths:
     - event/114-Friend/99
     - oarc/F000/l4
@@ -81,34 +81,34 @@ Upper Skyloft - Pumpkin Archery -- 600 Points:
 # Central Skyloft checks:
 Central Skyloft - Potion Lady's Gift:
   original item: Bottle
-  type: skyloft, free gift
+  type:
   Paths:
     - event/106-DrugStore/44
     - oarc/F004r/l0
 Central Skyloft - Wryna's Crystals:
   original item: Gratitude Crystal Pack
-  type: skyloft, free gift, crystal quest
+  type: crystal quest
   Paths:
     - event/118-Town3/144
     - oarc/F006r/l0
 Central Skyloft - Waterfall Cave First Chest:
   original item: Red Rupee
-  type: skyloft, miscellaneous
+  type:
   Paths:
     - stage/D000/r0/l0/TBox/67
 Central Skyloft - Waterfall Cave Second Chest:
   original item: Red Rupee
-  type: skyloft, miscellaneous
+  type:
   Paths:
     - stage/D000/r0/l0/TBox/68
 Central Skyloft - Rupee Waterfall Cave Crawlspace:
   original item: "Red Rupee #25"
-  type: skyloft, freestanding
+  type:
   Paths:
     - stage/D000/r0/l0/Item/88
 Central Skyloft - Parrow's Gift:
   original item: Bottle
-  type: skyloft, free gift, short
+  type:
   Paths:
     - event/115-Town2/230 # mushroom spores
     - event/115-Town2/733 # Bottle
@@ -117,7 +117,7 @@ Central Skyloft - Parrow's Gift:
     - oarc/F005r/l0
 Central Skyloft - Parrow's Crystals:
   original item: Gratitude Crystal Pack
-  type: skyloft, sky, short, crystal quest
+  type: crystal quest
   Paths:
     - event/115-Town2/814
     - oarc/F000/l4
@@ -125,7 +125,7 @@ Central Skyloft - Parrow's Crystals:
     - oarc/F005r/l0
 Central Skyloft - Peater/Peatrice's Crystals:
   original item: Gratitude Crystal Pack
-  type: skyloft, long, crystal quest, peatrice
+  type: crystal quest
   Paths:
     - event/109-TakeGoron/79
     - event/123-Town5/316
@@ -135,43 +135,43 @@ Central Skyloft - Peater/Peatrice's Crystals:
   text: the <r<item check girl>> hides
 Central Skyloft - Item in Bird Nest:
   original item: Baby's Rattle
-  type: skyloft, freestanding
+  type:
   Paths:
     - stage/F000/r0/l0/Item/13
 Central Skyloft - Shed Chest:
   original item: Silver Rupee
-  type: skyloft, miscellaneous
+  type:
   Paths:
     - stage/F000/r0/l0/TBox/70
 
 ## Goddess Chests
 Central Skyloft - West Cliff Goddess Chest:
   original item: Silver Rupee
-  type: skyloft, goddess, faron goddess
+  type: goddess, faron goddess
   Paths:
     - stage/F000/r0/l0/TBox/78
   cube_region: Faron Woods
 Central Skyloft - Bazaar Goddess Chest:
   original item: Gold Rupee
-  type: skyloft, goddess, sand sea goddess
+  type: goddess, sand sea goddess
   Paths:
     - stage/F004r/r0/l0/TBox/93
   cube_region: Lanayru Sand Sea
 Central Skyloft - Shed Goddess Chest:
   original item: Heart Piece
-  type: skyloft, goddess, eldin goddess
+  type: goddess, eldin goddess
   Paths:
     - stage/F000/r0/l0/TBox/79
   cube_region: Eldin Volcano
 Central Skyloft - Floating Island Goddess Chest:
   original item: Gold Rupee
-  type: skyloft, goddess, floria goddess
+  type: goddess, floria goddess
   Paths:
     - stage/F000/r0/l0/TBox/91
   cube_region: Lake Floria
 Central Skyloft - Waterfall Goddess Chest:
   original item: Heart Piece
-  type: skyloft, goddess, sand sea goddess, mini dungeon
+  type: goddess, sand sea goddess
   Paths:
     - stage/F000/r0/l0/TBox/80
   hint: sometimes
@@ -181,20 +181,20 @@ Central Skyloft - Waterfall Goddess Chest:
 # Skyloft Village checks:
 Skyloft Village - Mallara's Crystals:
   original item: Gratitude Crystal Pack
-  type: skyloft, short, crystal quest
+  type: crystal quest
   Paths:
     - event/123-Town5/186
     - oarc/F016r/l0
 Skyloft Village - Bertie's Crystals:
   original item: Gratitude Crystal Pack
-  type: skyloft, fetch, crystal quest
+  type: crystal quest
   Paths:
     - event/115-Town2/125
     - oarc/F014r/l0
   text: helping an <r<exhausted parent>> rewards
 Skyloft Village - Sparrot's Crystals:
   original item: Gratitude Crystal Pack
-  type: skyloft, eldin, long, scrapper, crystal quest
+  type: scrapper, crystal quest
   Paths:
     - event/118-Town3/141
     - oarc/F013r/l0
@@ -204,36 +204,36 @@ Skyloft Village - Sparrot's Crystals:
 # Batreaux Rewards:
 Batreaux's House - 5 Crystals:
   original item: Progressive Wallet
-  type: skyloft
+  type:
   Paths:
     - event/121-AkumaKun/21
     - oarc/F012r/l0
 Batreaux's House - 10 Crystals:
   original item: Heart Piece
-  type: skyloft
+  type:
   Paths:
     - event/121-AkumaKun/42
     - oarc/F012r/l0
 Batreaux's House - 30 Crystals:
   original item: Progressive Wallet
-  type: skyloft
+  type:
   Paths:
     - event/121-AkumaKun/24
     - oarc/F012r/l0
 Batreaux's House - 30 Crystals Chest:
   original item: Cursed Medal
-  type: skyloft
+  type:
   Paths:
     - stage/F012r/r0/l0/TBox/69
 Batreaux's House - 40 Crystals:
   original item: Gold Rupee
-  type: skyloft
+  type:
   Paths:
     - event/121-AkumaKun/49
     - oarc/F012r/l0
 Batreaux's House - 50 Crystals:
   original item: Progressive Wallet
-  type: skyloft
+  type:
   Paths:
     - event/121-AkumaKun/27
     - oarc/F012r/l0
@@ -241,7 +241,7 @@ Batreaux's House - 50 Crystals:
   text: <ye<50>> <r<pieces of gratitude>> can be exchanged for
 Batreaux's House - 70 Crystals:
   original item: Gold Rupee
-  type: skyloft
+  type:
   Paths:
     - event/121-AkumaKun/161
     - oarc/F012r/l0
@@ -249,7 +249,7 @@ Batreaux's House - 70 Crystals:
   text: the <r<demon's penultimate reward>> is
 Batreaux's House - 70 Crystals Second Reward:
   original item: Gold Rupee
-  type: skyloft
+  type:
   Paths:
     - event/121-AkumaKun/163
     - oarc/F012r/l0
@@ -257,7 +257,7 @@ Batreaux's House - 70 Crystals Second Reward:
   text: the <r<demon's penultimate reward>> is
 Batreaux's House - 80 Crystals:
   original item: Progressive Wallet
-  type: skyloft
+  type:
   Paths:
     - event/121-AkumaKun/37
     - oarc/F012r/l0
@@ -267,56 +267,56 @@ Batreaux's House - 80 Crystals:
 # Beedle's Shop:
 Beedle's Shop - 300 Rupee Item:
   original item: "Progressive Pouch #1"
-  type: skyloft, beedle, cheap
+  type: beedle
   Paths:
     - ShpSmpl/20
 Beedle's Shop - 600 Rupee Item:
   original item: "Progressive Pouch #2"
-  type: skyloft, beedle, medium
+  type: beedle
   Paths:
     - ShpSmpl/21
 Beedle's Shop - 1200 Rupee Item:
   original item: "Progressive Pouch #3"
-  type: skyloft, beedle, expensive
+  type: beedle
   hint: always
   Paths:
     - ShpSmpl/22
   text: for <g+<1200 rupees>> <r<Beedle>> sells
 Beedle's Shop - 800 Rupee Item:
   original item: "Life Medal #0"
-  type: skyloft, beedle, medium
+  type: beedle
   Paths:
     - ShpSmpl/26
 Beedle's Shop - 1600 Rupee Item:
   original item: "Heart Piece #0"
-  type: skyloft, beedle, expensive
+  type: beedle
   hint: always
   Paths:
     - ShpSmpl/23
   text: for <g+<1600 rupees>> <r<Beedle>> sells
 Beedle's Shop - First 100 Rupee Item:
   original item: "Extra Wallet #0"
-  type: skyloft, beedle, cheap
+  type: beedle
   Paths:
     - ShpSmpl/24
 Beedle's Shop - Second 100 Rupee Item:
   original item: "Extra Wallet #1"
-  type: skyloft, beedle, cheap
+  type: beedle
   Paths:
     - ShpSmpl/17
 Beedle's Shop - Third 100 Rupee Item:
   original item: "Extra Wallet #2"
-  type: skyloft, beedle, cheap
+  type: beedle
   Paths:
     - ShpSmpl/18
 Beedle's Shop - 50 Rupee Item:
   original item: "Progressive Bug Net #0"
-  type: skyloft, beedle, cheap
+  type: beedle
   Paths:
     - ShpSmpl/25
 Beedle's Shop - 1000 Rupee Item:
   original item: Bug Medal
-  type: skyloft, beedle, medium
+  type: beedle
   Paths:
     - ShpSmpl/27
 
@@ -374,13 +374,13 @@ Sky - Crystal on Beedle's Ship:
 # Sky:
 Sky - Lumpy Pumpkin - Chandelier:
   original item: Heart Piece
-  type: sky, freestanding
+  type:
   Paths:
     - stage/F011r/r0/l0/Chandel
   text: <r<angering a bartender>> dislodges
 Sky - Lumpy Pumpkin - Harp Minigame:
   original item: Heart Piece
-  type: sky, long, minigame
+  type: minigame
   Paths:
     - event/117-Pumpkin/305
     - oarc/F011r/l0
@@ -388,7 +388,7 @@ Sky - Lumpy Pumpkin - Harp Minigame:
   text: the <r<bartender>> holds
 Sky - Kina's Crystals:
   original item: Gratitude Crystal Pack
-  type: sky, eldin, scrapper, long, crystal quest
+  type: scrapper, crystal quest
   Paths:
     - event/117-Pumpkin/386
     - oarc/F020/l0
@@ -396,14 +396,14 @@ Sky - Kina's Crystals:
   text: <r<delivering a mogma to the sky>> is rewarded with
 Sky - Orielle's Crystals:
   original item: Gratitude Crystal Pack
-  type: sky, short, crystal quest
+  type: crystal quest
   Paths:
     - event/115-Town2/225
     - oarc/F020/l0
   text: saving a <r<sick loftwing>> is rewardede with
 Sky - Beedle's Crystals:
   original item: Gratitude Crystal Pack
-  type: sky, fetch, crystal quest
+  type: crystal quest
   Paths:
     - event/105-Terry/115
     - oarc/F020/l0
@@ -411,14 +411,14 @@ Sky - Beedle's Crystals:
   text: <r<reuniting two Beedles>> is rewarded with
 Sky - Dodoh's Crystals:
   original item: Gratitude Crystal Pack
-  type: sky, lanayru, long, scrapper
+  type: scrapper
   Paths:
     - event/110-DivingGame/60
     - oarc/F020/l0
   text: delivering a <r<colorful wheel>> is rewarded with
 Sky - Fun Fun Island Minigame -- 500 Rupees:
   original item: Heart Piece
-  type: sky, lanayru, minigame, long, scrapper
+  type: minigame, scrapper
   Paths:
     - event/110-DivingGame/19
     - oarc/F020/l2
@@ -426,37 +426,37 @@ Sky - Fun Fun Island Minigame -- 500 Rupees:
   text: <r<diving through 5 rings>> yields
 Sky - Chest in Breakable Boulder near Fun Fun Island:
   original item: Silver Rupee
-  type: sky, spiral charge
+  type:
   Paths:
     - stage/F020/r0/l0/TBox/70
 Sky - Chest in Breakable Boulder near Lumpy Pumpkin:
   original item: Silver Rupee
-  type: sky, spiral charge
+  type:
   Paths:
     - stage/F020/r0/l0/TBox/69
 
 ## Goddess Chests
 Sky - Bamboo Island Goddess Chest:
   original item: Gold Rupee
-  type: sky, goddess, eldin goddess, bombable
+  type: goddess, eldin goddess
   Paths:
     - stage/F020/r0/l0/TBox/82
   cube_region: Eldin Volcano
 Sky - Goddess Chest on Island next to Bamboo Island:
   original item: Silver Rupee
-  type: sky, goddess, eldin goddess
+  type: goddess, eldin goddess
   Paths:
     - stage/F020/r0/l0/TBox/71
   cube_region: Eldin Volcano
 Sky - Goddess Chest in Cave on Island next to Bamboo Island:
   original item: Heart Medal
-  type: sky, goddess, lanayru goddess, bombable
+  type: goddess, lanayru goddess
   Paths:
     - stage/F020/r0/l0/TBox/83
   cube_region: Lanayru Desert
 Sky - Beedle's Island Goddess Chest:
   original item: Heart Piece
-  type: sky, goddess, lanayru goddess, combat
+  type: goddess, lanayru goddess, combat
   Paths:
     - stage/F020/r0/l0/TBox/89
   hint: sometimes
@@ -464,73 +464,73 @@ Sky - Beedle's Island Goddess Chest:
   cube_region: Lanayru Desert
 Sky - Beedle's Island Cage Goddess Chest:
   original item: Rupee Medal
-  type: sky, goddess, faron goddess
+  type: goddess, faron goddess
   Paths:
     - stage/F020/r0/l0/TBox/81
   cube_region: Faron Woods
 Sky - Northeast Island Goddess Chest behind Bombable Rocks:
   original item: Silver Rupee
-  type: sky, goddess, lanayru goddess
+  type: goddess, lanayru goddess
   Paths:
     - stage/F020/r0/l0/TBox/72
   cube_region: Lanayru Mine
 Sky - Northeast Island Cage Goddess Chest:
   original item: Treasure Medal
-  type: sky, goddess, eldin goddess
+  type: goddess, eldin goddess
   Paths:
     - stage/F020/r0/l0/TBox/74
   cube_region: Eldin Volcano
 Sky - Lumpy Pumpkin - Goddess Chest on the Roof:
   original item: Gold Rupee
-  type: sky, goddess, faron goddess, dungeon
+  type: goddess, faron goddess
   Paths:
     - stage/F020/r0/l0/TBox/87
   cube_region: Skyview
 Sky - Lumpy Pumpkin - Outside Goddess Chest:
   original item: Progressive Pouch
-  type: sky, goddess, faron goddess
+  type: goddess, faron goddess
   Paths:
     - stage/F020/r0/l0/TBox/64
   cube_region: Faron Woods
 Sky - Goddess Chest on Island Closest to Faron Pillar:
   original item: Heart Piece
-  type: sky, goddess, faron goddess
+  type: goddess, faron goddess
   Paths:
     - stage/F020/r0/l0/TBox/65
   cube_region: Faron Woods
 Sky - Goddess Chest outside Volcanic Island:
   original item: Heart Medal
-  type: sky, goddess, lanayru goddess
+  type: goddess, lanayru goddess
   Paths:
     - stage/F020/r0/l0/TBox/67
   cube_region: Lanayru Desert
 Sky - Goddess Chest inside Volcanic Island:
   original item: Heart Piece
-  type: sky, goddess, faron goddess
+  type: goddess, faron goddess
   Paths:
     - stage/F020/r0/l0/TBox/68
   cube_region: Faron Woods
 Sky - Goddess Chest under Fun Fun Island:
   original item: Gold Rupee
-  type: sky, goddess, floria goddess
+  type: goddess, floria goddess
   Paths:
     - stage/F020/r0/l0/TBox/86
   cube_region: Lake Floria
 Sky - Southwest Triple Island Upper Goddess Chest:
   original item: Small Seed Satchel
-  type: sky, goddess, eldin goddess
+  type: goddess, eldin goddess
   Paths:
     - stage/F020/r0/l0/TBox/66
   cube_region: Eldin Volcano
 Sky - Southwest Triple Island Lower Goddess Chest:
   original item: Life Medal
-  type: sky, goddess, lanayru goddess
+  type: goddess, lanayru goddess
   Paths:
     - stage/F020/r0/l0/TBox/84
   cube_region: Lanayru Desert
 Sky - Southwest Triple Island Cage Goddess Chest:
   original item: Potion Medal
-  type: sky, goddess, sand sea goddess
+  type: goddess, sand sea goddess
   Paths:
     - stage/F020/r0/l0/TBox/75
   cube_region: Lanayru Sand Sea
@@ -538,26 +538,26 @@ Sky - Southwest Triple Island Cage Goddess Chest:
 # Thunderhead:
 Thunderhead - Isle of Songs - Farore's Courage:
   original item: Farore's Courage
-  type: thunderhead, song
+  type:
   Paths:
     - stage/F010r/r0/l0/SwSB/0
   text: the <r<goddess' blade>> reveals
 Thunderhead - Isle of Songs - Nayru's Wisdom:
   original item: Nayru's Wisdom
-  type: thunderhead, song
+  type:
   Paths:
     - stage/F010r/r0/l0/SwSB/1
   text: a <r<longsword>> reveals
 Thunderhead - Isle of Songs - Din's Power:
   original item: Din's Power
-  type: thunderhead, song
+  type:
   Paths:
     - stage/F010r/r0/l0/SwSB/2
   hint: sometimes
   text: a <r<blade of white>> reveals
 Thunderhead - Song from Levias:
   original item: Song of the Hero
-  type: thunderhead, sky, scrapper, combat, song
+  type: scrapper, combat
   Paths:
     - event/120-Nushi/give item after levias
     - oarc/F023/l0
@@ -565,7 +565,7 @@ Thunderhead - Song from Levias:
   text: the <r<ancient whale within a raging storm>> bellows out
 Thunderhead - Bug Heaven -- 10 Bugs in 3 Minutes:
   original item: Horned Colossus Beetle
-  type: thunderhead, minigame
+  type: minigame
   Paths:
     - event/116-InsectGame/69
     - oarc/F023/l0
@@ -573,44 +573,44 @@ Thunderhead - Bug Heaven -- 10 Bugs in 3 Minutes:
   text: <r<true bug catchers>> can find
 Thunderhead - East Island Chest:
   original item: Evil Crystal
-  type: thunderhead, miscellaneous
+  type:
   Paths:
     - stage/F023/r0/l0/TBox/94
 
 ## Goddess Cubes
 Thunderhead - East Island Goddess Chest:
   original item: Rupee Medal
-  type: thunderhead, goddess, faron goddess
+  type: goddess, faron goddess
   Paths:
     - stage/F023/r0/l0/TBox/73
   cube_region: Faron Woods
 Thunderhead - Goddess Chest on top of Isle of Songs:
   original item: Small Bomb Bag
-  type: thunderhead, goddess, summit goddess
+  type: goddess, summit goddess
   Paths:
     - stage/F023/r0/l0/TBox/85
   cube_region: Volcano Summit
 Thunderhead - Goddess Chest outside Isle of Songs:
   original item: Gold Rupee
-  type: thunderhead, goddess, eldin goddess
+  type: goddess, eldin goddess
   Paths:
     - stage/F023/r0/l0/TBox/92
   cube_region: Mogma Turf
 Thunderhead - First Goddess Chest on Mogma Mitts Island:
   original item: Bottle
-  type: thunderhead, goddess, summit goddess
+  type: goddess, summit goddess
   Paths:
     - stage/F023/r0/l0/TBox/77
   cube_region: Volcano Summit
 Thunderhead - Second Goddess Chest on Mogma Mitts Island:
   original item: Small Quiver
-  type: thunderhead, goddess, sand sea goddess
+  type: goddess, sand sea goddess
   Paths:
    - stage/F023/r0/l0/TBox/76
   cube_region: Lanayru Gorge
 Thunderhead - Bug Heaven Goddess Chest:
   original item: Heart Piece
-  type: thunderhead, goddess, summit goddess
+  type: goddess, summit goddess
   Paths:
     - stage/F023/r0/l0/TBox/88
   cube_region: Volcano Summit
@@ -618,17 +618,17 @@ Thunderhead - Bug Heaven Goddess Chest:
 # Sealed Grounds:
 Sealed Grounds - Chest inside Sealed Temple:
   original item: Revitalizing Potion
-  type: faron, miscellaneous
+  type:
   Paths:
     - stage/F402/r2/l0/TBox/64
 Sealed Grounds - Song from Impa:
   original item: Ballad of the Goddess
-  type: faron, song
+  type:
   Paths:
     - event/501-Inpa/267
     - oarc/F402/l2
 Sealed Grounds - Gorko's Goddess Wall Reward:
-  type: faron
+  type:
   original item: Heart Piece
   Paths:
     - event/503-Goron/630
@@ -637,13 +637,13 @@ Sealed Grounds - Gorko's Goddess Wall Reward:
   text: <r<drawing upon a magical wall>> reveals
 #Sealed Grounds - Behind the Temple Triforce on Goddess Wall:
 #  original item: Gold Rupee
-#  type: faron, long, dungeon
+#  type: long
 #  Paths:
 #   - event/503-Goron/418
 #   - oarc/F400/l0
 Sealed Grounds - Zelda's Blessing:
   original item: Progressive Sword
-  type: faron #TODO: this may need to be revisited as it doesnt really fit any other checks
+  type: #TODO: this may need to be revisited as it doesnt really fit any other checks
   Paths:
     - event/502-CenterFieldBack/17
     - oarc/F404/l1
@@ -653,17 +653,17 @@ Sealed Grounds - Zelda's Blessing:
 # Faron Woods:
 Faron Woods - Item behind Bombable Rock:
   original item: Heart Piece
-  type: faron, freestanding, bombable
+  type:
   Paths:
     - stage/F100/r0/l0/Item/33 #last thing is SceneflagID
 Faron Woods - Item on Tree:
   original item: Heart Piece
-  type: faron, freestanding
+  type:
   Paths:
     - stage/F100/r0/l0/Item/68
 Faron Woods - Kikwi Elder's Reward:
   original item: Progressive Slingshot
-  type: faron, long, combat #because of the Lopsa Bokoblin fight, this is a combat reward
+  type: combat #because of the Lopsa Bokoblin fight, this is a combat reward
   Paths:
     - event/200-Forest/595
     - oarc/F100/l0
@@ -671,95 +671,95 @@ Faron Woods - Kikwi Elder's Reward:
   text: the <r<Kikwi relic>> is
 Faron Woods - Rupee on Hollow Tree Root:
   original item: "Blue Rupee #6"
-  type: faron, freestanding
+  type:
   Paths:
     - stage/F100/r0/l0/Item/42
 Faron Woods - Rupee on Hollow Tree Branch:
   original item: "Red Rupee #27"
-  type: faron, freestanding
+  type:
   Paths:
     - stage/F100/r0/l0/Item/41
 Faron Woods - Rupee on Platform near Floria Door:
   original item: "Red Rupee #26"
-  type: faron, freestanding
+  type:
   Paths:
     - stage/F100/r0/l0/Item/40
 Faron Woods - Deep Woods Chest:
   original item: Red Rupee
-  type: faron, miscellaneous
+  type:
   Paths:
     - stage/F101/r0/l0/TBox/74
 Faron Woods - Chest behind Bombable Rocks near Erla:
   original item: Semi Rare Treasure
-  type: faron, bombable
+  type:
   Paths:
     - stage/F100/r0/l0/TBox/64
 Faron Woods - Chest inside Great Tree:
   original item: Gold Rupee
-  type: faron, miscellaneous
+  type:
   Paths:
     - stage/F100_1/r0/l0/TBox/84
   hint: sometimes
   text: climbing inside an <r<old hermit's home>> rewards
 Faron Woods - Rupee on Great Tree North Branch:
   original item: "Blue Rupee #4"
-  type: faron, freestanding
+  type:
   Paths:
     - stage/F100/r0/l0/Item/43
 Faron Woods - Rupee on Great Tree West Branch:
   original item: "Blue Rupee #5"
-  type: faron, freestanding
+  type:
   Paths:
     - stage/F100/r0/l0/Item/44
 
 # Lake Floria:
 Lake Floria - Rupee under Central Boulder:
  original item: "Silver Rupee #12"
- type: faron, freestanding
+ type:
  Paths:
   - stage/F102/r2/l0/Item/60
 Lake Floria - Rupee behind Southwest Boulder:
  original item: "Blue Rupee #7"
- type: faron, freestanding
+ type:
  Paths:
   - stage/F102/r2/l0/Item/63
 Lake Floria - Left Rupee behind Northwest Boulder:
  original item: "Red Rupee #29"
- type: faron, freestanding
+ type:
  Paths:
   - stage/F102/r2/l0/Item/62
 Lake Floria - Right Rupee behind Northwest Boulder:
  original item: "Red Rupee #28"
- type: faron, freestanding
+ type:
  Paths:
   - stage/F102/r2/l0/Item/61
 Lake Floria - Lake Floria Chest:
   original item: Goddess Plume
-  type: faron, miscellaneous
+  type:
   hint: sometimes
   text: a <r<lonely chest in the lake>> contains
   Paths:
     - stage/F102/r3/l0/TBox/64
 Lake Floria - Dragon Lair South Chest:
   original item: Silver Rupee
-  type: faron, miscellaneous
+  type:
   Paths:
     - stage/F102_2/r0/l0/TBox/84
 Lake Floria - Dragon Lair East Chest:
   original item: Semi Rare Treasure
-  type: faron, miscellaneous
+  type:
   Paths:
     - stage/F102_2/r0/l0/TBox/85
 Lake Floria - Rupee on High Ledge outside Ancient Cistern Entrance:
   original item: "Gold Rupee #10"
-  type: faron, freestanding
+  type:
   Paths:
    - stage/F102_1/r0/l0/Item/64
 
 # Flooded Faron Woods:
 Flooded Faron Woods - Water Dragon's Reward:
   original item: Faron Song of the Hero Part
-  type: faron, flooded faron, long
+  type:
   hint: sometimes
   text: completing a <r<watery song>> reveals
   Paths:
@@ -769,108 +769,108 @@ Flooded Faron Woods - Water Dragon's Reward:
 # Eldin Volcano:
 Eldin Volcano - Rupee on Ledge before First Room:
   original item: "Red Rupee #30"
-  type: eldin, freestanding
+  type:
   Paths:
     - stage/F200/r0/l0/Item/41
 Eldin Volcano - Chest behind Bombable Wall in First Room:
   original item: Red Rupee
-  type: eldin, bombable
+  type:
   Paths:
     - stage/F200/r1/l0/TBox/72
 Eldin Volcano - Rupee behind Bombable Wall in First Room:
   original item: "Blue Rupee #8"
-  type: eldin, freestanding, bombable
+  type:
   Paths:
     - stage/F200/r1/l0/Item/13
 Eldin Volcano - Rupee in Crawlspace in First Room:
   original item: "Blue Rupee #9"
-  type: eldin, freestanding, bombable
+  type:
   Paths:
     - stage/F200/r1/l0/Item/19
 Eldin Volcano - Chest after Crawlspace:
   original item: Red Rupee
-  type: eldin, bombable
+  type:
   Paths:
     - stage/F200/r2/l0/TBox/66
 Eldin Volcano - Southeast Rupee above Mogma Turf Entrance:
   original item: "Blue Rupee #10"
-  type: eldin, freestanding
+  type:
   Paths:
     - stage/F200/r2/l0/Item/125
 Eldin Volcano - North Rupee above Mogma Turf Entrance:
   original item: "Red Rupee #31"
-  type: eldin, freestanding
+  type:
   Paths:
     - stage/F200/r2/l0/Item/123
 Eldin Volcano - Chest behind Bombable Wall near Cliff:
   original item: Red Rupee
-  type: eldin, bombable
+  type:
   Paths:
     - stage/F200/r2/l0/TBox/73
 Eldin Volcano - Item on Cliff:
   original item: Heart Piece
-  type: eldin, freestanding
+  type:
   Paths:
     - stage/F200/r2/l0/Item/102 #sceneflagID
 Eldin Volcano - Chest behind Bombable Wall near Volcano Ascent:
   original item: Red Rupee
-  type: eldin, bombable
+  type:
   Paths:
     - stage/F200/r2/l0/TBox/71
 Eldin Volcano - Left Rupee behind Bombable Wall on First Slope:
   original item: "Red Rupee #32"
-  type: eldin, freestanding, bombable
+  type:
   Paths:
     - stage/F200/r4/l0/Item/45
 Eldin Volcano - Right Rupee behind Bombable Wall on First Slope:
   original item: "Red Rupee #33"
-  type: eldin, freestanding, bombable
+  type:
   Paths:
     - stage/F200/r4/l0/Item/11
 
 ## These checks are Digging Spots
 Eldin Volcano - Digging Spot in front of Earth Temple:
   original item: Key Piece
-  type: eldin, digging
+  type:
   Paths:
     - stage/F200/r4/l1/Soil/8
 Eldin Volcano - Digging Spot below Tower:
   original item: Key Piece
-  type: eldin, bombable, digging
+  type:
   Paths:
     - stage/F200/r4/l1/Soil/9
 Eldin Volcano - Digging Spot behind Boulder on Sandy Slope:
   original item: Key Piece
-  type: eldin, bombable, digging
+  type:
   hint: sometimes
   text: a <r<boulder on a sandy slope>> hides
   Paths:
     - stage/F200/r4/l1/Soil/12
 Eldin Volcano - Digging Spot after Vents:
   original item: Key Piece
-  type: eldin, digging
+  type:
   Paths:
     - stage/F200/r6/l1/Soil/10
 Eldin Volcano - Digging Spot after Draining Lava:
   original item: Key Piece
-  type: eldin, digging
+  type:
   Paths:
     - stage/F200/r2/l1/Soil/64
 
 # Mogma Turf:
 Mogma Turf - Free Fall Chest:
   original item: Eldin Ore
-  type: eldin, miscellaneous
+  type:
   Paths:
     - stage/F210/r0/l0/TBox/64
 Mogma Turf - Chest behind Bombable Wall at Entrance:
   original item: Golden Skull
-  type: eldin, bombable
+  type:
   Paths:
     - stage/F210/r0/l0/TBox/65
 Mogma Turf - Digging Mitts Fight:
   original item: Progressive Mitts
-  type: eldin, combat
+  type: combat
   Paths:
     - event/300-Mountain/6
     - event/300-Mountain/135
@@ -878,26 +878,26 @@ Mogma Turf - Digging Mitts Fight:
   text: helping <r<reclaim the mogmas' territory>> rewards
 Mogma Turf - Sand Slide Chest:
   original item: Eldin Ore
-  type: eldin, miscellaneous
+  type:
   text: <r<behind>> a slide mogmas buried
   Paths:
     - stage/F210/r0/l0/TBox/68
 Mogma Turf - Chest behind Bombable Wall in Fire Maze:
   original item: Silver Rupee
-  type: eldin, bombable
+  type:
   Paths:
     - stage/F210/r0/l0/TBox/70
 
 # Volcano Summit:
 Volcano Summit - Chest behind Bombable Wall in Waterfall Area:
   original item: Silver Rupee
-  type: eldin, bombable
+  type:
   Paths:
     - stage/F201_4/r0/l0/TBox/95
   text: atop a <r<volcanic waterfall>> hides
 Volcano Summit - Item behind Digging:
   original item: Heart Piece
-  type: eldin, freestanding
+  type:
   Paths:
     - stage/F201_3/r0/l0/Item/104 #sceneflagID
   hint: sometimes
@@ -906,57 +906,57 @@ Volcano Summit - Item behind Digging:
 # Bokoblin Base:
 Bokoblin Base - Plats' Gift:
   original item: Mogma Mitts
-  type: eldin, free gift
+  type:
   text: a gift from an <r<imprisoned mogma>> has
   Paths:
    - event/305-MountainF3/Plats' Gift
    - oarc/F202/l1
 Bokoblin Base - Chest near Bone Bridge:
   original item: Gust Bellows
-  type: eldin
+  type:
   Paths:
    - stage/F202/r2/l1/TBox/70
 Bokoblin Base - Chest on Cliff:
   original item: Clawshots
-  type: eldin
+  type:
   Paths:
    - stage/F202/r2/l1/TBox/66
 Bokoblin Base - Chest near Drawbridge:
   original item: Whip
-  type: eldin
+  type:
   Paths:
    - stage/F202/r2/l1/TBox/67
 Bokoblin Base - Chest East of Earth Temple Entrance:
   original item: Slingshot
-  type: eldin
+  type:
   Paths:
    - stage/F202/r4/l1/TBox/68
 Bokoblin Base - Chest West of Earth Temple Entrance:
   original item: Bombs
-  type: eldin
+  type:
   Paths:
    - stage/F202/r4/l1/TBox/69
 Bokoblin Base - First Chest in Volcano Summit:
   original item: Blue Rupee
-  type: eldin
+  type:
   Paths:
    - stage/F201_2/r0/l0/TBox/72
    - stage/F201_1/r0/l4/TBox/72
 Bokoblin Base - Raised Chest in Volcano Summit:
   original item: Progressive Sword
-  type: eldin
+  type:
   Paths:
    - stage/F201_2/r0/l0/TBox/73
    - stage/F201_1/r0/l4/TBox/73
 Bokoblin Base - Chest in Volcano Summit Alcove:
   original item: Progressive Pouch
-  type: eldin
+  type:
   Paths:
    - stage/F201_2/r0/l0/TBox/71
    - stage/F201_1/r0/l4/TBox/71
 Bokoblin Base - Fire Dragon's Reward:
   original item: Eldin Song of the Hero Part
-  type: eldin
+  type:
   text: <r<hearing a song atop the great mountain>> is rewarded with
   Paths:
    - event/305-MountainF3/Give item after Eldin SotH CS
@@ -965,67 +965,67 @@ Bokoblin Base - Fire Dragon's Reward:
 # Lanayru Mine:
 Lanayru Mine - Chest behind First Landing:
   original item: Evil Crystal
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F300_1/r0/l0/TBox/64
 Lanayru Mine - Chest near First Timeshift Stone:
   original item: Red Rupee
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F300_1/r1/l0/TBox/65
 Lanayru Mine - Chest behind Statue:
   original item: Red Rupee
-  type: lanayru, bombable
+  type:
   Paths:
     - stage/F300_1/r2/l0/TBox/67
 Lanayru Mine - Chest at the End of Mine:
   original item: Rare Treasure
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F300_1/r2/l0/TBox/66
 
 # Lanayru Desert:
 Lanayru Desert - Chest near Party Wheel:
   original item: Golden Skull
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F300/r0/l0/TBox/70
 Lanayru Desert - Chest near Hook Beetle Fight:
   original item: Tumbleweed
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F300/r0/l0/TBox/84
 Lanayru Desert - Hook Beetle Fight:
   original item: Progressive Beetle
-  type: lanayru, combat
+  type: combat
   Paths:
     - event/400-Desert/8
     - oarc/F300/l0
 Lanayru Desert - Chest on Platform near Fire Node:
   original item: Red Rupee
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F300/r0/l0/TBox/73
 Lanayru Desert - Chest on Platform near Lightning Node:
   original item: Dusk Relic
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F300/r0/l0/TBox/72
 Lanayru Desert - Chest near Sand Oasis:
   original item: Red Rupee
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F300/r0/l0/TBox/71
 Lanayru Desert - Chest on top of Lanayru Mining Facility: # actually spawns on raising LMF
   original item: Rare Treasure # TODO check
-  type: lanayru, miscellaneous, mini dungeon
+  type:
   Paths:
     - stage/F300/r0/l1/TBox/83
   hint: sometimes
   text: the <r<midst of the desert>> holds
 Lanayru Desert - Secret Passageway Chest:
   original item: Heart Piece
-  type: lanayru, bombable
+  type:
   hint: sometimes
   text: a <r<secret passage in the desert>> holds
   Paths:
@@ -1034,44 +1034,44 @@ Lanayru Desert - Secret Passageway Chest:
 ## Nodes
 Lanayru Desert - Fire Node - Shortcut Chest:
   original item: Rare Treasure # TODO check again
-  type: lanayru, mini dungeon
+  type:
   hint: sometimes
   text: a <r<raised chest in the Fire Node>> holds
   Paths:
     - stage/F300_3/r0/l0/TBox/79
 Lanayru Desert - Fire Node - First Small Chest:
   original item: Blue Rupee
-  type: lanayru, mini dungeon
+  type:
   Paths:
     - stage/F300_3/r0/l0/TBox/78
 Lanayru Desert - Fire Node - Second Small Chest:
   original item: Blue Rupee
-  type: lanayru, mini dungeon
+  type:
   Paths:
     - stage/F300_3/r0/l0/TBox/80
 Lanayru Desert - Fire Node - Left Ending Chest:
   original item: Golden Skull # TODO check again
-  type: lanayru, mini dungeon
+  type:
   Paths:
     - stage/F300_3/r0/l0/TBox/81
 Lanayru Desert - Fire Node - Right Ending Chest:
   original item: Blue Rupee
-  type: lanayru, mini dungeon
+  type:
   Paths:
     - stage/F300_3/r0/l0/TBox/82
 Lanayru Desert - Lightning Node - First Chest:
   original item: Red Rupee
-  type: lanayru, mini dungeon
+  type:
   Paths:
     - stage/F300_2/r0/l0/TBox/75
 Lanayru Desert - Lightning Node - Second Chest:
   original item: Blue Rupee
-  type: lanayru, mini dungeon
+  type:
   Paths:
     - stage/F300_2/r0/l0/TBox/76
 Lanayru Desert - Lightning Node - Raised Chest near Generator:
   original item: Rare Treasure # TODO check again
-  type: lanayru, mini dungeon
+  type:
   text: a <r<raised chest in the Lightning Node>> contains
   Paths:
     - stage/F300_2/r0/l0/TBox/77
@@ -1079,12 +1079,12 @@ Lanayru Desert - Lightning Node - Raised Chest near Generator:
 # Lanayru Caves:
 Lanayru Caves - Chest:
   original item: Golden Skull # TODO check again
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F303/r0/l0/TBox/127
 Lanayru Caves - Golo's Gift:
   original item: Lanayru Caves Small Key
-  type: lanayru, free gift
+  type:
   Paths:
     - event/404-DesertF3/127
     - oarc/F303/l0
@@ -1092,7 +1092,7 @@ Lanayru Caves - Golo's Gift:
 # Lanayru Gorge:
 Lanayru Gorge - Thunder Dragon's Reward:
   original item: Lanayru Song of the Hero Part
-  type: lanayru, fetch
+  type:
   Paths:
     - event/404-DesertF3/give item after Healing Thunderdragon
     - oarc/F302/l0
@@ -1100,12 +1100,12 @@ Lanayru Gorge - Thunder Dragon's Reward:
   text: <r<curing an ancient dragon>> is rewarded with
 Lanayru Gorge - Item on Pillar:
   original item: Red Rupee
-  type: lanayru, freestanding
+  type:
   Paths:
     - stage/F302/r0/l0/Item/9
 Lanayru Gorge - Life Tree Seedling:
   original item: Life Tree Seedling
-  type: lanayru, digging
+  type:
   Paths:
     - stage/F302/r0/l0/Soil/30
 
@@ -1113,49 +1113,49 @@ Lanayru Gorge - Life Tree Seedling:
 ## Ancient Harbour
 Lanayru Sand Sea - Ancient Harbour - Rupee on First Pillar:
   original item: "Red Rupee #34"
-  type: lanayru, freestanding
+  type:
   Paths:
     - stage/F301/r0/l0/Item/92
 Lanayru Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown:
   original item: "Silver Rupee #13"
-  type: lanayru, freestanding
+  type:
   Paths:
     - stage/F301/r0/l0/Item/91
 Lanayru Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown:
   original item: "Silver Rupee #14"
-  type: lanayru, freestanding
+  type:
   Paths:
     - stage/F301/r0/l0/Item/93
 
 ## Skipper's Retreat
 Lanayru Sand Sea - Skipper's Retreat - Chest after Moblin:
   original item: Red Rupee
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F301_3/r0/l0/TBox/78
 Lanayru Sand Sea - Skipper's Retreat - Chest on top of Cacti Pillar:
   original item: Semi Rare Treasure
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F301_3/r0/l0/TBox/76
   text: a <r<chest amongst cacti>> holds
 Lanayru Sand Sea - Skipper's Retreat - Chest in Shack:
   original item: Sea Chart
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F301_5/r0/l0/TBox/65
   hint: sometimes
   text: a <r<chest atop a sandy retreat>> holds
 Lanayru Sand Sea - Skipper's Retreat - Skydive Chest:
   original item: Silver Rupee
-  type: lanayru, miscellaneous
+  type:
   Paths:
     - stage/F301_3/r0/l0/TBox/77
 
 ## Shipyard
 Lanayru Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05:
   original item: Heart Piece
-  type: lanayru, minigame, combat #Moldarach 2 makes this a combat check
+  type: minigame, combat #Moldarach 2 makes this a combat check
   Paths:
     - event/406-TrolleyRace/77
     - oarc/F301_4/l0
@@ -1165,101 +1165,101 @@ Lanayru Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05:
 ## Pirate Stronghold
 Lanayru Sand Sea - Pirate Stronghold - Rupee on East Sea Pillar:
   original item: "Silver Rupee #16"
-  type: lanayru, freestanding
+  type:
   Paths:
     - stage/F301_6/r0/l0/Item/12
 Lanayru Sand Sea - Pirate Stronghold - Rupee on West Sea Pillar:
   original item: "Silver Rupee #15"
-  type: lanayru, freestanding
+  type:
   Paths:
     - stage/F301_6/r0/l0/Item/11
 Lanayru Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar or Nose:
   original item: "Silver Rupee #17"
-  type: lanayru, freestanding
+  type:
   Paths:
     - stage/F301_6/r0/l1/Item/13
     - stage/F301_6/r0/l2/Item/13
 Lanayru Sand Sea - Pirate Stronghold - First Chest:
   original item: Silver Rupee
-  type: lanayru, mini dungeon
+  type:
   Paths:
     - stage/F301_2/r4/l0/TBox/75
 Lanayru Sand Sea - Pirate Stronghold - Second Chest:
   original item: Semi Rare Treasure
-  type: lanayru, mini dungeon
+  type:
   Paths:
     - stage/F301_2/r5/l0/TBox/73
 Lanayru Sand Sea - Pirate Stronghold - Third Chest:
   original item: Semi Rare Treasure
-  type: lanayru, mini dungeon
+  type:
   Paths:
     - stage/F301_2/r6/l0/TBox/74
 
 # Skyview (SV):
 Skyview - Chest on Tree Branch:
   original item: Skyview Map
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D100/r2/l0/TBox/64
 Skyview - Digging Spot in Crawlspace:
   original item: Skyview Small Key
-  type: faron, dungeon, digging
+  type:
   hints: sometimes
   text: in a <r<temple in the forest>> a mogma <r<buried>>
   Paths:
     - stage/D100/r4/l0/Soil/15
 Skyview - Chest behind Two Eyes:
   original item: "Skyview Small Key #0"
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D100/r4/l0/TBox/67
   text: <r<two watchful eyes>> guard
 Skyview - Beetle:
   original item: Progressive Beetle
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D100/r10/l1/TBox/65
     - stage/D100/r10/l2/TBox/65
 Skyview - Item behind Bars:
   original item: Heart Piece
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D100/r5/l0/Item/103
 Skyview - Rupee in Southeast Tunnel:
   original item: "Red Rupee #35"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/D100/r5/l0/Item/65
 Skyview - Rupee in Southwest Tunnel:
   original item: "Red Rupee #36"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/D100/r5/l0/Item/67
 Skyview - Rupee in East Tunnel:
   original item: "Red Rupee #37"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/D100/r5/l0/Item/66
 Skyview - Chest behind Three Eyes:
   original item: "Skyview Small Key #1"
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D100/r7/l0/TBox/68
   hint: sometimes
   text: <r<three watchful eyes>> guard
 Skyview - Chest near Boss Door:
   original item: Red Rupee
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D100/r9/l0/TBox/70
 Skyview - Boss Key Chest:
   original item: Skyview Boss Key
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D100/r9/l0/TBox/66
 Skyview - Heart Container:
   original item: Heart Container
-  type: faron, dungeon
+  type:
   Paths:
     - stage/B100/r0/l1/HeartCo
     - stage/B100/r0/l2/HeartCo
@@ -1267,12 +1267,12 @@ Skyview - Heart Container:
     - stage/B100/r0/l4/HeartCo
 Skyview - Rupee on Spring Pillar:
   original item: "Red Rupee #38"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/B100_1/r0/l0/Item/109
 Skyview - Ruby Tablet:
   original item: Ruby Tablet
-  type: faron, dungeon
+  type:
   Paths:
     - event/201-ForestD1/6
     - oarc/B100_1/l0
@@ -1280,68 +1280,68 @@ Skyview - Ruby Tablet:
 # Earth Temple (ET):
 Earth Temple - Vent Chest:
   original item: Red Rupee
-  type: eldin, dungeon, digging
+  type:
   Paths:
     - stage/D200/r1/l0/TBox/66
 Earth Temple - Rupee above Drawbridge:
   original item: "Red Rupee #39"
-  type: eldin, dungeon, freestanding
+  type:
   Paths:
     - stage/D200/r1/l0/Item/25
 Earth Temple - Chest behind Bombable Rock:
   original item: Golden Skull
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D200/r1/l0/TBox/69
 Earth Temple - Chest Left of Main Room Bridge:
   original item: Golden Skull # TODO check again
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D200/r1/l0/TBox/70
 Earth Temple - Chest in West Room:
   original item: Earth Temple Map
-  type: eldin, dungeon
+  type:
   hint: sometimes
   text: the <r<western wing in the Earth Temple>> holds
   Paths:
     - stage/D200/r0/l0/TBox/64
 Earth Temple - Bomb Bag:
   original item: Bomb Bag
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D200/r3/l0/TBox/65
   text: a menacing <r<pair of Lizalfos>> protect
 Earth Temple - Ledd's Gift:
   original item: 5 Bombs
-  type: eldin, dungeon
+  type:
   Paths:
     - event/301-MountainD1/16
     - oarc/D200/l0
 Earth Temple - Rupee in Lava Tunnel:
   original item: "Silver Rupee #18"
-  type: eldin, dungeon, freestanding, bombable
+  type:
   Paths:
     - stage/D200/r2/l0/Item/21
   text: hidden within the <r<neck of a dragon>> rests
 Earth Temple - Chest Guarded by Lizalfos:
   original item: Red Rupee
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D200/r1/l0/TBox/67
 Earth Temple - Boss Key Chest:
   original item: Earth Temple Boss Key
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D200/r4/l0/TBox/68
 Earth Temple - Heart Container:
   original item: Heart Container
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/B200/r10/l1/HeartCo
     - stage/B200/r10/l2/HeartCo
 Earth Temple - Amber Tablet:
   original item: Amber Tablet
-  type: eldin, dungeon
+  type:
   Paths:
     - event/301-MountainD1/22
     - oarc/B210/l0
@@ -1349,72 +1349,72 @@ Earth Temple - Amber Tablet:
 # Lanayru Mining Facility (LMF):
 Lanayru Mining Facility - Chest behind Bars:
   original item: Red Rupee
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300/r0/l0/TBox/64
 Lanayru Mining Facility - First Chest in Hub Room:
   original item: Lanayru Mining Facility Small Key
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300_1/r5/l0/TBox/70
 Lanayru Mining Facility - Chest in First West Room:
   original item: Golden Skull # TODO check again
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300/r3/l0/TBox/66
 Lanayru Mining Facility - Chest after Armos Fight:
   original item: Lanayru Mining Facility Map
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300/r6/l0/TBox/69
 Lanayru Mining Facility - Chest in Key Locked Room:
   original item: Red Rupee
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300/r2/l0/TBox/65
 Lanayru Mining Facility - Gust Bellows:
   original item: Gust Bellows
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300/r4/l0/TBox/68
 Lanayru Mining Facility - Chest inside Gust Bellows Room:
   original item: Golden Skull # TODO check again
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300/r4/l0/TBox/76
 Lanayru Mining Facility - Chest behind First Crawlspace:
   original item: Golden Skull # TODO check again
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300_1/r9/l0/TBox/72
     - stage/D300/r9/l0/TBox/72
 Lanayru Mining Facility - Chest in Spike Maze:
   original item: Red Rupee
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300_1/r7/l0/TBox/73
     - stage/D300/r7/l0/TBox/73
 Lanayru Mining Facility - Boss Key Chest:
   original item: Lanayru Mining Facility Boss Key
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300_1/r8/l0/TBox/71
   hint: always
   text: deep inside <r<Lanayru Mining Facility, a pair of Armos>> guard
 Lanayru Mining Facility - Shortcut Chest in Main Hub:
   original item: Red Rupee
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D300_1/r5/l0/TBox/74
 Lanayru Mining Facility - Heart Container:
   original item: Heart Container
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/B300/r0/l1/HeartCo
     - stage/B300/r0/l3/HeartCo
 Lanayru Mining Facility - Goddess Harp:
   original item: Goddess Harp
-  type: lanayru, dungeon
+  type:
   Paths:
     - event/400-Desert/286
     - oarc/F300_5/l0
@@ -1422,42 +1422,42 @@ Lanayru Mining Facility - Goddess Harp:
 # Ancient Cistern (AC):
 Ancient Cistern - Rupee in West Hand:
   original item: "Silver Rupee #20"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/D101/r0/l0/Item/93
 Ancient Cistern - Rupee in East Hand:
   original item: "Silver Rupee #19"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/D101/r0/l0/Item/92
 Ancient Cistern - First Rupee in East Part in Short Tunnel:
   original item: "Green Rupee #0"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/D101/r2/l0/Item/65
 Ancient Cistern - Second Rupee in East Part in Short Tunnel:
   original item: "Green Rupee #1"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/D101/r2/l0/Item/66
 Ancient Cistern - Third Rupee in East Part in Short Tunnel:
   original item: "Green Rupee #2"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/D101/r2/l0/Item/67
 Ancient Cistern - Rupee in East Part in Cubby:
   original item: "Red Rupee #41"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/D101/r2/l0/Item/68
 Ancient Cistern - Rupee in East Part in Main Tunnel:
   original item: "Red Rupee #40"
-  type: faron, dungeon, freestanding
+  type:
   Paths:
     - stage/D101/r2/l0/Item/34
 Ancient Cistern - Chest in East Part:
   original item: "Ancient Cistern Small Key #0"
-  type: faron, dungeon
+  type:
   hint: sometimes
   text: the <r<lone east chest in the Ancient Cistern>> contains
   Paths:
@@ -1465,48 +1465,48 @@ Ancient Cistern - Chest in East Part:
 # # Can Be Locked Out Of if activating water pillar before collecting
 # Ancient Cistern - Rupee under Lilypad:
 #   original item: Red Rupee
-#   type: faron, dungeon, freestanding
+#   type:
 #   Paths:
 #     - stage/D101/r5/l0/Item/13
 Ancient Cistern - Chest after Whip Hooks:
   original item: Ancient Cistern Map
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D101/r0/l0/TBox/65
 Ancient Cistern - Chest near Vines:
   original item: Red Rupee
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D101/r0/l0/TBox/66
 Ancient Cistern - Chest behind the Waterfall:
   original item: Red Rupee
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D101/r3/l0/TBox/84
 Ancient Cistern - Bokoblin:
   original item: "Ancient Cistern Small Key #1"
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D101/r4/l0/EBc/0xFC00
 Ancient Cistern - Whip:
   original item: Whip
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D101/r7/l0/TBox/69
 Ancient Cistern - Boss Key Chest:
   original item: Ancient Cistern Boss Key
-  type: faron, dungeon
+  type:
   Paths:
     - stage/D101/r4/l0/TBox/68
 Ancient Cistern - Heart Container:
   original item: Heart Container
-  type: faron, dungeon
+  type:
   Paths:
     - stage/B101/r0/l1/HeartCo
     - stage/B101/r0/l3/HeartCo
 Ancient Cistern - Farore's Flame:
   original item: Progressive Sword
-  type: faron, dungeon
+  type:
   Paths:
     - event/202-ForestD2/give item after beating ancient cistern
     - oarc/B101_1/l0
@@ -1514,47 +1514,47 @@ Ancient Cistern - Farore's Flame:
 # Sandship (SSH):
 Sandship - Chest at the Stern:
   original item: Heart Piece
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D301/r0/l0/TBox/127
 Sandship - Chest before 4-Door Corridor:
   original item: Sandship Map
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D301/r3/l0/TBox/71
 Sandship - Chest behind Combination Lock:
   original item: "Sandship Small Key #0"
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D301/r10/l0/TBox/69
 Sandship - Treasure Room First Chest:
   original item: Semi Rare Treasure
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D301/r9/l0/TBox/64
 Sandship - Treasure Room Second Chest:
   original item: Silver Rupee
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D301/r9/l0/TBox/65
 Sandship - Treasure Room Third Chest:
   original item: Semi Rare Treasure
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D301/r9/l0/TBox/66
 Sandship - Treasure Room Fourth Chest:
   original item: Silver Rupee
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D301/r9/l0/TBox/67
 Sandship - Treasure Room Fifth Chest:
   original item: Semi Rare Treasure
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D301/r9/l0/TBox/68
 Sandship - Robot in Brig's Reward:
   original item: "Sandship Small Key #1"
-  type: lanayru, dungeon
+  type:
   hint: sometimes
   text: the <r<gratitude of a freed crew>> reveals
   Paths:
@@ -1562,21 +1562,21 @@ Sandship - Robot in Brig's Reward:
     - oarc/D301/l4
 Sandship - Bow:
   original item: Progressive Bow
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D301/r15/l0/TBox/72
   hint: sometimes
   text: a <r<robot upon the Sandship's bow>> guards
 Sandship - Boss Key Chest:
   original item: Sandship Boss Key
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/D301/r14/l3/TBox/73
   hint: sometimes
   text: the <r<secret treasure of the Sandship's captain>> is
 Sandship - Heart Container:
   original item: Heart Container
-  type: lanayru, dungeon
+  type:
   Paths:
     - stage/B301/r0/l1/HeartCo
     - stage/D301/r0/l1/HeartCo
@@ -1584,7 +1584,7 @@ Sandship - Heart Container:
   text: the <r<heart of an ancient sea creature>> holds
 Sandship - Nayru's Flame:
   original item: Progressive Sword
-  type: lanayru, dungeon
+  type:
   Paths:
     - event/401-DesertD2/45
     - oarc/B301/l1
@@ -1593,80 +1593,80 @@ Sandship - Nayru's Flame:
 # Fire Sanctuary (FS):
 Fire Sanctuary - Chest in First Room:
   original item: "Fire Sanctuary Small Key #0"
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201/r0/l0/TBox/64
 Fire Sanctuary - Chest in Second Room:
   original item: Red Rupee
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201_1/r1/l0/TBox/74
     - stage/D201/r1/l0/TBox/74
 Fire Sanctuary - Chest on Balcony:
   original item: Bottle
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201_1/r6/l0/TBox/70
     - stage/D201/r6/l0/TBox/70
 Fire Sanctuary - Chest near First Trapped Mogma:
   original item: "Fire Sanctuary Small Key #1"
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201_1/r5/l0/TBox/69
 Fire Sanctuary - First Chest in Water Fruit Room:
   original item: Red Rupee
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201_1/r7/l0/TBox/73
 Fire Sanctuary - Second Chest in Water Fruit Room:
   original item: Semi Rare Treasure
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201_1/r7/l0/TBox/72
 Fire Sanctuary - Mogma Mitts:
   original item: Progressive Mitts
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201_1/r5/l0/TBox/68
   text: saving a <r<mogma>> from a <r<fiery fate>> rewards
 Fire Sanctuary - Chest after Second Trapped Mogma:
   original item: Fire Sanctuary Map
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201_1/r2/l0/TBox/65
     - stage/D201/r2/l0/TBox/65
 Fire Sanctuary - Chest after Bombable Wall:
   original item: "Fire Sanctuary Small Key #2"
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201_1/r11/l0/TBox/71
   hint: always
   text: a <r<false wall in the Fire Sanctuary>> guards
 Fire Sanctuary - Plats' Chest:
   original item: Heart Piece
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201/r3/l0/TBox/66
 Fire Sanctuary - Chest in Staircase Room:
   original item: Semi Rare Treasure
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201/r9/l0/TBox/75
   text: exploring a <r<broken staircase>> reveals
 Fire Sanctuary - Boss Key Chest:
   original item: Fire Sanctuary Boss Key
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/D201/r4/l0/TBox/67
 Fire Sanctuary - Heart Container:
   original item: Heart Container
-  type: eldin, dungeon
+  type:
   Paths:
     - stage/B201/r0/l1/HeartCo
     - stage/B201/r0/l2/HeartCo
 Fire Sanctuary - Din's Flame:
   original item: Progressive Sword
-  type: eldin, dungeon
+  type:
   Paths:
     - event/304-MountainD2/5
     - oarc/B201_1/l0
@@ -1674,60 +1674,60 @@ Fire Sanctuary - Din's Flame:
 # Sky Keep (SK):
 Sky Keep - First Chest:
   original item: Sky Keep Map
-  type: skyloft, dungeon
+  type:
   Paths:
     - stage/D003_7/r0/l0/TBox/64
 Sky Keep - Chest after Dreadfuse:
   original item: Sky Keep Small Key
-  type: skyloft, dungeon
+  type:
   Paths:
     - stage/D003_6/r0/l0/TBox/65
 Sky Keep - Rupee in Fire Sanctuary Room in Alcove:
   original item: "Silver Rupee #21"
-  type: skyloft, dungeon, freestanding
+  type:
   Paths:
     - stage/D003_2/r0/l0/Item/36
 Sky Keep - Triforce of Power:
    original item: Triforce of Power
-   type: skyloft, dungeon
+   type:
    Paths:
     - stage/D003_8/r0/l2/Item/61
 Sky Keep - Triforce of Wisdom:
    original item: Triforce of Wisdom
-   type: skyloft, dungeon
+   type:
    Paths:
     - stage/D003_8/r0/l1/Item/62
 Sky Keep - Triforce of Courage:
    original item: Triforce of Courage
-   type: skyloft, dungeon
+   type:
    Paths:
     - stage/D003_8/r0/l3/Item/64
 
 # Silent Realms:
 Skyloft Silent Realm - Stone of Trials:
   original item: Stone of Trials
-  type: skyloft, silent realm
+  type:
   Paths:
     - stage/S000/r0/l2/WarpObj
   hint: always
   text: the <r<goddess's final trial>> grants
 Faron Silent Realm - Water Scale:
   original item: Water Scale
-  type: faron, silent realm
+  type:
   Paths:
     - stage/S100/r0/l2/WarpObj
   hint: always
   text: a <r<trial of courage>> grants
 Lanayru Silent Realm - Clawshots:
   original item: Clawshots
-  type: lanayru, silent realm
+  type:
   Paths:
     - stage/S300/r0/l2/WarpObj
   hint: always
   text: a <r<trial of wisdom>> grants
 Eldin Silent Realm - Fireshield Earrings:
   original item: Fireshield Earrings
-  type: eldin, silent realm
+  type:
   Paths:
     - stage/S200/r2/l2/WarpObj
   hint: always

--- a/gui/components/list_pair.py
+++ b/gui/components/list_pair.py
@@ -23,11 +23,14 @@ class ListPair(QObject):
         self.option_list = option_list
         self.non_option_list = non_option_list
         self.option_string = str(option_string)
+        self.has_type_filter = len(type_meta) > 0
         self._stored_filter_option_list = ""
         self._stored_filter_non_option_list = ""
+        self._stored_type_filter_option_list = ""
+        self._stored_type_filter_non_option_list = ""
 
         self.option_list_model = QStringListModel()
-        if type_meta:
+        if self.has_type_filter:
             self.option_list_proxy = TypeFilterModel(
                 self.option_list, OPTIONS[self.option_string]["choices"], type_meta
             )
@@ -40,7 +43,7 @@ class ListPair(QObject):
         self.option_list.setModel(self.option_list_proxy)
 
         self.non_option_list_model = QStringListModel()
-        if type_meta:
+        if self.has_type_filter:
             self.non_option_list_proxy = TypeFilterModel(
                 self.non_option_list, OPTIONS[self.option_string]["choices"], type_meta
             )
@@ -58,13 +61,13 @@ class ListPair(QObject):
     def update_option_list_filter(self, new_text: str | None):
         self.option_list_proxy.filterRows(new_text)
 
-    def update_option_list_type_filter(self, type_filter):
+    def update_option_list_type_filter(self, type_filter: str | None):
         self.option_list_proxy.filterType(type_filter)
 
     def update_non_option_list_filter(self, new_text: str | None):
         self.non_option_list_proxy.filterRows(new_text)
 
-    def update_non_option_list_type_filter(self, type_filter):
+    def update_non_option_list_type_filter(self, type_filter: str | None):
         self.non_option_list_proxy.filterType(type_filter)
 
     def add(self):
@@ -120,6 +123,20 @@ class ListPair(QObject):
         self.option_list_proxy.filterRows("")
         self.non_option_list_proxy.filterRows("")
 
+        if self.has_type_filter:
+            self._stored_type_filter_option_list = self.option_list_proxy.type_filter
+            self._stored_type_filter_non_option_list = (
+                self.non_option_list_proxy.type_filter
+            )
+            self.option_list_proxy.filterType("")
+            self.non_option_list_proxy.filterType("")
+
     def _restore_filters(self):
         self.option_list_proxy.filterRows(self._stored_filter_option_list)
         self.non_option_list_proxy.filterRows(self._stored_filter_non_option_list)
+
+        if self.has_type_filter:
+            self.option_list_proxy.filterType(self._stored_type_filter_option_list)
+            self.non_option_list_proxy.filterType(
+                self._stored_type_filter_non_option_list
+            )

--- a/gui/components/list_pair.py
+++ b/gui/components/list_pair.py
@@ -2,6 +2,7 @@ from PySide6.QtCore import QObject, QStringListModel, Signal
 from PySide6.QtWidgets import QListView, QPushButton
 
 from gui.models.sort_model import SearchableListModel
+from gui.models.type_filter_model import TypeFilterModel
 
 from options import OPTIONS
 
@@ -16,6 +17,7 @@ class ListPair(QObject):
         option_string: str,
         add_button: QPushButton,
         remove_button: QPushButton,
+        type_meta: dict = {},
     ):
         super().__init__()
         self.option_list = option_list
@@ -25,17 +27,27 @@ class ListPair(QObject):
         self._stored_filter_non_option_list = ""
 
         self.option_list_model = QStringListModel()
-        self.option_list_proxy = SearchableListModel(
-            self.option_list, OPTIONS[self.option_string]["choices"]
-        )
+        if type_meta:
+            self.option_list_proxy = TypeFilterModel(
+                self.option_list, OPTIONS[self.option_string]["choices"], type_meta
+            )
+        else:
+            self.option_list_proxy = SearchableListModel(
+                self.option_list, OPTIONS[self.option_string]["choices"]
+            )
         self.option_list_proxy.setSourceModel(self.option_list_model)
         self.option_list_model.setStringList(OPTIONS[self.option_string]["default"])
         self.option_list.setModel(self.option_list_proxy)
 
         self.non_option_list_model = QStringListModel()
-        self.non_option_list_proxy = SearchableListModel(
-            self.non_option_list, OPTIONS[self.option_string]["choices"]
-        )
+        if type_meta:
+            self.non_option_list_proxy = TypeFilterModel(
+                self.non_option_list, OPTIONS[self.option_string]["choices"], type_meta
+            )
+        else:
+            self.non_option_list_proxy = SearchableListModel(
+                self.non_option_list, OPTIONS[self.option_string]["choices"]
+            )
         self.non_option_list_proxy.setSourceModel(self.non_option_list_model)
         self.non_option_list_model.setStringList(OPTIONS[self.option_string]["choices"])
         self.non_option_list.setModel(self.non_option_list_proxy)
@@ -46,8 +58,14 @@ class ListPair(QObject):
     def update_option_list_filter(self, new_text: str | None):
         self.option_list_proxy.filterRows(new_text)
 
+    def update_option_list_type_filter(self, type_filter):
+        self.option_list_proxy.filterType(type_filter)
+
     def update_non_option_list_filter(self, new_text: str | None):
         self.non_option_list_proxy.filterRows(new_text)
+
+    def update_non_option_list_type_filter(self, type_filter):
+        self.non_option_list_proxy.filterType(type_filter)
 
     def add(self):
         self.move_selected_rows(self.non_option_list, self.option_list)

--- a/gui/dialogs/custom_theme/ui_custom_theme_dialog.py
+++ b/gui/dialogs/custom_theme/ui_custom_theme_dialog.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'custom_theme_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.2.4
+## Created by: Qt User Interface Compiler version 6.4.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/gui/dialogs/tricks/ui_tricks_dialog.py
+++ b/gui/dialogs/tricks/ui_tricks_dialog.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'tricks_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.2.4
+## Created by: Qt User Interface Compiler version 6.4.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/gui/models/type_filter_model.py
+++ b/gui/models/type_filter_model.py
@@ -1,0 +1,26 @@
+from typing import Union
+from PySide6.QtCore import QModelIndex, QPersistentModelIndex, Qt
+from gui.models.sort_model import SearchableListModel
+
+
+class TypeFilterModel(SearchableListModel):
+    def __init__(self, parent, full_list, type_meta):
+        super().__init__(parent, full_list)
+        self.type_meta = type_meta
+        self.type_filter = ""
+
+    def filterAcceptsRow(
+        self, source_row: int, source_parent: Union[QModelIndex, QPersistentModelIndex]
+    ) -> bool:
+        print("in acceptsrow")
+        if self.type_filter:
+            index = self.sourceModel().index(source_row, 0, source_parent)
+            data = self.sourceModel().data(index)
+            if self.type_filter not in self.type_meta[data]["type"]:
+                return False
+        return super().filterAcceptsRow(source_row, source_parent)
+
+    def filterType(self, type_filter):
+        print("filter updated")
+        self.type_filter = type_filter
+        self.invalidateFilter()

--- a/gui/models/type_filter_model.py
+++ b/gui/models/type_filter_model.py
@@ -1,6 +1,8 @@
 from typing import Union
-from PySide6.QtCore import QModelIndex, QPersistentModelIndex, Qt
+from PySide6.QtCore import QModelIndex, QPersistentModelIndex
 from gui.models.sort_model import SearchableListModel
+
+TYPE = "type"
 
 
 class TypeFilterModel(SearchableListModel):
@@ -12,15 +14,17 @@ class TypeFilterModel(SearchableListModel):
     def filterAcceptsRow(
         self, source_row: int, source_parent: Union[QModelIndex, QPersistentModelIndex]
     ) -> bool:
-        print("in acceptsrow")
         if self.type_filter:
             index = self.sourceModel().index(source_row, 0, source_parent)
             data = self.sourceModel().data(index)
-            if self.type_filter not in self.type_meta[data]["type"]:
+
+            if (
+                self.type_meta[data][TYPE] is None
+                or self.type_filter not in self.type_meta[data][TYPE]
+            ):
                 return False
         return super().filterAcceptsRow(source_row, source_parent)
 
     def filterType(self, type_filter):
-        print("filter updated")
         self.type_filter = type_filter
         self.invalidateFilter()

--- a/gui/models/type_filter_model.py
+++ b/gui/models/type_filter_model.py
@@ -14,7 +14,7 @@ class TypeFilterModel(SearchableListModel):
     def filterAcceptsRow(
         self, source_row: int, source_parent: Union[QModelIndex, QPersistentModelIndex]
     ) -> bool:
-        if self.type_filter:
+        if self.type_filter and not self.type_filter == "All":
             index = self.sourceModel().index(source_row, 0, source_parent)
             data = self.sourceModel().data(index)
 

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
 )
 from gui.dialogs.tricks.tricks_dialog import TricksDialog
 from gui.dialogs.custom_theme.custom_theme_dialog import CustomThemeDialog
+from logic.constants import LOCATION_FILTER_TYPES
 
 from logic.logic_input import Areas
 from options import OPTIONS, Options
@@ -34,6 +35,7 @@ from gui.guithreads import RandomizerThread, ExtractSetupThread
 from ssrando import Randomizer, VERSION
 from paths import RANDO_ROOT_PATH
 from gui.ui_randogui import Ui_MainWindow
+from yaml_files import checks
 from witmanager import WitManager
 
 # Allow keyboard interrupts on the command line to instantly close the program.
@@ -181,6 +183,7 @@ class RandoGUI(QMainWindow):
             "excluded-locations",
             self.ui.exclude_location,
             self.ui.include_location,
+            checks,
         )
         self.exclude_locations_pair.listPairChanged.connect(self.update_settings)
 
@@ -189,6 +192,18 @@ class RandoGUI(QMainWindow):
         )
         self.ui.included_free_search.textChanged.connect(
             self.exclude_locations_pair.update_non_option_list_filter
+        )
+
+        self.ui.include_category_filters.addItem("")
+        self.ui.include_category_filters.addItems(LOCATION_FILTER_TYPES.values())
+        self.ui.include_category_filters.currentIndexChanged.connect(
+            self.exclude_locations_pair.update_option_list_type_filter
+        )
+
+        self.ui.exclude_category_filters.addItem("")
+        self.ui.exclude_category_filters.addItems(LOCATION_FILTER_TYPES.values())
+        self.ui.exclude_category_filters.currentIndexChanged.connect(
+            self.exclude_locations_pair.update_non_option_list_type_filter
         )
 
         # Starting Items UI

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -195,15 +195,15 @@ class RandoGUI(QMainWindow):
         )
 
         self.ui.include_category_filters.addItem("")
-        self.ui.include_category_filters.addItems(LOCATION_FILTER_TYPES.values())
-        self.ui.include_category_filters.currentIndexChanged.connect(
-            self.exclude_locations_pair.update_option_list_type_filter
+        self.ui.include_category_filters.addItems(LOCATION_FILTER_TYPES)
+        self.ui.include_category_filters.currentTextChanged.connect(
+            self.exclude_locations_pair.update_non_option_list_type_filter
         )
 
         self.ui.exclude_category_filters.addItem("")
-        self.ui.exclude_category_filters.addItems(LOCATION_FILTER_TYPES.values())
-        self.ui.exclude_category_filters.currentIndexChanged.connect(
-            self.exclude_locations_pair.update_non_option_list_type_filter
+        self.ui.exclude_category_filters.addItems(LOCATION_FILTER_TYPES)
+        self.ui.exclude_category_filters.currentTextChanged.connect(
+            self.exclude_locations_pair.update_option_list_type_filter
         )
 
         # Starting Items UI

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -194,13 +194,13 @@ class RandoGUI(QMainWindow):
             self.exclude_locations_pair.update_non_option_list_filter
         )
 
-        self.ui.include_category_filters.addItem("")
+        self.ui.include_category_filters.addItem("All")
         self.ui.include_category_filters.addItems(LOCATION_FILTER_TYPES)
         self.ui.include_category_filters.currentTextChanged.connect(
             self.exclude_locations_pair.update_non_option_list_type_filter
         )
 
-        self.ui.exclude_category_filters.addItem("")
+        self.ui.exclude_category_filters.addItem("All")
         self.ui.exclude_category_filters.addItems(LOCATION_FILTER_TYPES)
         self.ui.exclude_category_filters.currentTextChanged.connect(
             self.exclude_locations_pair.update_option_list_type_filter

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1096</width>
-    <height>738</height>
+    <width>1202</width>
+    <height>759</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -60,7 +60,7 @@
        <number>-6</number>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>3</number>
       </property>
       <property name="usesScrollButtons">
        <bool>true</bool>
@@ -1326,6 +1326,9 @@
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Expanding</enum>
+              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>40</width>
@@ -1353,17 +1356,24 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLineEdit" name="included_free_search">
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="placeholderText">
-                   <string>Search</string>
-                  </property>
-                  <property name="clearButtonEnabled">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
+                 <layout class="QHBoxLayout" name="hlay_include_filters">
+                  <item>
+                   <widget class="QComboBox" name="include_category_filters"/>
+                  </item>
+                  <item>
+                   <widget class="QLineEdit" name="included_free_search">
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="placeholderText">
+                     <string>Search</string>
+                    </property>
+                    <property name="clearButtonEnabled">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </item>
                 <item>
                  <widget class="QListView" name="included_locations">
@@ -1464,14 +1474,21 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLineEdit" name="excluded_free_search">
-                  <property name="placeholderText">
-                   <string>Search</string>
-                  </property>
-                  <property name="clearButtonEnabled">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
+                 <layout class="QHBoxLayout" name="hlay_exclude_filters">
+                  <item>
+                   <widget class="QLineEdit" name="excluded_free_search">
+                    <property name="placeholderText">
+                     <string>Search</string>
+                    </property>
+                    <property name="clearButtonEnabled">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="exclude_category_filters"/>
+                  </item>
+                 </layout>
                 </item>
                 <item>
                  <widget class="QListView" name="excluded_locations">
@@ -2180,13 +2197,10 @@
                 <bool>false</bool>
                </property>
                <property name="currentText">
-                <string>Noto Sans</string>
+                <string>Lucida Grande</string>
                </property>
                <property name="sizeAdjustPolicy">
                 <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
-               </property>
-               <property name="placeholderText">
-                <string>Select Font Family</string>
                </property>
                <property name="writingSystem">
                 <enum>QFontDatabase::Any</enum>
@@ -2196,9 +2210,12 @@
                </property>
                <property name="currentFont">
                 <font>
-                 <family>Noto Sans</family>
+                 <family>Lucida Grande</family>
                  <pointsize>10</pointsize>
                 </font>
+               </property>
+               <property name="placeholderText" stdset="0">
+                <string>Select Font Family</string>
                </property>
               </widget>
              </item>
@@ -2390,7 +2407,7 @@
        <string/>
       </property>
       <property name="textFormat">
-       <enum>Qt::MarkdownText</enum>
+       <enum>Qt::PlainText</enum>
       </property>
       <property name="wordWrap">
        <bool>true</bool>

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -1358,10 +1358,13 @@
                 <item>
                  <layout class="QHBoxLayout" name="hlay_include_filters">
                   <item>
-                   <widget class="QComboBox" name="include_category_filters"/>
-                  </item>
-                  <item>
                    <widget class="QLineEdit" name="included_free_search">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
                     <property name="text">
                      <string/>
                     </property>
@@ -1370,6 +1373,13 @@
                     </property>
                     <property name="clearButtonEnabled">
                      <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="include_category_filters">
+                    <property name="placeholderText">
+                     <string/>
                     </property>
                    </widget>
                   </item>
@@ -1477,6 +1487,12 @@
                  <layout class="QHBoxLayout" name="hlay_exclude_filters">
                   <item>
                    <widget class="QLineEdit" name="excluded_free_search">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
                     <property name="placeholderText">
                      <string>Search</string>
                     </property>
@@ -2197,10 +2213,13 @@
                 <bool>false</bool>
                </property>
                <property name="currentText">
-                <string>Lucida Grande</string>
+                <string>Arial</string>
                </property>
                <property name="sizeAdjustPolicy">
                 <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
+               </property>
+               <property name="placeholderText">
+                <string>Select Font Family</string>
                </property>
                <property name="writingSystem">
                 <enum>QFontDatabase::Any</enum>
@@ -2210,12 +2229,9 @@
                </property>
                <property name="currentFont">
                 <font>
-                 <family>Lucida Grande</family>
+                 <family>Arial</family>
                  <pointsize>10</pointsize>
                 </font>
-               </property>
-               <property name="placeholderText" stdset="0">
-                <string>Select Font Family</string>
                </property>
               </widget>
              </item>

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -1358,6 +1358,13 @@
                 <item>
                  <layout class="QHBoxLayout" name="hlay_include_filters">
                   <item>
+                   <widget class="QComboBox" name="include_category_filters">
+                    <property name="placeholderText" stdset="0">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
                    <widget class="QLineEdit" name="included_free_search">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -1373,13 +1380,6 @@
                     </property>
                     <property name="clearButtonEnabled">
                      <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QComboBox" name="include_category_filters">
-                    <property name="placeholderText">
-                     <string/>
                     </property>
                    </widget>
                   </item>
@@ -1486,6 +1486,9 @@
                 <item>
                  <layout class="QHBoxLayout" name="hlay_exclude_filters">
                   <item>
+                   <widget class="QComboBox" name="exclude_category_filters"/>
+                  </item>
+                  <item>
                    <widget class="QLineEdit" name="excluded_free_search">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -1500,9 +1503,6 @@
                      <bool>true</bool>
                     </property>
                    </widget>
-                  </item>
-                  <item>
-                   <widget class="QComboBox" name="exclude_category_filters"/>
                   </item>
                  </layout>
                 </item>
@@ -2218,9 +2218,6 @@
                <property name="sizeAdjustPolicy">
                 <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
                </property>
-               <property name="placeholderText">
-                <string>Select Font Family</string>
-               </property>
                <property name="writingSystem">
                 <enum>QFontDatabase::Any</enum>
                </property>
@@ -2232,6 +2229,9 @@
                  <family>Arial</family>
                  <pointsize>10</pointsize>
                 </font>
+               </property>
+               <property name="placeholderText" stdset="0">
+                <string>Select Font Family</string>
                </property>
               </widget>
              </item>

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -998,6 +998,11 @@ class Ui_MainWindow(object):
 
         self.hlay_include_filters = QHBoxLayout()
         self.hlay_include_filters.setObjectName(u"hlay_include_filters")
+        self.include_category_filters = QComboBox(self.tab_logic_settings)
+        self.include_category_filters.setObjectName(u"include_category_filters")
+
+        self.hlay_include_filters.addWidget(self.include_category_filters)
+
         self.included_free_search = QLineEdit(self.tab_logic_settings)
         self.included_free_search.setObjectName(u"included_free_search")
         sizePolicy4.setHeightForWidth(self.included_free_search.sizePolicy().hasHeightForWidth())
@@ -1005,11 +1010,6 @@ class Ui_MainWindow(object):
         self.included_free_search.setClearButtonEnabled(True)
 
         self.hlay_include_filters.addWidget(self.included_free_search)
-
-        self.include_category_filters = QComboBox(self.tab_logic_settings)
-        self.include_category_filters.setObjectName(u"include_category_filters")
-
-        self.hlay_include_filters.addWidget(self.include_category_filters)
 
 
         self.vlay_include_locations.addLayout(self.hlay_include_filters)
@@ -1069,6 +1069,11 @@ class Ui_MainWindow(object):
 
         self.hlay_exclude_filters = QHBoxLayout()
         self.hlay_exclude_filters.setObjectName(u"hlay_exclude_filters")
+        self.exclude_category_filters = QComboBox(self.tab_logic_settings)
+        self.exclude_category_filters.setObjectName(u"exclude_category_filters")
+
+        self.hlay_exclude_filters.addWidget(self.exclude_category_filters)
+
         self.excluded_free_search = QLineEdit(self.tab_logic_settings)
         self.excluded_free_search.setObjectName(u"excluded_free_search")
         sizePolicy4.setHeightForWidth(self.excluded_free_search.sizePolicy().hasHeightForWidth())
@@ -1076,11 +1081,6 @@ class Ui_MainWindow(object):
         self.excluded_free_search.setClearButtonEnabled(True)
 
         self.hlay_exclude_filters.addWidget(self.excluded_free_search)
-
-        self.exclude_category_filters = QComboBox(self.tab_logic_settings)
-        self.exclude_category_filters.setObjectName(u"exclude_category_filters")
-
-        self.hlay_exclude_filters.addWidget(self.exclude_category_filters)
 
 
         self.verticalLayout_30.addLayout(self.hlay_exclude_filters)
@@ -1792,9 +1792,9 @@ class Ui_MainWindow(object):
         self.label_for_option_logic_mode.setText(QCoreApplication.translate("MainWindow", u"Logic Mode", None))
         self.edit_tricks.setText(QCoreApplication.translate("MainWindow", u"Tricks", None))
         self.label_include_locations.setText(QCoreApplication.translate("MainWindow", u"Included Locations", None))
+        self.include_category_filters.setProperty("placeholderText", "")
         self.included_free_search.setText("")
         self.included_free_search.setPlaceholderText(QCoreApplication.translate("MainWindow", u"Search", None))
-        self.include_category_filters.setPlaceholderText("")
         self.include_location.setText(QCoreApplication.translate("MainWindow", u"Include\n"
 "<--", None))
         self.exclude_location.setText(QCoreApplication.translate("MainWindow", u"Exclude\n"
@@ -1844,7 +1844,7 @@ class Ui_MainWindow(object):
         self.box_font.setTitle(QCoreApplication.translate("MainWindow", u"Fonts", None))
         self.label_for_option_font_family.setText(QCoreApplication.translate("MainWindow", u"Font Family", None))
         self.option_font_family.setCurrentText(QCoreApplication.translate("MainWindow", u"Arial", None))
-        self.option_font_family.setPlaceholderText(QCoreApplication.translate("MainWindow", u"Select Font Family", None))
+        self.option_font_family.setProperty("placeholderText", QCoreApplication.translate("MainWindow", u"Select Font Family", None))
         self.label_for_option_font_size.setText(QCoreApplication.translate("MainWindow", u"Font Size", None))
         self.reset_font_button.setText(QCoreApplication.translate("MainWindow", u"Reset", None))
         self.box_1.setTitle("")

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -998,16 +998,18 @@ class Ui_MainWindow(object):
 
         self.hlay_include_filters = QHBoxLayout()
         self.hlay_include_filters.setObjectName(u"hlay_include_filters")
+        self.included_free_search = QLineEdit(self.tab_logic_settings)
+        self.included_free_search.setObjectName(u"included_free_search")
+        sizePolicy4.setHeightForWidth(self.included_free_search.sizePolicy().hasHeightForWidth())
+        self.included_free_search.setSizePolicy(sizePolicy4)
+        self.included_free_search.setClearButtonEnabled(True)
+
+        self.hlay_include_filters.addWidget(self.included_free_search)
+
         self.include_category_filters = QComboBox(self.tab_logic_settings)
         self.include_category_filters.setObjectName(u"include_category_filters")
 
         self.hlay_include_filters.addWidget(self.include_category_filters)
-
-        self.included_free_search = QLineEdit(self.tab_logic_settings)
-        self.included_free_search.setObjectName(u"included_free_search")
-        self.included_free_search.setClearButtonEnabled(True)
-
-        self.hlay_include_filters.addWidget(self.included_free_search)
 
 
         self.vlay_include_locations.addLayout(self.hlay_include_filters)
@@ -1069,6 +1071,8 @@ class Ui_MainWindow(object):
         self.hlay_exclude_filters.setObjectName(u"hlay_exclude_filters")
         self.excluded_free_search = QLineEdit(self.tab_logic_settings)
         self.excluded_free_search.setObjectName(u"excluded_free_search")
+        sizePolicy4.setHeightForWidth(self.excluded_free_search.sizePolicy().hasHeightForWidth())
+        self.excluded_free_search.setSizePolicy(sizePolicy4)
         self.excluded_free_search.setClearButtonEnabled(True)
 
         self.hlay_exclude_filters.addWidget(self.excluded_free_search)
@@ -1522,7 +1526,7 @@ class Ui_MainWindow(object):
         self.option_font_family.setWritingSystem(QFontDatabase.Any)
         self.option_font_family.setFontFilters(QFontComboBox.ScalableFonts)
         font1 = QFont()
-        font1.setFamilies([u"Lucida Grande"])
+        font1.setFamilies([u"Arial"])
         font1.setPointSize(10)
         self.option_font_family.setCurrentFont(font1)
 
@@ -1790,6 +1794,7 @@ class Ui_MainWindow(object):
         self.label_include_locations.setText(QCoreApplication.translate("MainWindow", u"Included Locations", None))
         self.included_free_search.setText("")
         self.included_free_search.setPlaceholderText(QCoreApplication.translate("MainWindow", u"Search", None))
+        self.include_category_filters.setPlaceholderText("")
         self.include_location.setText(QCoreApplication.translate("MainWindow", u"Include\n"
 "<--", None))
         self.exclude_location.setText(QCoreApplication.translate("MainWindow", u"Exclude\n"
@@ -1838,8 +1843,8 @@ class Ui_MainWindow(object):
         self.option_use_sharp_corners.setText(QCoreApplication.translate("MainWindow", u"Sharp Corners", None))
         self.box_font.setTitle(QCoreApplication.translate("MainWindow", u"Fonts", None))
         self.label_for_option_font_family.setText(QCoreApplication.translate("MainWindow", u"Font Family", None))
-        self.option_font_family.setCurrentText(QCoreApplication.translate("MainWindow", u"Lucida Grande", None))
-        self.option_font_family.setProperty("placeholderText", QCoreApplication.translate("MainWindow", u"Select Font Family", None))
+        self.option_font_family.setCurrentText(QCoreApplication.translate("MainWindow", u"Arial", None))
+        self.option_font_family.setPlaceholderText(QCoreApplication.translate("MainWindow", u"Select Font Family", None))
         self.label_for_option_font_size.setText(QCoreApplication.translate("MainWindow", u"Font Size", None))
         self.reset_font_button.setText(QCoreApplication.translate("MainWindow", u"Reset", None))
         self.box_1.setTitle("")

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -25,7 +25,7 @@ class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         if not MainWindow.objectName():
             MainWindow.setObjectName(u"MainWindow")
-        MainWindow.resize(1096, 738)
+        MainWindow.resize(1202, 759)
         sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -996,11 +996,21 @@ class Ui_MainWindow(object):
 
         self.vlay_include_locations.addWidget(self.label_include_locations)
 
+        self.hlay_include_filters = QHBoxLayout()
+        self.hlay_include_filters.setObjectName(u"hlay_include_filters")
+        self.include_category_filters = QComboBox(self.tab_logic_settings)
+        self.include_category_filters.setObjectName(u"include_category_filters")
+
+        self.hlay_include_filters.addWidget(self.include_category_filters)
+
         self.included_free_search = QLineEdit(self.tab_logic_settings)
         self.included_free_search.setObjectName(u"included_free_search")
         self.included_free_search.setClearButtonEnabled(True)
 
-        self.vlay_include_locations.addWidget(self.included_free_search)
+        self.hlay_include_filters.addWidget(self.included_free_search)
+
+
+        self.vlay_include_locations.addLayout(self.hlay_include_filters)
 
         self.included_locations = QListView(self.tab_logic_settings)
         self.included_locations.setObjectName(u"included_locations")
@@ -1055,11 +1065,21 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_30.addWidget(self.label_exclude_locations)
 
+        self.hlay_exclude_filters = QHBoxLayout()
+        self.hlay_exclude_filters.setObjectName(u"hlay_exclude_filters")
         self.excluded_free_search = QLineEdit(self.tab_logic_settings)
         self.excluded_free_search.setObjectName(u"excluded_free_search")
         self.excluded_free_search.setClearButtonEnabled(True)
 
-        self.verticalLayout_30.addWidget(self.excluded_free_search)
+        self.hlay_exclude_filters.addWidget(self.excluded_free_search)
+
+        self.exclude_category_filters = QComboBox(self.tab_logic_settings)
+        self.exclude_category_filters.setObjectName(u"exclude_category_filters")
+
+        self.hlay_exclude_filters.addWidget(self.exclude_category_filters)
+
+
+        self.verticalLayout_30.addLayout(self.hlay_exclude_filters)
 
         self.excluded_locations = QListView(self.tab_logic_settings)
         self.excluded_locations.setObjectName(u"excluded_locations")
@@ -1502,7 +1522,7 @@ class Ui_MainWindow(object):
         self.option_font_family.setWritingSystem(QFontDatabase.Any)
         self.option_font_family.setFontFilters(QFontComboBox.ScalableFonts)
         font1 = QFont()
-        font1.setFamilies([u"Noto Sans"])
+        font1.setFamilies([u"Lucida Grande"])
         font1.setPointSize(10)
         self.option_font_family.setCurrentFont(font1)
 
@@ -1603,7 +1623,7 @@ class Ui_MainWindow(object):
         self.option_description.setSizePolicy(sizePolicy9)
         self.option_description.setMinimumSize(QSize(0, 48))
         self.option_description.setStyleSheet(u"")
-        self.option_description.setTextFormat(Qt.MarkdownText)
+        self.option_description.setTextFormat(Qt.PlainText)
         self.option_description.setWordWrap(True)
 
         self.verticalLayout.addWidget(self.option_description)
@@ -1671,7 +1691,7 @@ class Ui_MainWindow(object):
 
         self.retranslateUi(MainWindow)
 
-        self.tabWidget.setCurrentIndex(0)
+        self.tabWidget.setCurrentIndex(3)
         self.option_triforce_shuffle.setCurrentIndex(-1)
         self.option_randomize_entrances.setCurrentIndex(-1)
         self.option_chest_dowsing.setCurrentIndex(-1)
@@ -1818,8 +1838,8 @@ class Ui_MainWindow(object):
         self.option_use_sharp_corners.setText(QCoreApplication.translate("MainWindow", u"Sharp Corners", None))
         self.box_font.setTitle(QCoreApplication.translate("MainWindow", u"Fonts", None))
         self.label_for_option_font_family.setText(QCoreApplication.translate("MainWindow", u"Font Family", None))
-        self.option_font_family.setCurrentText(QCoreApplication.translate("MainWindow", u"Noto Sans", None))
-        self.option_font_family.setPlaceholderText(QCoreApplication.translate("MainWindow", u"Select Font Family", None))
+        self.option_font_family.setCurrentText(QCoreApplication.translate("MainWindow", u"Lucida Grande", None))
+        self.option_font_family.setProperty("placeholderText", QCoreApplication.translate("MainWindow", u"Select Font Family", None))
         self.label_for_option_font_size.setText(QCoreApplication.translate("MainWindow", u"Font Size", None))
         self.reset_font_button.setText(QCoreApplication.translate("MainWindow", u"Reset", None))
         self.box_1.setTitle("")

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -878,18 +878,18 @@ ALLOWED_STARTING_ITEMS = (
     | ALL_MAPS
 )
 
-LOCATION_FILTER_TYPES = {
-    "goddess": "Goddess Chests",
-    "faron goddess": "Faron Woods Goddess Chests",
-    "floria goddess": "Lake Floria Goddess Chests",
-    "eldin goddess": "Eldin Volcano Goddess Chests",
-    "summit goddess": "Volcan SUmmit Goddess Chests",
-    "lanayru goddess": "Lanayru Desert Goddess Chests",
-    "sand sea goddess": "Sand Sea Goddess Chests",
-    "combat": "Combat",
-    "crystal": "Loose Crystals",
-    "minigame": "Minigames",
-    "beedle": "Beedle's Shop Ship Purchases",
-    "crystal quest": "Gratitiude Crystal Sidequests",
-    "scrapper": "Scrapper Deliveries",
-}
+LOCATION_FILTER_TYPES = (
+    "Goddess Chests",
+    "Faron Woods Goddess Chests",
+    "Lake Floria Goddess Chests",
+    "Eldin Volcano Goddess Chests",
+    "Volcano Summit Goddess Chests",
+    "Lanayru Desert Goddess Chests",
+    "Sand Sea Goddess Chests",
+    "Combat",
+    "Minigames",
+    "Beedle's Shop Purchases",
+    "Loose Crystals",
+    "Gratitiude Crystal Sidequests",
+    "Scrapper Deliveries",
+)

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -877,3 +877,19 @@ ALLOWED_STARTING_ITEMS = (
     | ALL_BOSS_KEYS
     | ALL_MAPS
 )
+
+LOCATION_FILTER_TYPES = {
+    "goddess": "Goddess Chests",
+    "faron goddess": "Faron Woods Goddess Chests",
+    "floria goddess": "Lake Floria Goddess Chests",
+    "eldin goddess": "Eldin Volcano Goddess Chests",
+    "summit goddess": "Volcan SUmmit Goddess Chests",
+    "lanayru goddess": "Lanayru Desert Goddess Chests",
+    "sand sea goddess": "Sand Sea Goddess Chests",
+    "combat": "Combat",
+    "crystal": "Loose Crystals",
+    "minigame": "Minigames",
+    "beedle": "Beedle's Shop Ship Purchases",
+    "crystal quest": "Gratitiude Crystal Sidequests",
+    "scrapper": "Scrapper Deliveries",
+}

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -890,6 +890,7 @@ LOCATION_FILTER_TYPES = (
     "Minigames",
     "Beedle's Shop Purchases",
     "Loose Crystals",
-    "Gratitiude Crystal Sidequests",
+    "Gratitude Crystal Sidequests",
     "Scrapper Deliveries",
+    "Rupees",
 )


### PR DESCRIPTION
Adds the ability to add selection based filters to list pairs. This system requires metadata on the composition of the root list in order to function (specifically a mapping of displayed data to type list).

This change includes the addition of select filters for the excluded locations list pair, mimicking a toned down version of banned types from the previous versions of the randomizer. Most types were removed, leaving the following types which are useful either because they can't be text searched or they are an otherwise understandable grouping of checks.
- Goddess Chests
- Faron Woods Goddess Chests
- Lake Floria Goddess Chests
- Eldin Volcano Goddess Chests
- Volcano Summit Goddess Chests
- Lanayru Desert Goddess Chests
- Sand Sea Goddess Chests
- Combat
- Loose Crystals
- Minigames
- Beedle's Shop Ship Purchases
- Gratitude Crystal Sidequests
- Scrapper Deliveries
- Rupees

Marked as draft so initial review can begin, but note that filtering functionality is fragile and almost always immediately crashes