### PR TITLE
Logic tweaks

### DIFF
--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -1373,7 +1373,7 @@ Lanayru Mine - Chest near First Timeshift Stone:
 Can Access Second Part of Lanayru Mine:
   Can Access Lanayru &
   Can Activate Mine First Timeshift Stone &
-  (Bomb Bag | Hook Beetle | Lanayru Mine Brakeslide Trick | (Unlocked Endurance Potion & Bottle))
+  (Bomb Bag | Hook Beetle | Brakeslide Trick | (Unlocked Endurance Potion & Bottle))
 
 Lanayru Mine - Chest behind Statue:
   Can Access Second Part of Lanayru Mine & (Bomb Bag | Hook Beetle)
@@ -1422,12 +1422,12 @@ Can Access Sand Oasis:
   (Can Access Lanayru Desert & (Hook Beetle | Clawshots)) |
   (
     Can Access Lanayru Desert &
-    Lanayru Desert - Brakeslide to Sand Oasis Trick &
+    Brakeslide Trick &
     (
       Long Range Skyward Strike |
       Bomb Bag |
       Bow |
-      (Lanayru Desert - Spume Brakeslide Trick & Sword)
+      (Brakeslide Trick & Sword)
     )
   ) |
   Can Access West Desert Statue
@@ -1437,7 +1437,7 @@ Can Access Sand Oasis:
 Can Access West Desert Statue:
   (
     Can Access Sand Oasis &
-    (Can Defeat Ampilus | Hook Beetle | Lanayru Desert - Sand Oasis Brakeslide Trick)
+    (Can Defeat Ampilus | Hook Beetle | Brakeslide Trick)
   ) |
   (Can Access Lanayru Desert & Clawshots) |
   Can Access Lanayru Caves
@@ -1456,7 +1456,7 @@ Lanayru Desert - Chest near Sand Oasis:
 Can Access Desert Gorge Statue:
   (
     Can Access West Desert Statue &
-    (Can Defeat Ampilus | Hook Beetle | Lanayru Desert - Sand Oasis Brakeslide Trick | Clawshots)
+    (Can Defeat Ampilus | Hook Beetle | Brakeslide Trick | Clawshots)
   ) |
   (Can Access Second Part of Lanayru Desert & Distance Activator) |
   Can Access Lanayru Caves
@@ -1605,7 +1605,7 @@ Can Access Fire Node in Past:
   Can Access Fire Node & Bomb Bag
 
 Can Access Second Part of Fire Node:
-  Can Access Fire Node & (Can Defeat Ampilus | Fire Node - Brakeslide Trick)
+  Can Access Fire Node & (Can Defeat Ampilus | Brakeslide Trick)
 
 Can Access End of Fire Node:
   Can Access Second Part of Fire Node & Bomb Bag & Hook Beetle

--- a/SS Rando Logic - Glitchless Requirements.yaml
+++ b/SS Rando Logic - Glitchless Requirements.yaml
@@ -816,7 +816,8 @@ Faron Woods - Item on Tree:
   Can Access Most of Faron Woods
 
 Faron Woods - Kikwi Elder's Reward:
-  Can Access Most of Faron Woods & Can Defeat Bokoblins
+  # Access to all Kikwis         &    Can Save Lopsa    &  Can Save Erla
+  Can Access Most of Faron Woods & Can Defeat Bokoblins & (Sword | Beetle)
 
 Faron Woods - Item behind Lower Bombable Rock:
   Can Access Most of Faron Woods & Bomb Bag

--- a/entrances.yaml
+++ b/entrances.yaml
@@ -3740,7 +3740,7 @@ Temple of Time - North Exit to Desert:
 Temple of Time - Exit to Lanayru Mining Facility:
   type: exit
   subtype: vanilla
-  # vanilla: Lanayru Mining Facility - Great Hall - Entrance from Temple of Time
+  # vanilla: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Temple of Time
   stage: F300_4
   room: 0
   index: 4
@@ -4441,7 +4441,7 @@ Lanayru Mining Facility - Boss Room - Entrance from Dungeon:
   can-start-at: false
   tod: 2
 
