### PR TITLE
Place restricted items first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 ## 1.4.1
 ### Bugfixes
 - Fix Sealed Grounds crashing after receiving the fire dragon item after obtaining the other dragon items
+- Prevent several "no more locations accessible for item" errors from occuring (seed should now fail to generate less frequently)
 
 ## 1.4.0
 ### Options

--- a/checks.yaml
+++ b/checks.yaml
@@ -1,6 +1,6 @@
 # Upper Skyloft checks:
 Upper Skyloft - Fledge's Gift:
-  original item: Progressive Pouch
+  original item: "Progressive Pouch #0"
   type:
   Paths:
     - event/114-Friend/16
@@ -266,29 +266,29 @@ Batreaux's House - 80 Crystals:
 
 # Beedle's Shop:
 Beedle's Shop - 300 Rupee Item:
-  original item: "Progressive Pouch #1"
+  original item: "Progressive Pouch #2"
   type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
   Paths:
     - ShpSmpl/20
 Beedle's Shop - 600 Rupee Item:
-  original item: "Progressive Pouch #2"
+  original item: "Progressive Pouch #3"
   type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
   Paths:
     - ShpSmpl/21
 Beedle's Shop - 1200 Rupee Item:
-  original item: "Progressive Pouch #3"
+  original item: "Progressive Pouch #4"
   type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
   hint: always
   Paths:
     - ShpSmpl/22
   text: for <g+<1200 rupees>> <r<Beedle>> sells
 Beedle's Shop - 800 Rupee Item:
-  original item: "Life Medal #0"
+  original item: "Life Medal #1"
   type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
   Paths:
     - ShpSmpl/26
 Beedle's Shop - 1600 Rupee Item:
-  original item: "Heart Piece #0"
+  original item: "Heart Piece #23"
   type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
   hint: always
   Paths:
@@ -487,7 +487,7 @@ Sky - Lumpy Pumpkin - Goddess Chest on the Roof:
     - stage/F020/r0/l0/TBox/87
   cube_region: Skyview
 Sky - Lumpy Pumpkin - Outside Goddess Chest:
-  original item: Progressive Pouch
+  original item: "Progressive Pouch #1"
   type: goddess, Faron Woods Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/64
@@ -523,7 +523,7 @@ Sky - Southwest Triple Island Upper Goddess Chest:
     - stage/F020/r0/l0/TBox/66
   cube_region: Eldin Volcano
 Sky - Southwest Triple Island Lower Goddess Chest:
-  original item: Life Medal
+  original item: "Life Medal #0"
   type: goddess, Lanayru Desert Goddess Chests
   Paths:
     - stage/F020/r0/l0/TBox/84

--- a/logic/assumed_fill.py
+++ b/logic/assumed_fill.py
@@ -8,6 +8,9 @@ from .logic import Logic
 from .inventory import BANNED_BIT, EVERYTHING_UNBANNED_BIT, EXTENDED_ITEM
 from .fill_algo_common import RandomizationSettings, UserOutput
 
+PRINT_PROGRESS = False
+PRINT_NONPROGRESS = False
+
 
 class AssumedFill:
     def __init__(
@@ -23,18 +26,32 @@ class AssumedFill:
         )
 
         # Initialize item related attributes.
+        self.restricted_vanilla_items: Dict[EIN, None] = {
+            item: None for item in randosettings.restricted_vanilla_items
+        }
+
+        self.restricted_non_vanilla_items: Dict[EIN, None] = {
+            item: None for item in randosettings.restricted_non_vanilla_items
+        }
+
         self.progress_items: Dict[EIN, None] = {
             item: None
             for item in randosettings.must_be_placed_items
             | dict.fromkeys(randosettings.may_be_placed_items)
             if truly_progress_item[EXTENDED_ITEM[item]]
+            if item
+            not in self.restricted_vanilla_items | self.restricted_non_vanilla_items
         }
 
         self.must_be_placed_items = [
             item
             for item in self.randosettings.must_be_placed_items
-            if item not in self.progress_items
+            if item
+            not in self.progress_items
+            | self.restricted_vanilla_items
+            | self.restricted_non_vanilla_items
         ]
