### PR TITLE
Add hint distro for bksanity races

### DIFF
--- a/hints/distributions/Boss Keysanity Fi Hints.json
+++ b/hints/distributions/Boss Keysanity Fi Hints.json
@@ -1,0 +1,50 @@
+{
+    "fi_hints": 14,
+    "hints_per_stone": 0,
+    "banned_stones": [],
+    "added_locations": [
+      {"location": "Upper Skyloft - Fledge's Crystals", "type": "always"},
+      {"location": "Faron Woods - Item behind Bombable Rock", "type": "sometimes"},
+      {"location": "Lanayru Sand Sea - Skipper's Retreat - Chest in Shack", "type": "always"},
+      {"location": "Skyview - Rupee on Spring Pillar", "type": "sometimes"},
+      {"location": "Earth Temple - Rupee in Lava Tunnel", "type": "sometimes"},
+      {"location": "Ancient Cistern - Bokoblin", "type": "sometimes"},
+      {"location": "Fire Sanctuary - Chest after Second Trapped Mogma", "type": "sometimes"},
+      {"location": "Fire Sanctuary - Chest after Bombable Wall", "type": "sometimes"},
+      {"location": "Lanayru Mining Facility - Boss Key Chest", "type": "sometimes"},
+      {"location": "Sandship - Robot in Brig's Reward", "type": "always"}
+    ],
+    "removed_locations": [
+      "Thunderhead - Isle of Songs - Din's Power",
+      "Faron Woods - Chest inside Great Tree",
+      "Lake Floria - Lake Floria Chest",
+      "Eldin Volcano - Digging Spot behind Boulder on Sandy Slope",
+      "Lanayru Desert - Chest on top of Lanayru Mining Facility",
+      "Lanayru Desert - Secret Passageway Chest",
+      "Lanayru Desert - Fire Node - Shortcut Chest",
+      "Skyview - Chest behind Three Eyes",
+      "Earth Temple - Chest in West Room",
+      "Ancient Cistern - Chest in East Part",
+      "Sandship - Boss Key Chest",
+      "Sandship - Heart Container",
+      "Lanayru Gorge - Thunder Dragon's Reward"
+    ],
+    "added_items": [
+      {"name": "Triforce of Courage", "amount": 1},
+      {"name": "Triforce of Wisdom", "amount": 1},
+      {"name": "Triforce of Power", "amount": 1}
+    ],
+    "removed_items": [],
+    "dungeon_sots_limit": 1,
+    "dungeon_barren_limit": 1,
+    "distribution": {
+      "always": {"order":  0, "weight":  0.00, "fixed":  0, "copies":  1},
+      "goal": {"order":  1, "weight":  0.00, "fixed":  1, "copies":  1},
+      "barren": {"order": 2, "weight":  0.00, "fixed":  3, "copies":  1},
+      "item": {"order":  3, "weight":  0.00, "fixed":  2, "copies":  1},
+      "sometimes": {"order":  4, "weight":  1.60, "fixed":  5, "copies":  1},
+      "sots": {"order":  5, "weight":  0.00, "fixed":  0, "copies":  1},
+      "random": {"order":  6, "weight":  0.15, "fixed":  0, "copies":  1},
+      "junk": {"order":  7, "weight":  0.00, "fixed":  0, "copies":  1}
+    }
+  }

--- a/options.yaml
+++ b/options.yaml
@@ -801,6 +801,7 @@
     - CDMC
     - Dowsing & Fi Hints
     - 2D Dowsing & Fi Hints
+    - Boss Keysanity Fi Hints
     - Custom
   default: Balanced
   help: "Determines the distribution of hints that appear on Gossip Stones.


### PR DESCRIPTION
This new hint distribution is modeled off the existing Fi hint / chest dowsing-centric distributions, with a few changes tailored to races with boss keysanity enabled, namely...

- The addition of 2 item hints (not really specific to BKsanity, but requested for the new distribution anyway)
- Sandship - Robot in Brig's Reward is an always hint (warranted with the possibility of a no-ping treasure room)
- The old LMF/FS always hints that were removed with dowsing are now sometimes hints - as sometimes a simple ping isn't quite enough information for when to gamble for those checks
- Sandship - Heart Container sometimes hint removed