### PR TITLE
Remove Ambiguous Options in Favor of Exclusions

### DIFF
--- a/SS Rando Logic - Glitched Requirements.yaml
+++ b/SS Rando Logic - Glitched Requirements.yaml
@@ -1097,17 +1097,17 @@ Can Access Beedle's Shop:
 Beedle's Shop - 300 Rupee Item:
   Can Access Beedle's Shop &
   Can Afford 300 Rupees &
-  (Progressive Pouch x1 | Option "shop-mode" Is Not "Vanilla")
+  (Progressive Pouch x1 | Option "shopsanity" Enabled)
 
 Beedle's Shop - 600 Rupee Item:
   Can Access Beedle's Shop &
   Can Afford 600 Rupees &
-  (Progressive Pouch x1 | Option "shop-mode" Is Not "Vanilla")
+  (Progressive Pouch x1 | Option "shopsanity" Enabled)
 
 Beedle's Shop - 1200 Rupee Item:
   Can Access Beedle's Shop &
   Can Afford 1200 Rupees &
-  (Progressive Pouch x1 | Option "shop-mode" Is Not "Vanilla")
+  (Progressive Pouch x1 | Option "shopsanity" Enabled)
 
 ### Left
 

--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -418,17 +418,17 @@ Can Access Beedle's Shop:
 Beedle's Shop - 300 Rupee Item:
   Can Access Beedle's Shop &
   Can Afford 300 Rupees &
-  (Progressive Pouch x1 | Option "shop-mode" Is Not "Vanilla")
+  (Progressive Pouch x1 | Option "shopsanity" Enabled)
 
 Beedle's Shop - 600 Rupee Item:
   Can Access Beedle's Shop &
   Can Afford 600 Rupees &
-  (Progressive Pouch x1 | Option "shop-mode" Is Not "Vanilla")
+  (Progressive Pouch x1 | Option "shopsanity" Enabled)
 
 Beedle's Shop - 1200 Rupee Item:
   Can Access Beedle's Shop &
   Can Afford 1200 Rupees &
-  (Progressive Pouch x1 | Option "shop-mode" Is Not "Vanilla")
+  (Progressive Pouch x1 | Option "shopsanity" Enabled)
 
 ### Left
 

--- a/checks.yaml
+++ b/checks.yaml
@@ -204,36 +204,36 @@ Skyloft Village - Sparrot's Crystals:
 # Batreaux Rewards:
 Batreaux's House - 5 Crystals:
   original item: Progressive Wallet
-  type:
+  type: Batreaux's Rewards
   Paths:
     - event/121-AkumaKun/21
     - oarc/F012r/l0
 Batreaux's House - 10 Crystals:
   original item: Heart Piece
-  type:
+  type: Batreaux's Rewards
   Paths:
     - event/121-AkumaKun/42
     - oarc/F012r/l0
 Batreaux's House - 30 Crystals:
   original item: Progressive Wallet
-  type:
+  type: Batreaux's Rewards
   Paths:
     - event/121-AkumaKun/24
     - oarc/F012r/l0
 Batreaux's House - 30 Crystals Chest:
   original item: Cursed Medal
-  type:
+  type: Batreaux's Rewards
   Paths:
     - stage/F012r/r0/l0/TBox/69
 Batreaux's House - 40 Crystals:
   original item: Gold Rupee
-  type:
+  type: Batreaux's Rewards
   Paths:
     - event/121-AkumaKun/49
     - oarc/F012r/l0
 Batreaux's House - 50 Crystals:
   original item: Progressive Wallet
-  type:
+  type: Batreaux's Rewards
   Paths:
     - event/121-AkumaKun/27
     - oarc/F012r/l0
@@ -241,7 +241,7 @@ Batreaux's House - 50 Crystals:
   text: <ye<50>> <r<pieces of gratitude>> can be exchanged for
 Batreaux's House - 70 Crystals:
   original item: Gold Rupee
-  type:
+  type: Batreaux's Rewards
   Paths:
     - event/121-AkumaKun/161
     - oarc/F012r/l0
@@ -249,7 +249,7 @@ Batreaux's House - 70 Crystals:
   text: the <r<demon's penultimate reward>> is
 Batreaux's House - 70 Crystals Second Reward:
   original item: Gold Rupee
-  type:
+  type: Batreaux's Rewards
   Paths:
     - event/121-AkumaKun/163
     - oarc/F012r/l0
