### PR TITLE
Add Option to De-Obfuscate Location Hints

### DIFF
--- a/gui/dialogs/custom_theme/ui_custom_theme_dialog.py
+++ b/gui/dialogs/custom_theme/ui_custom_theme_dialog.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'custom_theme_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.1
+## Created by: Qt User Interface Compiler version 6.6.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/gui/dialogs/tricks/ui_tricks_dialog.py
+++ b/gui/dialogs/tricks/ui_tricks_dialog.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'tricks_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.1
+## Created by: Qt User Interface Compiler version 6.6.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -60,7 +60,7 @@
        <number>-6</number>
       </property>
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <property name="usesScrollButtons">
        <bool>true</bool>
@@ -237,6 +237,13 @@
             <layout class="QVBoxLayout" name="verticalLayout_24">
              <item>
               <layout class="QVBoxLayout" name="vlay_cosmetics">
+               <item>
+                <widget class="QCheckBox" name="option_clear_location_hints">
+                 <property name="text">
+                  <string>Clear Location Hints</string>
+                 </property>
+                </widget>
+               </item>
                <item>
                 <widget class="QCheckBox" name="option_lightning_skyward_strike">
                  <property name="text">

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'randogui.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.5.2
+## Created by: Qt User Interface Compiler version 6.6.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -179,6 +179,11 @@ class Ui_MainWindow(object):
         self.verticalLayout_24.setObjectName(u"verticalLayout_24")
         self.vlay_cosmetics = QVBoxLayout()
         self.vlay_cosmetics.setObjectName(u"vlay_cosmetics")
+        self.option_clear_location_hints = QCheckBox(self.box_cosmetics)
+        self.option_clear_location_hints.setObjectName(u"option_clear_location_hints")
+
+        self.vlay_cosmetics.addWidget(self.option_clear_location_hints)
+
         self.option_lightning_skyward_strike = QCheckBox(self.box_cosmetics)
         self.option_lightning_skyward_strike.setObjectName(u"option_lightning_skyward_strike")
 
@@ -2002,7 +2007,7 @@ class Ui_MainWindow(object):
 
         self.retranslateUi(MainWindow)
 
-        self.tabWidget.setCurrentIndex(1)
+        self.tabWidget.setCurrentIndex(0)
         self.option_triforce_shuffle.setCurrentIndex(-1)
         self.option_randomize_entrances.setCurrentIndex(-1)
         self.option_chest_dowsing.setCurrentIndex(-1)
@@ -2028,6 +2033,7 @@ class Ui_MainWindow(object):
         self.box_advanced.setTitle(QCoreApplication.translate("MainWindow", u"Advanced Options", None))
         self.option_dry_run.setText(QCoreApplication.translate("MainWindow", u"Dry Run", None))
         self.box_cosmetics.setTitle(QCoreApplication.translate("MainWindow", u"Cosmetics", None))
+        self.option_clear_location_hints.setText(QCoreApplication.translate("MainWindow", u"Clear Location Hints", None))
         self.option_lightning_skyward_strike.setText(QCoreApplication.translate("MainWindow", u"Lightning Skyward Strike", None))
         self.option_starry_skies.setText(QCoreApplication.translate("MainWindow", u"Starry Skies", None))
         self.label_for_option_star_count.setText(QCoreApplication.translate("MainWindow", u"Number of stars", None))

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -306,7 +306,10 @@ class HintDistribution:
 
         loc = self.always_hints.pop()
         item = self.logic.placement.locations[loc]
-        text = self.areas.checks[loc].get("text")
+        if self.options["clear-location-hints"]:
+            text = None
+        else:
+            text = self.areas.checks[loc].get("text")
 
         if loc in self.hinted_locations:
             return self._create_always_hint()
@@ -330,7 +333,10 @@ class HintDistribution:
 
         loc = self.sometimes_hints.pop()
         item = self.logic.placement.locations[loc]
-        text = self.areas.checks[loc].get("text")
+        if self.options["clear-location-hints"]:
+            text = None
+        else:
+            text = self.areas.checks[loc].get("text")
 
         if loc in self.hinted_locations:
             return self._create_sometimes_hint()
@@ -344,7 +350,10 @@ class HintDistribution:
 
         item = self.required_boss_keys.pop()
         loc = self.logic.placement.items[item]
-        text = self.areas.checks[loc].get("text")
+        if self.options["clear-location-hints"]:
+            text = None
+        else:
+            text = self.areas.checks[loc].get("text")
 
         if loc in self.hinted_locations:
             return self._create_bk_hint()
@@ -385,7 +394,10 @@ class HintDistribution:
 
         loc = self.rng.choice(all_locations_without_hint)
         item = self.logic.placement.locations[loc]
-        text = self.areas.checks[loc].get("text")
+        if self.options["clear-location-hints"]:
+            text = None
+        else:
+            text = self.areas.checks[loc].get("text")
         self.hinted_locations.append(loc)
 
         return LocationHint("random", loc, item, text)

--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -186,13 +186,11 @@ class Areas:
                 f"Could not find '{partial_address_str}' from '{base_address_str}'."
             )
 
-    def prettify(self, s, *, custom=False):
+    def prettify(self, s):
         if s in ALL_ITEM_NAMES:
             return strip_item_number(s)
         if s in self.checks:
             check = self.checks[s]
-            if custom and (override := check.get("text")) is not None:
-                return override
             return check["short_name"]
         if s in self.gossip_stones:
             return self.gossip_stones[s]["short_name"]

--- a/options.yaml
+++ b/options.yaml
@@ -1098,3 +1098,12 @@
   bits: 4
   help: How many treasures per Silent Realm you want to randomize.
   ui: option_trial_treasure_amount
+- name: Clear Location Hints
+  command: clear-location-hints
+  type: boolean
+  default: false
+  permalink: false
+  cosmetic: true
+  help: If enabled, location hints (always, sometimes, & random hints) that normally have flavor text
+        will just appear as their location name, like other locations.
+  ui: option_clear_location_hints

--- a/ssrando.py
+++ b/ssrando.py
@@ -240,7 +240,7 @@ class Randomizer(BaseRandomizer):
         plcmt_file.start_entrance = self.logic.randomized_start_entrance
         plcmt_file.hash_str = self.randomizer_hash
         plcmt_file.hints = {
-            k: v.to_ingame_text(lambda s: self.areas.prettify(s, custom=True))
+            k: v.to_ingame_text(lambda s: self.areas.prettify(s))
             for (k, v) in self.logic.placement.hints.items()
         }
         plcmt_file.item_locations = self.logic.placement.locations


### PR DESCRIPTION
Adds a cosmetic option to remove the flavor text for location hints.

For example, this turns "a chest atop a sandy retreat" into "Lanayru Sand Sea - Skipper's Retreat - Chest in Shack"