### PR TITLE
Change story flag for archery Fledge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add an option for a custom hint distribution (by cjs07)
 ### Bugfixes
 - Ensure the tadtones jingle music isn't randomized or manually replaced to prevent a softlock
+- Fix bug where Fledge wouldn't correctly spawn for the Archery minigame when starting with the bow
 
 ## 1.4.1
 ### Bugfixes

--- a/patches.yaml
+++ b/patches.yaml
@@ -787,7 +787,7 @@ F000: # Skyloft
     room: 0
     objtype: OBJ
     object:
-      trigstoryfid: 1114 # bow
+      trigstoryfid: 944 # bow
   - name: Fledge for Arrow minigame
     type: objpatch
     id: 0xFDD8
@@ -795,7 +795,7 @@ F000: # Skyloft
     room: 0
     objtype: OBJ
     object:
-      trigstoryfid: 1114 # bow
+      trigstoryfid: 944 # bow
 #  - name: Batreaux unlock
 #    type: objpatch
 #    id: 0xFC4A
@@ -885,7 +885,7 @@ F000: # Skyloft
     room: 0
     objtype: OBJ
     object:
-      untrigstoryfid: 1114 # bow
+      untrigstoryfid: 944 # bow
   - name: untrigger fledge on academy after bow layer 6
     type: objpatch
     id: 0xFDD3
@@ -893,7 +893,7 @@ F000: # Skyloft
     room: 0
     objtype: OBJ
     object:
-      untrigstoryfid: 1114 # bow
+      untrigstoryfid: 944 # bow
   - name: delete Wryna l4 2
     type: objdelete
     id: 0xFDF1


### PR DESCRIPTION
Fixes the bug where Fledge wouldn't spawn outside the Sparring Hall when starting with bow. Changed story flag 1114 (Bow text) for 944 (rando flag for obtaining the Bow)