@@ -257,7 +257,7 @@ Batreaux's House - 70 Crystals Second Reward:
   text: the <r<demon's penultimate reward>> is
 Batreaux's House - 80 Crystals:
   original item: Progressive Wallet
-  type:
+  type: Batreaux's Rewards
   Paths:
     - event/121-AkumaKun/37
     - oarc/F012r/l0
@@ -267,56 +267,56 @@ Batreaux's House - 80 Crystals:
 # Beedle's Shop:
 Beedle's Shop - 300 Rupee Item:
   original item: "Progressive Pouch #1"
-  type: Beedle's Shop Purchases
+  type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
   Paths:
     - ShpSmpl/20
 Beedle's Shop - 600 Rupee Item:
   original item: "Progressive Pouch #2"
-  type: Beedle's Shop Purchases
+  type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
   Paths:
     - ShpSmpl/21
 Beedle's Shop - 1200 Rupee Item:
   original item: "Progressive Pouch #3"
-  type: Beedle's Shop Purchases
+  type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
   hint: always
   Paths:
     - ShpSmpl/22
   text: for <g+<1200 rupees>> <r<Beedle>> sells
 Beedle's Shop - 800 Rupee Item:
   original item: "Life Medal #0"
-  type: Beedle's Shop Purchases
+  type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
   Paths:
     - ShpSmpl/26
 Beedle's Shop - 1600 Rupee Item:
   original item: "Heart Piece #0"
-  type: Beedle's Shop Purchases
+  type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
   hint: always
   Paths:
     - ShpSmpl/23
   text: for <g+<1600 rupees>> <r<Beedle>> sells
 Beedle's Shop - First 100 Rupee Item:
   original item: "Extra Wallet #0"
-  type: Beedle's Shop Purchases
+  type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
   Paths:
     - ShpSmpl/24
 Beedle's Shop - Second 100 Rupee Item:
   original item: "Extra Wallet #1"
-  type: Beedle's Shop Purchases
+  type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
   Paths:
     - ShpSmpl/17
 Beedle's Shop - Third 100 Rupee Item:
   original item: "Extra Wallet #2"
-  type: Beedle's Shop Purchases
+  type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
   Paths:
     - ShpSmpl/18
 Beedle's Shop - 50 Rupee Item:
   original item: "Progressive Bug Net #0"
-  type: Beedle's Shop Purchases
+  type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
   Paths:
     - ShpSmpl/25
 Beedle's Shop - 1000 Rupee Item:
   original item: Bug Medal
-  type: Beedle's Shop Purchases
+  type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
   Paths:
     - ShpSmpl/27
 

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -856,19 +856,19 @@
       - 43 # do event as normal
       - Show can't buy Pouch text
   - name: go to Check for Pouch
-    onlyif: Option "shop-mode" Is "Vanilla"
+    onlyif: Option "shopsanity" Disabled
     type: flowpatch
     index: 16
     flow:
       next: Check for Pouch
   - name: Second 100 Rupee Item
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: entryadd
     entry:
       name: "105_39"
       value: Second 100R first event
   - name: Second 100R first event
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: flowadd
     flow:
       type: type3
@@ -878,7 +878,7 @@
       next: Second 100R second event
       param3: 12
   - name: Second 100R second event
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: flowadd
     flow:
       type: type3
@@ -888,7 +888,7 @@
       next: Second 100R discount switch 1
       param3: 13
   - name: Second 100R discount switch 1
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: switchadd
     flow:
       subType: 6
@@ -898,7 +898,7 @@
       - Show Second 100R undiscounted Text
       - Second 100R discount switch 2
   - name: Second 100R discount switch 2
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: switchadd
     flow:
       subType: 6
@@ -908,7 +908,7 @@
       - Show Second 100R discounted Text
       - Show Second 100R undiscounted Text
   - name: Show Second 100R undiscounted Text
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: flowadd
     flow:
       type: type1
@@ -916,7 +916,7 @@
       param3: 87
       param4: Second 100R undiscounted Text
   - name: Show Second 100R discounted Text
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: flowadd
     flow:
       type: type1
@@ -924,13 +924,13 @@
       param3: 87
       param4: Second 100R discounted Text
   - name: Third 100 Rupee Item
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: entryadd
     entry:
       name: "105_40"
       value: Third 100R first event
   - name: Third 100R first event
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: flowadd
     flow:
       type: type3
