### PR TITLE
Make locations in an already barren-hinted region unhintable

### DIFF
--- a/hints/distributions/2D Dowsing & Fi Hints.json
+++ b/hints/distributions/2D Dowsing & Fi Hints.json
@@ -34,10 +34,10 @@
   "dungeon_barren_limit": 1,
   "distribution": {
     "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
-    "sometimes": {"order":  1, "weight":  1.20, "fixed":  4, "copies":  1},
-    "goal": {"order":  2, "weight":  0.00, "fixed":  1, "copies":  1},
-    "sots": {"order":  3, "weight":  0.60, "fixed":  0, "copies":  1},
-    "barren": {"order": 4, "weight":  0.00, "fixed":  3, "copies":  1},
+    "barren": {"order": 1, "weight":  0.00, "fixed":  3, "copies":  1},
+    "sometimes": {"order":  2, "weight":  1.20, "fixed":  4, "copies":  1},
+    "goal": {"order":  3, "weight":  0.00, "fixed":  1, "copies":  1},
+    "sots": {"order":  4, "weight":  0.60, "fixed":  0, "copies":  1},
     "item": {"order":  5, "weight":  0.10, "fixed":  0, "copies":  1},
     "random": {"order":  6, "weight":  0.30, "fixed":  0, "copies":  1},
     "junk": {"order":  7, "weight":  0.00, "fixed":  0, "copies":  1}

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -495,6 +495,7 @@ class HintDistribution:
 
         area = self.rng.choices(barren_area_list, weights)[0]
         barren_area_list.remove(area)
+        self.hinted_locations.extend(self.logic.locations_by_hint_region(area))
         self.barren_hinted_areas.add(area)
         self.prev_barren_type = barren_type
 


### PR DESCRIPTION
This functionality was brought up a while ago but shot down for fear of removing useful dungeon sometimes hints for dungeon boss keys. In my opinion, that case (a dungeon being barren at all + an otherwise useless location hint that would have been placed) is so rare now that it's a non-issue (plus, if this behavior isn't desired, it can be prevented if all sometimes hints come before barren in the hint distribution. I believe it is preferable to prevent otherwise useless sometimes hints from being placed.

The 2D Dowsing & Fi Hints distribution has also been updated to place barren hints before sometimes -- this distro was especially vulnerable to useless sometimes hints given how relatively weak the hint pool is.