-Lanayru Mining Facility - Boss Room - Entrance from Great Hall:
+Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient Robots:
   type: entrance
   province: Lanayru Province
   can-start-at: false
@@ -4451,18 +4451,18 @@ Lanayru Mining Facility - Boss Room - Exit to Dungeon:
   type: exit
   vanilla: Lanayru Mining Facility - Boss Door Entrance
 
-Lanayru Mining Facility - Boss Room - Exit to Great Hall:
+Lanayru Mining Facility - Boss Room - Exit to Hall of Ancient Robots:
   type: exit
-  vanilla: Lanayru Mining Facility - Great Hall - Entrance from Boss Room
+  vanilla: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss Room
 
 
-Lanayru Mining Facility - Great Hall - Entrance from Boss Room:
+Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss Room:
   type: entrance
   province: Lanayru Province
   can-start-at: false
   tod: 2
 
-Lanayru Mining Facility - Great Hall - Entrance from Temple of Time:
+Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Temple of Time:
   type: entrance
   province: Lanayru Province
   can-start-at: false
@@ -4474,11 +4474,11 @@ Lanayru Mining Facility - Great Hall - Entrance from Temple of Time:
   tod: 2
 
 
-Lanayru Mining Facility - Great Hall - Exit to Boss Room:
+Lanayru Mining Facility - Hall of Ancient Robots - Exit to Boss Room:
   type: exit
-  vanilla: Lanayru Mining Facility - Boss Room - Entrance from Great Hall
+  vanilla: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient Robots
 
-Lanayru Mining Facility - Great Hall - Exit to Temple of Time:
+Lanayru Mining Facility - Hall of Ancient Robots - Exit to Temple of Time:
   type: exit
   subtype: vanilla
   vanilla: Temple of Time - Entrance from Lanayru Mining Facility

--- a/logic/requirements/Earth Temple.yaml
+++ b/logic/requirements/Earth Temple.yaml
@@ -50,9 +50,10 @@ Main:
 
   West Room:
     exits:
-      Hub Room: Rock to West Room
+      Hub Room: Rock to Hub Room
     locations:
       Chest in West Room: Nothing
+      Rock to Hub Room: Bomb Bag | Hook Beetle
 
   Room with Slopes:
     exits:

--- a/logic/requirements/Earth Temple.yaml
+++ b/logic/requirements/Earth Temple.yaml
@@ -27,7 +27,7 @@ Main:
       Chest behind Bombable Rock: Access to Boulder
       Chest Left of Main Room Bridge: Access to Boulder
       Ledd's Gift: Can Defeat Lizalfos
-      Rock to West Room: (Bomb Bag | Hook Beetle) & Access to Boulder
+      Rock to West Room: Bomb Bag | Hook Beetle
       Wall to Lava Section: Bomb Bag | (Hook Beetle & Access to Boulder)
       Rupee in Lava Tunnel: Wall to Lava Section & Beetle
       Lower Lava Section Portcullis: Wall to Lava Section & Beetle
@@ -50,7 +50,7 @@ Main:
 
   West Room:
     exits:
-      Hub Room: Bomb Bag | Hook Beetle
+      Hub Room: Rock to West Room
     locations:
       Chest in West Room: Nothing
 

--- a/logic/requirements/Earth Temple.yaml
+++ b/logic/requirements/Earth Temple.yaml
@@ -50,7 +50,7 @@ Main:
 
   West Room:
     exits:
-      Hub Room: Nothing
+      Hub Room: Bomb Bag | Hook Beetle
     locations:
       Chest in West Room: Nothing
 

--- a/logic/requirements/Eldin.yaml
+++ b/logic/requirements/Eldin.yaml
@@ -18,7 +18,7 @@ Volcano:
       Goddess Cube at Eldin Entrance: Goddess Sword
       Unlock Statue: Nothing
       Rupee on Ledge before First Room: Nothing
-      Ascent - Unlock Shortcut to Entry: Bomb Bag # I'm pretty sure Hook Beetle won't work here
+      Ascent - Unlock Shortcut to Entry: Bomb Bag # No bomb flowers are close enough for even tough beetle
 
   First Room: # Until the rocks
     exits:
@@ -40,7 +40,7 @@ Volcano:
       Past Mogma Turf: Past Mogma Turf - Unlock Shortcut to Pre Turf
       Exit to Bokoblin Base: Nothing
     locations:
-      First Room - Blow up Rock to East: Bomb Bag # can probably also use hook beetle
+      First Room - Blow up Rock to East: Bomb Bag # There's a beetle void plane
       Unlock Statue: Nothing
       Goddess Cube near Mogma Turf Entrance: Goddess Sword
       Chest after Crawlspace: Nothing
@@ -76,7 +76,7 @@ Volcano:
       Unlock Statue: Nothing
       Unlock Shortcut to Entry: Nothing
       Past Slide - Unlock Shortcut to Ascent: Bomb Bag | Hook Beetle # | (Whip & Whip Bomb Trick)
-      Defeat Slope Bokoblins: Bow | Slingshot | Beetle
+      Defeat Slope Bokoblins: Bow | Slingshot # Beetle can be used to scare the boko away but that's really not obvious
       Open Trial Gate: Goddess's Harp & Din's Power
 
   Near Thrill Digger Cave:

--- a/logic/requirements/Fire Sanctuary.yaml
+++ b/logic/requirements/Fire Sanctuary.yaml
@@ -58,7 +58,7 @@ Main:
 
     Past Lava:
       exits:
-        Room with Water Plant: Projectile Item
+        Room with Water Plant: Clawshots | Hook Beetle # Clawshot to vines or heetle to blow up the lavaflow rock
         First Trapped Mogma Room: Nothing
         Water Fruit Room: Unlock Key Door
       locations:
@@ -75,9 +75,10 @@ Main:
       exits:
         First Trapped Mogma Room: Magmanos Fight Room - Magmanos Fight
         Magmanos Fight Room - Upper Part: Magmanos Fight Room - Magmanos Fight
-        Magmanos Fight Room - Lower Part: Mogma Mitts
+        Magmanos Fight Room - Lower Part: Mogma Mitts & Blow up Rock in Tunnel
       locations:
         Rescue First Trapped Mogma: Nothing
+        Blow up Rock in Tunnel: Mogma Mitts
 
   Water Fruit Room:
     exits:
@@ -106,7 +107,7 @@ Main:
 
     Lower Part:
       exits:
-        First Trapped Mogma Room - Lower Area: Mogma Mitts
+        First Trapped Mogma Room - Lower Area: Mogma Mitts & First Trapped Mogma Room - Lower Area - Blow up Rock in Tunnel
         Past Sliding Door: Move Sliding Door
         Exit to West of Boss Door: Unlock Key Door
       locations:
@@ -148,7 +149,7 @@ Main:
       Hydrate Frog: Move Sliding Doors Correctly & Sword
       Rescue Mogma: Hydrate Frog
       Rescue Second Trapped Mogma: Rescue Mogma
-      Blow up Wall: Hydrate Frog & Bomb Bag # & Fire Sanctuary - Map
+      Blow up Wall: Bomb Bag # & Fire Sanctuary - Map
 
     Past Bombable Wall:
       exits:

--- a/logic/requirements/Fire Sanctuary.yaml
+++ b/logic/requirements/Fire Sanctuary.yaml
@@ -58,7 +58,7 @@ Main:
 
     Past Lava:
       exits:
-        Room with Water Plant: Clawshots | Blow up Rock # Clawshot to vines or heetle to blow up the lavaflow rock
+        Room with Water Plant: Clawshots | Blow up Rock # Clawshot to vines or Hook Beetle to blow up the lavaflow rock
         First Trapped Mogma Room: Nothing
         Water Fruit Room: Unlock Key Door
       locations:

--- a/logic/requirements/Fire Sanctuary.yaml
+++ b/logic/requirements/Fire Sanctuary.yaml
@@ -58,7 +58,7 @@ Main:
 
     Past Lava:
       exits:
-        Room with Water Plant: Clawshots | Hook Beetle # Clawshot to vines or heetle to blow up the lavaflow rock
+        Room with Water Plant: Clawshots | Blow up Rock # Clawshot to vines or heetle to blow up the lavaflow rock
         First Trapped Mogma Room: Nothing
         Water Fruit Room: Unlock Key Door
       locations:
@@ -149,7 +149,7 @@ Main:
       Hydrate Frog: Move Sliding Doors Correctly & Sword
       Rescue Mogma: Hydrate Frog
       Rescue Second Trapped Mogma: Rescue Mogma
-      Blow up Wall: Bomb Bag # & Fire Sanctuary - Map
+      Blow up Wall: Hydrate Frog & Bomb Bag # & Fire Sanctuary - Map
 
     Past Bombable Wall:
       exits:

--- a/logic/requirements/Lanayru Mining Facility.yaml
+++ b/logic/requirements/Lanayru Mining Facility.yaml
@@ -61,9 +61,10 @@ Main:
     exits:
       Exit to Big Hub: Defeat Armos
     locations:
-      Activate Timeshift Stone: Gust Bellows &
-                                (Slingshot | Bow | Goddess Sword |
-                                (LMF - Whip Armos Room Timeshift Stone Trick & Whip))
+      Activate Timeshift Stone:
+        Gust Bellows &
+        (Slingshot | Bow | Goddess Sword |
+        (LMF - Whip Armos Room Timeshift Stone Trick & Whip))
       Defeat Armos: Activate Timeshift Stone & Can Defeat Armos
       Chest after Armos Fight: Defeat Armos
 

--- a/logic/requirements/Lanayru Mining Facility.yaml
+++ b/logic/requirements/Lanayru Mining Facility.yaml
@@ -61,7 +61,9 @@ Main:
     exits:
       Exit to Big Hub: Defeat Armos
     locations:
-      Activate Timeshift Stone: Distance Activator | Goddess Sword
+      Activate Timeshift Stone: Gust Bellows &
+                                (Slingshot | Bow | Goddess Sword |
+                                (LMF - Whip Armos Room Timeshift Stone Trick & Whip))
       Defeat Armos: Activate Timeshift Stone & Can Defeat Armos
       Chest after Armos Fight: Defeat Armos
 
@@ -155,14 +157,14 @@ Boss Room:
 
   After Sand Drain:
     exits:
-      Exit to Great Hall: Beat Moldarach
+      Exit to Hall of Ancient Robots: Beat Moldarach
     locations:
       Beat Moldarach:
         (Gust Bellows | LMF - Moldarach without Gust Bellows Trick) & Sword
         # Bow also works instead of sword but you need a LOT of arrows
       Heart Container: Beat Moldarach
 
-Great Hall:
+Hall of Ancient Robots:
   Entry:
     exits:
       Exit to Boss Room: Nothing

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -101,7 +101,7 @@ Desert:
       # Blow down statue or stamina potion or defeat spume and brakeslide through
       Get Past Spume to Sand Oasis: Blow Statues to Sand Oasis Down |
                                     Central Skyloft - Bazaar - Endurance Potion |
-                                    (Lanayru Desert - Sand Oasis Brakeslide Trick & (Bomb Bag | Bow | Long Range Skyward Strike))
+                                    (Lanayru Desert - Sand Oasis Brakeslide Trick & Stuttersprint Trick & (Bomb Bag | Bow | Long Range Skyward Strike))
 
   Sand Oasis: # Before
     exits:

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -2,7 +2,7 @@ allowed-time-of-day: DayOnly
 macros:
   All Three Nodes: LMF Nodes On option | (North Part - Water Node & Lightning Node - Lightning Node & East - Fire Node - Fire Node)
   Raise Lanayru Mining Facility: Open LMF option | Desert - North Part - Activate Main Node