@@ -940,7 +940,7 @@
       next: Third 100R second event
       param3: 12
   - name: Third 100R second event
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: flowadd
     flow:
       type: type3
@@ -950,7 +950,7 @@
       next: Third 100R discount switch 1
       param3: 13
   - name: Third 100R discount switch 1
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: switchadd
     flow:
       subType: 6
@@ -960,7 +960,7 @@
       - Show Third 100R undiscounted Text
       - Third 100R discount switch 2
   - name: Third 100R discount switch 2
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: switchadd
     flow:
       subType: 6
@@ -970,7 +970,7 @@
       - Show Third 100R discounted Text
       - Show Third 100R undiscounted Text
   - name: Show Third 100R undiscounted Text
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: flowadd
     flow:
       type: type1
@@ -978,7 +978,7 @@
       param3: 87
       param4: Third 100R undiscounted Text
   - name: Show Third 100R discounted Text
-    onlyif: Option "shop-mode" Is Not "Vanilla"
+    onlyif: Option "shopsanity" Enabled
     type: flowadd
     flow:
       type: type1

--- a/gamepatches.py
+++ b/gamepatches.py
@@ -1397,7 +1397,7 @@ class GamePatcher:
         self.load_base_patches()
         self.add_entrance_rando_patches()
         self.add_trial_rando_patches()
-        if self.placement_file.options["shop-mode"] != "Vanilla":
+        if self.placement_file.options["shopsanity"]:
             self.shopsanity_patches()
         self.do_build_arc_cache()
         self.add_startitem_patches()
@@ -1501,7 +1501,7 @@ class GamePatcher:
         self.add_asm_patch("ss_necessary")
         self.add_asm_patch("keysanity")
         self.add_asm_patch("post_boko_base_platforms")
-        if self.placement_file.options["shop-mode"] != "Vanilla":
+        if self.placement_file.options["shopsanity"]:
             self.add_asm_patch("shopsanity")
         self.add_asm_patch("gossip_stone_hints")
         if self.placement_file.options["bit-patches"] == "Disable BiT":
@@ -2962,7 +2962,7 @@ class GamePatcher:
             apply_rel_patch(self, rel, file, codepatches)
             if (
                 file == "d_a_shop_sampleNP.rel"
-                and self.placement_file.options["shop-mode"] != "Vanilla"
+                and self.placement_file.options["shopsanity"]
             ):
                 self.do_shoptable_rel_patch(rel)
             rel.save_changes()

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -60,7 +60,7 @@
        <number>-6</number>
       </property>
       <property name="currentIndex">
-       <number>3</number>
+       <number>1</number>
       </property>
       <property name="usesScrollButtons">
        <bool>true</bool>
@@ -518,32 +518,11 @@
            <item>
             <layout class="QVBoxLayout" name="vlay_shuffles">
              <item>
-              <layout class="QVBoxLayout" name="vlay_batreaux">
-               <item>
-                <widget class="QLabel" name="label_for_option_max_batreaux_reward">
-                 <property name="text">
-                  <string>Maximum Batreaux Reward</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="option_max_batreaux_reward"/>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="vlay_shopsanity">
-               <item>
-                <widget class="QLabel" name="label_for_option_shopsanity">
-                 <property name="text">
-                  <string>Beedle's Shop</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="option_shopsanity"/>
-               </item>
-              </layout>
+              <widget class="QCheckBox" name="option_shopsanity">
+               <property name="text">
+                <string>Shuffle Beedle's Shop</string>
+               </property>
+              </widget>
              </item>
              <item>
               <layout class="QVBoxLayout" name="vlay_rupeesanity">
@@ -1352,7 +1331,7 @@
                  <layout class="QHBoxLayout" name="hlay_include_filters">
                   <item>
                    <widget class="QComboBox" name="include_category_filters">
-                    <property name="placeholderText" stdset="0">
+                    <property name="placeholderText">
                      <string/>
                     </property>
                    </widget>
@@ -2315,6 +2294,9 @@
                <property name="sizeAdjustPolicy">
                 <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
                </property>
+               <property name="placeholderText">
+                <string>Select Font Family</string>
+               </property>
                <property name="writingSystem">
                 <enum>QFontDatabase::Any</enum>
                </property>
@@ -2326,9 +2308,6 @@
                  <family>Arial</family>
                  <pointsize>10</pointsize>
                 </font>
