### PR TITLE
Fix incorrect code for cube sots

### DIFF
--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -442,7 +442,8 @@ class HintDistribution:
                 elif zone == LANAYRU_GORGE:
                     zone = LANAYRU_SAND_SEA
                 return CubeSotsGoalHint(loc, item, zone, goal)
-        zone = self.areas.checks[loc]["hint_region"]
+        else:
+            zone = self.areas.checks[loc]["hint_region"]
         return SotsGoalHint(loc, item, zone, goal)
 
     def _create_sots_hint(self):


### PR DESCRIPTION
Zone should be the normal zone if and only if it's not a cube, not just if separate cube sots is enabled.