-  Can Navigate in Oasis: Can Defeat Ampilus | Hook Beetle | Lanayru Desert - Sand Oasis Brakeslide Trick | Central Skyloft - Bazaar - Endurance Potion
+  Can Navigate in Oasis: Can Defeat Ampilus | Hook Beetle | Central Skyloft - Bazaar - Endurance Potion | Lanayru Desert - Sand Oasis Brakeslide Trick | Stuttersprint Trick
 
 Mine:
   toplevel-alias: Lanayru Mine

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -462,7 +462,7 @@ Lanayru Sand Sea:
       Rupee on East Sea Pillar: Quick Beetle
       Rupee on Bird Statue Pillar or Nose: Beetle
 
-    # "'Finish_Pirate_Stronghold'" means the Shark Head is raised
+    # Inside - Finish Minidungeon means the Shark Head is raised
     Inside the Shark Head:
       exits:
         # Clawshot up and run along the Shark Head or just run out if it's been raised

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -470,9 +470,9 @@ Lanayru Sand Sea:
         Top Exit: Nothing # Door closes behind you if not yet beaten
       locations:
         # You *just* can't make it. If the Shark Head is lowered, it's easy but we can't check for it being lowered
-        Rupee on West Sea Pillar: Quick Beetle
-        Rupee on East Sea Pillar: Quick Beetle
-        Rupee on Bird Statue Pillar or Nose: Beetle # Still possible
+        Pirate Stronghold - Rupee on West Sea Pillar: Quick Beetle
+        Pirate Stronghold - Rupee on East Sea Pillar: Quick Beetle
+        Pirate Stronghold - Rupee on Bird Statue Pillar or Nose: Beetle # Still possible
         Goddess Cube in Pirate Stronghold: Clawshots & Goddess Sword
 
     Inside:

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -2,7 +2,7 @@ allowed-time-of-day: DayOnly
 macros:
   All Three Nodes: LMF Nodes On option | (North Part - Water Node & Lightning Node - Lightning Node & East - Fire Node - Fire Node)
   Raise Lanayru Mining Facility: Open LMF option | Desert - North Part - Activate Main Node
-  Can Navigate in Oasis: Can Defeat Ampilus | Hook Beetle | Central Skyloft - Bazaar - Endurance Potion | Lanayru Desert - Sand Oasis Brakeslide Trick | Stuttersprint Trick
+  Can Navigate in Oasis: Can Defeat Ampilus | Hook Beetle | Central Skyloft - Bazaar - Endurance Potion | Brakeslide Trick | Stuttersprint Trick
 
 Mine:
   toplevel-alias: Lanayru Mine
@@ -37,14 +37,14 @@ Mine:
   Statues Area:
     exits:
       Entry: Nothing
-      End: Blow Statues Down | Lanayru Mine Brakeslide Trick | Central Skyloft - Bazaar - Endurance Potion
+      End: Blow Statues Down | Brakeslide Trick | Central Skyloft - Bazaar - Endurance Potion
     locations:
       Blow Statues Down: Bomb Bag | Hook Beetle
       Chest behind Statue: Blow Statues Down
 
   End:
     exits:
-      Statues Area: Statues Area - Blow Statues Down | Lanayru Mine Brakeslide Trick | Central Skyloft - Bazaar - Endurance Potion
+      Statues Area: Statues Area - Blow Statues Down | Brakeslide Trick | Central Skyloft - Bazaar - Endurance Potion
     locations:
       Blow up Rock on Track: Nothing
       Chest at the End of Mine: Nothing # There's a baba in the way
@@ -101,7 +101,7 @@ Desert:
       # Blow down statue or stamina potion or defeat spume and brakeslide through
       Get Past Spume to Sand Oasis: Blow Statues to Sand Oasis Down |
                                     Central Skyloft - Bazaar - Endurance Potion |
-                                    (Lanayru Desert - Sand Oasis Brakeslide Trick & Stuttersprint Trick & (Bomb Bag | Bow | Long Range Skyward Strike))
+                                    (Brakeslide Trick & Stuttersprint Trick & (Bomb Bag | Bow | Long Range Skyward Strike))
 
   Sand Oasis: # Before
     exits:
@@ -229,7 +229,7 @@ Desert:
           Exit: Nothing
           Past: Timeshift Stone
           Present after Sand:
