### PR TITLE
fix fire dragon causing sealed grounds crash when both other dragons are met

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Dev
+### Bugfixes
+- Fix Sealed Grounds crashing after receiving the fire dragon item after obtaining the other dragon items
 
 ## 1.4.0
 ### Options

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -2581,6 +2581,13 @@
     flow:
       next: 276
 404-DesertF3:
+  - name: Don't act when both other Dragons are already met
+    type: flowpatch
+    index: 21
+    flow: {}
+    cases:
+      - 79
+      - 79
   - name: Set story flags from skipped cutscene
     type: flowpatch
     index: 165


### PR DESCRIPTION
Fixes using the unpatched branch, which sets storyflag 20 (which is probably what caused the crash)