### PR TITLE
Fix some Eldin logic

### DIFF
--- a/logic/requirements/Eldin.yaml
+++ b/logic/requirements/Eldin.yaml
@@ -23,6 +23,8 @@ Volcano:
   First Room: # Until the rocks
     exits:
       East: Blow up Rock to East
+      Entry: Nothing
+      Exit to Bokoblin Base: Nothing
     locations:
       Chest behind Bombable Wall in First Room: Nothing
       Rupee behind Bombable Wall in First Room: Nothing
@@ -38,7 +40,6 @@ Volcano:
       First Vent from Mogma Turf: Impossible
       First Room: First Room - Blow up Rock to East
       Past Mogma Turf: Past Mogma Turf - Unlock Shortcut to Pre Turf
-      Exit to Bokoblin Base: Nothing
     locations:
       First Room - Blow up Rock to East: Bomb Bag # There's a beetle void plane
       Unlock Statue: Nothing


### PR DESCRIPTION
I started a "Random Starting Entrance" run that spawned me at the Eldin East statue, and my [WIP new logic tracker](https://robojumper.github.io/SS-Randomizer-Tracker/) said that Plat's Gift in Boko Base was in logic. This is because logic thought the entrance was on this side of the rock when it actually was on the other side.

There also appears to be a missing path from First Room to Entry that I added.