-               </property>
-               <property name="placeholderText" stdset="0">
-                <string>Select Font Family</string>
                </property>
               </widget>
              </item>

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'randogui.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.4.3
+## Created by: Qt User Interface Compiler version 6.5.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -372,35 +372,10 @@ class Ui_MainWindow(object):
         self.verticalLayout_17.setObjectName(u"verticalLayout_17")
         self.vlay_shuffles = QVBoxLayout()
         self.vlay_shuffles.setObjectName(u"vlay_shuffles")
-        self.vlay_batreaux = QVBoxLayout()
-        self.vlay_batreaux.setObjectName(u"vlay_batreaux")
-        self.label_for_option_max_batreaux_reward = QLabel(self.box_shuffles)
-        self.label_for_option_max_batreaux_reward.setObjectName(u"label_for_option_max_batreaux_reward")
-
-        self.vlay_batreaux.addWidget(self.label_for_option_max_batreaux_reward)
-
-        self.option_max_batreaux_reward = QComboBox(self.box_shuffles)
-        self.option_max_batreaux_reward.setObjectName(u"option_max_batreaux_reward")
-
-        self.vlay_batreaux.addWidget(self.option_max_batreaux_reward)
-
-
-        self.vlay_shuffles.addLayout(self.vlay_batreaux)
-
-        self.vlay_shopsanity = QVBoxLayout()
-        self.vlay_shopsanity.setObjectName(u"vlay_shopsanity")
-        self.label_for_option_shopsanity = QLabel(self.box_shuffles)
-        self.label_for_option_shopsanity.setObjectName(u"label_for_option_shopsanity")
-
-        self.vlay_shopsanity.addWidget(self.label_for_option_shopsanity)
-
-        self.option_shopsanity = QComboBox(self.box_shuffles)
+        self.option_shopsanity = QCheckBox(self.box_shuffles)
         self.option_shopsanity.setObjectName(u"option_shopsanity")
 
-        self.vlay_shopsanity.addWidget(self.option_shopsanity)
-
-
-        self.vlay_shuffles.addLayout(self.vlay_shopsanity)
+        self.vlay_shuffles.addWidget(self.option_shopsanity)
 
         self.vlay_rupeesanity = QVBoxLayout()
         self.vlay_rupeesanity.setObjectName(u"vlay_rupeesanity")
@@ -1759,7 +1734,7 @@ class Ui_MainWindow(object):
 
         self.retranslateUi(MainWindow)
 
-        self.tabWidget.setCurrentIndex(3)
+        self.tabWidget.setCurrentIndex(1)
         self.option_triforce_shuffle.setCurrentIndex(-1)
         self.option_randomize_entrances.setCurrentIndex(-1)
         self.option_chest_dowsing.setCurrentIndex(-1)
@@ -1805,8 +1780,7 @@ class Ui_MainWindow(object):
         self.tab_randomization_settings.setToolTip("")
 #endif // QT_CONFIG(tooltip)
         self.box_shuffles.setTitle(QCoreApplication.translate("MainWindow", u"Shuffles", None))
-        self.label_for_option_max_batreaux_reward.setText(QCoreApplication.translate("MainWindow", u"Maximum Batreaux Reward", None))
-        self.label_for_option_shopsanity.setText(QCoreApplication.translate("MainWindow", u"Beedle's Shop", None))
+        self.option_shopsanity.setText(QCoreApplication.translate("MainWindow", u"Shuffle Beedle's Shop", None))
         self.label_for_option_rupeesanity.setText(QCoreApplication.translate("MainWindow", u"Rupeesanity", None))
         self.box_completion.setTitle(QCoreApplication.translate("MainWindow", u"Completion Conditions", None))
         self.label_for_option_got_starting_state.setText(QCoreApplication.translate("MainWindow", u"Starting State", None))
@@ -1857,7 +1831,7 @@ class Ui_MainWindow(object):
         self.label_for_option_logic_mode.setText(QCoreApplication.translate("MainWindow", u"Logic Mode", None))
         self.edit_tricks.setText(QCoreApplication.translate("MainWindow", u"Tricks", None))
         self.label_include_locations.setText(QCoreApplication.translate("MainWindow", u"Included Locations", None))