-            Can Defeat Ampilus | Fire Node - Brakeslide Trick | Present after Sand - Push Box
+            Can Defeat Ampilus | Brakeslide Trick | Present after Sand - Push Box
         locations:
           Blow up Rock for Timeshift Stone: Bomb Bag
           Timeshift Stone: Blow up Rock for Timeshift Stone & Can Hit Timeshift Stone

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -90,15 +90,19 @@ Desert:
       Top of West Wall: Clawshots
       Top of LMF: Raise Lanayru Mining Facility
       East: Temple of Time Skip - Brakeslide Trick | East - Open Wall Shortcut | Clawshots | Central Skyloft - Bazaar - Endurance Potion
-      Sand Oasis: Blow Statues to Sand Oasis Down | (Defeat Spume to Sand Oasis & Lanayru Desert - Sand Oasis Brakeslide Trick) | Central Skyloft - Bazaar - Endurance Potion
+      Sand Oasis: Get Past Spume to Sand Oasis
     locations:
       Chest near Caged Robot: Nothing
       Goddess Cube near Caged Robot: Long Range Skyward Strike # Also accessible elsewhere
       Blow up Rock for Timeshift Stone: Bomb Bag | Hook Beetle
-      Timeshift Stone: Blow up Rock for Timeshift Stone & Nothing # Use the nearby bombflower ?
-      Rescue Caged Robot: Timeshift Stone & Can Defeat Bokoblins
+      Rescue Caged Robot: Blow up Rock for Timeshift Stone & Can Defeat Bokoblins
       Defeat Spume to Sand Oasis: Long Range Skyward Strike | Bomb Bag | Bow | Hook Beetle | (Goddess Sword & Lanayru Desert - Spume Brakeslide Trick)
       Blow Statues to Sand Oasis Down: Hook Beetle
+
+      # Blow down statue or stamina potion or defeat spume and brakeslide through
+      Get Past Spume to Sand Oasis: Blow Statues to Sand Oasis Down |
+                                    Central Skyloft - Bazaar - Endurance Potion |
+                                    (Lanayru Desert - Sand Oasis Brakeslide Trick & (Bomb Bag | Bow | Long Range Skyward Strike))
 
   Sand Oasis: # Before
     exits:

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -94,7 +94,7 @@ Desert:
     locations:
       Chest near Caged Robot: Nothing
       Goddess Cube near Caged Robot: Long Range Skyward Strike # Also accessible elsewhere
-      Blow up Rock for Timeshift Stone: Bomb Bag | Hook Beetle
+      Blow up Rock for Timeshift Stone: Bomb Bag | Hook Beetle | Lanayru Desert - Ampilus Bomb Toss Trick
       Rescue Caged Robot: Blow up Rock for Timeshift Stone & Can Defeat Bokoblins
       Blow Statues to Sand Oasis Down: Hook Beetle
 

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -96,7 +96,6 @@ Desert:
       Goddess Cube near Caged Robot: Long Range Skyward Strike # Also accessible elsewhere
       Blow up Rock for Timeshift Stone: Bomb Bag | Hook Beetle
       Rescue Caged Robot: Blow up Rock for Timeshift Stone & Can Defeat Bokoblins
-      Defeat Spume to Sand Oasis: Long Range Skyward Strike | Bomb Bag | Bow | Hook Beetle | (Goddess Sword & Lanayru Desert - Spume Brakeslide Trick)
       Blow Statues to Sand Oasis Down: Hook Beetle
 
       # Blow down statue or stamina potion or defeat spume and brakeslide through
@@ -106,15 +105,10 @@ Desert:
 
   Sand Oasis: # Before
     exits:
-      Near Caged Robot:
-        Near Caged Robot - Blow Statues to Sand Oasis Down |
-        (Near Caged Robot - Defeat Spume to Sand Oasis & Lanayru Desert - Sand Oasis Brakeslide Trick) |
-        Central Skyloft - Bazaar - Endurance Potion
+      Near Caged Robot: Nothing # You can just run up the wall
       Top of West Wall: Clawshots | Top of West Wall - Push Minecart
       West Part: Can Navigate in Oasis | West Part - Push Minecart
     locations:
