### PR TITLE
Require scale for getting whip chest as a trick

### DIFF
--- a/logic/requirements/Ancient Cistern.yaml
+++ b/logic/requirements/Ancient Cistern.yaml
@@ -15,7 +15,7 @@ Main:
       Behind the Waterfall: Lever to Block Waterfall & Water Scale
       Inside Statue: Can Lower Statue | Ancient Cistern Small Key x 2
       Basement - Under the Statue: Ancient Cistern - Cistern Clip Trick
-      Inside Statue - Whip Chest Room: Ancient Cistern - Cistern Clip Trick & Ancient Cistern - Cistern Whip Room Clip Trick
+      Inside Statue - Whip Chest Room: Ancient Cistern - Cistern Clip Trick & Ancient Cistern - Cistern Whip Room Clip Trick & Water Scale
     locations:
       Lock Combination Knowledge: Nothing
       Lever to East Part: Nothing


### PR DESCRIPTION
Was talked about ages ago but never fixed. Adds scale as a requirement for getting the Whip chest with use of the various AC tricks