### PR TITLE
actually fix firedragon when both other dragons are met

### DIFF
--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -2460,6 +2460,13 @@
     index: 46
     flow:
       next: 47
+  - name: Don't act differently when both other Dragons are already met
+    type: flowpatch
+    index: 31
+    flow: {}
+    cases:
+      - 57
+      - 57
 399-Demo:
   - name: Skip setting sword itemflag
     type: flowpatch


### PR DESCRIPTION
my previous fix was incomplete, but now it actually directly patches the fire dragon even, so there is no chance of it going to the unpatched flow which doesn't give the item and spits you out near earth temple