### PR TITLE
Prevent Tadtones Jingle Softlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     - Collecting each vanilla group of tadtones in Flooded Faron Woods will give you an item
 ### Changes
 - Getting an item underwater gives the item immediately (instead of having to stand on solid ground)
+### Bugfixes
+- Ensure the tadtones jingle music isn't randomized or manually replaced to prevent a softlock
 
 ## 1.4.1
 ### Bugfixes

--- a/gamepatches.py
+++ b/gamepatches.py
@@ -1445,7 +1445,9 @@ class GamePatcher:
         self.do_patch_title_screen_logo()
         self.do_patch_custom_dowsing_images()
 
-        music_rando(self.placement_file, self.modified_extract_path)
+        music_rando(
+            self.placement_file, self.modified_extract_path, self.actual_extract_path
+        )
 
     def filter_option_requirement(self, entry):
         return not (

--- a/musicrando.py
+++ b/musicrando.py
@@ -30,7 +30,7 @@ def get_derangement(length: int, rng: random.Random) -> List[int]:
     return lst
 
 
-def music_rando(placement_file, modified_extract_path):
+def music_rando(placement_file, modified_extract_path, actual_extract_path):
     musiclist = yaml_load(RANDO_ROOT_PATH / "music.yaml")
 
     NON_SHUFFLED_TYPES = [10, 11]
@@ -66,9 +66,16 @@ def music_rando(placement_file, modified_extract_path):
             else:  # this should not be shuffled
                 for track in tracks:
                     music[track] = track
-                # Force vanilla tadtones music to prevent softlock.
-                # Tadtones music can still be randomized to other locations.
-                music[TADTONES_FILE_NAME] = TADTONES_FILE_NAME
+
+        # Force vanilla tadtones music to prevent softlock.
+        # Tadtones music can still be randomized to other locations.
+        music[TADTONES_FILE_NAME] = TADTONES_FILE_NAME
+
+    # Really force it.
+    shutil.copy(
+        actual_extract_path / "DATA" / "files" / "Sound" / "wzs" / TADTONES_FILE_NAME,
+        modified_extract_path / "DATA" / "files" / "Sound" / "wzs" / TADTONES_FILE_NAME,
+    )
 
     # patch WZSound.brsar for filename and length requirements
     with (modified_extract_path / "DATA" / "files" / "Sound" / "WZSound.brsar").open(


### PR DESCRIPTION
Adds additional protections to ensure the vanilla tadtones jingle plays when all the Group of Tadtones have been collected.