### PR TITLE
Fix Skipper DER Bug

### DIFF
--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -2495,6 +2495,11 @@
       next: -1
       param3: 10
 402-DesertF2:
+  - name: Override Skipper check for first time conversation
+    type: flowpatch
+    index: 2
+    flow:
+      next: 150 # Check for SSH visible flag
   - name: Never ask player to go inside shark mouth for ship dowsing
     type: flowpatch
     index: 17

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -2410,17 +2410,17 @@
       subType: 0
       param1: 0
       param2: 3 # item
-      next: Give Sadship beaten story flag
+      next: Give Sandship beaten story flag
       param3: 9
       param4: 0
       param5: 0
-  - name: Give Sadship beaten story flag
+  - name: Give Sandship beaten story flag
     type: flowadd
     flow:
       type: type3
       subType: 0
       param1: 0
-      param2: 15 # Sadship beaten story flag
+      param2: 15 # Sandship beaten story flag
       next: Give rando Tentalus Defeated storyflag
       param3: 0
   - name: Give rando Tentalus Defeated storyflag

--- a/patches.yaml
+++ b/patches.yaml
@@ -4218,6 +4218,12 @@ F301_1: # Sand Sea Main Area
     room: 0
     objtype: STAG
     id: 0xFC6B
+  - name: Remove post-tentalus entrance to Sadship
+    type: objdelete
+    id: 0xFCB7
+    layer: 3
+    room: 0
+    objtype: STAG
   - name: Cutscene after shipyard
     type: objdelete
     id: 0xFC07

--- a/patches.yaml
+++ b/patches.yaml
@@ -4218,10 +4218,28 @@ F301_1: # Sand Sea Main Area
     room: 0
     objtype: STAG
     id: 0xFC6B
-  - name: Remove post-tentalus entrance to Sadship
+  - name: Remove excess entrance to Sadship (layer 2)
+    type: objdelete
+    id: 0xFC98
+    layer: 2
+    room: 0
+    objtype: STAG
+  - name: Remove excess entrance to Sadship (layer 3)
     type: objdelete
     id: 0xFCB7
     layer: 3
+    room: 0
+    objtype: STAG
+  - name: Remove excess entrance to Sadship (layer 4)
+    type: objdelete
+    id: 0xFCB7
+    layer: 4
+    room: 0
+    objtype: STAG
+  - name: Remove excess entrance to Sadship (layer 5)
+    type: objdelete
+    id: 0xFCB7
+    layer: 5
     room: 0
     objtype: STAG
   - name: Cutscene after shipyard

--- a/patches.yaml
+++ b/patches.yaml
@@ -8,8 +8,6 @@ global:
     - 96  # Fi's text after obtaining first map
     - 745 # 5 Beacons
     - 496 # Skipper's cutscene after Sea Chart
-    - 264 # Talked to Skipper first time
-    - 273 # Talked to Skipper first time after saying no (prevents weird first text)
     - 130 # Start with Beacon
     - 358 # Interface choice unlocked
     - 792 # SG Big Door cs

--- a/patches.yaml
+++ b/patches.yaml
@@ -4218,25 +4218,25 @@ F301_1: # Sand Sea Main Area
     room: 0
     objtype: STAG
     id: 0xFC6B
-  - name: Remove excess entrance to Sadship (layer 2)
+  - name: Remove excess entrance to Sandship (layer 2)
     type: objdelete
     id: 0xFC98
     layer: 2
     room: 0
     objtype: STAG
-  - name: Remove excess entrance to Sadship (layer 3)
+  - name: Remove excess entrance to Sandship (layer 3)
     type: objdelete
     id: 0xFCB7
     layer: 3
     room: 0
     objtype: STAG
-  - name: Remove excess entrance to Sadship (layer 4)
+  - name: Remove excess entrance to Sandship (layer 4)
     type: objdelete
     id: 0xFCB7
     layer: 4
     room: 0
     objtype: STAG
-  - name: Remove excess entrance to Sadship (layer 5)
+  - name: Remove excess entrance to Sandship (layer 5)
     type: objdelete
     id: 0xFCB7
     layer: 5


### PR DESCRIPTION
Fixes bug were Skipper's "To the Sandship" dialog option opens up after beating Tentalus - even in DER.

Removes extra entrance to SSH after beating Tentalus (causes problems with DER).