-        self.include_category_filters.setProperty("placeholderText", "")
+        self.include_category_filters.setPlaceholderText("")
         self.included_free_search.setText("")
         self.included_free_search.setPlaceholderText(QCoreApplication.translate("MainWindow", u"Search", None))
         self.include_location.setText(QCoreApplication.translate("MainWindow", u"Include\n"
@@ -1918,7 +1892,7 @@ class Ui_MainWindow(object):
         self.box_font.setTitle(QCoreApplication.translate("MainWindow", u"Fonts", None))
         self.label_for_option_font_family.setText(QCoreApplication.translate("MainWindow", u"Font Family", None))
         self.option_font_family.setCurrentText(QCoreApplication.translate("MainWindow", u"Arial", None))
-        self.option_font_family.setProperty("placeholderText", QCoreApplication.translate("MainWindow", u"Select Font Family", None))
+        self.option_font_family.setPlaceholderText(QCoreApplication.translate("MainWindow", u"Select Font Family", None))
         self.label_for_option_font_size.setText(QCoreApplication.translate("MainWindow", u"Font Size", None))
         self.reset_font_button.setText(QCoreApplication.translate("MainWindow", u"Reset", None))
         self.box_1.setTitle("")

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -33,11 +33,6 @@ GOT_OPENING_REQUIREMENT = EIN("GoT Opening Requirement")
 GOT_RAISING_REQUIREMENT = EIN("GoT Raising Requirement")
 HORDE_DOOR_REQUIREMENT = EIN("Horde Door Requirement")
 
-BEEDLE_STALL_ACCESS = EIN("Beedle Stall Access Token")
-MEDIUM_PURCHASES = EIN("Medium Purchases Token")
-EXPENSIVE_PURCHASES = EIN("Expensive Purchases Token")
-MAY_GET_n_CRYSTALS = lambda n: EIN(f"May Get {n} Crystals Token")
-
 CRYSTAL_THRESHOLDS = [5, 10, 30, 40, 50, 70, 80]
 
 LOGIC_OPTIONS = dict.fromkeys(
@@ -58,11 +53,7 @@ LOGIC_OPTIONS = dict.fromkeys(
         GOT_OPENING_REQUIREMENT,
         GOT_RAISING_REQUIREMENT,
         HORDE_DOOR_REQUIREMENT,
-        BEEDLE_STALL_ACCESS,
-        MEDIUM_PURCHASES,
-        EXPENSIVE_PURCHASES,
     ]
-    + [MAY_GET_n_CRYSTALS(n) for n in CRYSTAL_THRESHOLDS]
 )
 
 # Locations
@@ -901,6 +892,10 @@ LOCATION_FILTER_TYPES = (
     "Combat",
     "Minigames",
     "Beedle's Shop Purchases",
+    "Beedle's Shop Purchase (Cheap)",
+    "Beedle's Shop Purchase (Medium)",
+    "Beedle's Shop Purchase (Expensive)",
+    "Batreaux's Rewards",
     "Loose Crystals",
     "Gratitude Crystal Sidequests",
     "Scrapper Deliveries",

--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -235,19 +235,7 @@ class Rando:
         banned_req = DNFInventory(BANNED_BIT)
         nothing_req = DNFInventory(True)
         maybe_req = lambda b: banned_req if b else nothing_req
-        self.ban_options = {
-            BEEDLE_STALL_ACCESS: maybe_req(self.options["shop-mode"] == "Always Junk"),
-            MEDIUM_PURCHASES: maybe_req(
-                self.options["shop-mode"] == "Randomized - Cheap"
-            ),
-            EXPENSIVE_PURCHASES: maybe_req(
-                self.options["shop-mode"] == "Randomized - Cheap"
-                or self.options["shop-mode"] == "Randomized - Medium"
-            ),
-        } | {
-            MAY_GET_n_CRYSTALS(c): (maybe_req(c > self.options["max-batreaux-reward"]))
-            for c in CRYSTAL_THRESHOLDS
-        }
+        self.ban_options = {}
 
         self.banned: List[EIN] = []
         self.banned.extend(map(self.norm, self.options["excluded-locations"]))
@@ -347,7 +335,7 @@ class Rando:
         )
 
     def set_placement_options(self):
-        shop_mode = self.options["shop-mode"]
+        shopsanity = self.options["shopsanity"]
         place_gondo_progressives = self.options["gondo-upgrades"]
         damage_multiplier = self.options["damage-multiplier"]
 
@@ -360,7 +348,7 @@ class Rando:
             TALK_TO_YERBAL_OPTION: self.options["open-lake-floria"] == "Talk to Yerbal",
             VANILLA_LAKE_FLORIA_OPTION: self.options["open-lake-floria"] == "Vanilla",
             OPEN_LAKE_FLORIA_OPTION: self.options["open-lake-floria"] == "Open",
-            RANDOMIZED_BEEDLE_OPTION: shop_mode != "Vanilla",
+            RANDOMIZED_BEEDLE_OPTION: shopsanity != "Vanilla",
             GONDO_UPGRADES_ON_OPTION: not place_gondo_progressives,
             NO_BIT_CRASHES: self.options["bit-patches"] == "Fix BiT Crashes",
             NONLETHAL_HOT_CAVE: damage_multiplier < 12,
@@ -436,12 +424,8 @@ class Rando:
         if not place_gondo_progressives:
             self.placement.add_unplaced_items(GONDO_ITEMS)
 
-        if shop_mode == "Vanilla":
+        if not shopsanity:
             self.placement |= VANILLA_BEEDLE_PLACEMENT(self.norm, self.areas.checks)
-        elif shop_mode == "Randomized":
-            pass
-        elif shop_mode == "Always Junk":
-            pass
 
         small_key_mode = self.options["small-key-mode"]
         boss_key_mode = self.options["boss-key-mode"]

--- a/logic/requirements/Skyloft.yaml
+++ b/logic/requirements/Skyloft.yaml
@@ -294,7 +294,7 @@ Beedle's Shop:
     Day Exit: Day
 
   Stall:
-    entrance: Day & Beedle Stall Access Token
+    entrance: Day
     exits:
       Beedle's Shop: Nothing
     locations:

--- a/logic/requirements/macros.yaml
+++ b/logic/requirements/macros.yaml
@@ -82,16 +82,16 @@ Can Afford 300 Rupees:
   Can Medium Rupee Farm
 
 Can Afford 600 Rupees:
-  Medium Purchases Token & Can High Rupee Farm & (1 Extra Wallet | Big Wallet)
+  Can High Rupee Farm & (1 Extra Wallet | Big Wallet)
 
 Can Afford 800 Rupees:
-  Medium Purchases Token & Can High Rupee Farm & (2 Extra Wallets | (Medium Wallet & 1 Extra Wallet) | Big Wallet)
+  Can High Rupee Farm & (2 Extra Wallets | (Medium Wallet & 1 Extra Wallet) | Big Wallet)
 
 Can Afford 1000 Rupees:
-  Medium Purchases Token & Can High Rupee Farm & (3 Extra Wallets | (Medium Wallet & 2 Extra Wallets) | Big Wallet)
+  Can High Rupee Farm & (3 Extra Wallets | (Medium Wallet & 2 Extra Wallets) | Big Wallet)
 
 Can Afford 1200 Rupees:
-  Expensive Purchases Token & Can High Rupee Farm &
+  Can High Rupee Farm &
   (
     3 Extra Wallets |
     (Medium Wallet & 3 Extra Wallets) |
@@ -100,7 +100,7 @@ Can Afford 1200 Rupees:
   )
 
 Can Afford 1600 Rupees:
-  Expensive Purchases Token & Can High Rupee Farm & ((Big Wallet & 2 Extra Wallets) | Giant Wallet)
+  Can High Rupee Farm & ((Big Wallet & 2 Extra Wallets) | Giant Wallet)
 
 Can Medium Rupee Farm:
   Sky - Clean Cut Minigame | Can High Rupee Farm
@@ -172,52 +172,38 @@ Water Bottle: Bottle & Can Collect Water
   $ Gratitude Crystal Pack x 13
 
 5 Gratitude Crystals:
-  May Get 5 Crystals Token & (
   5 Single Gratitude Crystals | 1 Gratitude Crystal Pack
-  )
 
 10 Gratitude Crystals:
-  May Get 10 Crystals Token & (
   10 Single Gratitude Crystals |
   (5 Single Gratitude Crystals & 1 Gratitude Crystal Pack) |
   2 Gratitude Crystal Packs
-  )
 
 30 Gratitude Crystals:
-  May Get 30 Crystals Token & (
   (15 Single Gratitude Crystals & 3 Gratitude Crystal Packs) |
   (10 Single Gratitude Crystals & 4 Gratitude Crystal Packs) |
   (5 Single Gratitude Crystals & 5 Gratitude Crystal Packs) |
   6 Gratitude Crystal Packs
-  )
 
 40 Gratitude Crystals:
-  May Get 40 Crystals Token & (
   (15 Single Gratitude Crystals & 5 Gratitude Crystal Packs) |
   (10 Single Gratitude Crystals & 6 Gratitude Crystal Packs) |
   (5 Single Gratitude Crystals & 7 Gratitude Crystal Packs) |
   8 Gratitude Crystal Packs
-  )
 
 50 Gratitude Crystals:
-  May Get 50 Crystals Token & (
   (15 Single Gratitude Crystals & 7 Gratitude Crystal Packs) |
   (10 Single Gratitude Crystals & 8 Gratitude Crystal Packs) |
   (5 Single Gratitude Crystals & 9 Gratitude Crystal Packs) |
   10 Gratitude Crystal Packs
-  )
 
 70 Gratitude Crystals:
-  May Get 70 Crystals Token & (
   (15 Single Gratitude Crystals & 11 Gratitude Crystal Packs) |
   (10 Single Gratitude Crystals & 12 Gratitude Crystal Packs) |
   (5 Single Gratitude Crystals & 13 Gratitude Crystal Packs)
-  )
 
 80 Gratitude Crystals:
-  May Get 80 Crystals Token & (
   15 Single Gratitude Crystals & 13 Gratitude Crystal Packs
-  )
 
 Sword:
   Practice Sword

--- a/options.yaml
+++ b/options.yaml
@@ -209,37 +209,13 @@
         This is highly discouraged to enable as it means issues are much harder solve if you get stuck or encounter a
         problem with the game."
   ui: option_no_spoiler_log
-- name: Max Batreaux Reward
-  command: max-batreaux-reward
-  type: singlechoice
-  default: 50
-  choices:
-    - 0
-    - 5
-    - 10
-    - 30
-    - 40
-    - 50
-    - 70
-    - 80
-  bits: 3
-  help: "Enables progression items to appear in all Batreaux rewards up to and including the selected amount."
-  ui: option_max_batreaux_reward
-- name: Shop Mode
-  command: shop-mode
-  type: singlechoice
-  default: Randomized - Cheap
-  choices:
-    - Vanilla
-    - Randomized - Cheap
-    - Randomized - Medium
-    - Randomized - Expensive
-  bits: 2
-  help: "Determines how shops are randomized.
-        **Vanilla**: shops will always contain their vanilla items, but may still be logically required for progression.
-        **Cheap**: all purchases that cost 300 rupees or less.
-        **Medium**: all purchases that cost 1000 or less rupees.
-        **Expensive**: includes all purchases, regardless of cost."
+- name: Shopsanity
+  command: shopsanity
+  type: boolean
+  default: true
+  help: "Determines if shops are randomized. When enabled, shop items and locations will be shuffled like normal items,
+        and the shop locations will get a randomized item. When disabled, shops will always contain their vanilla items,
+        however those items may still be required for progression. **Currently shuffled shops**: Beedle's Airshop"
   ui: option_shopsanity
 - name: Rupoor Mode
   command: rupoor-mode

--- a/randoscript.py
+++ b/randoscript.py
@@ -56,7 +56,6 @@ def main():
                 ] = f'(default: {opt["default"]}, min: {opt["min"]}, max: {opt["max"]}) {opt["help"]}'
         elif opt["type"] == "singlechoice":
             args["choices"] = opt["choices"]
-            # --max-batreaux-reward being the only int choice...
             if isinstance(opt["default"], int):
                 args["type"] = int
         seed_opts.add_argument(f"--{optname}", **args)


### PR DESCRIPTION
Removes the ambiguous options of Beedle's Shop Shuffle and Max Batreaux Reward in favor of using the exclusions system to prevent those locations from having progression..

## Changes
- Adds 4 new types to the excluded locations select filters
  - Batreaux's Rewards
  - Beedle's Shop Purchases (Cheap)
  - Beedle's Shop Purchases (Medium)
  - Beedle's Shop Purchases (Expensive)
- Removes the Max Batreaux Reward option completely
- Beedle's Shop option is now a boolean (checkbox) option for if the shop is shuffled or not

## Testing
- Mess with the UI, and ensure the filters behave as expected in various combinations
- Dry run a few seeds, no (new) errors should be produced
  - When the new Beedle's Shop option is disabled, all items Beedle sells should be vanilla

## Technical Note
- For now, I've elected to not make the Beedle option specific to Beedle internally, it is the generic "shopsanity" option. The display text is specific to Beedle just for simplicity and clarity. The help text is not generic, but does mention that Beedle is the only shop currently affected by the option.