### PR TITLE
Add startflag for BtB to Faron Woods log

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -116,6 +116,7 @@ global:
       - 19 # Great Tree Intro Cutscene
       - 30 # Enter Skyview Cutscene
     Sealed Grounds:
+      - 4  # Pushed log from BtT to Faron Woods
       - 7  # vents active
       - 13 # door to temple unlocked
       - 21 # ballad of the goddess played (item and cutscene trigger instantly activate when outside of BiT)


### PR DESCRIPTION
Doesn't change logic, just a nice QoL change