### PR TITLE
Fix some duplicated locations

### DIFF
--- a/logic/requirements/Eldin.yaml
+++ b/logic/requirements/Eldin.yaml
@@ -59,9 +59,7 @@ Volcano:
     locations:
       Unlock Shortcut to Pre Turf: Nothing
       Watch Bridge Cutscene: Nothing
-      East - Southeast Rupee above Mogma Turf Entrance: Beetle
-      East - North Rupee above Mogma Turf Entrance: Beetle
-      East - Goddess Cube near Mogma Turf Entrance: Goddess Sword
+      # can get cube and mogma turf entrance rupees from here, but getting to East from here requires nothing
 
   Ascent:
     exits:
@@ -326,7 +324,7 @@ Bokoblin Base:
       First Chest in Volcano Summit: Fireshield Earrings
       Raised Chest in Volcano Summit: Fireshield Earrings
       Chest in Volcano Summit Alcove: Fireshield Earrings & Practice Sword
-      Volcano Summit - Goddess Cube inside Volcano Summit: Fireshield Earrings
+      Volcano Summit - Goddess Cube inside Volcano Summit: Fireshield Earrings & Goddess Sword
   
   Fire Dragon's Lair:
     exits:

--- a/logic/requirements/Eldin.yaml
+++ b/logic/requirements/Eldin.yaml
@@ -59,9 +59,9 @@ Volcano:
     locations:
       Unlock Shortcut to Pre Turf: Nothing
       Watch Bridge Cutscene: Nothing
-      Southeast Rupee above Mogma Turf Entrance: Beetle
-      North Rupee above Mogma Turf Entrance: Beetle
-      Goddess Cube near Mogma Turf Entrance: Goddess Sword
+      East - Southeast Rupee above Mogma Turf Entrance: Beetle
+      East - North Rupee above Mogma Turf Entrance: Beetle
+      East - Goddess Cube near Mogma Turf Entrance: Goddess Sword
 
   Ascent:
     exits:
@@ -273,7 +273,7 @@ Bokoblin Base:
     locations:
       Chest near Bone Bridge: Can bypass Boko Base Watch Tower | Mogma Mitts | Gust Bellows
       Chest on Cliff: (Can bypass Boko Base Watch Tower | Mogma Mitts) & Gust Bellows
-      Goddess Cube near Mogma Turf Entrance: Goddess Sword
+      Volcano - Goddess Cube near Mogma Turf Entrance: Goddess Sword
   
   Before Drawbridge:
     exits:
@@ -295,7 +295,7 @@ Bokoblin Base:
       Before Drawbridge: Nothing
       Volcano East: Nothing
     locations:
-      Gossip Stone in Lower Platform Cave: Nothing
+      Volcano - Gossip Stone in Lower Platform Cave: Nothing
   
   Outside Earth Temple:
     exits:
@@ -303,15 +303,15 @@ Bokoblin Base:
       Bokoblin Base - Upper Platform Cave: Nothing
     locations:
       Chest East of Earth Temple Entrance: Nothing
-      Goddess Cube East of Earth Temple Entrance: Goddess Sword
+      Volcano - Goddess Cube East of Earth Temple Entrance: Goddess Sword
       Chest West of Earth Temple Entrance: (Slingshot | Bow | Bomb Bag | Goddess Sword) & Can bypass Boko Base Watch Tower & Mogma Mitts
-      Goddess Cube West of Earth Temple Entrance: Goddess Sword & Can bypass Boko Base Watch Tower & Mogma Mitts
+      Volcano - Goddess Cube West of Earth Temple Entrance: Goddess Sword & Can bypass Boko Base Watch Tower & Mogma Mitts
   
   Upper Platform Cave:
     exits:
       Outside Earth Temple: Nothing
     locations:
-      Gossip Stone in Upper Platform Cave: Nothing
+      Volcano - Gossip Stone in Upper Platform Cave: Nothing
   
   Hot Cave:
     exits:
@@ -326,7 +326,7 @@ Bokoblin Base:
       First Chest in Volcano Summit: Fireshield Earrings
       Raised Chest in Volcano Summit: Fireshield Earrings
       Chest in Volcano Summit Alcove: Fireshield Earrings & Practice Sword
-      Goddess Cube inside Volcano Summit: Fireshield Earrings
+      Volcano Summit - Goddess Cube inside Volcano Summit: Fireshield Earrings
   
   Fire Dragon's Lair:
     exits:

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -56,7 +56,7 @@ Mine:
       exits:
         Exit to Desert: Nothing
       locations:
-        Blow up Rock on Track: Bomb Bag & Lanayru Mine - Quick Bomb Trick
+        End - Blow up Rock on Track: Bomb Bag & Lanayru Mine - Quick Bomb Trick
 
 Desert:
   toplevel-alias: Lanayru Desert

--- a/logic/requirements/Skyloft.yaml
+++ b/logic/requirements/Skyloft.yaml
@@ -152,8 +152,8 @@ Central Skyloft:
       Exit: Nothing
     locations:
       Crystal in Orielle and Parrow's House: Nothing
-      Parrow's Gift: Sky - Talk to Orielle & Night
-      Parrow's Crystals: Sky - Save Orielle & Night
+      Central Skyloft - Parrow's Gift: Sky - Talk to Orielle & Night
+      Central Skyloft - Parrow's Crystals: Sky - Save Orielle & Night
 
   Peatrice's House:
     can-sleep: true


### PR DESCRIPTION
These were found by a simple "unused location" check in the new-logic tracker (area locations that don't correspond to a check and also aren't mentioned in any other expressions). This fixes the ones that very obviously look like bugs -- there are more unused locations but some of them are simply unused in a benign way.