-      Near Caged Robot - Defeat Spume to Sand Oasis: Bomb Bag | Bow | Hook Beetle | Goddess Sword
-      Near Caged Robot - Blow Statues to Sand Oasis Down: Hook Beetle
       Goddess Cube in Sand Oasis: Can Navigate in Oasis & Goddess Sword
 
   West Part:
@@ -384,7 +378,7 @@ Lanayru Sand Sea:
     locations:
       Goddess Cube in Ancient Harbour: Clawshots & Goddess Sword
       Unlock Statue: Nothing
-      Ship Timeshift Stone: Distance Activator | Goddess Sword | Bomb Bag
+      Ship Timeshift Stone: Distance Activator | Sword | Bomb Bag
 
     Near Exit to Caves:
       entrance: Clawshots
@@ -408,12 +402,12 @@ Lanayru Sand Sea:
     Past Rock:
       exits:
         Skipper's Retreat: Nothing
-        Top Part: Clawshots & Whip Peahat & Deal with Boko Baba
+        Top Part: Clawshots & Whip Peahat & Deal with Deku Baba
       locations:
         Chest after Moblin: Nothing
         Goddess Cube in Skipper's Retreat: Clawshots & Goddess Sword
         Whip Peahat: Clawshots & Whip
-        Deal with Boko Baba: Slingshot | Beetle | Bow | Skipper's Retreat Fast Clawshots Trick
+        Deal with Deku Baba: Projectile Item | (Skipper's Retreat Fast Clawshots Trick & Clawshots)
 
     Top Part:
       exits:
@@ -431,7 +425,7 @@ Lanayru Sand Sea:
 
     Skydive Platform:
       exits:
-        Skipper's Retreat: Nothing
+        Skipper's Retreat: Clawshots # Should add bomb flower
       locations:
         Skydive Chest: Nothing
 
@@ -460,25 +454,37 @@ Lanayru Sand Sea:
       Statue: Unlock Statue
       Dock: Nothing
       Side Exit: Nothing
-      Top Exit: Inside - Finish Minidungeon # What happens if you take it before finishing the minidungeon ?
+      Inside the Shark Head: Inside - Finish Minidungeon
     locations:
       Unlock Statue: Nothing
       Rupee on West Sea Pillar: Quick Beetle
       Rupee on East Sea Pillar: Quick Beetle
       Rupee on Bird Statue Pillar or Nose: Beetle
-      Goddess Cube in Pirate Stronghold: Inside - Finish Minidungeon & Clawshots & Goddess Sword
+
+    # "'Finish_Pirate_Stronghold'" means the Shark Head is raised
+    Inside the Shark Head:
+      exits:
+        # Clawshot up and run along the Shark Head or just run out if it's been raised
+        Pirate Stronghold: Clawshots | Inside - Finish Minidungeon
+        Top Exit: Nothing # Door closes behind you if not yet beaten
+      locations:
+        # You *just* can't make it. If the Shark Head is lowered, it's easy but we can't check for it being lowered
+        Rupee on West Sea Pillar: Quick Beetle
+        Rupee on East Sea Pillar: Quick Beetle
+        Rupee on Bird Statue Pillar or Nose: Beetle # Still possible
+        Goddess Cube in Pirate Stronghold: Clawshots & Goddess Sword
 
     Inside:
       exits:
         First Door: Nothing
         Second Door: Finish Minidungeon
       locations:
-        First Chest: Nothing
         # You can run past the Beamos without killing it. You can also run past the boko baba (in logic?) #UNSURE
+        First Chest: Nothing
         Second Chest: Nothing
         Third Chest: Nothing
-        Finish Minidungeon: Can Defeat Beamos & Can Defeat Armos & Goddess Sword
         # Technically this is possible without beating a Beamos but it's hard
+        Finish Minidungeon: Can Defeat Beamos & Can Defeat Armos
         General - Ancient Flower Farming: Nothing
 
   Gorge:

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -99,9 +99,10 @@ Desert:
       Blow Statues to Sand Oasis Down: Hook Beetle
 
       # Blow down statue or stamina potion or defeat spume and brakeslide through
-      Get Past Spume to Sand Oasis: Blow Statues to Sand Oasis Down |
-                                    Central Skyloft - Bazaar - Endurance Potion |
-                                    (Brakeslide Trick & Stuttersprint Trick & (Bomb Bag | Bow | Long Range Skyward Strike))
+      Get Past Spume to Sand Oasis:
+        Blow Statues to Sand Oasis Down |
+        Central Skyloft - Bazaar - Endurance Potion |
+        (Brakeslide Trick & Stuttersprint Trick & (Bomb Bag | Bow | Long Range Skyward Strike))
 
   Sand Oasis: # Before
     exits:

--- a/logic/requirements/Skyview.yaml
+++ b/logic/requirements/Skyview.yaml
@@ -87,7 +87,7 @@ Main:
 
   Second Hub:
     exits:
-      First Hub: Skyview Small Key
+      First Hub: Skyview Small Key x2 # If you somehow make it into this room first, assume worst key usage
       Miniboss Room: Switch to Miniboss Room
       Left Rooms: Switch to Left Room
       Staldra Room: Skyview Small Key x 2
@@ -148,7 +148,7 @@ Main:
       locations:
         Chest near Boss Door: Nothing
         Hit Vines: Long Range Skyward Strike | Distance Activator
-        Before Rope - Deal with Archers: Can Defeat Bokoblins
+        Before Rope - Deal with Archers: Can Defeat Bokoblins | Hook Beetle
 
     Near Boss Key Chest:
       exits:

--- a/options.yaml
+++ b/options.yaml
@@ -440,6 +440,7 @@
     ## Lanayru Mining Facility
     - LMF - Whip First Room Switch
     - LMF - Keylocked Slingshot Trickshot
+    - LMF - Whip Armos Room Timeshift Stone
     - LMF - Minecart Jump
     - LMF - Moldarach without Gust Bellows
     ## Ancient Cistern

--- a/options.yaml
+++ b/options.yaml
@@ -420,14 +420,12 @@
     ## Lanayru
     - Itemless First Timeshift Stone
     - Lanayru Mine - Quick Bomb
-    - Lanayru Mine Brakeslide
+    - Brakeslide
     - Lanayru Desert - Ampilus Bomb Toss
-    - Lanayru Desert - Sand Oasis Brakeslide
     - Temple of Time - Slingshot Shot
     - Temple of Time Skip - Brakeslide
     - Secret Passageway Hook Beetle Opening
     - Lightning Node End with Bombs  # Is it worth
-    - Fire Node - Brakeslide
     - Cactus Bomb Whip
     - Skipper's Retreat Fast Clawshots
     ## Skyview

--- a/options.yaml
+++ b/options.yaml
@@ -421,7 +421,6 @@
     - Itemless First Timeshift Stone
     - Lanayru Mine - Quick Bomb
     - Lanayru Mine Brakeslide
-    - Lanayru Desert - Spume Brakeslide
     - Lanayru Desert - Sand Oasis Brakeslide
     - Temple of Time - Slingshot Shot
     - Temple of Time Skip - Brakeslide

--- a/options.yaml
+++ b/options.yaml
@@ -421,6 +421,7 @@
     - Itemless First Timeshift Stone
     - Lanayru Mine - Quick Bomb
     - Lanayru Mine Brakeslide
+    - Lanayru Desert - Ampilus Bomb Toss
     - Lanayru Desert - Sand Oasis Brakeslide
     - Temple of Time - Slingshot Shot
     - Temple of Time Skip - Brakeslide


### PR DESCRIPTION
Updates the logic discussed in the discord server over the last few days.

I also verified what happens with the Pirate Stronghold entrances if you take them without first beating the minidungeon. If you arrive at the ending entrance inside Pirate Stronghold, the door will have bars put up behind you. If you arrive at the ending entrance to the Pirate Stronghold Docks, you are within the Shark Head but you can freely exit through the door you came through.

As a result, I've added a sub-area for Pirate Stronghold and verified what you can do from there