+
         self.may_be_placed_items = [
             item
             for item in self.randosettings.may_be_placed_items
@@ -47,7 +64,33 @@ class AssumedFill:
     def randomize(self, useroutput: UserOutput):
         self.useroutput = useroutput
 
-        # The order of operations is a guess at this point
+        # The order of operations (mostly) is a guess at this point
+        restricted_vanilla_list = list(self.restricted_vanilla_items)
+        restricted_non_vanilla_list = list(self.restricted_non_vanilla_items)
+
+        self.rng.shuffle(restricted_vanilla_list)
+        self.rng.shuffle(restricted_non_vanilla_list)
+
+        # Ensure vanilla items get placed 1st by adding it to restricted_items 1st.
+        # Otherwise, more loosly restricted items could steal the place of vanilla restricted items.
+        restricted_list = restricted_vanilla_list + restricted_non_vanilla_list
+
+        # Allow items with restrictions in banned locations to be placed.
+        # Mainly allows for dungeon items to be placed even if they are unrequired.
+        # Logic should still fail to place items in banned locations (see logic.py def accessible_checks).
+        self.logic.add_item(BANNED_BIT)
+
+        for item in restricted_list:
+            self.useroutput.progress_callback("placing restricted items...")
+
+            if not self.place_item(item):
+                raise self.useroutput.GenerationFailed(
+                    f"Could not find a valid location to place {item}. This may be because the settings are too restrictive. Try randomizing a new seed."
+                )
+
+        # Re-ban the banned when placing non-restricted progress items.
+        self.logic.remove_item(BANNED_BIT)
+
         progress_list = list(self.progress_items)
         self.rng.shuffle(progress_list)
 
@@ -65,20 +108,27 @@ class AssumedFill:
         self.rng.shuffle(self.must_be_placed_items)
         self.rng.shuffle(self.may_be_placed_items)
 
+        # Now that progress items have been placed, allow items to be placed in banned locations.
         self.logic.add_item(BANNED_BIT)
+
         for item in self.must_be_placed_items:
             self.useroutput.progress_callback("placing nonprogress items...")
-            assert self.place_item(item)
+            assert self.place_item(item, is_progress=False)
+
         self.useroutput.progress_callback("placing remaining items...")
 
         unplaced = set()
         for item in self.may_be_placed_items:
             if not unplaced:
-                if not self.place_item(item, force=False):
+                if not self.place_item(item, force=False, is_progress=False):
                     unplaced.add(item)
             else:
                 unplaced.add(item)
+
         self.logic.placement.add_unplaced_items(unplaced)
+
+        if PRINT_NONPROGRESS:
+            print(f"Unplaced items: {list(unplaced)}")
 
         self.fill_with_junk(self.randosettings.duplicable_items)
 
@@ -94,12 +144,16 @@ class AssumedFill:
             result = self.logic.place_item(location, self.rng.choice(junk), fill=False)
             assert result
 
-    def place_item(self, item: EXTENDED_ITEM_NAME, depth=0, force=True) -> bool:
+    def place_item(
+        self, item: EXTENDED_ITEM_NAME, depth=0, force=True, is_progress=True
+    ) -> bool:
         if item in EXTENDED_ITEM:
             self.logic.remove_item(EXTENDED_ITEM[item])
+
         placement_limit: EIN = self.logic.placement.item_placement_limit.get(
             item, EIN("")
         )
+
         accessible_locations = self.logic.accessible_checks(placement_limit)
 
         empty_locations = [
@@ -111,6 +165,13 @@ class AssumedFill:
         if empty_locations:
             location = self.rng.choice(empty_locations)
             result = self.logic.place_item(location, item, fill=force)
+            if (is_progress and PRINT_PROGRESS) or (
+                not is_progress and PRINT_NONPROGRESS
+            ):
+                print(
+                    f"Placed {self.logic.areas.prettify(item)}"
+                    f" in {self.logic.areas.prettify(location)}"
+                )
             assert result  # Undefined if False
             return True
 
@@ -126,7 +187,14 @@ class AssumedFill:
 
         if had_banned := self.logic.inventory[BANNED_BIT]:
             self.logic.remove_item(BANNED_BIT)
-        new_item = self.logic.replace_item(self.rng.choice(accessible_locations), item)
+        location = self.rng.choice(accessible_locations)
+        new_item = self.logic.replace_item(location, item)
+        if (is_progress and PRINT_PROGRESS) or (not is_progress and PRINT_NONPROGRESS):
+            print(
+                f"No empty location, placed {self.logic.areas.prettify(item)}"
+                f" in {self.logic.areas.prettify(location)}"
+                f" removing {self.logic.areas.prettify(new_item)}"
+            )
         if new_item not in self.progress_items and had_banned:
             self.logic.add_item(BANNED_BIT)
         ret = self.place_item(new_item, depth + 1)

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -455,8 +455,9 @@ ALL_MAPS = dict.fromkeys(MAP.values())
 
 # If you add to this, remember to update the restricted_vanilla_items and restricted_non_vanilla_items
 # vars in randomize.py (see def initialize_items)
+# Doesn't include rupeesanity checks as they aren't required for anything.
 POTENTIALLY_RESTRICTED_ITEMS = (
-    ALL_SMALL_KEYS | ALL_BOSS_KEYS | ALL_MAPS | TRIFORCES | GONDO_ITEMS
+    ALL_SMALL_KEYS | ALL_BOSS_KEYS | ALL_MAPS | TRIFORCES | GONDO_ITEMS | TADTONE_GROUPS
 )
 
 INVENTORY_ITEMS = (

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -453,12 +453,12 @@ ALL_BOSS_KEYS = (
 )
 ALL_MAPS = dict.fromkeys(MAP.values())
 
+DUNGEON_ITEMS = ALL_SMALL_KEYS | ALL_BOSS_KEYS | ALL_MAPS
+
 # If you add to this, remember to update the restricted_vanilla_items and restricted_non_vanilla_items
 # vars in randomize.py (see def initialize_items)
 # Doesn't include rupeesanity checks as they aren't required for anything.
-POTENTIALLY_RESTRICTED_ITEMS = (
-    ALL_SMALL_KEYS | ALL_BOSS_KEYS | ALL_MAPS | TRIFORCES | GONDO_ITEMS | TADTONE_GROUPS
-)
+POTENTIALLY_RESTRICTED_ITEMS = DUNGEON_ITEMS | TRIFORCES | GONDO_ITEMS | TADTONE_GROUPS
 
 INVENTORY_ITEMS = (
     PROGRESS_ITEMS | NONPROGRESS_ITEMS | CONSUMABLE_ITEMS | POTENTIALLY_RESTRICTED_ITEMS
@@ -891,9 +891,7 @@ ALLOWED_STARTING_ITEMS = (
     | HEART_CONTAINERS
     | HEART_PIECES
     | KEY_PIECES
-    | ALL_SMALL_KEYS
-    | ALL_BOSS_KEYS
-    | ALL_MAPS
+    | DUNGEON_ITEMS
     | GRATITUDE_CRYSTAL_PACKS
     | EMPTY_BOTTLES
     | TADTONE_GROUPS

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -311,6 +311,24 @@ DUSK_RELICS = group(DUSK_RELIC, 1)
 TUMBLEWEEDS = group(TUMBLEWEED, 1)
 FIVE_BOMBS_GROUP = group(FIVE_BOMBS, 1)
 
+GONDO_ITEMS = {
+    number(PROGRESSIVE_BEETLE, 2): None,
+    number(PROGRESSIVE_BEETLE, 3): None,
+    number(PROGRESSIVE_SLINGSHOT, 1): None,
+    number(PROGRESSIVE_BOW, 1): None,
+    number(PROGRESSIVE_BOW, 2): None,
+    number(PROGRESSIVE_BUG_NET, 1): None,
+}
+
+BEEDLE_VANILLA_ITEMS = {
+    number(PROGRESSIVE_POUCH, 2): None,
+    number(PROGRESSIVE_POUCH, 3): None,
+    number(PROGRESSIVE_POUCH, 4): None,
+    number(LIFE_MEDAL, 1): None,
+    number(HEART_PIECE, 23): None,
+    number(PROGRESSIVE_BUG_NET, 0): None,
+    BUG_MEDAL: None,
+} | EXTRA_WALLETS
 
 RUPOOR = "Rupoor"
 
@@ -435,13 +453,14 @@ ALL_BOSS_KEYS = (
 )
 ALL_MAPS = dict.fromkeys(MAP.values())
 
+# If you add to this, remember to update the restricted_vanilla_items and restricted_non_vanilla_items
+# vars in randomize.py (see def initialize_items)
+POTENTIALLY_RESTRICTED_ITEMS = (
+    ALL_SMALL_KEYS | ALL_BOSS_KEYS | ALL_MAPS | TRIFORCES | GONDO_ITEMS
+)
+
 INVENTORY_ITEMS = (
-    PROGRESS_ITEMS
-    | NONPROGRESS_ITEMS
-    | CONSUMABLE_ITEMS
-    | ALL_SMALL_KEYS
-    | ALL_BOSS_KEYS
-    | ALL_MAPS
+    PROGRESS_ITEMS | NONPROGRESS_ITEMS | CONSUMABLE_ITEMS | POTENTIALLY_RESTRICTED_ITEMS
 )
 
 ALL_ITEM_NAMES = INVENTORY_ITEMS | DUPLICABLE_ITEMS | DUPLICABLE_COUNTERPROGRESS_ITEMS
@@ -734,15 +753,6 @@ QUICK_BEETLE_CHECKS = [
     "Pirate Stronghold - Rupee on West Sea Pillar",
     "Pirate Stronghold - Rupee on East Sea Pillar",
 ]
-
-GONDO_ITEMS = {
-    number(PROGRESSIVE_BEETLE, 2),
-    number(PROGRESSIVE_BEETLE, 3),
-    number(PROGRESSIVE_SLINGSHOT, 1),
-    number(PROGRESSIVE_BOW, 1),
-    number(PROGRESSIVE_BOW, 2),
-    number(PROGRESSIVE_BUG_NET, 1),
-}
 
 EXTRA_WALLET_SIZE = 300
 

--- a/logic/fill_algo_common.py
+++ b/logic/fill_algo_common.py
@@ -10,6 +10,8 @@ class RandomizationSettings:
     must_be_placed_items: Dict[EXTENDED_ITEM_NAME, None]
     may_be_placed_items: Dict[EXTENDED_ITEM_NAME, None]
     duplicable_items: Dict[str, None]
+    restricted_vanilla_items: list[EXTENDED_ITEM_NAME]
+    restricted_non_vanilla_items: list[EXTENDED_ITEM_NAME]
 
 
 @dataclass

--- a/logic/logic.py
+++ b/logic/logic.py
@@ -418,7 +418,13 @@ class Logic:
             placement_limit2, loc = placement_limit.rsplit("\\", 1)
             locations = self.areas[placement_limit2].locations
             assert loc in locations
-            if placement_limit in self.fixed_locations:
+
+            if (
+                placement_limit in self.fixed_locations
+                or not self.full_inventory[EXTENDED_ITEM[placement_limit]]
+                # means banning checks in dungeons should still work
+                or placement_limit in self.banned
+            ):
                 return []
             return [EIN(placement_limit)]
         else:
@@ -505,7 +511,9 @@ class Logic:
                 name = ""
             else:
                 name = "Item "
-            raise ValueError(f"{name}{item} is already placed.")
+            raise ValueError(
+                f"Cannot place {name}{item} at {location} as it is already placed at {items[item]}."
+            )
 
         if item in self.placement.item_placement_limit and not location.startswith(
             self.placement.item_placement_limit[item]

--- a/logic/placements.py
+++ b/logic/placements.py
@@ -24,11 +24,20 @@ SINGLE_CRYSTAL_CHECKS = [
 
 # Tries to force an item to its vanilla location.
 # Produces an error if this is not possible.
-def norm_force_vanilla(list: List[str]):
+def norm_force_vanilla(locations: List[str]):
     def norm_keys(norm: Callable[[str], EIN], checks: Dict[EIN, Any]) -> Placement:
-        list2 = map(norm, list)
-        dict = {k: EIN(checks[k]["original item"]) for k in list2}
-        return Placement(locations=dict, items={v: k for k, v in dict.items()})
+        mapped_locations = map(norm, locations)
+        forced_vanilla_locations = {
+            location: EIN(checks[location]["original item"])
+            for location in mapped_locations
+        }
+
+        return Placement(
+            locations=forced_vanilla_locations,
+            items={
+                item: location for location, item in forced_vanilla_locations.items()
+            },
+        )
 
     return norm_keys
 
@@ -37,8 +46,11 @@ def norm_force_vanilla(list: List[str]):
 # This is always possible.
 def norm_restrict_vanilla(locations: List[str]):
     def norm_keys(norm: Callable[[str], EIN], checks: Dict[EIN, Any]) -> Placement:
-        locs2 = map(norm, locations)
-        restriction = {EIN(checks[loc]["original item"]): loc for loc in locs2}
+        mapped_locations = map(norm, locations)
+        restriction = {
+            EIN(checks[location]["original item"]): location
+            for location in mapped_locations
+        }
         return Placement(item_placement_limit=restriction)
 
     return norm_keys

--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -312,11 +312,7 @@ class Rando:
             self.placement.add_unplaced_items(set(unplaced))
 
         must_be_placed_items = (
-            PROGRESS_ITEMS
-            | NONPROGRESS_ITEMS
-            | ALL_SMALL_KEYS
-            | ALL_BOSS_KEYS
-            | ALL_MAPS
+            PROGRESS_ITEMS | NONPROGRESS_ITEMS | POTENTIALLY_RESTRICTED_ITEMS
         )
         may_be_placed_items = CONSUMABLE_ITEMS.copy()
         duplicable_items = (
@@ -329,8 +325,37 @@ class Rando:
             must_be_placed_items.pop(item, None)
             may_be_placed_items.pop(item, None)
 
+        ANYWHERE = "Anywhere"
+        VANILLA = "Vanilla"
+
+        restricted_vanilla_items = [
+            item
+            for item in POTENTIALLY_RESTRICTED_ITEMS
+            if (item in ALL_SMALL_KEYS and self.options["small-key-mode"] == VANILLA)
+            or (item in ALL_BOSS_KEYS and self.options["boss-key-mode"] == VANILLA)
+            or (item in ALL_MAPS and self.options["map-mode"] == VANILLA)
+            or (item in TRIFORCES and self.options["triforce-shuffle"] == VANILLA)
+            or (item in BEEDLE_VANILLA_ITEMS and not self.options["shopsanity"])
+        ]
+
+        restricted_non_vanilla_items = [
+            item
+            for item in POTENTIALLY_RESTRICTED_ITEMS
+            if (item not in restricted_vanilla_items)
+            and (
+                (item in ALL_SMALL_KEYS and self.options["small-key-mode"] != ANYWHERE)
+                or (item in ALL_BOSS_KEYS and self.options["boss-key-mode"] != ANYWHERE)
+                or (item in ALL_MAPS and self.options["map-mode"] != ANYWHERE)
+                or (item in TRIFORCES and self.options["triforce-shuffle"] != ANYWHERE)
+            )
+        ]
+
         self.randosettings = RandomizationSettings(
-            must_be_placed_items, may_be_placed_items, duplicable_items
+            must_be_placed_items,
+            may_be_placed_items,
+            duplicable_items,
+            restricted_vanilla_items,
+            restricted_non_vanilla_items,
         )
 
     def set_placement_options(self):
@@ -422,7 +447,7 @@ class Rando:
             self.placement.add_unplaced_items(set(KEY_PIECES))
 
         if not place_gondo_progressives:
-            self.placement.add_unplaced_items(GONDO_ITEMS)
+            self.placement.add_unplaced_items(set(GONDO_ITEMS))
 
         if not shopsanity:
             self.placement |= VANILLA_BEEDLE_PLACEMENT(self.norm, self.areas.checks)

--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -322,6 +322,7 @@ class Rando:
             or (item in ALL_MAPS and self.options["map-mode"] == VANILLA)
             or (item in TRIFORCES and self.options["triforce-shuffle"] == VANILLA)
             or (item in BEEDLE_VANILLA_ITEMS and not self.options["shopsanity"])
+            or (item in TADTONE_GROUPS and not self.options["tadtonesanity"])
         ]
 
         restricted_non_vanilla_items = [

--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -311,20 +311,6 @@ class Rando:
                 raise ValueError(f"Option rupoor-mode has unknown value {rupoor_mode}.")
             self.placement.add_unplaced_items(set(unplaced))
 
-        must_be_placed_items = (
-            PROGRESS_ITEMS | NONPROGRESS_ITEMS | POTENTIALLY_RESTRICTED_ITEMS
-        )
-        may_be_placed_items = CONSUMABLE_ITEMS.copy()
-        duplicable_items = (
-            DUPLICABLE_ITEMS
-            if rupoor_mode == "Off"
-            else DUPLICABLE_COUNTERPROGRESS_ITEMS  # Rupoors
-        )
-
-        for item in self.placement.items:
-            must_be_placed_items.pop(item, None)
-            may_be_placed_items.pop(item, None)
-
         ANYWHERE = "Anywhere"
         VANILLA = "Vanilla"
 
@@ -349,6 +335,28 @@ class Rando:
                 or (item in TRIFORCES and self.options["triforce-shuffle"] != ANYWHERE)
             )
         ]
+
+        must_be_placed_items = (
+            PROGRESS_ITEMS | NONPROGRESS_ITEMS | POTENTIALLY_RESTRICTED_ITEMS
+        )
+
+        may_be_placed_items = CONSUMABLE_ITEMS.copy()
+        duplicable_items = (
+            DUPLICABLE_ITEMS
+            if rupoor_mode == "Off"
+            else DUPLICABLE_COUNTERPROGRESS_ITEMS  # Rupoors
+        )
+
+        # Account for starting items.
+        for item in self.placement.items:
+            if item in restricted_vanilla_items:
+                restricted_vanilla_items.remove(item)
+
+            if item in restricted_non_vanilla_items:
+                restricted_non_vanilla_items.remove(item)
+
+            must_be_placed_items.pop(item, None)
+            may_be_placed_items.pop(item, None)
 
         self.randosettings = RandomizationSettings(
             must_be_placed_items,


### PR DESCRIPTION
Prevents those `No more locations accessible for item` errors from occurring by placing items with placement restrictions before all other items.