### PR TITLE
Logic dump v2

### DIFF
--- a/.github/workflows/dump-check.yaml
+++ b/.github/workflows/dump-check.yaml
@@ -20,6 +20,6 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install ffmpeg libsm6 libxext6  -y
       - name: Create dump file
-        run: python3 randoscript.py --noui --dump dump-check.yaml
+        run: PYTHONHASHSEED=0 python3 randoscript.py --noui --dump dump-check.yaml
       - name: Check contents
         run: diff dump.yaml dump-check.yaml

--- a/.github/workflows/dump-check.yaml
+++ b/.github/workflows/dump-check.yaml
@@ -20,6 +20,6 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install ffmpeg libsm6 libxext6  -y
       - name: Create dump file
-        run: PYTHONHASHSEED=0 python3 randoscript.py --noui --dump dump-check.yaml
+        run: python3 randoscript.py --noui --dump dump-check.yaml
       - name: Check contents
         run: diff dump.yaml dump-check.yaml

--- a/.github/workflows/dump-check.yaml
+++ b/.github/workflows/dump-check.yaml
@@ -1,0 +1,25 @@
+name: Check Logic Dump Contents
+on:
+  - push
+  - pull_request
+jobs:
+  dump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+      - name: Setup poetry
+        run: python3 -mpip install poetry
+      - name: Install dependencies
+        run: poetry install
+        env:
+          POETRY_VIRTUALENVS_CREATE: false
+      - name: Install system dependencies
+        run: apt-get update && apt-get install ffmpeg libsm6 libxext6  -y
+      - name: Create dump file
+        run: python3 randoscript.py --noui --dump dump-check.yaml
+      - name: Check contents
+        run: diff dump.yaml dump-check.yaml

--- a/.github/workflows/dump-check.yaml
+++ b/.github/workflows/dump-check.yaml
@@ -18,7 +18,7 @@ jobs:
         env:
           POETRY_VIRTUALENVS_CREATE: false
       - name: Install system dependencies
-        run: apt-get update && apt-get install ffmpeg libsm6 libxext6  -y
+        run: sudo apt-get update && sudo apt-get install ffmpeg libsm6 libxext6  -y
       - name: Create dump file
         run: python3 randoscript.py --noui --dump dump-check.yaml
       - name: Check contents

--- a/.github/workflows/dump-check.yaml
+++ b/.github/workflows/dump-check.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Setup poetry
         run: python3 -mpip install poetry
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ Tests need a source installation and an extracted ISO:
     python -mpytest test
 If your system uses old versions of Python, you may need to replace `python` with `python3`
 
+### Logic Dump
+The `dump.yaml` file contains a dump of the static logic data for downstream consumers (such as trackers).
+If you make changes to logic, you may have to re-generate the dump
+
+    poetry run python randoscript.py --dump dump.yaml
+and commit the result, otherwise a GitHub action will fail and flag the outdated dump.
+
 ## Contributing
 Contributions are always welcome! Discussion happens on Discord.
 

--- a/dump.yaml
+++ b/dump.yaml
@@ -14358,11 +14358,11 @@ linked_entrances:
       exit_from_outside: \Skyloft\Central Skyloft\Near Temple Entrance\Exit to Sky
         Keep
       exit_from_inside: \Sky Keep\Main\First Room\Bottom Exit
-  dungeon_completion_requirements:
-    Skyview: \Skyview\Spring\Strike Crest
-    Earth Temple: \Earth Temple\Spring\Strike Crest
-    Lanayru Mining Facility: \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit
-      Hall of Ancient Robots
-    Ancient Cistern: \Ancient Cistern\Flame Room\Farore's Flame
-    Sandship: \Sandship\Boss Room\Nayru's Flame
-    Fire Sanctuary: \Fire Sanctuary\Flame Room\Din's Flame
+dungeon_completion_requirements:
+  Skyview: \Skyview\Spring\Strike Crest
+  Earth Temple: \Earth Temple\Spring\Strike Crest
+  Lanayru Mining Facility: \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit
+    Hall of Ancient Robots
+  Ancient Cistern: \Ancient Cistern\Flame Room\Farore's Flame
+  Sandship: \Sandship\Boss Room\Nayru's Flame
+  Fire Sanctuary: \Fire Sanctuary\Flame Room\Din's Flame

--- a/dump.yaml
+++ b/dump.yaml
@@ -2378,7 +2378,7 @@ areas:
   allowed_time_of_day: 3
   can_save: false
   can_sleep: false
-  entrances: !!set {}
+  entrances: []
   exits:
     Start: 'True'
   hint_region: null
@@ -2504,7 +2504,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: Ancient Cistern
       locations:
@@ -2517,7 +2517,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Ancient Cistern
           locations: {}
@@ -2528,8 +2528,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Main Entrance: null
+              entrances:
+              - Main Entrance
               exits:
                 Main Exit: 'True'
                 \Ancient Cistern\Main\East Part: \Ancient Cistern\Main\Main Room\Lever
@@ -2560,7 +2560,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Main Room\Vines Area: Clawshots
                     \Ancient Cistern\Main\Main Room\After Gutters: \Ancient Cistern\Main\Main
@@ -2577,7 +2577,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Main Room\After Whip Hooks: "\\Sword & Ancient\
                       \ Cistern - Map Chest Jump Trick"
@@ -2601,7 +2601,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Basement Gutters: \Ancient Cistern\Main\Main
                       Room\Behind the Waterfall\Toilet Flush
@@ -2622,7 +2622,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Main Room\After Whip Hooks: 'True'
                     \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: "\\\
@@ -2650,7 +2650,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Ancient Cistern\Main\Main Room\After Gutters: 'True'
                         \Ancient Cistern\Main\Main Room\Vines Area: \Ancient Cistern\Main\Main
@@ -2667,7 +2667,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Main Room\Vines Area: \Ancient Cistern\Main\Main
                       Room\Spider Thread Area\Extend Platform
@@ -2686,7 +2686,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Ancient Cistern\Main\Main Room: 'True'
                 \Ancient Cistern\Main\East Part\Second Room: \Ancient Cistern\Main\East
@@ -2702,7 +2702,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\East Part: 'True'
                     \Ancient Cistern\Main\East Part\Chest Ledge: "\\Ancient Cistern\\\
@@ -2727,7 +2727,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Main Room: 'True'
                   hint_region: Ancient Cistern
@@ -2742,7 +2742,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Ancient Cistern\Main\Basement Gutters\Past Skulltula: "\\Ancient\
                   \ Cistern\\Main\\Basement Gutters\\Can Get Past Skulltula & Water\
@@ -2757,7 +2757,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Basement Gutters: Water Dragon's Scale
                     \Ancient Cistern\Main\Main Room\After Gutters: Ancient Cistern
@@ -2774,7 +2774,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Ancient Cistern\Main\Inside Statue: 'True'
                 \Ancient Cistern\Main\Basement\Rotating Vines: "Whip & \\Ancient Cistern\\\
@@ -2795,7 +2795,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Basement: 'True'
                     \Ancient Cistern\Main\Basement\Spider Thread: Whip
@@ -2809,7 +2809,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Basement: 'True'
                     \Ancient Cistern\Main\Basement\Under the Statue: \Ancient Cistern\Can
@@ -2826,7 +2826,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Basement: 'True'
                   hint_region: Ancient Cistern
@@ -2842,8 +2842,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Boss Door Entrance: null
+              entrances:
+              - Boss Door Entrance
               exits:
                 \Ancient Cistern\Main\Basement: \Ancient Cistern\Can Lower Statue
                 \Ancient Cistern\Main\Main Room: \Ancient Cistern\Main\Inside Statue\Activate
@@ -2863,7 +2863,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Ancient Cistern\Main\Inside Statue: Ancient Cistern Small Key
                       x 2
@@ -2880,9 +2880,9 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance from Dungeon: null
-            Entrance from Flame Room: null
+          entrances:
+          - Entrance from Flame Room
+          - Entrance from Dungeon
           exits:
             Exit to Dungeon: \Ancient Cistern\Boss Room\Beat Koloktos
             Exit to Flame Room: \Ancient Cistern\Boss Room\Beat Koloktos
@@ -2898,8 +2898,8 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance: null
+          entrances:
+          - Entrance
           exits:
             Exit: 'True'
           hint_region: Ancient Cistern
@@ -2914,7 +2914,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: Earth Temple
       locations: {}
@@ -2925,7 +2925,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Earth Temple
           locations: {}
@@ -2936,8 +2936,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Main Entrance: null
+              entrances:
+              - Main Entrance
               exits:
                 Main Exit: 'True'
                 \Earth Temple\Main\Hub Room: "\\Earth Temple\\Main\\First Room\\Lower\
@@ -2959,7 +2959,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Earth Temple\Main\Hub Room\Past Lava Section: "\\Earth Temple\\Main\\\
                   Hub Room\\Access to Boulder & (\\Earth Temple\\Main\\Hub Room\\\
@@ -2997,7 +2997,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Earth Temple\Main\Hub Room: 'True'
                   hint_region: Earth Temple
@@ -3013,7 +3013,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Earth Temple\Main\Hub Room: 'True'
               hint_region: Earth Temple
@@ -3027,7 +3027,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Earth Temple\Main\Hub Room: \Earth Temple\Main\West Room\Rock to
                   Hub Room
@@ -3043,7 +3043,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Earth Temple\Main\Room with Slopes\Front of Boss Door: "\\Earth Temple\\\
                   Main\\Room with Slopes\\Rock in Second Slope Resting Area | Earth\
@@ -3060,8 +3060,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Boss Door Entrance: null
+                  entrances:
+                  - Boss Door Entrance
                   exits:
                     \Earth Temple\Main\Room with Slopes: 'True'
                     Boss Door Exit: \Earth Temple\Main\Room with Slopes\Front of Boss
@@ -3080,7 +3080,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Earth Temple
           locations: {}
@@ -3091,8 +3091,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Dungeon: null
+              entrances:
+              - Entrance from Dungeon
               exits:
                 Exit to Dungeon: \Earth Temple\Boss Room\Slope\Beat Scaldera
                 \Earth Temple\Boss Room\Slope: 'True'
@@ -3106,8 +3106,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Spring: null
+              entrances:
+              - Entrance from Spring
               exits:
                 Exit to Spring: \Earth Temple\Boss Room\Slope\Beat Scaldera
               hint_region: Earth Temple
@@ -3131,8 +3131,8 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance: null
+          entrances:
+          - Entrance
           exits:
             Exit: 'True'
           hint_region: Earth Temple
@@ -3147,7 +3147,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: null
       locations:
@@ -3159,7 +3159,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Eldin Volcano
           locations: {}
@@ -3170,9 +3170,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Volcano Entrance Statue Entrance: null
-                First Time Entrance: null
+              entrances:
+              - First Time Entrance
+              - Volcano Entrance Statue Entrance
               exits:
                 Volcano Entrance Statue Exit: \Eldin\Volcano\Entry\Unlock Statue
                 \Eldin\Volcano\Ascent: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
@@ -3191,7 +3191,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Volcano\East: \Eldin\Volcano\First Room\Blow up Rock to East
               hint_region: Eldin Volcano
@@ -3208,10 +3208,10 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                First Vent from Mogma Turf: null
-                Volcano East Statue Entrance: null
-                Entrance from Bokoblin Base: null
+              entrances:
+              - Volcano East Statue Entrance
+              - Entrance from Bokoblin Base
+              - First Vent from Mogma Turf
               exits:
                 Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\East\Unlock
                   Statue
@@ -3243,8 +3243,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Second Vent from Mogma Turf: null
+              entrances:
+              - Second Vent from Mogma Turf
               exits:
                 \Eldin\Volcano\East: \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut
                   to Pre Turf
@@ -3265,9 +3265,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Trial Gate Entrance: null
-                Volcano Ascent Statue Entrance: null
+              entrances:
+              - Trial Gate Entrance
+              - Volcano Ascent Statue Entrance
               exits:
                 \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\Ascent\Unlock
                   Statue
@@ -3294,8 +3294,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Thrill Digger Cave Entrance: null
+              entrances:
+              - Thrill Digger Cave Entrance
               exits:
                 \Eldin\Volcano\Ascent: 'True'
                 \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Thrill Digger
@@ -3314,8 +3314,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Eldin Volcano
@@ -3330,9 +3330,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Temple Entrance Statue Entrance: null
-                Entrance from Earth Temple: null
+              entrances:
+              - Entrance from Earth Temple
+              - Temple Entrance Statue Entrance
               exits:
                 Temple Entrance Statue Exit: \Eldin\Volcano\Near Temple Entrance\Unlock
                   Statue
@@ -3364,7 +3364,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Volcano\Near Temple Entrance: "\\Eldin\\Bokoblin Base\\Fire\
                   \ Dragon's Lair\\Beaten Boko Base | Clawshots"
@@ -3379,9 +3379,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Vent Entrance near Hot Cave: null
-                Entrance from Summit: null
+              entrances:
+              - Entrance from Summit
+              - Vent Entrance near Hot Cave
               exits:
                 Exit to Summit: Fireshield Earrings
                 \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Temple Entrance\Blow
@@ -3398,7 +3398,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Volcano\Past Slide: 'True'
               hint_region: Eldin Volcano
@@ -3413,7 +3413,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Volcano\Ascent: \Eldin\Volcano\Past Slide\Unlock Shortcut to
                   Ascent
@@ -3432,7 +3432,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Volcano\Past Slide: Clawshots
                 \Eldin\Volcano\Past Mogma Turf: \Eldin\Bokoblin Base\Fire Dragon's
@@ -3451,7 +3451,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Mogma Turf
           locations: {}
@@ -3462,8 +3462,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 First Vent: 'True'
                 \Eldin\Mogma Turf\Past Vent: \Eldin\Mogma Turf\Pre Vent\Open Vent
@@ -3484,7 +3484,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Mogma Turf\Pre Vent: 'True'
               hint_region: Mogma Turf
@@ -3498,7 +3498,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Mogma Turf\Pre Vent: 'True'
                 \Eldin\Mogma Turf\Sand Slide Platform: 'True'
@@ -3515,8 +3515,8 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance: null
+          entrances:
+          - Entrance
           exits:
             Exit: 'True'
           hint_region: Eldin Silent Realm
@@ -3540,10 +3540,10 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance from Outside Fire Sanctuary: null
-            Entrance from Waterfall: null
-            Entrance from Eldin Volcano: null
+          entrances:
+          - Entrance from Eldin Volcano
+          - Entrance from Waterfall
+          - Entrance from Outside Fire Sanctuary
           exits:
             Exit to Eldin Volcano: Fireshield Earrings
             Exit to Waterfall: Fireshield Earrings
@@ -3559,8 +3559,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
                 \Eldin\Volcano Summit\Waterfall\Higher Area: Clawshots
@@ -3575,7 +3575,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Eldin\Volcano Summit\Waterfall: 'True'
                   hint_region: Volcano Summit
@@ -3591,9 +3591,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Statue Entrance: null
-                Entrance from Fire Sanctuary: null
+              entrances:
+              - Statue Entrance
+              - Entrance from Fire Sanctuary
               exits:
                 Statue Exit: \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
                 \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: \Eldin\Volcano
@@ -3614,8 +3614,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Summit: null
+                  entrances:
+                  - Entrance from Summit
                   exits:
                     Exit to Summit: 'True'
                     \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: \Eldin\Volcano
@@ -3633,7 +3633,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs: \Eldin\Volcano
                       Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Hydrate First
@@ -3656,7 +3656,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Bokoblin Base
           locations: {}
@@ -3667,8 +3667,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
                 \Eldin\Bokoblin Base\Volcano East: \Mogma Mitts
@@ -3683,7 +3683,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Bokoblin Base\Prison: \Mogma Mitts
                 \Eldin\Bokoblin Base\Before Drawbridge: 'True'
@@ -3703,7 +3703,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Bokoblin Base\Volcano East: 'True'
                 \Eldin\Bokoblin Base\After Drawbridge: "Whip & Clawshots"
@@ -3718,7 +3718,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Bokoblin Base\Before Drawbridge: Clawshots
                 \Eldin\Bokoblin Base\Lower Platform Cave: 'True'
@@ -3734,7 +3734,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Bokoblin Base\After Drawbridge: Clawshots
                 \Eldin\Bokoblin Base\Before Drawbridge: 'True'
@@ -3750,7 +3750,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Bokoblin Base\Hot Cave: 'True'
                 \Eldin\Bokoblin Base\Upper Platform Cave: 'True'
@@ -3771,7 +3771,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Bokoblin Base\Outside Earth Temple: 'True'
               hint_region: Bokoblin Base
@@ -3785,7 +3785,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Bokoblin Base\After Drawbridge: "Fireshield Earrings & Bomb\
                   \ Bag"
@@ -3801,7 +3801,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Bokoblin Base\Hot Cave: Fireshield Earrings
                 \Eldin\Bokoblin Base\Fire Dragon's Lair: Fireshield Earrings
@@ -3820,7 +3820,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Eldin\Bokoblin Base\Bokoblin Base Summit: 'True'
               hint_region: Bokoblin Base
@@ -3838,7 +3838,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: null
       locations: {}
@@ -3849,7 +3849,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Sealed Grounds
           locations: {}
@@ -3860,8 +3860,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Door Entrance: null
+              entrances:
+              - Door Entrance
               exits:
                 \Faron\Sealed Grounds\Spiral\Upper Part: \Faron\Sealed Grounds\Spiral\Defeat
                   Imprisoned 2
@@ -3877,8 +3877,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Statue Entrance: null
+                  entrances:
+                  - Statue Entrance
                   exits:
                     Statue Exit: \Faron\Sealed Grounds\Spiral\Upper Part\Unlock Statue
                     \Faron\Sealed Grounds\Spiral: 'True'
@@ -3893,8 +3893,8 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set
-                        Shortcut Entrance from Behind the Temple: null
+                      entrances:
+                      - Shortcut Entrance from Behind the Temple
                       exits:
                         \Faron\Sealed Grounds\Spiral\Upper Part: 'True'
                         Shortcut Exit to Behind the Temple: 'True'
@@ -3911,10 +3911,10 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Main Entrance: null
-                Gate of Time Entrance: null
-                Side Entrance: null
+              entrances:
+              - Main Entrance
+              - Side Entrance
+              - Gate of Time Entrance
               exits:
                 Main Exit: 'True'
                 Side Exit: 'True'
@@ -3938,8 +3938,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Gate of Time Entrance: null
+              entrances:
+              - Gate of Time Entrance
               exits:
                 Gate of Time Exit: 'True'
               hint_region: Sealed Grounds
@@ -3954,11 +3954,11 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Faron Woods: null
-                Statue Entrance: null
-                Door Entrance: null
-                Shortcut Entrance from Spiral: null
+              entrances:
+              - Statue Entrance
+              - Shortcut Entrance from Spiral
+              - Door Entrance
+              - Entrance from Faron Woods
               exits:
                 Statue Exit: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
                 Door Exit: 'True'
@@ -3979,10 +3979,10 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            In the Woods Statue Entrance: null
-            Trial Gate Entrance: null
-            Viewing Platform Statue Entrance: null
+          entrances:
+          - In the Woods Statue Entrance
+          - Viewing Platform Statue Entrance
+          - Trial Gate Entrance
           exits:
             \Faron\Faron Woods\Entry: 'True'
             Shared Statue Exit: "\\Faron\\Faron Woods\\Unlock In the Woods Statue\
@@ -4025,9 +4025,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Faron Woods Entry Statue Entrance: null
-                Entrance from Behind the Temple: null
+              entrances:
+              - Entrance from Behind the Temple
+              - Faron Woods Entry Statue Entrance
               exits:
                 \Faron\Faron Woods\Shared Statue Exit: \Faron\Faron Woods\Entry\Unlock
                   Statue
@@ -4045,8 +4045,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Shortcut Entrance from Floria Waterfall: null
+              entrances:
+              - Shortcut Entrance from Floria Waterfall
               exits:
                 \Faron\Faron Woods: 'True'
                 Shortcut Exit to Floria Waterfall: "\\Faron\\Faron Woods\\Open Door\
@@ -4062,8 +4062,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Deep Woods: null
+              entrances:
+              - Entrance from Deep Woods
               exits:
                 \Faron\Faron Woods: 'True'
                 Exit to Deep Woods: 'True'
@@ -4077,7 +4077,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Faron\Faron Woods: 'True'
               hint_region: Faron Woods
@@ -4093,7 +4093,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Faron\Faron Woods: 'True'
               hint_region: Faron Woods
@@ -4107,7 +4107,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Faron\Faron Woods: 'True'
               hint_region: Faron Woods
@@ -4121,7 +4121,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Faron\Faron Woods: 'True'
               hint_region: Faron Woods
@@ -4135,7 +4135,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits: {}
               hint_region: Faron Woods
               locations: {}
@@ -4146,8 +4146,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Underwater Hole Entrance: null
+                  entrances:
+                  - Underwater Hole Entrance
                   exits:
                     \Faron\Faron Woods: 'True'
                     Underwater Hole Exit: Water Dragon's Scale
@@ -4161,8 +4161,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Underwater Tunnel Entrance: null
+                  entrances:
+                  - Underwater Tunnel Entrance
                   exits:
                     Underwater Tunnel Exit: Water Dragon's Scale
                     \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: Gust Bellows
@@ -4176,7 +4176,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Faron\Faron Woods\Great Tree\Lower Area: 'True'
                         \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: 'True'
@@ -4191,8 +4191,8 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set
-                        Lower Entrance from Platforms: null
+                      entrances:
+                      - Lower Entrance from Platforms
                       exits:
                         \Faron\Faron Woods\Great Tree\Lower Area: 'True'
                         Lower Exit to Platforms: 'True'
@@ -4207,9 +4207,9 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Upper Entrance from Great Tree: null
-                    Lower Entrance from Great Tree: null
+                  entrances:
+                  - Upper Entrance from Great Tree
+                  - Lower Entrance from Great Tree
                   exits:
                     Lower Exit to Great Tree: 'True'
                     Upper Exit to Great Tree: 'True'
@@ -4225,10 +4225,10 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Top: null
-                    Upper Entrance from Platforms: null
-                    Entrance from Flooded Great Tree: null
+                  entrances:
+                  - Entrance from Flooded Great Tree
+                  - Upper Entrance from Platforms
+                  - Entrance from Top
                   exits:
                     \Faron\Faron Woods\Great Tree\Lower Area: \Faron\Faron Woods\Great
                       Tree\Upper Area\Remove Void Plane
@@ -4248,9 +4248,9 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Top Entrance from Great Tree: null
-                    The Great Tree Statue Entrance: null
+                  entrances:
+                  - The Great Tree Statue Entrance
+                  - Top Entrance from Great Tree
                   exits:
                     \Faron\Faron Woods\Shared Statue Exit: \Faron\Faron Woods\Great
                       Tree\Top\Unlock Statue
@@ -4273,10 +4273,10 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Deep Woods Statue Entrance: null
-                Forest Temple Statue Entrance: null
-                Entrance from Skyview Temple: null
+              entrances:
+              - Deep Woods Statue Entrance
+              - Entrance from Skyview Temple
+              - Forest Temple Statue Entrance
               exits:
                 Shared Statue Exit: 'True'
                 \Faron\Faron Woods\Deep Woods\Entry: 'True'
@@ -4298,8 +4298,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Faron Woods: null
+                  entrances:
+                  - Entrance from Faron Woods
                   exits:
                     Exit to Faron Woods: 'True'
                     \Faron\Faron Woods\Deep Woods: "\\Faron\\Faron Woods\\Deep Woods\\\
@@ -4317,8 +4317,8 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance: null
+          entrances:
+          - Entrance
           exits:
             Exit: 'True'
           hint_region: Faron Silent Realm
@@ -4342,9 +4342,9 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance from Lower Flooded Great Tree: null
-            Entrance from Upper Flooded Great Tree: null
+          entrances:
+          - Entrance from Upper Flooded Great Tree
+          - Entrance from Lower Flooded Great Tree
           exits:
             Exit to Upper Flooded Great Tree: 'True'
             Exit to Lower Flooded Great Tree: Water Dragon's Scale
@@ -4378,10 +4378,10 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Upper Flooded Faron Woods: null
-                Entrance: null
-                Entrance from Lower Flooded Faron Woods: null
+              entrances:
+              - Entrance from Lower Flooded Faron Woods
+              - Entrance from Upper Flooded Faron Woods
+              - Entrance
               exits:
                 Exit: 'True'
                 Exit to Upper Flooded Faron Woods: 'True'
@@ -4399,7 +4399,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Lake Floria
           locations: {}
@@ -4410,8 +4410,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Dive from Faron Woods: null
+              entrances:
+              - Dive from Faron Woods
               exits:
                 \Faron\Lake Floria\Below Rock: "\\Faron\\Lake Floria\\Above Rock\\\
                   Blow Rock & Water Dragon's Scale"
@@ -4430,8 +4430,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Farore's Lair: null
+              entrances:
+              - Entrance from Farore's Lair
               exits:
                 \Faron\Lake Floria\Below Rock\Emerged Area: Water Dragon's Scale
                 \Faron\Lake Floria\Above Rock: Water Dragon's Scale
@@ -4445,8 +4445,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Statue Entrance: null
+                  entrances:
+                  - Statue Entrance
                   exits:
                     Statue Exit: \Faron\Lake Floria\Below Rock\Emerged Area\Unlock
                       Statue
@@ -4465,9 +4465,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Waterfall: null
-                Entrance from Lake Floria: null
+              entrances:
+              - Entrance from Waterfall
+              - Entrance from Lake Floria
               exits:
                 Exit to Waterfall: 'True'
                 Exit to Lake Floria: Water Dragon's Scale
@@ -4484,11 +4484,11 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Faron Woods: null
-                Statue Entrance: null
-                Entrance from Farore's Lair: null
-                Entrance from Ancient Cistern: null
+              entrances:
+              - Entrance from Farore's Lair
+              - Statue Entrance
+              - Entrance from Ancient Cistern
+              - Entrance from Faron Woods
               exits:
                 Statue Exit: \Faron\Lake Floria\Waterfall\Unlock Statue
                 Exit to Farore's Lair: 'True'
@@ -4510,7 +4510,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: Fire Sanctuary
       locations: {}
@@ -4521,7 +4521,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Fire Sanctuary
           locations: {}
@@ -4532,8 +4532,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Main Entrance: null
+              entrances:
+              - Main Entrance
               exits:
                 Main Exit: 'True'
                 \Fire Sanctuary\Main\First Room\Past Water Plant: \Fire Sanctuary\Main\First
@@ -4548,8 +4548,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Second Room: null
+                  entrances:
+                  - Entrance from Second Room
                   exits:
                     \Fire Sanctuary\Main\First Room: \Fire Sanctuary\Main\First Room\Hit
                       Water Plant
@@ -4570,7 +4570,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Fire Sanctuary\Main\Second Room\Outside Section: 'True'
                 \Fire Sanctuary\Main\Second Room\Balcony: \Fire Sanctuary\Main\Second
@@ -4589,8 +4589,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from First Room: null
+                  entrances:
+                  - Entrance from First Room
                   exits:
                     Exit to First Room: 'True'
                     \Fire Sanctuary\Main\Second Room: 'True'
@@ -4604,7 +4604,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\Second Room: \Fire Sanctuary\Main\Second
                       Room\Defeat Magmanos
@@ -4620,7 +4620,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Fire Sanctuary\Main\Second Room: \Fire Sanctuary\Main\First Bridge\Lizalfos
                   Fight
@@ -4639,7 +4639,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Fire Sanctuary\Main\First Bridge: 'True'
                 \Fire Sanctuary\Main\Room with Water Plant\Past Lava: "\\Fire Sanctuary\\\
@@ -4656,7 +4656,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\Room with Water Plant: "Clawshots | \\Fire\
                       \ Sanctuary\\Main\\Room with Water Plant\\Blow up Rock"
@@ -4675,7 +4675,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Fire Sanctuary\Main\Room with Water Plant\Past Lava: 'True'
                 \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: \Fire Sanctuary\Main\Magmanos
@@ -4690,7 +4690,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\First Trapped Mogma Room: \Fire Sanctuary\Main\Magmanos
                       Fight Room\Upper Part\Magmanos Fight
@@ -4712,7 +4712,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Fire Sanctuary\Main\Room with Water Plant\Past Lava: \Fire Sanctuary\Main\Room
                   with Water Plant\Past Lava\Unlock Key Door
@@ -4732,7 +4732,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\Water Fruit Room: \Fire Sanctuary\Main\Water
                       Fruit Room\Hydrate Frog
@@ -4748,7 +4748,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits: {}
               hint_region: Fire Sanctuary
               locations: {}
@@ -4759,7 +4759,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\Water Fruit Room\After Frog: \Fire Sanctuary\Main\Magmanos
                       Fight Room\Upper Part\Magmanos Fight
@@ -4776,8 +4776,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from West of Boss Door: null
+                  entrances:
+                  - Entrance from West of Boss Door
                   exits:
                     \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: "\\\
                       Mogma Mitts & \\Fire Sanctuary\\Main\\First Trapped Mogma Room\\\
@@ -4799,7 +4799,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: \Fire
                           Sanctuary\Main\Magmanos Fight Room\Lower Part\Move Sliding
@@ -4818,7 +4818,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits: {}
               hint_region: Fire Sanctuary
               locations: {}
@@ -4829,7 +4829,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\First Bridge: \Fire Sanctuary\Main\Second
                       Bridge\Left\Unlock Shortcut to First Bridge
@@ -4846,7 +4846,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\Second Bridge\Left: Clawshots
                     \Fire Sanctuary\Main\Second Bridge\Right: Clawshots
@@ -4860,7 +4860,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\Second Bridge\Bottom Part: 'True'
                     \Fire Sanctuary\Main\Second Bridge\Left: Clawshots
@@ -4876,7 +4876,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Fire Sanctuary\Main\Second Bridge\Right: 'True'
                 \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall: "\\\
@@ -4901,7 +4901,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\Second Trapped Mogma Room: 'True'
                   hint_region: Fire Sanctuary
@@ -4917,7 +4917,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Fire Sanctuary\Main\West of Boss Door\Entry: \Fire Sanctuary\Main\West
                   of Boss Door\Hit Water Plant
@@ -4940,8 +4940,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Magmanos Fight Room: null
+                  entrances:
+                  - Entrance from Magmanos Fight Room
                   exits:
                     Exit to Magmanos Fight Room: 'True'
                     \Fire Sanctuary\Main\West of Boss Door: \Fire Sanctuary\Main\West
@@ -4961,7 +4961,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: true
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\West of Boss Door: \Fire Sanctuary\Main\West
                       of Boss Door\Past Plats\Unlock Shortcut to Pre Plats
@@ -4978,9 +4978,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Statue Entrance: null
-                Boss Door Entrance: null
+              entrances:
+              - Statue Entrance
+              - Boss Door Entrance
               exits:
                 Statue Exit: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
                 Boss Door Exit: Fire Sanctuary Boss Key
@@ -4997,7 +4997,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\Boss Key Room: 'True'
                     \Fire Sanctuary\Main\Front of Boss Door: \Fire Sanctuary\Main\Front
@@ -5014,7 +5014,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Fire Sanctuary\Main\Staircase Room: \Fire Sanctuary\Main\Lizalfos
                   Fight Room\Fight
@@ -5029,7 +5029,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Fire Sanctuary\Main\Staircase Room\Upper Part: Clawshots
               hint_region: Fire Sanctuary
@@ -5042,7 +5042,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Fire Sanctuary\Main\Staircase Room: 'True'
                     \Fire Sanctuary\Main\Boss Key Room: 'True'
@@ -5057,7 +5057,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Fire Sanctuary\Main\Staircase Room\Upper Part: 'True'
                 \Fire Sanctuary\Main\Front of Boss Door\Past Bars: 'True'
@@ -5077,9 +5077,9 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance from Dungeon: null
-            Entrance from Flame Room: null
+          entrances:
+          - Entrance from Flame Room
+          - Entrance from Dungeon
           exits:
             Exit to Dungeon: \Fire Sanctuary\Boss Room\Beat Ghirahim
             Exit to Flame Room: \Fire Sanctuary\Boss Room\Beat Ghirahim
@@ -5095,8 +5095,8 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance: null
+          entrances:
+          - Entrance
           exits:
             Exit: 'True'
           hint_region: Fire Sanctuary
@@ -5111,7 +5111,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: Lanayru Mining Facility
       locations:
@@ -5124,7 +5124,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Lanayru Mining Facility
           locations: {}
@@ -5135,8 +5135,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Main Entrance: null
+              entrances:
+              - Main Entrance
               exits:
                 \Lanayru Mining Facility\Main\First Hub: \Lanayru Mining Facility\Main\First
                   Room\Left Lever
@@ -5155,8 +5155,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Big Hub: null
+              entrances:
+              - Entrance from Big Hub
               exits:
                 \Lanayru Mining Facility\Main\First Room: 'True'
                 Exit to Big Hub: 'True'
@@ -5175,7 +5175,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru Mining Facility\Main\First Hub: 'True'
                 \Lanayru Mining Facility\Main\Hop Across Boxes Room: \Lanayru Mining
@@ -5196,7 +5196,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit: "\\\
                   Lanayru Mining Facility\\Main\\Hop Across Boxes Room\\Blow Up Rocks\
@@ -5217,8 +5217,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Big Hub: null
+                  entrances:
+                  - Entrance from Big Hub
                   exits:
                     Exit to Big Hub: \Lanayru Mining Facility\Main\Hop Across Boxes
                       Room\Near Exit\Remove Dust Pile at Door
@@ -5235,7 +5235,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru Mining Facility\Main\First Hub: 'True'
                 \Lanayru Mining Facility\Main\Armos Fight Room: "Gust Bellows & \\\
@@ -5251,8 +5251,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Big Hub: null
+              entrances:
+              - Entrance from Big Hub
               exits:
                 Exit to Big Hub: \Lanayru Mining Facility\Main\Armos Fight Room\Defeat
                   Armos
@@ -5272,7 +5272,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits: {}
               hint_region: Lanayru Mining Facility
               locations: {}
@@ -5283,8 +5283,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from First Hub: null
+                  entrances:
+                  - Entrance from First Hub
                   exits:
                     Exit to First Hub: 'True'
                     \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: \Lanayru
@@ -5305,7 +5305,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Lanayru Mining Facility\Main\Big Hub\Entry: 'True'
                     \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room: \Lanayru
@@ -5322,8 +5322,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Hop Across Boxes Room: null
+                  entrances:
+                  - Entrance from Hop Across Boxes Room
                   exits:
                     Exit to Hop Across Boxes Room: 'True'
                     \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: 'True'
@@ -5339,8 +5339,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Armos Fight Room: null
+                  entrances:
+                  - Entrance from Armos Fight Room
                   exits:
                     \Lanayru Mining Facility\Main\Big Hub\Entry: \Lanayru Mining Facility\Main\Big
                       Hub\Past West Gate\Open Gate
@@ -5363,7 +5363,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Lanayru Mining Facility\Main\Near Boss Door: "\\Lanayru Mining\
                       \ Facility\\Main\\Big Hub\\Sand Spike Maze\\Switch under Sand\
@@ -5381,7 +5381,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Lanayru Mining Facility\Main\Boss Key Room: \Lanayru Mining Facility\Main\Big
                       Hub\Between Wind Gates\Unlock Exit to Boss Key Room
@@ -5396,7 +5396,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: 'True'
                     \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: 'True'
@@ -5415,7 +5415,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Lanayru Mining Facility\Main\Big Hub\Entry: \Lanayru Mining Facility\Main\Big
                       Hub\Between Wind Gates\Open First Wind Gate
@@ -5446,8 +5446,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Boss Door Entrance: null
+              entrances:
+              - Boss Door Entrance
               exits:
                 Boss Door Exit: "Lanayru Mining Facility Boss Key & \\Lanayru Mining\
                   \ Facility\\Can Activate Minecart Timeshift Stone"
@@ -5470,7 +5470,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: \Lanayru
                   Mining Facility\Main\Boss Key Room\Can Beat Room
@@ -5488,8 +5488,8 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance from Dungeon: null
+          entrances:
+          - Entrance from Dungeon
           exits:
             Exit to Dungeon: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat
               Moldarach
@@ -5503,8 +5503,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Hall of Ancient Robots: null
+              entrances:
+              - Entrance from Hall of Ancient Robots
               exits:
                 Exit to Hall of Ancient Robots: \Lanayru Mining Facility\Boss Room\After
                   Sand Drain\Beat Moldarach
@@ -5523,7 +5523,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Lanayru Mining Facility
           locations: {}
@@ -5534,8 +5534,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Boss Room: null
+              entrances:
+              - Entrance from Boss Room
               exits:
                 Exit to Boss Room: 'True'
                 \Lanayru Mining Facility\Hall of Ancient Robots\End: \Lanayru Mining
@@ -5551,8 +5551,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Temple of Time: null
+              entrances:
+              - Entrance from Temple of Time
               exits:
                 Exit to Temple of Time: 'True'
               hint_region: Lanayru Mining Facility
@@ -5568,7 +5568,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: null
       locations:
@@ -5587,7 +5587,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Lanayru Mine
           locations: {}
@@ -5598,9 +5598,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Statue Entrance: null
-                First Time Entrance: null
+              entrances:
+              - Statue Entrance
+              - First Time Entrance
               exits:
                 Statue Exit: \Lanayru\Mine\Entry\Unlock Statue
                 \Lanayru\Mine\Statues Area: \Lanayru\Mine\Entry\Timeshift Stone
@@ -5620,7 +5620,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Lanayru\Mine\Entry: 'True'
                     \Lanayru\Mine\Entry\Caves Entrance: Clawshots
@@ -5635,8 +5635,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Caves: null
+                  entrances:
+                  - Entrance from Caves
                   exits:
                     \Lanayru\Mine\Entry\Higher Area: Clawshots
                     Exit to Caves: 'True'
@@ -5651,7 +5651,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru\Mine\Entry: 'True'
                 \Lanayru\Mine\End: "\\Lanayru\\Mine\\Statues Area\\Blow Statues Down\
@@ -5669,7 +5669,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru\Mine\Statues Area: "\\Lanayru\\Mine\\Statues Area\\Blow Statues\
                   \ Down | Brakeslide Trick | \\Skyloft\\Central Skyloft\\Bazaar\\\
@@ -5687,8 +5687,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Desert: null
+                  entrances:
+                  - Entrance from Desert
                   exits:
                     Exit to Desert: 'True'
                   hint_region: Lanayru Mine
@@ -5704,7 +5704,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits:
             Shared Statue Exit: 'False'
           hint_region: Lanayru Desert
@@ -5716,9 +5716,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Desert Entrance Statue Entrance: null
-                Entrance from Mine: null
+              entrances:
+              - Desert Entrance Statue Entrance
+              - Entrance from Mine
               exits:
                 Exit to Mine: \Lanayru\Desert\Entry\Timeshift Stone
                 \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\Entry\Unlock Statue
@@ -5738,7 +5738,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits: {}
                   hint_region: Lanayru Desert
                   locations:
@@ -5755,7 +5755,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru\Desert\Entry: 'True'
                 \Lanayru\Desert\Top of West Wall: Clawshots
@@ -5786,7 +5786,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru\Desert\Near Caged Robot: 'True'
                 \Lanayru\Desert\Top of West Wall: "Clawshots | \\Lanayru\\Desert\\\
@@ -5805,8 +5805,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                West Desert Statue Entrance: null
+              entrances:
+              - West Desert Statue Entrance
               exits:
                 \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\West Part\Unlock
                   Statue
@@ -5828,8 +5828,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                South Entrance from Temple of Time: null
+              entrances:
+              - South Entrance from Temple of Time
               exits:
                 South Exit to Temple of Time: 'True'
                 \Lanayru\Desert\West Part: 'True'
@@ -5844,8 +5844,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Caves: null
+                  entrances:
+                  - Entrance from Caves
                   exits:
                     \Lanayru\Desert\Near South Exit to Temple of Time: 'True'
                     Exit to Caves: 'True'
@@ -5861,7 +5861,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru\Desert\Near Caged Robot: 'True'
                 \Lanayru\Desert\Sand Oasis: 'True'
@@ -5880,8 +5880,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Lanayru Mining Facility: null
+              entrances:
+              - Entrance from Lanayru Mining Facility
               exits:
                 \Lanayru\Desert\North Part: 'True'
                 \Lanayru\Desert\East: 'True'
@@ -5898,11 +5898,11 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Trial Gate Entrance: null
-                North Desert Statue Entrance: null
-                Lightning Node Entrance: null
-                North Entrance from Temple of Time: null
+              entrances:
+              - Lightning Node Entrance
+              - North Entrance from Temple of Time
+              - Trial Gate Entrance
+              - North Desert Statue Entrance
               exits:
                 North Exit to Temple of Time: 'True'
                 \Lanayru\Desert\East: 'True'
@@ -5936,7 +5936,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Lanayru\Desert\North Part: 'True'
                   hint_region: Lanayru Desert
@@ -5951,7 +5951,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits: {}
                   hint_region: Lanayru Desert
                   locations: {}
@@ -5962,8 +5962,8 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set
-                        Entrance: null
+                      entrances:
+                      - Entrance
                       exits:
                         Exit: 'True'
                         \Lanayru\Desert\North Part\Lightning Node\Past: \Lanayru\Desert\North
@@ -5982,7 +5982,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Lanayru\Desert\North Part\Lightning Node\Present\Exit: 'True'
                         \Lanayru\Desert\North Part\Lightning Node\Present: \Projectile
@@ -6003,7 +6003,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Lanayru\Desert\North Part\Lightning Node\Past: "\\Beetle\
                           \ | \\Bow"
@@ -6022,9 +6022,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Fire Node Entrance: null
-                Stone Cache Statue Entrance: null
+              entrances:
+              - Stone Cache Statue Entrance
+              - Fire Node Entrance
               exits:
                 \Lanayru\Desert\North Part: 'True'
                 \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
@@ -6044,7 +6044,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits: {}
                   hint_region: Lanayru Desert
                   locations: {}
@@ -6055,8 +6055,8 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set
-                        Entrance: null
+                      entrances:
+                      - Entrance
                       exits:
                         Exit: 'True'
                         \Lanayru\Desert\East\Fire Node\Past: \Lanayru\Desert\East\Fire
@@ -6077,7 +6077,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Lanayru\Desert\East\Fire Node\Past after Void: "\\Lanayru\\\
                           Desert\\East\\Fire Node\\Present\\Timeshift Stone & \\Projectile\
@@ -6095,7 +6095,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Lanayru\Desert\East\Fire Node\Present\Exit: 'True'
                         \Lanayru\Desert\East\Fire Node\Present: "\\Projectile Item\
@@ -6114,7 +6114,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Lanayru\Desert\East\Fire Node\Past: 'True'
                         \Lanayru\Desert\East\Fire Node\Past after Grate: \Lanayru\Desert\East\Fire
@@ -6130,7 +6130,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Lanayru\Desert\East\Fire Node\Past after Void: 'True'
                       hint_region: Lanayru Desert
@@ -6149,7 +6149,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits:
             Shared Statue Exit: 'False'
           hint_region: null
@@ -6161,9 +6161,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                South Entrance from Desert: null
-                Desert Gorge Statue Entrance: null
+              entrances:
+              - South Entrance from Desert
+              - Desert Gorge Statue Entrance
               exits:
                 South Exit to Desert: 'True'
                 \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\South
@@ -6182,7 +6182,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru\Temple of Time\Inside: 'True'
                 \Lanayru\Temple of Time\Near Goddess Cube: \Lanayru\Temple of Time\Near
@@ -6207,9 +6207,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Temple of Time Statue Entrance: null
-                Entrance from Lanayru Mining Facility: null
+              entrances:
+              - Entrance from Lanayru Mining Facility
+              - Temple of Time Statue Entrance
               exits:
                 \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\Inside\Unlock
                   Statue
@@ -6226,7 +6226,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Lanayru\Temple of Time\North East: 'True'
               hint_region: null
@@ -6241,8 +6241,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                North Entrance from Desert: null
+              entrances:
+              - North Entrance from Desert
               exits:
                 \Lanayru\Temple of Time\South East: \Distance Activator
                 North Exit to Desert: 'True'
@@ -6258,8 +6258,8 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance: null
+          entrances:
+          - Entrance
           exits:
             Exit: 'True'
           hint_region: Lanayru Silent Realm
@@ -6283,9 +6283,9 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance from Desert: null
-            Entrance from Mine: null
+          entrances:
+          - Entrance from Desert
+          - Entrance from Mine
           exits:
             \Lanayru\Caves\Past Door to Lanayru Sand Sea: "Clawshots & Lanayru Caves\
               \ Small Key"
@@ -6304,8 +6304,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Lanayru Sand Sea: null
+              entrances:
+              - Entrance from Lanayru Sand Sea
               exits:
                 \Lanayru\Caves: Lanayru Caves Small Key
                 Exit to Lanayru Sand Sea: 'True'
@@ -6319,8 +6319,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Gorge: null
+              entrances:
+              - Entrance from Gorge
               exits:
                 \Lanayru\Caves: Bomb Bag
                 Exit to Gorge: 'True'
@@ -6336,12 +6336,12 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Sandship Dock Entrance: null
-            Pirate Stronghold Dock Entrance: null
-            Ancient Harbour Dock Entrance: null
-            Shipyard Dock Entrance: null
-            Skipper's Retreat Dock Entrance: null
+          entrances:
+          - Sandship Dock Entrance
+          - Pirate Stronghold Dock Entrance
+          - Ancient Harbour Dock Entrance
+          - Shipyard Dock Entrance
+          - Skipper's Retreat Dock Entrance
           exits:
             Ancient Harbour Dock Exit: 'True'
             Sandship Dock Exit: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
@@ -6358,9 +6358,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Statue Entrance: null
-                Dock Entrance: null
+              entrances:
+              - Statue Entrance
+              - Dock Entrance
               exits:
                 Dock Exit: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Ship Timeshift
                   Stone
@@ -6379,8 +6379,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance from Caves: null
+                  entrances:
+                  - Entrance from Caves
                   exits:
                     Exit to Caves: 'True'
                     \Lanayru\Lanayru Sand Sea\Ancient Harbour: Clawshots
@@ -6398,9 +6398,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Statue Entrance: null
-                Dock Entrance: null
+              entrances:
+              - Statue Entrance
+              - Dock Entrance
               exits:
                 Statue Exit: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Unlock Statue
                 Dock Exit: 'True'
@@ -6418,7 +6418,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Lanayru\Lanayru Sand Sea\Skipper's Retreat: 'True'
                     \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part: "Clawshots\
@@ -6440,8 +6440,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Shack Entrance: null
+                  entrances:
+                  - Shack Entrance
                   exits:
                     Shack Exit: 'True'
                     \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: 'True'
@@ -6457,8 +6457,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance: null
+                  entrances:
+                  - Entrance
                   exits:
                     Exit: 'True'
                   hint_region: Lanayru Sand Sea
@@ -6472,7 +6472,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Lanayru\Lanayru Sand Sea\Skipper's Retreat: Clawshots
                   hint_region: Lanayru Sand Sea
@@ -6487,11 +6487,11 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Statue Entrance: null
-                Construction Bay Upper Entrance: null
-                Dock Entrance: null
-                Construction Bay Lower Entrance: null
+              entrances:
+              - Statue Entrance
+              - Dock Entrance
+              - Construction Bay Lower Entrance
+              - Construction Bay Upper Entrance
               exits:
                 Statue Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
                 Dock Exit: 'True'
@@ -6511,9 +6511,9 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Lower Entrance: null
-                    Upper Entrance: null
+                  entrances:
+                  - Lower Entrance
+                  - Upper Entrance
                   exits:
                     Upper Exit: 'True'
                     Lower Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
@@ -6530,10 +6530,10 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Statue Entrance: null
-                Dock Entrance: null
-                Side Entrance: null
+              entrances:
+              - Statue Entrance
+              - Side Entrance
+              - Dock Entrance
               exits:
                 Statue Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
                 Dock Exit: 'True'
@@ -6553,8 +6553,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Top Entrance: null
+                  entrances:
+                  - Top Entrance
                   exits:
                     \Lanayru\Lanayru Sand Sea\Pirate Stronghold: "Clawshots | \\Lanayru\\\
                       Lanayru Sand Sea\\Pirate Stronghold\\Inside\\Finish Minidungeon"
@@ -6576,9 +6576,9 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    First Door Entrance: null
-                    Second Door Entrance: null
+                  entrances:
+                  - Second Door Entrance
+                  - First Door Entrance
                   exits:
                     First Door Exit: 'True'
                     Second Door Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
@@ -6599,9 +6599,9 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Statue Entrance: null
-                Entrance: null
+              entrances:
+              - Statue Entrance
+              - Entrance
               exits:
                 Statue Exit: \Lanayru\Lanayru Sand Sea\Gorge\Unlock Statue
                 \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge: \Lanayru\Lanayru Sand
@@ -6625,7 +6625,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Lanayru\Lanayru Sand Sea\Gorge: "\\Beetle | \\Bow"
                   hint_region: Lanayru Gorge
@@ -6648,7 +6648,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: Sandship
       locations:
@@ -6661,7 +6661,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Sandship
           locations: {}
@@ -6672,8 +6672,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Main Entrance: null
+              entrances:
+              - Main Entrance
               exits:
                 Main Exit: 'True'
                 \Sandship\Main\Before Ship's Bow: 'True'
@@ -6698,7 +6698,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sandship\Main\Deck: 'True'
                     \Sandship\Main\Deck\Stern: "\\Bow & (Clawshots | Sandship - Mast\
@@ -6714,7 +6714,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sandship\Main\Deck: Clawshots
                   hint_region: Sandship
@@ -6728,7 +6728,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sandship\Main\Deck: Sandship Small Key x 2
                   hint_region: Sandship
@@ -6747,7 +6747,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sandship\Main\Ship's Bow: Sandship Small Key x 2
                 \Sandship\Main\Corridor: "\\Sandship\\Pass Spume | \\Sandship\\Main\\\
@@ -6764,7 +6764,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sandship\Main\Before Ship's Bow: \Lanayru\Caves\Chest
               hint_region: Sandship
@@ -6778,7 +6778,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sandship\Main\Before Ship's Bow: "\\Sandship\\Pass Spume | \\Sandship\\\
                   Main\\Deck\\Freely Usable Timeshift Stone"
@@ -6797,7 +6797,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sandship\Main\Deck: "\\Sandship\\Main\\Starboard Rooms\\Switch &\
                   \ \\Bow"
@@ -6817,7 +6817,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sandship\Main\Corridor: \Sandship\Main\Port Rooms\Switch
               hint_region: Sandship
@@ -6833,7 +6833,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sandship\Main\Corridor: 'True'
                 Boss Door one-way Exit: \Sandship\Main\Before Boss Door\Open Boss
@@ -6855,7 +6855,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sandship\Main\Treasure Room: "\\Sandship\\Main\\Starboard Rooms\\\
                   Generator & Whip"
@@ -6872,7 +6872,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sandship\Main\Brig: 'True'
               hint_region: Sandship
@@ -6890,7 +6890,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sandship\Main\Brig: 'True'
               hint_region: Sandship
@@ -6905,8 +6905,8 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance: null
+          entrances:
+          - Entrance
           exits: {}
           hint_region: Sandship
           locations:
@@ -6922,7 +6922,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: Sky Keep
       locations: {}
@@ -6933,7 +6933,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Sky Keep
           locations: {}
@@ -6944,8 +6944,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Bottom Entrance: null
+              entrances:
+              - Bottom Entrance
               exits:
                 Bottom Exit: 'True'
                 \Sky Keep\Main\Puzzle Solving Meta Room: 'True'
@@ -6961,7 +6961,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits: {}
               hint_region: Sky Keep
               locations: {}
@@ -6972,7 +6972,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Skyview Room\End: "Whip & \\Sky Keep\\Main\\Skyview\
                       \ Room\\Beginning\\Free Rope & Clawshots & \\Sky Keep\\Main\\\
@@ -6991,7 +6991,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Skyview Room\Beginning: \Sky Keep\Main\Skyview
                       Room\End\Lever
@@ -7008,7 +7008,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits: {}
               hint_region: Sky Keep
               locations:
@@ -7024,7 +7024,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits: {}
               hint_region: Sky Keep
               locations:
@@ -7038,7 +7038,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits: {}
               hint_region: Sky Keep
               locations: {}
@@ -7049,7 +7049,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Mini Boss Room\Near Chest: "\\Sky Keep\\Main\\\
                       Mini Boss Room\\From Bottom\\Defeat Dreadfuse & Clawshots"
@@ -7066,7 +7066,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Mini Boss Room\From Left: \Sky Keep\Main\Mini Boss
                       Room\Near Chest\Unlock Door
@@ -7083,7 +7083,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Mini Boss Room\Near Chest: \Sky Keep\Main\Mini
                       Boss Room\Near Chest\Unlock Door
@@ -7099,7 +7099,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sky Keep\Main\Ancient Cistern Room\After Key: \Sky Keep\Main\Ancient
                   Cistern Room\Unlock Key Door
@@ -7117,7 +7117,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Ancient Cistern Room\Triforce Room: \Sky Keep\Main\Ancient
                       Cistern Room\After Key\Beat Trial
@@ -7134,7 +7134,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Ancient Cistern Room\After Key: 'True'
                     \Sky Keep\Main\Ancient Cistern Room: \Sky Keep\Main\Ancient Cistern
@@ -7152,7 +7152,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits: {}
               hint_region: Sky Keep
               locations: {}
@@ -7163,7 +7163,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Fire Sanctuary Room\First Platform: "\\Beetle |\
                       \ \\Sky Keep\\Main\\Fire Sanctuary Room\\First Platform\\Lever"
@@ -7182,7 +7182,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: Clawshots
                   hint_region: Sky Keep
@@ -7195,7 +7195,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: "\\Beetle &\
                       \ Clawshots"
@@ -7211,7 +7211,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Fire Sanctuary Room\From Left: \Sky Keep\Main\Fire
                       Sanctuary Room\Triforce Room\Lower Lever
@@ -7230,7 +7230,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: \Sky Keep\Main\Fire
                       Sanctuary Room\Triforce Room\Lower Lever
@@ -7246,7 +7246,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sky Keep\Main\Sandship Room\Triforce Area: "\\Sky Keep\\Main\\Sandship\
                   \ Room\\Lower Eye & Clawshots"
@@ -7262,7 +7262,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky Keep\Main\Sandship Room: 'True'
                   hint_region: Sky Keep
@@ -7277,7 +7277,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sky Keep\Main\Skyview Room\Beginning: \Sky Keep\Main\First Room\Right
                   Exit
@@ -7302,7 +7302,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: Sky
       locations: {}
@@ -7313,7 +7313,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits:
             \Sky\North East\Beedle's Island\Top: 'True'
             \Sky\North East\Beedle's Island\Cage: Sky - Beedle's Island Cage Chest
@@ -7341,8 +7341,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 First Time Dive: Ruby Tablet
                 Volcano Entrance Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\Entry\\\
@@ -7368,8 +7368,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Inside: null
+              entrances:
+              - Entrance from Inside
               exits:
                 \Sky\North East: Day
                 Exit to Inside: 'True'
@@ -7384,8 +7384,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance: null
+                  entrances:
+                  - Entrance
                   exits:
                     Exit: 'True'
                   hint_region: Sky
@@ -7401,8 +7401,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Beedle's Ship Entrance: null
+              entrances:
+              - Beedle's Ship Entrance
               exits:
                 \Sky\North East: Day
                 Beedle's Ship Exit: Night
@@ -7418,7 +7418,7 @@ areas:
                   allowed_time_of_day: 3
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky\North East\Beedle's Island: 'True'
                   hint_region: Sky
@@ -7433,7 +7433,7 @@ areas:
                   allowed_time_of_day: 3
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Sky\North East\Beedle's Island: 'True'
                   hint_region: Sky
@@ -7450,7 +7450,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits:
             \Sky\North East: 'True'
             \Sky\South West: 'True'
@@ -7469,8 +7469,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 First Time Dive: Emerald Tablet
                 Sealed Grounds Statue Dive: "Emerald Tablet & \\Faron\\Sealed Grounds\\\
@@ -7504,10 +7504,10 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Main Right Door Entrance: null
-                Main Left Door Entrance: null
-                Back Door Entrance: null
+              entrances:
+              - Main Right Door Entrance
+              - Back Door Entrance
+              - Main Left Door Entrance
               exits:
                 \Sky\South East: Day
                 Main Right Door Exit: 'True'
@@ -7533,10 +7533,10 @@ areas:
                   allowed_time_of_day: 3
                   can_save: false
                   can_sleep: true
-                  entrances: !!set
-                    Main Right Door Entrance: null
-                    Main Left Door Entrance: null
-                    Back Door Entrance: null
+                  entrances:
+                  - Main Right Door Entrance
+                  - Back Door Entrance
+                  - Main Left Door Entrance
                   exits:
                     Main Right Door Exit: 'True'
                     Main Left Door Exit: 'True'
@@ -7566,7 +7566,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits:
             \Sky\South East: 'True'
             \Sky\Around Skyloft: 'True'
@@ -7585,8 +7585,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 First Time Dive: Amber Tablet
                 Lanayru Mine Entry Statue Dive: "Amber Tablet & \\Lanayru\\Mine\\\
@@ -7624,7 +7624,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sky\South West: Day
               hint_region: Sky
@@ -7643,7 +7643,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sky\South West: Day
               hint_region: Sky
@@ -7659,7 +7659,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sky\South West: Day
               hint_region: Sky
@@ -7681,7 +7681,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sky\South West: Day
               hint_region: Sky
@@ -7702,9 +7702,9 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance from Skyloft: null
-            Entrance from Thunderhead: null
+          entrances:
+          - Entrance from Skyloft
+          - Entrance from Thunderhead
           exits:
             \Sky\North East: 'True'
             \Sky\South West: 'True'
@@ -7721,8 +7721,8 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance: null
+          entrances:
+          - Entrance
           exits:
             Exit: 'True'
             \Sky\Thunderhead\Isle of Songs: 'True'
@@ -7740,8 +7740,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Inside: null
+              entrances:
+              - Entrance from Inside
               exits:
                 \Sky\Thunderhead: Day
                 Exit to Inside: \Sky\Thunderhead\Isle of Songs\Puzzle Solved
@@ -7759,8 +7759,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Entrance: null
+                  entrances:
+                  - Entrance
                   exits:
                     Exit: 'True'
                   hint_region: Thunderhead
@@ -7777,7 +7777,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sky\Thunderhead: Day
               hint_region: Thunderhead
@@ -7794,7 +7794,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sky\Thunderhead: Day
               hint_region: Thunderhead
@@ -7812,7 +7812,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Sky\Thunderhead: Day
               hint_region: Thunderhead
@@ -7831,7 +7831,7 @@ areas:
       allowed_time_of_day: 3
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: null
       locations: {}
@@ -7842,14 +7842,14 @@ areas:
           allowed_time_of_day: 3
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Sparring Hall Right Door Entrance: null
-            Goddess Statue Entrance: null
-            Knight Academy Upper Left Door Entrance: null
-            Knight Academy Lower Left Door Entrance: null
-            Sparring Hall Left Door Entrance: null
-            Knight Academy Lower Right Door Entrance: null
-            Knight Academy Upper Right Door Entrance: null
+          entrances:
+          - Knight Academy Upper Right Door Entrance
+          - Goddess Statue Entrance
+          - Knight Academy Lower Right Door Entrance
+          - Sparring Hall Left Door Entrance
+          - Sparring Hall Right Door Entrance
+          - Knight Academy Upper Left Door Entrance
+          - Knight Academy Lower Left Door Entrance
           exits:
             Knight Academy Upper Right Door Exit: 'True'
             Knight Academy Upper Left Door Exit: 'True'
@@ -7872,11 +7872,11 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: true
-              entrances: !!set
-                Lower Left Door Entrance: null
-                Upper Left Door Entrance: null
-                Upper Right Door Entrance: null
-                Lower Right Door Entrance: null
+              entrances:
+              - Upper Right Door Entrance
+              - Lower Right Door Entrance
+              - Upper Left Door Entrance
+              - Lower Left Door Entrance
               exits:
                 Upper Right Door Exit: 'True'
                 Upper Left Door Exit: 'True'
@@ -7905,8 +7905,8 @@ areas:
                   allowed_time_of_day: 3
                   can_save: false
                   can_sleep: true
-                  entrances: !!set
-                    Start Entrance: null
+                  entrances:
+                  - Start Entrance
                   exits:
                     \Skyloft\Upper Skyloft\Knight Academy: 'True'
                   hint_region: Upper Skyloft
@@ -7920,8 +7920,8 @@ areas:
                   allowed_time_of_day: 3
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Chimney: null
+                  entrances:
+                  - Chimney
                   exits:
                     \Skyloft\Upper Skyloft\Knight Academy: 'True'
                   hint_region: Upper Skyloft
@@ -7938,9 +7938,9 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Right Door Entrance: null
-                Left Door Entrance: null
+              entrances:
+              - Right Door Entrance
+              - Left Door Entrance
               exits:
                 Right Door Exit: 'True'
                 Left Door Exit: 'True'
@@ -7958,8 +7958,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Upper Skyloft
@@ -7975,18 +7975,18 @@ areas:
           allowed_time_of_day: 3
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Waterfall Cave Upper Entrance: null
-            Entrance from Beedle's Shop: null
-            Bazaar West Entrance: null
-            Wryna's House Entrance: null
-            Peatrice's House Entrance: null
-            Orielle and Parrow's House Entrance: null
-            Bazaar South Entrance: null
-            Trial Gate Entrance: null
-            Piper's House Entrance: null
-            Entrance from Sky: null
-            Bazaar North Entrance: null
+          entrances:
+          - Waterfall Cave Upper Entrance
+          - Bazaar South Entrance
+          - Bazaar North Entrance
+          - Peatrice's House Entrance
+          - Entrance from Sky
+          - Trial Gate Entrance
+          - Piper's House Entrance
+          - Entrance from Beedle's Shop
+          - Wryna's House Entrance
+          - Orielle and Parrow's House Entrance
+          - Bazaar West Entrance
           exits:
             Exit to Beedle's Shop: "Day & (\\Distance Activator | Beedle's Shop With\
               \ Bombs Trick & Bomb Bag)"
@@ -8039,7 +8039,7 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Skyloft\Central Skyloft: 'True'
               hint_region: Central Skyloft
@@ -8053,10 +8053,10 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                North Entrance: null
-                South Entrance: null
-                West Entrance: null
+              entrances:
+              - West Entrance
+              - North Entrance
+              - South Entrance
               exits:
                 North Exit: 'True'
                 West Exit: 'True'
@@ -8079,7 +8079,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Skyloft\Central Skyloft\Bazaar: 'True'
                   hint_region: Central Skyloft
@@ -8100,8 +8100,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: true
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Central Skyloft
@@ -8119,8 +8119,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: true
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Central Skyloft
@@ -8135,8 +8135,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: true
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Central Skyloft
@@ -8150,8 +8150,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: true
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Central Skyloft
@@ -8164,8 +8164,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance from Sky Keep: null
+              entrances:
+              - Entrance from Sky Keep
               exits:
                 Exit to Sky Keep: Stone of Trials
                 \Skyloft\Central Skyloft: Clawshots
@@ -8179,7 +8179,7 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Skyloft\Central Skyloft: 'True'
                 \Skyloft\Skyloft Village: 'True'
@@ -8200,9 +8200,9 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Lower Entrance: null
-                Upper Entrance: null
+              entrances:
+              - Lower Entrance
+              - Upper Entrance
               exits:
                 Upper Exit: 'True'
                 Lower Exit: 'True'
@@ -8219,8 +8219,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Waterfall Cave Lower Entrance: null
+              entrances:
+              - Waterfall Cave Lower Entrance
               exits:
                 Waterfall Cave Lower Exit: 'True'
                 \Skyloft\Central Skyloft\Exit to Sky: Day
@@ -8237,8 +8237,8 @@ areas:
           allowed_time_of_day: 3
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance: null
+          entrances:
+          - Entrance
           exits:
             Exit: 'True'
           hint_region: Skyloft Silent Realm
@@ -8262,13 +8262,13 @@ areas:
           allowed_time_of_day: 3
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Gondo's House Entrance: null
-            Rupin's House Entrance: null
-            Bertie's House Entrance: null
-            Mallara's House Entrance: null
-            Sparrot's House Entrance: null
-            Batreaux's House Entrance: null
+          entrances:
+          - Batreaux's House Entrance
+          - Rupin's House Entrance
+          - Sparrot's House Entrance
+          - Bertie's House Entrance
+          - Gondo's House Entrance
+          - Mallara's House Entrance
           exits:
             \Skyloft\Central Skyloft: 'True'
             \Skyloft\Central Skyloft\Past Waterfall Cave: "Waterfall Cave Jump Trick\
@@ -8292,8 +8292,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: true
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Skyloft Village
@@ -8307,8 +8307,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: true
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Skyloft Village
@@ -8324,8 +8324,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: true
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Skyloft Village
@@ -8339,8 +8339,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: true
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Skyloft Village
@@ -8353,8 +8353,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: true
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Skyloft Village
@@ -8367,8 +8367,8 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Entrance: null
+              entrances:
+              - Entrance
               exits:
                 Exit: 'True'
               hint_region: Batreaux's House
@@ -8391,9 +8391,9 @@ areas:
           allowed_time_of_day: 3
           can_save: false
           can_sleep: true
-          entrances: !!set
-            Night Entrance: null
-            Day Entrance: null
+          entrances:
+          - Night Entrance
+          - Day Entrance
           exits:
             Night Exit: Night
             Day Exit: Day
@@ -8407,7 +8407,7 @@ areas:
               allowed_time_of_day: 3
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Skyloft\Beedle's Shop: 'True'
               hint_region: Beedle's Shop
@@ -8434,7 +8434,7 @@ areas:
       allowed_time_of_day: 1
       can_save: false
       can_sleep: false
-      entrances: !!set {}
+      entrances: []
       exits: {}
       hint_region: Skyview
       locations:
@@ -8449,7 +8449,7 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set {}
+          entrances: []
           exits: {}
           hint_region: Skyview
           locations: {}
@@ -8460,8 +8460,8 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set
-                Main Entrance: null
+              entrances:
+              - Main Entrance
               exits:
                 Main Exit: 'True'
                 \Skyview\Main\First Room: \Skyview\Main\Entry\Cut Tree
@@ -8476,7 +8476,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Skyview\Main\Entry: \Skyview\Main\Entry\Cut Tree
                 \Skyview\Main\One Eye Room: \Skyview\Main\First Room\Switch to One
@@ -8496,7 +8496,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Skyview\Main\First Room: \Skyview\Main\First Room\Switch to One Eye
                   Room
@@ -8513,7 +8513,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Skyview\Main\One Eye Room: \Skyview\Main\One Eye Room\Unlock Door
                   to First Hub
@@ -8543,7 +8543,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Skyview\Main\First Hub: 'True'
                   hint_region: Skyview
@@ -8564,7 +8564,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits: {}
                   hint_region: Skyview
                   locations: {}
@@ -8575,7 +8575,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Skyview\Main\First Hub: 'True'
                         \Skyview\Main\First Hub\Right Room\After Crawlspace: 'True'
@@ -8591,7 +8591,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
                       hint_region: Skyview
@@ -8605,7 +8605,7 @@ areas:
                           allowed_time_of_day: 1
                           can_save: false
                           can_sleep: false
-                          entrances: !!set {}
+                          entrances: []
                           exits:
                             \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
                           hint_region: Skyview
@@ -8622,7 +8622,7 @@ areas:
                       allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
-                      entrances: !!set {}
+                      entrances: []
                       exits:
                         \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
                         \Skyview\Main\First Hub: 'True'
@@ -8639,7 +8639,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits:
                 \Skyview\Main\First Hub: Skyview Small Key x 2
                 \Skyview\Main\Second Hub\Miniboss Room: \Skyview\Main\Second Hub\Switch
@@ -8667,7 +8667,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Skyview\Main\Second Hub: 'True'
                   hint_region: Skyview
@@ -8681,7 +8681,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Skyview\Main\Second Hub: "\\Sword & \\Projectile Item"
                   hint_region: Skyview
@@ -8695,7 +8695,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Skyview\Main\Second Hub: Skyview Small Key
                     \Skyview\Main\Last Room\Near East Entrance: \Skyview\Main\Second
@@ -8712,7 +8712,7 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: !!set {}
+              entrances: []
               exits: {}
               hint_region: Skyview
               locations: {}
@@ -8723,7 +8723,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Skyview\Main\Second Hub\Staldra Room: 'True'
                     \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Near
@@ -8740,7 +8740,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Skyview\Main\Last Room\Near East Entrance: \Skyview\Main\Last
                       Room\Near East Entrance\Deal with Hanging Skulltula
@@ -8764,8 +8764,8 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set
-                    Boss Door Entrance: null
+                  entrances:
+                  - Boss Door Entrance
                   exits:
                     \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Before
                       Rope\Deal with Archers
@@ -8786,7 +8786,7 @@ areas:
                   allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
-                  entrances: !!set {}
+                  entrances: []
                   exits:
                     \Skyview\Main\Last Room\Before Rope: 'True'
                     \Skyview\Main\Last Room\After Rope: \Skyview\Main\Last Room\After
@@ -8804,9 +8804,9 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance from Dungeon: null
-            Entrance from Spring: null
+          entrances:
+          - Entrance from Spring
+          - Entrance from Dungeon
           exits:
             Exit to Dungeon: \Skyview\Boss Room\Beat Ghirahim
             Exit to Spring: \Skyview\Boss Room\Beat Ghirahim
@@ -8822,8 +8822,8 @@ areas:
           allowed_time_of_day: 1
           can_save: false
           can_sleep: false
-          entrances: !!set
-            Entrance: null
+          entrances:
+          - Entrance
           exits:
             Exit: 'True'
           hint_region: Skyview

--- a/dump.yaml
+++ b/dump.yaml
@@ -14318,3 +14318,43 @@ entrances:
     allowed_time_of_day: 1
     req_index: 2342
     short_name: Sky Keep - First Room - Bottom Entrance
+linked_entrances:
+  silent_realms:
+    Skyloft Silent Realm:
+      exit_from_outside: \Skyloft\Central Skyloft\Trial Gate Exit
+      exit_from_inside: \Skyloft\Skyloft Silent Realm\Exit
+    Faron Silent Realm:
+      exit_from_outside: \Faron\Faron Woods\Trial Gate Exit
+      exit_from_inside: \Faron\Faron Silent Realm\Exit
+    Lanayru Silent Realm:
+      exit_from_outside: \Lanayru\Desert\North Part\Trial Gate Exit
+      exit_from_inside: \Lanayru\Lanayru Silent Realm\Exit
+    Eldin Silent Realm:
+      exit_from_outside: \Eldin\Volcano\Ascent\Trial Gate Exit
+      exit_from_inside: \Eldin\Eldin Silent Realm\Exit
+  dungeons:
+    Skyview:
+      exit_from_outside: \Faron\Faron Woods\Deep Woods\Exit to Skyview Temple
+      exit_from_inside: \Skyview\Main\Entry\Main Exit
+    Earth Temple:
+      exit_from_outside: \Eldin\Volcano\Near Temple Entrance\Exit to Earth Temple
+      exit_from_inside: \Earth Temple\Main\First Room\Main Exit
+    Lanayru Mining Facility:
+      exit_from_outside: \Lanayru\Desert\Top of LMF\Exit to Lanayru Mining Facility
+      exit_from_inside: \Lanayru Mining Facility\Main\First Room\Main Exit
+    Ancient Cistern:
+      exit_from_outside: \Faron\Lake Floria\Waterfall\Exit to Ancient Cistern
+      exit_from_inside: \Ancient Cistern\Main\Main Room\Main Exit
+    Sandship:
+      exit_from_outside:
+      - \Lanayru\Lanayru Sand Sea\Sandship Dock Exit
+      - \Lanayru\Lanayru Sand Sea\Ancient Harbour\Exit to Sandship
+      exit_from_inside: \Sandship\Main\Deck\Main Exit
+    Fire Sanctuary:
+      exit_from_outside: \Eldin\Volcano Summit\Outside Fire Sanctuary\Exit to Fire
+        Sanctuary
+      exit_from_inside: \Fire Sanctuary\Main\First Room\Main Exit
+    Sky Keep:
+      exit_from_outside: \Skyloft\Central Skyloft\Near Temple Entrance\Exit to Sky
+        Keep
+      exit_from_inside: \Sky Keep\Main\First Room\Bottom Exit

--- a/dump.yaml
+++ b/dump.yaml
@@ -3210,9 +3210,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
+              - Volcano East Statue Entrance
               - First Vent from Mogma Turf
               - Entrance from Bokoblin Base
-              - Volcano East Statue Entrance
               exits:
                 Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\East\Unlock
                   Statue
@@ -3267,8 +3267,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Trial Gate Entrance
               - Volcano Ascent Statue Entrance
+              - Trial Gate Entrance
               exits:
                 \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\Ascent\Unlock
                   Statue
@@ -3381,8 +3381,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Vent Entrance near Hot Cave
               - Entrance from Summit
+              - Vent Entrance near Hot Cave
               exits:
                 Exit to Summit: Fireshield Earrings
                 \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Temple Entrance\Blow
@@ -3542,8 +3542,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Entrance from Waterfall
           - Entrance from Eldin Volcano
+          - Entrance from Waterfall
           - Entrance from Outside Fire Sanctuary
           exits:
             Exit to Eldin Volcano: Fireshield Earrings
@@ -3593,8 +3593,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Fire Sanctuary
               - Statue Entrance
+              - Entrance from Fire Sanctuary
               exits:
                 Statue Exit: \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
                 \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: \Eldin\Volcano
@@ -3913,8 +3913,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Side Entrance
               - Main Entrance
+              - Side Entrance
               - Gate of Time Entrance
               exits:
                 Main Exit: 'True'
@@ -3956,9 +3956,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Faron Woods
               - Statue Entrance
               - Door Entrance
+              - Entrance from Faron Woods
               - Shortcut Entrance from Spiral
               exits:
                 Statue Exit: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
@@ -3981,8 +3981,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Viewing Platform Statue Entrance
           - In the Woods Statue Entrance
+          - Viewing Platform Statue Entrance
           - Trial Gate Entrance
           exits:
             \Faron\Faron Woods\Entry: 'True'
@@ -4027,8 +4027,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Behind the Temple
               - Faron Woods Entry Statue Entrance
+              - Entrance from Behind the Temple
               exits:
                 \Faron\Faron Woods\Shared Statue Exit: \Faron\Faron Woods\Entry\Unlock
                   Statue
@@ -4227,9 +4227,9 @@ areas:
                   can_save: false
                   can_sleep: false
                   entrances:
-                  - Entrance from Top
                   - Entrance from Flooded Great Tree
                   - Upper Entrance from Platforms
+                  - Entrance from Top
                   exits:
                     \Faron\Faron Woods\Great Tree\Lower Area: \Faron\Faron Woods\Great
                       Tree\Upper Area\Remove Void Plane
@@ -4275,8 +4275,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Forest Temple Statue Entrance
               - Deep Woods Statue Entrance
+              - Forest Temple Statue Entrance
               - Entrance from Skyview Temple
               exits:
                 Shared Statue Exit: 'True'
@@ -4344,8 +4344,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Entrance from Lower Flooded Great Tree
           - Entrance from Upper Flooded Great Tree
+          - Entrance from Lower Flooded Great Tree
           exits:
             Exit to Upper Flooded Great Tree: 'True'
             Exit to Lower Flooded Great Tree: Water Dragon's Scale
@@ -4380,9 +4380,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Lower Flooded Faron Woods
-              - Entrance from Upper Flooded Faron Woods
               - Entrance
+              - Entrance from Upper Flooded Faron Woods
+              - Entrance from Lower Flooded Faron Woods
               exits:
                 Exit: 'True'
                 Exit to Upper Flooded Faron Woods: 'True'
@@ -4486,10 +4486,10 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Farore's Lair
-              - Entrance from Ancient Cistern
               - Statue Entrance
+              - Entrance from Farore's Lair
               - Entrance from Faron Woods
+              - Entrance from Ancient Cistern
               exits:
                 Statue Exit: \Faron\Lake Floria\Waterfall\Unlock Statue
                 Exit to Farore's Lair: 'True'
@@ -5601,8 +5601,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Statue Entrance
               - First Time Entrance
+              - Statue Entrance
               exits:
                 Statue Exit: \Lanayru\Mine\Entry\Unlock Statue
                 \Lanayru\Mine\Statues Area: \Lanayru\Mine\Entry\Timeshift Stone
@@ -5719,8 +5719,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Desert Entrance Statue Entrance
               - Entrance from Mine
+              - Desert Entrance Statue Entrance
               exits:
                 Exit to Mine: \Lanayru\Desert\Entry\Timeshift Stone
                 \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\Entry\Unlock Statue
@@ -5902,9 +5902,9 @@ areas:
               can_sleep: false
               entrances:
               - North Entrance from Temple of Time
+              - North Desert Statue Entrance
               - Trial Gate Entrance
               - Lightning Node Entrance
-              - North Desert Statue Entrance
               exits:
                 North Exit to Temple of Time: 'True'
                 \Lanayru\Desert\East: 'True'
@@ -6164,8 +6164,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Desert Gorge Statue Entrance
               - South Entrance from Desert
+              - Desert Gorge Statue Entrance
               exits:
                 South Exit to Desert: 'True'
                 \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\South
@@ -6339,11 +6339,11 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Pirate Stronghold Dock Entrance
-          - Sandship Dock Entrance
-          - Shipyard Dock Entrance
-          - Skipper's Retreat Dock Entrance
           - Ancient Harbour Dock Entrance
+          - Sandship Dock Entrance
+          - Skipper's Retreat Dock Entrance
+          - Shipyard Dock Entrance
+          - Pirate Stronghold Dock Entrance
           exits:
             Ancient Harbour Dock Exit: 'True'
             Sandship Dock Exit: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
@@ -6361,8 +6361,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Statue Entrance
               - Dock Entrance
+              - Statue Entrance
               exits:
                 Dock Exit: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Ship Timeshift
                   Stone
@@ -6490,10 +6490,10 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Construction Bay Upper Entrance
               - Statue Entrance
-              - Construction Bay Lower Entrance
               - Dock Entrance
+              - Construction Bay Upper Entrance
+              - Construction Bay Lower Entrance
               exits:
                 Statue Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
                 Dock Exit: 'True'
@@ -6534,8 +6534,8 @@ areas:
               can_sleep: false
               entrances:
               - Statue Entrance
-              - Side Entrance
               - Dock Entrance
+              - Side Entrance
               exits:
                 Statue Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
                 Dock Exit: 'True'
@@ -6579,8 +6579,8 @@ areas:
                   can_save: false
                   can_sleep: false
                   entrances:
-                  - Second Door Entrance
                   - First Door Entrance
+                  - Second Door Entrance
                   exits:
                     First Door Exit: 'True'
                     Second Door Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
@@ -7507,8 +7507,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Main Left Door Entrance
               - Main Right Door Entrance
+              - Main Left Door Entrance
               - Back Door Entrance
               exits:
                 \Sky\South East: Day
@@ -7536,8 +7536,8 @@ areas:
                   can_save: false
                   can_sleep: true
                   entrances:
-                  - Main Left Door Entrance
                   - Main Right Door Entrance
+                  - Main Left Door Entrance
                   - Back Door Entrance
                   exits:
                     Main Right Door Exit: 'True'
@@ -7845,13 +7845,13 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Sparring Hall Right Door Entrance
-          - Knight Academy Lower Right Door Entrance
-          - Goddess Statue Entrance
-          - Knight Academy Lower Left Door Entrance
           - Knight Academy Upper Right Door Entrance
           - Knight Academy Upper Left Door Entrance
+          - Knight Academy Lower Right Door Entrance
+          - Knight Academy Lower Left Door Entrance
+          - Sparring Hall Right Door Entrance
           - Sparring Hall Left Door Entrance
+          - Goddess Statue Entrance
           exits:
             Knight Academy Upper Right Door Exit: 'True'
             Knight Academy Upper Left Door Exit: 'True'
@@ -7875,9 +7875,9 @@ areas:
               can_save: false
               can_sleep: true
               entrances:
-              - Lower Right Door Entrance
               - Upper Right Door Entrance
               - Upper Left Door Entrance
+              - Lower Right Door Entrance
               - Lower Left Door Entrance
               exits:
                 Upper Right Door Exit: 'True'
@@ -7978,17 +7978,17 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Bazaar West Entrance
-          - Orielle and Parrow's House Entrance
-          - Bazaar North Entrance
-          - Bazaar South Entrance
-          - Waterfall Cave Upper Entrance
-          - Peatrice's House Entrance
-          - Entrance from Sky
-          - Trial Gate Entrance
-          - Piper's House Entrance
           - Entrance from Beedle's Shop
+          - Bazaar North Entrance
+          - Bazaar West Entrance
+          - Bazaar South Entrance
+          - Trial Gate Entrance
+          - Orielle and Parrow's House Entrance
+          - Peatrice's House Entrance
           - Wryna's House Entrance
+          - Piper's House Entrance
+          - Entrance from Sky
+          - Waterfall Cave Upper Entrance
           exits:
             Exit to Beedle's Shop: "Day & (\\Distance Activator | (Beedle's Shop With\
               \ Bombs Trick & Bomb Bag))"
@@ -8265,12 +8265,12 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Sparrot's House Entrance
-          - Gondo's House Entrance
-          - Mallara's House Entrance
           - Bertie's House Entrance
-          - Batreaux's House Entrance
+          - Sparrot's House Entrance
+          - Mallara's House Entrance
+          - Gondo's House Entrance
           - Rupin's House Entrance
+          - Batreaux's House Entrance
           exits:
             \Skyloft\Central Skyloft: 'True'
             \Skyloft\Central Skyloft\Past Waterfall Cave: "Waterfall Cave Jump Trick\
@@ -8807,8 +8807,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Entrance from Spring
           - Entrance from Dungeon
+          - Entrance from Spring
           exits:
             Exit to Dungeon: \Skyview\Boss Room\Beat Ghirahim
             Exit to Spring: \Skyview\Boss Room\Beat Ghirahim

--- a/dump.yaml
+++ b/dump.yaml
@@ -805,9 +805,6 @@ items:
 - \Eldin\Volcano\East\North Rupee above Mogma Turf Entrance
 - \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf
 - \Eldin\Volcano\Past Mogma Turf\Watch Bridge Cutscene
-- \Eldin\Volcano\Past Mogma Turf\Southeast Rupee above Mogma Turf Entrance
-- \Eldin\Volcano\Past Mogma Turf\North Rupee above Mogma Turf Entrance
-- \Eldin\Volcano\Past Mogma Turf\Goddess Cube near Mogma Turf Entrance
 - \Eldin\Volcano\Ascent\Chest behind Bombable Wall near Volcano Ascent
 - \Eldin\Volcano\Ascent\Unlock Statue
 - \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
@@ -872,18 +869,12 @@ items:
 - \Eldin\Bokoblin Base\Prison\Plats' Gift
 - \Eldin\Bokoblin Base\Volcano East\Chest near Bone Bridge
 - \Eldin\Bokoblin Base\Volcano East\Chest on Cliff
-- \Eldin\Bokoblin Base\Volcano East\Goddess Cube near Mogma Turf Entrance
 - \Eldin\Bokoblin Base\Before Drawbridge\Chest near Drawbridge
-- \Eldin\Bokoblin Base\Lower Platform Cave\Gossip Stone in Lower Platform Cave
 - \Eldin\Bokoblin Base\Outside Earth Temple\Chest East of Earth Temple Entrance
-- \Eldin\Bokoblin Base\Outside Earth Temple\Goddess Cube East of Earth Temple Entrance
 - \Eldin\Bokoblin Base\Outside Earth Temple\Chest West of Earth Temple Entrance
-- \Eldin\Bokoblin Base\Outside Earth Temple\Goddess Cube West of Earth Temple Entrance
-- \Eldin\Bokoblin Base\Upper Platform Cave\Gossip Stone in Upper Platform Cave
 - \Eldin\Bokoblin Base\Bokoblin Base Summit\First Chest in Volcano Summit
 - \Eldin\Bokoblin Base\Bokoblin Base Summit\Raised Chest in Volcano Summit
 - \Eldin\Bokoblin Base\Bokoblin Base Summit\Chest in Volcano Summit Alcove
-- \Eldin\Bokoblin Base\Bokoblin Base Summit\Goddess Cube inside Volcano Summit
 - \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
 - \Eldin\Bokoblin Base\Fire Dragon's Lair\Fire Dragon's Reward
 - \Faron\Sealed Grounds\Spiral\Defeat Imprisoned 2
@@ -1083,7 +1074,6 @@ items:
 - \Lanayru\Mine\Statues Area\Chest behind Statue
 - \Lanayru\Mine\End\Blow up Rock on Track
 - \Lanayru\Mine\End\Chest at the End of Mine
-- \Lanayru\Mine\End\In Minecart\Blow up Rock on Track
 - \Lanayru\Desert\Entry\Unlock Statue
 - \Lanayru\Desert\Entry\Blow up Rock for Timeshift Stone
 - \Lanayru\Desert\Entry\Timeshift Stone
@@ -1359,8 +1349,6 @@ items:
 - \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades\Upgrade to Tough Beetle
 - \Skyloft\Central Skyloft\Orielle and Parrow's House\Crystal in Orielle and Parrow's
   House
-- \Skyloft\Central Skyloft\Orielle and Parrow's House\Parrow's Gift
-- \Skyloft\Central Skyloft\Orielle and Parrow's House\Parrow's Crystals
 - \Skyloft\Central Skyloft\Peatrice's House\Peater/Peatrice's Crystals
 - \Skyloft\Central Skyloft\Wryna's House\Wryna's Crystals
 - \Skyloft\Central Skyloft\Waterfall Island\Crystal on Waterfall Island
@@ -1982,7 +1970,7 @@ items:
 - \Eldin\Volcano\Hot Cave\Exit to Summit
 - \Eldin\Volcano\Ascent\Trial Gate Exit
 - \Eldin\Volcano\Past Slide\Vent Exit near Ascent
-- \Eldin\Volcano\East\Exit to Bokoblin Base
+- \Eldin\Volcano\First Room\Exit to Bokoblin Base
 - \Eldin\Bokoblin Base\Prison\Exit
 - \Eldin\Mogma Turf\Pre Vent\First Vent
 - \Eldin\Mogma Turf\Past Vent\Second Vent
@@ -2271,7 +2259,7 @@ items:
 - \Eldin\Volcano\Hot Cave\Entrance from Summit
 - \Eldin\Volcano\Ascent\Trial Gate Entrance
 - \Eldin\Volcano\Hot Cave\Vent Entrance near Hot Cave
-- \Eldin\Volcano\East\Entrance from Bokoblin Base
+- \Eldin\Volcano\First Room\Entrance from Bokoblin Base
 - \Eldin\Bokoblin Base\Prison\Entrance
 - \Eldin\Mogma Turf\Pre Vent\Entrance
 - \Eldin\Volcano\Thrill Digger Cave\Entrance
@@ -3191,9 +3179,12 @@ areas:
               allowed_time_of_day: 1
               can_save: false
               can_sleep: false
-              entrances: []
+              entrances:
+              - Entrance from Bokoblin Base
               exits:
                 \Eldin\Volcano\East: \Eldin\Volcano\First Room\Blow up Rock to East
+                \Eldin\Volcano\Entry: 'True'
+                Exit to Bokoblin Base: 'True'
               hint_region: Eldin Volcano
               locations:
                 Chest behind Bombable Wall in First Room: 'True'
@@ -3211,7 +3202,6 @@ areas:
               entrances:
               - Volcano East Statue Entrance
               - First Vent from Mogma Turf
-              - Entrance from Bokoblin Base
               exits:
                 Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\East\Unlock
                   Statue
@@ -3221,7 +3211,6 @@ areas:
                   to East
                 \Eldin\Volcano\Past Mogma Turf: \Eldin\Volcano\Past Mogma Turf\Unlock
                   Shortcut to Pre Turf
-                Exit to Bokoblin Base: 'True'
               hint_region: Eldin Volcano
               locations:
                 \Eldin\Volcano\First Room\Blow up Rock to East: Bomb Bag
@@ -3254,9 +3243,6 @@ areas:
               locations:
                 Unlock Shortcut to Pre Turf: 'True'
                 Watch Bridge Cutscene: 'True'
-                Southeast Rupee above Mogma Turf Entrance: \Beetle
-                North Rupee above Mogma Turf Entrance: \Beetle
-                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
               name: \Eldin\Volcano\Past Mogma Turf
               sub_areas: {}
               toplevel_alias: null
@@ -3694,7 +3680,8 @@ areas:
                   \ Mitts | Gust Bellows"
                 Chest on Cliff: "(\\Can bypass Boko Base Watch Tower | \\Mogma Mitts)\
                   \ & Gust Bellows"
-                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
+                \Eldin\Volcano\East\Goddess Cube near Mogma Turf Entrance: \Goddess
+                  Sword
               name: \Eldin\Bokoblin Base\Volcano East
               sub_areas: {}
               toplevel_alias: null
@@ -3741,7 +3728,7 @@ areas:
                 \Eldin\Bokoblin Base\Volcano East: 'True'
               hint_region: Bokoblin Base
               locations:
-                Gossip Stone in Lower Platform Cave: 'True'
+                \Eldin\Volcano\Lower Platform Cave\Gossip Stone in Lower Platform Cave: 'True'
               name: \Eldin\Bokoblin Base\Lower Platform Cave
               sub_areas: {}
               toplevel_alias: null
@@ -3757,12 +3744,13 @@ areas:
               hint_region: Bokoblin Base
               locations:
                 Chest East of Earth Temple Entrance: 'True'
-                Goddess Cube East of Earth Temple Entrance: \Goddess Sword
+                \Eldin\Volcano\Near Temple Entrance\Goddess Cube East of Earth Temple Entrance: \Goddess
+                  Sword
                 Chest West of Earth Temple Entrance: "(\\Slingshot | \\Bow | Bomb\
                   \ Bag | \\Goddess Sword) & \\Can bypass Boko Base Watch Tower &\
                   \ \\Mogma Mitts"
-                Goddess Cube West of Earth Temple Entrance: "\\Goddess Sword & \\\
-                  Can bypass Boko Base Watch Tower & \\Mogma Mitts"
+                \Eldin\Volcano\Near Temple Entrance\Goddess Cube West of Earth Temple Entrance: "\\\
+                  Goddess Sword & \\Can bypass Boko Base Watch Tower & \\Mogma Mitts"
               name: \Eldin\Bokoblin Base\Outside Earth Temple
               sub_areas: {}
               toplevel_alias: null
@@ -3776,7 +3764,7 @@ areas:
                 \Eldin\Bokoblin Base\Outside Earth Temple: 'True'
               hint_region: Bokoblin Base
               locations:
-                Gossip Stone in Upper Platform Cave: 'True'
+                \Eldin\Volcano\Upper Platform Cave\Gossip Stone in Upper Platform Cave: 'True'
               name: \Eldin\Bokoblin Base\Upper Platform Cave
               sub_areas: {}
               toplevel_alias: null
@@ -3811,7 +3799,8 @@ areas:
                 Raised Chest in Volcano Summit: Fireshield Earrings
                 Chest in Volcano Summit Alcove: "Fireshield Earrings & \\Practice\
                   \ Sword"
-                Goddess Cube inside Volcano Summit: Fireshield Earrings
+                \Eldin\Volcano Summit\Goddess Cube inside Volcano Summit: "Fireshield\
+                  \ Earrings & \\Goddess Sword"
               name: \Eldin\Bokoblin Base\Bokoblin Base Summit
               sub_areas: {}
               toplevel_alias: null
@@ -4984,6 +4973,7 @@ areas:
               exits:
                 Statue Exit: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
                 Boss Door Exit: Fire Sanctuary Boss Key
+                \Fire Sanctuary\Main\West of Boss Door: 'True'
                 \Fire Sanctuary\Main\Lizalfos Fight Room: 'True'
                 \Fire Sanctuary\Main\Front of Boss Door\Past Bars: \Fire Sanctuary\Main\Front
                   of Boss Door\Past Bars\Unlock Way to Front
@@ -5694,7 +5684,8 @@ areas:
                     Exit to Desert: 'True'
                   hint_region: Lanayru Mine
                   locations:
-                    Blow up Rock on Track: "Bomb Bag & Lanayru Mine - Quick Bomb Trick"
+                    \Lanayru\Mine\End\Blow up Rock on Track: "Bomb Bag & Lanayru Mine\
+                      \ - Quick Bomb Trick"
                   name: \Lanayru\Mine\End\In Minecart
                   sub_areas: {}
                   toplevel_alias: null
@@ -8109,10 +8100,10 @@ areas:
               hint_region: Central Skyloft
               locations:
                 Crystal in Orielle and Parrow's House: 'True'
-                Parrow's Gift: "\\Sky\\South West\\Orielle's Island\\Talk to Orielle\
-                  \ & Night"
-                Parrow's Crystals: "\\Sky\\South West\\Orielle's Island\\Save Orielle\
-                  \ & Night"
+                \Skyloft\Central Skyloft\Parrow's Gift: "\\Sky\\South West\\Orielle's\
+                  \ Island\\Talk to Orielle & Night"
+                \Skyloft\Central Skyloft\Parrow's Crystals: "\\Sky\\South West\\Orielle's\
+                  \ Island\\Save Orielle & Night"
               name: \Skyloft\Central Skyloft\Orielle and Parrow's House
               sub_areas: {}
               toplevel_alias: null
@@ -9935,7 +9926,7 @@ exits:
     stage: F001r
     room: 1
     index: 2
-    req_index: 1801
+    req_index: 1789
     short_name: Start
   \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Exit:
     type: exit
@@ -9943,7 +9934,7 @@ exits:
     stage: F001r
     room: 0
     index: 0
-    req_index: 1802
+    req_index: 1790
     short_name: Skyloft - Knight Academy - Lower Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Exit:
     type: exit
@@ -9951,7 +9942,7 @@ exits:
     stage: F001r
     room: 0
     index: 1
-    req_index: 1803
+    req_index: 1791
     short_name: Skyloft - Knight Academy - Lower Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Exit:
     type: exit
@@ -9959,7 +9950,7 @@ exits:
     stage: F001r
     room: 0
     index: 2
-    req_index: 1804
+    req_index: 1792
     short_name: Skyloft - Knight Academy - Upper Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Exit:
     type: exit
@@ -9967,7 +9958,7 @@ exits:
     stage: F001r
     room: 0
     index: 3
-    req_index: 1805
+    req_index: 1793
     short_name: Skyloft - Knight Academy - Upper Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Exit:
     type: exit
@@ -9975,7 +9966,7 @@ exits:
     stage: F000
     room: 0
     index: 3
-    req_index: 1806
+    req_index: 1794
     short_name: Skyloft - Knight Academy Lower Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Exit:
     type: exit
@@ -9983,7 +9974,7 @@ exits:
     stage: F000
     room: 0
     index: 4
-    req_index: 1807
+    req_index: 1795
     short_name: Skyloft - Knight Academy Lower Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Exit:
     type: exit
@@ -9991,7 +9982,7 @@ exits:
     stage: F000
     room: 0
     index: 23
-    req_index: 1808
+    req_index: 1796
     short_name: Skyloft - Knight Academy Upper Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Exit:
     type: exit
@@ -9999,7 +9990,7 @@ exits:
     stage: F000
     room: 0
     index: 24
-    req_index: 1809
+    req_index: 1797
     short_name: Skyloft - Knight Academy Upper Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Chimney Entrance:
     type: exit
@@ -10007,7 +9998,7 @@ exits:
     stage: F000
     room: 0
     index: 57
-    req_index: 1810
+    req_index: 1798
     short_name: Skyloft - Knight Academy Chimney Entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Right Door Exit:
     type: exit
@@ -10015,7 +10006,7 @@ exits:
     stage: F009r
     room: 0
     index: 0
-    req_index: 1811
+    req_index: 1799
     short_name: Sparring Hall - Right Door Exit
   \Skyloft\Upper Skyloft\Sparring Hall\Left Door Exit:
     type: exit
@@ -10023,7 +10014,7 @@ exits:
     stage: F009r
     room: 0
     index: 1
-    req_index: 1812
+    req_index: 1800
     short_name: Sparring Hall - Left Door Exit
   \Skyloft\Upper Skyloft\Sparring Hall Left Door Exit:
     type: exit
@@ -10031,7 +10022,7 @@ exits:
     stage: F000
     room: 0
     index: 20
-    req_index: 1813
+    req_index: 1801
     short_name: Skyloft - Sparring Hall Left Door Exit
   \Skyloft\Upper Skyloft\Sparring Hall Right Door Exit:
     type: exit
@@ -10039,7 +10030,7 @@ exits:
     stage: F000
     room: 0
     index: 27
-    req_index: 1814
+    req_index: 1802
     short_name: Skyloft - Sparring Hall Right Door Exit
   \Skyloft\Upper Skyloft\Goddess Statue\Exit:
     type: exit
@@ -10047,7 +10038,7 @@ exits:
     stage: F008r
     room: 0
     index: 0
-    req_index: 1815
+    req_index: 1803
     short_name: Goddess Statue - Exit
   \Skyloft\Upper Skyloft\Goddess Statue Exit:
     type: exit
@@ -10055,7 +10046,7 @@ exits:
     stage: F000
     room: 0
     index: 5
-    req_index: 1816
+    req_index: 1804
     short_name: Goddess Statue Exit
   \Skyloft\Central Skyloft\Waterfall Cave\Upper Exit:
     type: exit
@@ -10063,7 +10054,7 @@ exits:
     stage: D000
     room: 0
     index: 0
-    req_index: 1817
+    req_index: 1805
     short_name: Waterfall Cave - Upper Exit
   \Skyloft\Central Skyloft\Waterfall Cave\Lower Exit:
     type: exit
@@ -10071,7 +10062,7 @@ exits:
     stage: D000
     room: 0
     index: 1
-    req_index: 1818
+    req_index: 1806
     short_name: Waterfall Cave - Lower Exit
   \Skyloft\Central Skyloft\Waterfall Cave Upper Exit:
     type: exit
@@ -10079,7 +10070,7 @@ exits:
     stage: F000
     room: 0
     index: 6
-    req_index: 1819
+    req_index: 1807
     short_name: Waterfall Cave Upper Exit
   \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Exit:
     type: exit
@@ -10087,7 +10078,7 @@ exits:
     stage: F000
     room: 0
     index: 7
-    req_index: 1820
+    req_index: 1808
     short_name: Waterfall Cave Lower Exit
   \Skyloft\Central Skyloft\Bazaar\North Exit:
     type: exit
@@ -10095,7 +10086,7 @@ exits:
     stage: F004r
     room: 0
     index: 0
-    req_index: 1821
+    req_index: 1809
     short_name: Bazaar - North Exit
   \Skyloft\Central Skyloft\Bazaar\South Exit:
     type: exit
@@ -10103,7 +10094,7 @@ exits:
     stage: F004r
     room: 0
     index: 1
-    req_index: 1822
+    req_index: 1810
     short_name: Bazaar - South Exit
   \Skyloft\Central Skyloft\Bazaar\West Exit:
     type: exit
@@ -10111,7 +10102,7 @@ exits:
     stage: F004r
     room: 0
     index: 2
-    req_index: 1823
+    req_index: 1811
     short_name: Bazaar - West Exit
   \Skyloft\Central Skyloft\Bazaar North Exit:
     type: exit
@@ -10119,7 +10110,7 @@ exits:
     stage: F000
     room: 0
     index: 1
-    req_index: 1824
+    req_index: 1812
     short_name: Bazaar North Exit
   \Skyloft\Central Skyloft\Bazaar South Exit:
     type: exit
@@ -10127,7 +10118,7 @@ exits:
     stage: F000
     room: 0
     index: 2
-    req_index: 1825
+    req_index: 1813
     short_name: Bazaar South Exit
   \Skyloft\Central Skyloft\Bazaar West Exit:
     type: exit
@@ -10135,7 +10126,7 @@ exits:
     stage: F000
     room: 0
     index: 19
-    req_index: 1826
+    req_index: 1814
     short_name: Bazaar West Exit
   \Skyloft\Beedle's Shop\Day Exit:
     type: exit
@@ -10143,7 +10134,7 @@ exits:
     stage: F002r
     room: 0
     index: 0
-    req_index: 1827
+    req_index: 1815
     short_name: Beedle's Shop - Day Exit
   \Skyloft\Beedle's Shop\Night Exit:
     type: exit
@@ -10152,7 +10143,7 @@ exits:
     stage: F002r
     room: 0
     index: 2
-    req_index: 1828
+    req_index: 1816
     short_name: Beedle's Shop - Night Exit
   \Skyloft\Central Skyloft\Exit to Beedle's Shop:
     type: exit
@@ -10160,17 +10151,17 @@ exits:
     stage: F000
     room: 0
     index: 26
-    req_index: 1829
+    req_index: 1817
     short_name: Skyloft - Exit to Beedle's Shop
   \Skyloft\Skyloft Silent Realm\Exit:
     type: exit
     vanilla: Skyloft - Trial Gate Entrance
-    req_index: 1830
+    req_index: 1818
     short_name: Skyloft Silent Realm - Exit
   \Skyloft\Central Skyloft\Trial Gate Exit:
     type: exit
     vanilla: Skyloft Silent Realm - Entrance
-    req_index: 1831
+    req_index: 1819
     short_name: Skyloft - Trial Gate Exit
   \Skyloft\Central Skyloft\Near Temple Entrance\Exit to Sky Keep:
     type: exit
@@ -10178,7 +10169,7 @@ exits:
     stage: F000
     room: 0
     index: 48
-    req_index: 1832
+    req_index: 1820
     short_name: Skyloft - Exit to Sky Keep
   \Skyloft\Central Skyloft\Orielle and Parrow's House\Exit:
     type: exit
@@ -10186,7 +10177,7 @@ exits:
     stage: F005r
     room: 0
     index: 0
-    req_index: 1833
+    req_index: 1821
     short_name: Orielle and Parrow's House - Exit
   \Skyloft\Central Skyloft\Orielle and Parrow's House Exit:
     type: exit
@@ -10194,7 +10185,7 @@ exits:
     stage: F000
     room: 0
     index: 31
-    req_index: 1834
+    req_index: 1822
     short_name: Orielle and Parrow's House Exit
   \Skyloft\Central Skyloft\Peatrice's House\Exit:
     type: exit
@@ -10202,7 +10193,7 @@ exits:
     stage: F018r
     room: 0
     index: 0
-    req_index: 1835
+    req_index: 1823
     short_name: Peatrice's House - Exit
   \Skyloft\Central Skyloft\Peatrice's House Exit:
     type: exit
@@ -10210,7 +10201,7 @@ exits:
     stage: F000
     room: 0
     index: 38
-    req_index: 1836
+    req_index: 1824
     short_name: Peatrice's House Exit
   \Skyloft\Central Skyloft\Wryna's House\Exit:
     type: exit
@@ -10218,7 +10209,7 @@ exits:
     stage: F006r
     room: 0
     index: 0
-    req_index: 1837
+    req_index: 1825
     short_name: Wryna's House - Exit
   \Skyloft\Central Skyloft\Wryna's House Exit:
     type: exit
@@ -10226,7 +10217,7 @@ exits:
     stage: F000
     room: 0
     index: 10
-    req_index: 1838
+    req_index: 1826
     short_name: Wryna's House Exit
   \Skyloft\Skyloft Village\Bertie's House\Exit:
     type: exit
@@ -10234,7 +10225,7 @@ exits:
     stage: F014r
     room: 0
     index: 0
-    req_index: 1839
+    req_index: 1827
     short_name: Bertie's House - Exit
   \Skyloft\Skyloft Village\Bertie's House Exit:
     type: exit
@@ -10242,7 +10233,7 @@ exits:
     stage: F000
     room: 0
     index: 34
-    req_index: 1840
+    req_index: 1828
     short_name: Bertie's House Exit
   \Skyloft\Skyloft Village\Sparrot's House\Exit:
     type: exit
@@ -10250,7 +10241,7 @@ exits:
     stage: F013r
     room: 0
     index: 0
-    req_index: 1841
+    req_index: 1829
     short_name: Sparrot's House - Exit
   \Skyloft\Skyloft Village\Sparrot's House Exit:
     type: exit
@@ -10258,7 +10249,7 @@ exits:
     stage: F000
     room: 0
     index: 33
-    req_index: 1842
+    req_index: 1830
     short_name: Sparrot's House Exit
   \Skyloft\Skyloft Village\Mallara's House Exit:
     type: exit
@@ -10266,7 +10257,7 @@ exits:
     stage: F000
     room: 0
     index: 36
-    req_index: 1843
+    req_index: 1831
     short_name: Skyloft - Mallara's House Exit
   \Skyloft\Skyloft Village\Mallara's House\Exit:
     type: exit
@@ -10274,7 +10265,7 @@ exits:
     stage: F016r
     room: 0
     index: 0
-    req_index: 1844
+    req_index: 1832
     short_name: Mallara's House - Exit
   \Skyloft\Skyloft Village\Batreaux's House\Exit:
     type: exit
@@ -10282,7 +10273,7 @@ exits:
     stage: F012r
     room: 0
     index: 0
-    req_index: 1845
+    req_index: 1833
     short_name: Batreaux's House - Exit
   \Skyloft\Skyloft Village\Batreaux's House Exit:
     type: exit
@@ -10290,7 +10281,7 @@ exits:
     stage: F000
     room: 0
     index: 30
-    req_index: 1846
+    req_index: 1834
     short_name: Batreaux's House Exit
   \Skyloft\Skyloft Village\Gondo's House\Exit:
     type: exit
@@ -10298,7 +10289,7 @@ exits:
     stage: F015r
     room: 0
     index: 0
-    req_index: 1847
+    req_index: 1835
     short_name: Gondo's House - Exit
   \Skyloft\Skyloft Village\Gondo's House Exit:
     type: exit
@@ -10306,7 +10297,7 @@ exits:
     stage: F000
     room: 0
     index: 35
-    req_index: 1848
+    req_index: 1836
     short_name: Gondo's House Exit
   \Skyloft\Skyloft Village\Rupin's House\Exit:
     type: exit
@@ -10314,7 +10305,7 @@ exits:
     stage: F017r
     room: 0
     index: 1
-    req_index: 1849
+    req_index: 1837
     short_name: Rupin's House - Exit
   \Skyloft\Skyloft Village\Rupin's House Exit:
     type: exit
@@ -10322,7 +10313,7 @@ exits:
     stage: F000
     room: 0
     index: 37
-    req_index: 1850
+    req_index: 1838
     short_name: Rupin's House Exit
   \Skyloft\Central Skyloft\Piper's House\Exit:
     type: exit
@@ -10330,7 +10321,7 @@ exits:
     stage: F007r
     room: 0
     index: 0
-    req_index: 1851
+    req_index: 1839
     short_name: Piper's House - Exit
   \Skyloft\Central Skyloft\Piper's House Exit:
     type: exit
@@ -10338,17 +10329,17 @@ exits:
     stage: F000
     room: 0
     index: 32
-    req_index: 1852
+    req_index: 1840
     short_name: Piper's House Exit
   \Skyloft\Central Skyloft\Exit to Sky:
     type: exit
     vanilla: Sky - Entrance from Skyloft
-    req_index: 1853
+    req_index: 1841
     short_name: Skyloft - Exit to Sky
   \Sky\Around Skyloft\Exit to Skyloft:
     type: exit
     vanilla: Skyloft - Entrance from Sky
-    req_index: 1854
+    req_index: 1842
     short_name: Sky - Exit to Skyloft
   \Sky\North East\Bamboo Island\Inside\Exit:
     type: exit
@@ -10356,7 +10347,7 @@ exits:
     stage: F019r
     room: 0
     index: 2
-    req_index: 1855
+    req_index: 1843
     short_name: Bamboo Island - Inside - Exit
   \Sky\North East\Bamboo Island\Exit to Inside:
     type: exit
@@ -10364,7 +10355,7 @@ exits:
     stage: F020
     room: 0
     index: 13
-    req_index: 1856
+    req_index: 1844
     short_name: Bamboo Island - Exit to Inside
   \Sky\North East\Beedle's Island\Beedle's Ship Exit:
     type: exit
@@ -10373,7 +10364,7 @@ exits:
     stage: F020
     room: 0
     index: 14
-    req_index: 1857
+    req_index: 1845
     short_name: Sky - Beedle's Island - Beedle's Ship Exit
   \Sky\North East\Eldin Pillar\First Time Dive:
     type: exit
@@ -10381,7 +10372,7 @@ exits:
     stage: F020
     room: 0
     index: 1
-    req_index: 1858
+    req_index: 1846
     short_name: Sky - Eldin Pillar - First Time Dive
   \Sky\North East\Eldin Pillar\Temple Entrance Statue Dive:
     type: exit
@@ -10389,7 +10380,7 @@ exits:
     stage: F020
     room: 0
     index: 29
-    req_index: 1859
+    req_index: 1847
     short_name: Sky - Eldin Pillar - Temple Entrance Statue Dive
   \Sky\North East\Eldin Pillar\Inside the Volcano Statue Dive:
     type: exit
@@ -10397,7 +10388,7 @@ exits:
     stage: F020
     room: 0
     index: 30
-    req_index: 1860
+    req_index: 1848
     short_name: Sky - Eldin Pillar - Inside the Volcano Statue Dive
   \Sky\North East\Eldin Pillar\Volcano Entrance Statue Dive:
     type: exit
@@ -10405,7 +10396,7 @@ exits:
     stage: F020
     room: 0
     index: 50
-    req_index: 1861
+    req_index: 1849
     short_name: Sky - Eldin Pillar - Volcano Entrance Statue Dive
   \Sky\North East\Eldin Pillar\Volcano East Statue Dive:
     type: exit
@@ -10413,7 +10404,7 @@ exits:
     stage: F020
     room: 0
     index: 51
-    req_index: 1862
+    req_index: 1850
     short_name: Sky - Eldin Pillar - Volcano East Statue Dive
   \Sky\North East\Eldin Pillar\Volcano Ascent Statue Dive:
     type: exit
@@ -10421,7 +10412,7 @@ exits:
     stage: F020
     room: 0
     index: 52
-    req_index: 1863
+    req_index: 1851
     short_name: Sky - Eldin Pillar - Volcano Ascent Statue Dive
   \Sky\North East\Eldin Pillar\Fire Sanctuary Statue Dive:
     type: exit
@@ -10429,7 +10420,7 @@ exits:
     stage: F020
     room: 0
     index: 55
-    req_index: 1864
+    req_index: 1852
     short_name: Sky - Eldin Pillar - Fire Sanctuary Statue Dive
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Exit:
     type: exit
@@ -10437,7 +10428,7 @@ exits:
     stage: F011r
     room: 0
     index: 0
-    req_index: 1865
+    req_index: 1853
     short_name: Lumpy Pumpkin Building - Main Right Door Exit
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Exit:
     type: exit
@@ -10445,7 +10436,7 @@ exits:
     stage: F011r
     room: 0
     index: 1
-    req_index: 1866
+    req_index: 1854
     short_name: Lumpy Pumpkin Building - Main Left Door Exit
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Exit:
     type: exit
@@ -10453,7 +10444,7 @@ exits:
     stage: F011r
     room: 0
     index: 2
-    req_index: 1867
+    req_index: 1855
     short_name: Lumpy Pumpkin Building - Back Door Exit
   \Sky\South East\Lumpy Pumpkin\Main Right Door Exit:
     type: exit
@@ -10461,7 +10452,7 @@ exits:
     stage: F020
     room: 0
     index: 18
-    req_index: 1868
+    req_index: 1856
     short_name: Lumpy Pumpkin - Main Right Door Exit
   \Sky\South East\Lumpy Pumpkin\Main Left Door Exit:
     type: exit
@@ -10469,7 +10460,7 @@ exits:
     stage: F020
     room: 0
     index: 19
-    req_index: 1869
+    req_index: 1857
     short_name: Lumpy Pumpkin - Main Left Door Exit
   \Sky\South East\Lumpy Pumpkin\Back Door Exit:
     type: exit
@@ -10477,7 +10468,7 @@ exits:
     stage: F020
     room: 0
     index: 20
-    req_index: 1870
+    req_index: 1858
     short_name: Lumpy Pumpkin - Back Door Exit
   \Sky\South East\Faron Pillar\First Time Dive:
     type: exit
@@ -10485,7 +10476,7 @@ exits:
     stage: F020
     room: 0
     index: 0
-    req_index: 1871
+    req_index: 1859
     short_name: Sky - Faron Pillar - First Time Dive
   \Sky\South East\Faron Pillar\Sealed Grounds Statue Dive:
     type: exit
@@ -10493,7 +10484,7 @@ exits:
     stage: F020
     room: 0
     index: 68
-    req_index: 1872
+    req_index: 1860
     short_name: Sky - Faron Pillar - Sealed Grounds Statue Dive
   \Sky\South East\Faron Pillar\Forest Temple Statue Dive:
     type: exit
@@ -10501,7 +10492,7 @@ exits:
     stage: F020
     room: 0
     index: 27
-    req_index: 1873
+    req_index: 1861
     short_name: Sky - Faron Pillar - Forest Temple Statue Dive
   \Sky\South East\Faron Pillar\Behind the Temple Statue Dive:
     type: exit
@@ -10509,7 +10500,7 @@ exits:
     stage: F020
     room: 0
     index: 40
-    req_index: 1874
+    req_index: 1862
     short_name: Sky - Faron Pillar - Behind the Temple Statue Dive
   \Sky\South East\Faron Pillar\Faron Woods Entry Statue Dive:
     type: exit
@@ -10517,7 +10508,7 @@ exits:
     stage: F020
     room: 0
     index: 41
-    req_index: 1875
+    req_index: 1863
     short_name: Sky - Faron Pillar - Faron Woods Entry Statue Dive
   \Sky\South East\Faron Pillar\In the Woods Statue Dive:
     type: exit
@@ -10525,7 +10516,7 @@ exits:
     stage: F020
     room: 0
     index: 42
-    req_index: 1876
+    req_index: 1864
     short_name: Sky - Faron Pillar - In the Woods Statue Dive
   \Sky\South East\Faron Pillar\Viewing Platform Statue Dive:
     type: exit
@@ -10533,7 +10524,7 @@ exits:
     stage: F020
     room: 0
     index: 43
-    req_index: 1877
+    req_index: 1865
     short_name: Sky - Faron Pillar - Viewing Platform Statue Dive
   \Sky\South East\Faron Pillar\The Great Tree Statue Dive:
     type: exit
@@ -10541,7 +10532,7 @@ exits:
     stage: F020
     room: 0
     index: 44
-    req_index: 1878
+    req_index: 1866
     short_name: Sky - Faron Pillar - The Great Tree Statue Dive
   \Sky\South East\Faron Pillar\Deep Woods Statue Dive:
     type: exit
@@ -10549,7 +10540,7 @@ exits:
     stage: F020
     room: 0
     index: 46
-    req_index: 1879
+    req_index: 1867
     short_name: Sky - Faron Pillar - Deep Woods Statue Dive
   \Sky\South East\Faron Pillar\Lake Floria Statue Dive:
     type: exit
@@ -10557,7 +10548,7 @@ exits:
     stage: F020
     room: 0
     index: 47
-    req_index: 1880
+    req_index: 1868
     short_name: Sky - Faron Pillar - Lake Floria Statue Dive
   \Sky\South East\Faron Pillar\Floria Waterfall Statue Dive:
     type: exit
@@ -10565,7 +10556,7 @@ exits:
     stage: F020
     room: 0
     index: 48
-    req_index: 1881
+    req_index: 1869
     short_name: Sky - Faron Pillar - Floria Waterfall Statue Dive
   \Sky\South West\Lanayru Pillar\First Time Dive:
     type: exit
@@ -10573,7 +10564,7 @@ exits:
     stage: F020
     room: 0
     index: 2
-    req_index: 1882
+    req_index: 1870
     short_name: Sky - Lanayru Pillar - First Time Dive
   \Sky\South West\Lanayru Pillar\Lanayru Mine Entry Statue Dive:
     type: exit
@@ -10581,7 +10572,7 @@ exits:
     stage: F020
     room: 0
     index: 56
-    req_index: 1883
+    req_index: 1871
     short_name: Sky - Lanayru Pillar - Lanayru Mine Entry Statue Dive
   \Sky\South West\Lanayru Pillar\Desert Entrance Statue Dive:
     type: exit
@@ -10589,7 +10580,7 @@ exits:
     stage: F020
     room: 0
     index: 57
-    req_index: 1884
+    req_index: 1872
     short_name: Sky - Lanayru Pillar - Desert Entrance Statue Dive
   \Sky\South West\Lanayru Pillar\West Desert Statue Dive:
     type: exit
@@ -10597,7 +10588,7 @@ exits:
     stage: F020
     room: 0
     index: 58
-    req_index: 1885
+    req_index: 1873
     short_name: Sky - Lanayru Pillar - West Desert Statue Dive
   \Sky\South West\Lanayru Pillar\North Desert Statue Dive:
     type: exit
@@ -10605,7 +10596,7 @@ exits:
     stage: F020
     room: 0
     index: 59
-    req_index: 1886
+    req_index: 1874
     short_name: Sky - Lanayru Pillar - North Desert Statue Dive
   \Sky\South West\Lanayru Pillar\Stone Cache Statue Dive:
     type: exit
@@ -10613,7 +10604,7 @@ exits:
     stage: F020
     room: 0
     index: 60
-    req_index: 1887
+    req_index: 1875
     short_name: Sky - Lanayru Pillar - Stone Cache Statue Dive
   \Sky\South West\Lanayru Pillar\Desert Gorge Statue Dive:
     type: exit
@@ -10621,7 +10612,7 @@ exits:
     stage: F020
     room: 0
     index: 61
-    req_index: 1888
+    req_index: 1876
     short_name: Sky - Lanayru Pillar - Desert Gorge Statue Dive
   \Sky\South West\Lanayru Pillar\Temple of Time Statue Dive:
     type: exit
@@ -10629,7 +10620,7 @@ exits:
     stage: F020
     room: 0
     index: 62
-    req_index: 1889
+    req_index: 1877
     short_name: Sky - Lanayru Pillar - Temple of Time Statue Dive
   \Sky\South West\Lanayru Pillar\Ancient Harbour Statue Dive:
     type: exit
@@ -10637,7 +10628,7 @@ exits:
     stage: F020
     room: 0
     index: 63
-    req_index: 1890
+    req_index: 1878
     short_name: Sky - Lanayru Pillar - Ancient Harbour Statue Dive
   \Sky\South West\Lanayru Pillar\Skipper's Retreat Statue Dive:
     type: exit
@@ -10645,7 +10636,7 @@ exits:
     stage: F020
     room: 0
     index: 64
-    req_index: 1891
+    req_index: 1879
     short_name: Sky - Lanayru Pillar - Skipper's Retreat Statue Dive
   \Sky\South West\Lanayru Pillar\Shipyard Statue Dive:
     type: exit
@@ -10653,7 +10644,7 @@ exits:
     stage: F020
     room: 0
     index: 65
-    req_index: 1892
+    req_index: 1880
     short_name: Sky - Lanayru Pillar - Shipyard Statue Dive
   \Sky\South West\Lanayru Pillar\Pirate Stronghold Statue Dive:
     type: exit
@@ -10661,12 +10652,12 @@ exits:
     stage: F020
     room: 0
     index: 66
-    req_index: 1893
+    req_index: 1881
     short_name: Sky - Lanayru Pillar - Pirate Stronghold Statue Dive
   \Sky\South West\Lanayru Pillar\Lanayru Gorge Statue Dive:
     type: exit
     vanilla: Lanayru Gorge - Statue Entrance
-    req_index: 1894
+    req_index: 1882
     short_name: Sky - Lanayru Pillar - Lanayru Gorge Statue Dive
   \Sky\Around Skyloft\Exit to Thunderhead:
     type: exit
@@ -10674,7 +10665,7 @@ exits:
     stage: F020
     room: 0
     index: 25
-    req_index: 1895
+    req_index: 1883
     short_name: Sky - Exit to Thunderhead
   \Sky\Thunderhead\Exit:
     type: exit
@@ -10682,7 +10673,7 @@ exits:
     stage: F023
     room: 0
     index: 1
-    req_index: 1896
+    req_index: 1884
     short_name: Thunderhead - Exit
   \Sky\Thunderhead\Isle of Songs\Inside\Exit:
     type: exit
@@ -10690,7 +10681,7 @@ exits:
     stage: F010r
     room: 0
     index: 0
-    req_index: 1897
+    req_index: 1885
     short_name: Isle of Songs - Exit
   \Sky\Thunderhead\Isle of Songs\Exit to Inside:
     type: exit
@@ -10698,7 +10689,7 @@ exits:
     stage: F023
     room: 0
     index: 2
-    req_index: 1898
+    req_index: 1886
     short_name: Isle of Songs - Exit to Inside
   \Faron\Sealed Grounds\Spiral\Upper Part\Statue Exit:
     type: exit
@@ -10706,7 +10697,7 @@ exits:
     stage: F401
     room: 1
     index: 19
-    req_index: 1899
+    req_index: 1887
     short_name: Sealed Grounds Spiral - Statue Exit
   \Faron\Sealed Grounds\Spiral\Door Exit:
     type: exit
@@ -10714,7 +10705,7 @@ exits:
     stage: F401
     room: 1
     index: 0
-    req_index: 1900
+    req_index: 1888
     short_name: Sealed Grounds Spiral - Door Exit
   \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Exit to Behind the Temple:
     type: exit
@@ -10722,7 +10713,7 @@ exits:
     stage: F401
     room: 1
     index: 1
-    req_index: 1901
+    req_index: 1889
     short_name: Sealed Grounds Spiral - Shortcut Exit to Behind the Temple
   \Faron\Sealed Grounds\Sealed Temple\Main Exit:
     type: exit
@@ -10730,7 +10721,7 @@ exits:
     stage: F402
     room: 2
     index: 0
-    req_index: 1902
+    req_index: 1890
     short_name: Sealed Temple - Main Exit
   \Faron\Sealed Grounds\Sealed Temple\Side Exit:
     type: exit
@@ -10738,7 +10729,7 @@ exits:
     stage: F402
     room: 2
     index: 1
-    req_index: 1903
+    req_index: 1891
     short_name: Sealed Temple - Side Exit
   \Faron\Sealed Grounds\Sealed Temple\Gate of Time Exit:
     type: exit
@@ -10746,7 +10737,7 @@ exits:
     stage: F402
     room: 2
     index: 5
-    req_index: 1904
+    req_index: 1892
     short_name: Sealed Temple - Gate of Time Exit
   \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Exit:
     type: exit
@@ -10754,7 +10745,7 @@ exits:
     stage: F404
     room: 2
     index: 1
-    req_index: 1905
+    req_index: 1893
     short_name: Hylia's Temple - Gate of Time Exit
   \Faron\Sealed Grounds\Behind the Temple\Statue Exit:
     type: exit
@@ -10762,7 +10753,7 @@ exits:
     stage: F400
     room: 0
     index: 5
-    req_index: 1906
+    req_index: 1894
     short_name: Behind the Temple - Statue Exit
   \Faron\Sealed Grounds\Behind the Temple\Shortcut Exit to Spiral:
     type: exit
@@ -10770,7 +10761,7 @@ exits:
     stage: F400
     room: 0
     index: 0
-    req_index: 1907
+    req_index: 1895
     short_name: Behind the Temple - Shortcut Exit to Spiral
   \Faron\Sealed Grounds\Behind the Temple\Door Exit:
     type: exit
@@ -10778,7 +10769,7 @@ exits:
     stage: F400
     room: 0
     index: 1
-    req_index: 1908
+    req_index: 1896
     short_name: Behind the Temple - Door Exit
   \Faron\Sealed Grounds\Behind the Temple\Exit to Faron Woods:
     type: exit
@@ -10786,7 +10777,7 @@ exits:
     stage: F400
     room: 0
     index: 2
-    req_index: 1909
+    req_index: 1897
     short_name: Behind the Temple - Exit to Faron Woods
   \Faron\Faron Woods\Shared Statue Exit:
     type: exit
@@ -10794,7 +10785,7 @@ exits:
     stage: F100
     room: 0
     index: 10
-    req_index: 1910
+    req_index: 1898
     short_name: Faron Woods - Shared Statue Exit
   \Faron\Faron Woods\Entry\Exit to Behind the Temple:
     type: exit
@@ -10802,7 +10793,7 @@ exits:
     stage: F100
     room: 0
     index: 0
-    req_index: 1911
+    req_index: 1899
     short_name: Faron Woods - Exit to Behind the Temple
   \Faron\Faron Woods\Ledge To Deep Woods\Exit to Deep Woods:
     type: exit
@@ -10810,7 +10801,7 @@ exits:
     stage: F100
     room: 0
     index: 1
-    req_index: 1912
+    req_index: 1900
     short_name: Faron Woods - Exit to Deep Woods
   \Faron\Faron Woods\Lake Floria Dive:
     type: exit
@@ -10818,7 +10809,7 @@ exits:
     stage: F100
     room: 0
     index: 9
-    req_index: 1913
+    req_index: 1901
     short_name: Faron Woods - Lake Floria Dive
   \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Exit to Floria Waterfall:
     type: exit
@@ -10826,17 +10817,17 @@ exits:
     stage: F100
     room: 0
     index: 11
-    req_index: 1914
+    req_index: 1902
     short_name: Faron Woods - Shortcut Exit to Floria Waterfall
   \Faron\Faron Woods\Trial Gate Exit:
     type: exit
     vanilla: Faron Silent Realm - Entrance
-    req_index: 1915
+    req_index: 1903
     short_name: Faron Woods - Trial Gate Exit
   \Faron\Faron Silent Realm\Exit:
     type: exit
     vanilla: Faron Woods - Trial Gate Entrance
-    req_index: 1916
+    req_index: 1904
     short_name: Faron Silent Realm - Exit
   \Faron\Faron Woods\Great Tree\Platforms\Lower Exit to Great Tree:
     type: exit
@@ -10844,7 +10835,7 @@ exits:
     stage: F100
     room: 0
     index: 3
-    req_index: 1917
+    req_index: 1905
     short_name: Great Tree - Platforms - Lower Exit to Great Tree
   \Faron\Faron Woods\Great Tree\Platforms\Upper Exit to Great Tree:
     type: exit
@@ -10852,7 +10843,7 @@ exits:
     stage: F100
     room: 0
     index: 4
-    req_index: 1918
+    req_index: 1906
     short_name: Great Tree - Platforms - Upper Exit to Great Tree
   \Faron\Faron Woods\Great Tree\Top\Top Exit to Great Tree:
     type: exit
@@ -10860,7 +10851,7 @@ exits:
     stage: F100
     room: 0
     index: 5
-    req_index: 1919
+    req_index: 1907
     short_name: Great Tree - Top Exit to Great Tree
   \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Exit:
     type: exit
@@ -10868,7 +10859,7 @@ exits:
     stage: F100
     room: 0
     index: 6
-    req_index: 1920
+    req_index: 1908
     short_name: Great Tree - Underwater Hole Exit
   \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Exit to Platforms:
     type: exit
@@ -10876,7 +10867,7 @@ exits:
     stage: F100_1
     room: 0
     index: 1
-    req_index: 1921
+    req_index: 1909
     short_name: Great Tree - Lower Exit to Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Upper Exit to Platforms:
     type: exit
@@ -10884,7 +10875,7 @@ exits:
     stage: F100_1
     room: 0
     index: 2
-    req_index: 1922
+    req_index: 1910
     short_name: Great Tree - Upper Exit to Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Exit to Top:
     type: exit
@@ -10892,7 +10883,7 @@ exits:
     stage: F100_1
     room: 0
     index: 3
-    req_index: 1923
+    req_index: 1911
     short_name: Great Tree - Exit to Top
   \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Exit:
     type: exit
@@ -10900,37 +10891,37 @@ exits:
     stage: F100_1
     room: 0
     index: 4
-    req_index: 1924
+    req_index: 1912
     short_name: Great Tree - Underwater Tunnel Exit
   \Faron\Faron Woods\Great Tree\Upper Area\Exit to Flooded Great Tree:
     type: exit
     vanilla: Flooded Great Tree - Entrance
-    req_index: 1925
+    req_index: 1913
     short_name: Great Tree - Exit to Flooded Great Tree
   \Faron\Flooded Faron Woods\Flooded Great Tree\Exit:
     type: exit
     vanilla: Entrance from Flooded Great Tree
-    req_index: 1926
+    req_index: 1914
     short_name: Flooded Great Tree - Exit
   \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Upper Flooded Faron Woods:
     type: exit
     vanilla: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
-    req_index: 1927
+    req_index: 1915
     short_name: Flooded Great Tree - Exit to Upper Flooded Faron Woods
   \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Lower Flooded Faron Woods:
     type: exit
     vanilla: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
-    req_index: 1928
+    req_index: 1916
     short_name: Flooded Great Tree - Exit to Lower Flooded Faron Woods
   \Faron\Flooded Faron Woods\Exit to Upper Flooded Great Tree:
     type: exit
     vanilla: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
-    req_index: 1929
+    req_index: 1917
     short_name: Flooded Faron Woods - Exit to Upper Flooded Great Tree
   \Faron\Flooded Faron Woods\Exit to Lower Flooded Great Tree:
     type: exit
     vanilla: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
-    req_index: 1930
+    req_index: 1918
     short_name: Flooded Faron Woods - Exit to Lower Flooded Great Tree
   \Faron\Faron Woods\Deep Woods\Shared Statue Exit:
     type: exit
@@ -10938,7 +10929,7 @@ exits:
     stage: F101
     room: 0
     index: 2
-    req_index: 1931
+    req_index: 1919
     short_name: Deep Woods - Shared Statue Exit
   \Faron\Faron Woods\Deep Woods\Entry\Exit to Faron Woods:
     type: exit
@@ -10946,7 +10937,7 @@ exits:
     stage: F101
     room: 0
     index: 0
-    req_index: 1932
+    req_index: 1920
     short_name: Deep Woods - Exit to Faron Woods
   \Faron\Faron Woods\Deep Woods\Exit to Skyview Temple:
     type: exit
@@ -10954,7 +10945,7 @@ exits:
     stage: F101
     room: 0
     index: 1
-    req_index: 1933
+    req_index: 1921
     short_name: Deep Woods - Exit to Skyview Temple
   \Faron\Lake Floria\Below Rock\Emerged Area\Statue Exit:
     type: exit
@@ -10962,7 +10953,7 @@ exits:
     stage: F102
     room: 3
     index: 0
-    req_index: 1934
+    req_index: 1922
     short_name: Lake Floria - Below Rock - Statue Exit
   \Faron\Lake Floria\Below Rock\Exit to Farore's Lair:
     type: exit
@@ -10970,7 +10961,7 @@ exits:
     stage: F102
     room: 4
     index: 0
-    req_index: 1935
+    req_index: 1923
     short_name: Lake Floria - Exit to Farore's Lair
   \Faron\Lake Floria\Farore's Lair\Exit to Lake Floria:
     type: exit
@@ -10978,7 +10969,7 @@ exits:
     stage: F102_2
     room: 0
     index: 0
-    req_index: 1936
+    req_index: 1924
     short_name: Farore's Lair - Exit to Lake Floria
   \Faron\Lake Floria\Farore's Lair\Exit to Waterfall:
     type: exit
@@ -10986,7 +10977,7 @@ exits:
     stage: F102_2
     room: 0
     index: 1
-    req_index: 1937
+    req_index: 1925
     short_name: Farore's Lair - Exit to Waterfall
   \Faron\Lake Floria\Waterfall\Statue Exit:
     type: exit
@@ -10994,7 +10985,7 @@ exits:
     stage: F102_1
     room: 0
     index: 3
-    req_index: 1938
+    req_index: 1926
     short_name: Floria Waterfall - Statue Exit
   \Faron\Lake Floria\Waterfall\Exit to Farore's Lair:
     type: exit
@@ -11002,7 +10993,7 @@ exits:
     stage: F102_1
     room: 0
     index: 0
-    req_index: 1939
+    req_index: 1927
     short_name: Floria Waterfall - Exit to Farore's Lair
   \Faron\Lake Floria\Waterfall\Exit to Ancient Cistern:
     type: exit
@@ -11010,7 +11001,7 @@ exits:
     stage: F102_1
     room: 0
     index: 1
-    req_index: 1940
+    req_index: 1928
     short_name: Floria Waterfall - Exit to Ancient Cistern
   \Faron\Lake Floria\Waterfall\Exit to Faron Woods:
     type: exit
@@ -11018,57 +11009,57 @@ exits:
     stage: F102_1
     room: 0
     index: 2
-    req_index: 1941
+    req_index: 1929
     short_name: Floria Waterfall - Exit to Faron Woods
   \Skyview\Main\Entry\Main Exit:
     type: exit
     vanilla: Deep Woods - Entrance from Skyview Temple
-    req_index: 1942
+    req_index: 1930
     short_name: Skyview Temple - Main Exit
   \Skyview\Main\Last Room\After Rope\Boss Door Exit:
     type: exit
     vanilla: Skyview Temple - Boss Room - Entrance from Dungeon
-    req_index: 1943
+    req_index: 1931
     short_name: Skyview Temple - Boss Door Exit
   \Skyview\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Skyview Temple - Boss Door Entrance
-    req_index: 1944
+    req_index: 1932
     short_name: Skyview Temple - Boss Room - Exit to Dungeon
   \Skyview\Boss Room\Exit to Spring:
     type: exit
     vanilla: Skyview Temple - Spring - Entrance
-    req_index: 1945
+    req_index: 1933
     short_name: Skyview Temple - Boss Room - Exit to Spring
   \Skyview\Spring\Exit:
     type: exit
     vanilla: Skyview Temple - Boss Room - Entrance from Spring
-    req_index: 1946
+    req_index: 1934
     short_name: Skyview Temple - Spring - Exit
   \Ancient Cistern\Main\Main Room\Main Exit:
     type: exit
     vanilla: Floria Waterfall - Entrance from Ancient Cistern
-    req_index: 1947
+    req_index: 1935
     short_name: Ancient Cistern - Main Exit
   \Ancient Cistern\Main\Inside Statue\Boss Door Exit:
     type: exit
     vanilla: Ancient Cistern - Boss Room - Entrance from Dungeon
-    req_index: 1948
+    req_index: 1936
     short_name: Ancient Cistern - Boss Door Exit
   \Ancient Cistern\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Ancient Cistern - Boss Door Entrance
-    req_index: 1949
+    req_index: 1937
     short_name: Ancient Cistern - Boss Room - Exit to Dungeon
   \Ancient Cistern\Boss Room\Exit to Flame Room:
     type: exit
     vanilla: Ancient Cistern - Flame Room - Entrance
-    req_index: 1950
+    req_index: 1938
     short_name: Ancient Cistern - Boss Room - Exit to Flame Room
   \Ancient Cistern\Flame Room\Exit:
     type: exit
     vanilla: Ancient Cistern - Boss Room - Entrance from Flame Room
-    req_index: 1951
+    req_index: 1939
     short_name: Ancient Cistern - Flame Room - Exit
   \Eldin\Volcano\Entry\Volcano Entrance Statue Exit:
     type: exit
@@ -11076,7 +11067,7 @@ exits:
     stage: F200
     room: 0
     index: 0
-    req_index: 1952
+    req_index: 1940
     short_name: Eldin Volcano - Volcano Entrance Statue Exit
   \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit:
     type: exit
@@ -11084,7 +11075,7 @@ exits:
     stage: F200
     room: 2
     index: 2
-    req_index: 1953
+    req_index: 1941
     short_name: Eldin Volcano - Volcano East / Volcano Ascent Statue Exit
   \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Exit:
     type: exit
@@ -11092,7 +11083,7 @@ exits:
     stage: F200
     room: 4
     index: 2
-    req_index: 1954
+    req_index: 1942
     short_name: Eldin Volcano - Temple Entrance Statue Exit
   \Eldin\Volcano\East\Dive to Mogma Turf:
     type: exit
@@ -11100,7 +11091,7 @@ exits:
     stage: F200
     room: 2
     index: 1
-    req_index: 1955
+    req_index: 1943
     short_name: Eldin Volcano - Dive to Mogma Turf
   \Eldin\Volcano\Near Temple Entrance\Exit to Earth Temple:
     type: exit
@@ -11108,7 +11099,7 @@ exits:
     stage: F200
     room: 4
     index: 0
-    req_index: 1956
+    req_index: 1944
     short_name: Eldin Volcano - Exit to Earth Temple
   \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Exit:
     type: exit
@@ -11116,7 +11107,7 @@ exits:
     stage: F200
     room: 4
     index: 1
-    req_index: 1957
+    req_index: 1945
     short_name: Eldin Volcano - Thrill Digger Cave Exit
   \Eldin\Volcano\Hot Cave\Exit to Summit:
     type: exit
@@ -11124,27 +11115,27 @@ exits:
     stage: F200
     room: 5
     index: 1
-    req_index: 1958
+    req_index: 1946
     short_name: Eldin Volcano - Exit to Summit
   \Eldin\Volcano\Ascent\Trial Gate Exit:
     type: exit
     vanilla: Eldin Silent Realm - Entrance
-    req_index: 1959
+    req_index: 1947
     short_name: Eldin Volcano - Trial Gate Exit
   \Eldin\Volcano\Past Slide\Vent Exit near Ascent:
     type: exit
     vanilla: Eldin Volcano - Vent Entrance near Hot Cave
-    req_index: 1960
+    req_index: 1948
     short_name: Eldin Volcano - Vent Exit near Ascent
-  \Eldin\Volcano\East\Exit to Bokoblin Base:
+  \Eldin\Volcano\First Room\Exit to Bokoblin Base:
     type: exit
     vanilla: Bokoblin Base - Entrance
-    req_index: 1961
+    req_index: 1949
     short_name: Eldin Volcano - Exit to Bokoblin Base
   \Eldin\Bokoblin Base\Prison\Exit:
     type: exit
     vanilla: Entrance from Bokoblin Base
-    req_index: 1962
+    req_index: 1950
     short_name: Bokoblin Base - Exit
   \Eldin\Mogma Turf\Pre Vent\First Vent:
     type: exit
@@ -11152,7 +11143,7 @@ exits:
     stage: F210
     room: 0
     index: 0
-    req_index: 1963
+    req_index: 1951
     short_name: Mogma Turf - First Vent
   \Eldin\Mogma Turf\Past Vent\Second Vent:
     type: exit
@@ -11160,7 +11151,7 @@ exits:
     stage: F210
     room: 0
     index: 1
-    req_index: 1964
+    req_index: 1952
     short_name: Mogma Turf - Second Vent
   \Eldin\Volcano\Thrill Digger Cave\Exit:
     type: exit
@@ -11168,12 +11159,12 @@ exits:
     stage: F211
     room: 0
     index: 0
-    req_index: 1965
+    req_index: 1953
     short_name: Thrill Digger Cave - Exit
   \Eldin\Eldin Silent Realm\Exit:
     type: exit
     vanilla: Eldin Volcano - Trial Gate Entrance
-    req_index: 1966
+    req_index: 1954
     short_name: Eldin Silent Realm - Exit
   \Eldin\Volcano Summit\Exit to Eldin Volcano:
     type: exit
@@ -11181,7 +11172,7 @@ exits:
     stage: F201_1
     room: 0
     index: 0
-    req_index: 1967
+    req_index: 1955
     short_name: Volcano Summit - Exit to Eldin Volcano
   \Eldin\Volcano Summit\Exit to Waterfall:
     type: exit
@@ -11189,7 +11180,7 @@ exits:
     stage: F201_1
     room: 0
     index: 1
-    req_index: 1968
+    req_index: 1956
     short_name: Volcano Summit - Exit to Waterfall
   \Eldin\Volcano Summit\Exit to Outside Fire Sanctuary:
     type: exit
@@ -11197,7 +11188,7 @@ exits:
     stage: F201_1
     room: 0
     index: 2
-    req_index: 1969
+    req_index: 1957
     short_name: Volcano Summit - Exit to Outside Fire Sanctuary
   \Eldin\Volcano Summit\Waterfall\Exit:
     type: exit
@@ -11205,7 +11196,7 @@ exits:
     stage: F201_4
     room: 0
     index: 0
-    req_index: 1970
+    req_index: 1958
     short_name: Volcano Summit - Waterfall - Exit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Exit:
     type: exit
@@ -11213,7 +11204,7 @@ exits:
     stage: F201_3
     room: 0
     index: 2
-    req_index: 1971
+    req_index: 1959
     short_name: Outside Fire Sanctuary - Statue Exit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Exit to Summit:
     type: exit
@@ -11221,7 +11212,7 @@ exits:
     stage: F201_3
     room: 0
     index: 0
-    req_index: 1972
+    req_index: 1960
     short_name: Outside Fire Sanctuary - Exit to Summit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Exit to Fire Sanctuary:
     type: exit
@@ -11229,32 +11220,32 @@ exits:
     stage: F201_3
     room: 0
     index: 1
-    req_index: 1973
+    req_index: 1961
     short_name: Outside Fire Sanctuary - Exit to Fire Sanctuary
   \Earth Temple\Main\First Room\Main Exit:
     type: exit
     vanilla: Eldin Volcano - Entrance from Earth Temple
-    req_index: 1974
+    req_index: 1962
     short_name: Earth Temple - Main Exit
   \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Exit:
     type: exit
     vanilla: Earth Temple - Boss Room - Entrance from Dungeon
-    req_index: 1975
+    req_index: 1963
     short_name: Earth Temple - Boss Door Exit
   \Earth Temple\Boss Room\Entry\Exit to Dungeon:
     type: exit
     vanilla: Earth Temple - Boss Door Entrance
-    req_index: 1976
+    req_index: 1964
     short_name: Earth Temple - Boss Room - Exit to Dungeon
   \Earth Temple\Boss Room\Slope\Exit to Spring:
     type: exit
     vanilla: Earth Temple - Spring - Entrance
-    req_index: 1977
+    req_index: 1965
     short_name: Earth Temple - Boss Room - Exit to Spring
   \Earth Temple\Spring\Exit:
     type: exit
     vanilla: Earth Temple - Boss Room - Entrance from Spring
-    req_index: 1978
+    req_index: 1966
     short_name: Earth Temple - Spring - Exit
   \Fire Sanctuary\Main\Front of Boss Door\Statue Exit:
     type: exit
@@ -11262,52 +11253,52 @@ exits:
     stage: D201
     room: 10
     index: 3
-    req_index: 1979
+    req_index: 1967
     short_name: Fire Sanctuary - Statue Exit
   \Fire Sanctuary\Main\First Room\Main Exit:
     type: exit
     vanilla: Outside Fire Sanctuary - Entrance from Fire Sanctuary
-    req_index: 1980
+    req_index: 1968
     short_name: Fire Sanctuary - Main Exit
   \Fire Sanctuary\Main\First Room\Past Water Plant\Exit to Second Room:
     type: exit
     vanilla: Fire Sanctuary - Second Room - Entrance from First Room
-    req_index: 1981
+    req_index: 1969
     short_name: Fire Sanctuary - First Room - Exit to Second Room
   \Fire Sanctuary\Main\Second Room\Outside Section\Exit to First Room:
     type: exit
     vanilla: Fire Sanctuary - First Room - Entrance from Second Room
-    req_index: 1982
+    req_index: 1970
     short_name: Fire Sanctuary - Second Room - Exit to First Room
   \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Exit to West of Boss Door:
     type: exit
     vanilla: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight Room
-    req_index: 1983
+    req_index: 1971
     short_name: Fire Sanctuary - Magmanos Fight Room - Exit to West of Boss Door
   \Fire Sanctuary\Main\West of Boss Door\Entry\Exit to Magmanos Fight Room:
     type: exit
     vanilla: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss Door
-    req_index: 1984
+    req_index: 1972
     short_name: Fire Sanctuary - West of Boss Door - Exit to Magmanos Fight Room
   \Fire Sanctuary\Main\Front of Boss Door\Boss Door Exit:
     type: exit
     vanilla: Fire Sanctuary - Boss Room - Entrance from Dungeon
-    req_index: 1985
+    req_index: 1973
     short_name: Fire Sanctuary - Boss Door Exit
   \Fire Sanctuary\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Fire Sanctuary - Boss Door Entrance
-    req_index: 1986
+    req_index: 1974
     short_name: Fire Sanctuary - Boss Room - Exit to Dungeon
   \Fire Sanctuary\Boss Room\Exit to Flame Room:
     type: exit
     vanilla: Fire Sanctuary - Flame Room - Entrance
-    req_index: 1987
+    req_index: 1975
     short_name: Fire Sanctuary - Boss Room - Exit to Flame Room
   \Fire Sanctuary\Flame Room\Exit:
     type: exit
     vanilla: Fire Sanctuary - Boss Room - Entrance from Flame Room
-    req_index: 1988
+    req_index: 1976
     short_name: Fire Sanctuary - Flame Room - Exit
   \Lanayru\Mine\Entry\Statue Exit:
     type: exit
@@ -11315,7 +11306,7 @@ exits:
     stage: F300_1
     room: 0
     index: 0
-    req_index: 1989
+    req_index: 1977
     short_name: Lanayru Mine - Statue Exit
   \Lanayru\Mine\Entry\Caves Entrance\Exit to Caves:
     type: exit
@@ -11323,7 +11314,7 @@ exits:
     stage: F300_1
     room: 0
     index: 1
-    req_index: 1990
+    req_index: 1978
     short_name: Lanayru Mine - Exit to Caves
   \Lanayru\Mine\End\In Minecart\Exit to Desert:
     type: exit
@@ -11331,7 +11322,7 @@ exits:
     stage: F300_1
     room: 2
     index: 0
-    req_index: 1991
+    req_index: 1979
     short_name: Lanayru Mine - Exit to Desert
   \Lanayru\Desert\Shared Statue Exit:
     type: exit
@@ -11339,7 +11330,7 @@ exits:
     stage: F300
     room: 0
     index: 6
-    req_index: 1992
+    req_index: 1980
     short_name: Lanayru Desert - Shared Statue Exit
   \Lanayru\Desert\North Part\Lightning Node Exit:
     type: exit
@@ -11347,7 +11338,7 @@ exits:
     stage: F300
     room: 0
     index: 0
-    req_index: 1993
+    req_index: 1981
     short_name: Lanayru Desert - Lightning Node Exit
   \Lanayru\Desert\Entry\Exit to Mine:
     type: exit
@@ -11355,7 +11346,7 @@ exits:
     stage: F300
     room: 0
     index: 1
-    req_index: 1994
+    req_index: 1982
     short_name: Lanayru Desert - Exit to Mine
   \Lanayru\Desert\East\Fire Node Exit:
     type: exit
@@ -11363,7 +11354,7 @@ exits:
     stage: F300
     room: 0
     index: 2
-    req_index: 1995
+    req_index: 1983
     short_name: Lanayru Desert - Fire Node Exit
   \Lanayru\Desert\Near South Exit to Temple of Time\South Exit to Temple of Time:
     type: exit
@@ -11371,7 +11362,7 @@ exits:
     stage: F300
     room: 0
     index: 3
-    req_index: 1996
+    req_index: 1984
     short_name: Lanayru Desert - South Exit to Temple of Time
   \Lanayru\Desert\North Part\North Exit to Temple of Time:
     type: exit
@@ -11379,7 +11370,7 @@ exits:
     stage: F300
     room: 0
     index: 4
-    req_index: 1997
+    req_index: 1985
     short_name: Lanayru Desert - North Exit to Temple of Time
   \Lanayru\Desert\Top of LMF\Exit to Lanayru Mining Facility:
     type: exit
@@ -11387,7 +11378,7 @@ exits:
     stage: F300
     room: 0
     index: 5
-    req_index: 1998
+    req_index: 1986
     short_name: Lanayru Desert - Exit to Lanayru Mining Facility
   \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Exit to Caves:
     type: exit
@@ -11395,17 +11386,17 @@ exits:
     stage: F300
     room: 0
     index: 8
-    req_index: 1999
+    req_index: 1987
     short_name: Lanayru Desert - Exit to Caves
   \Lanayru\Desert\North Part\Trial Gate Exit:
     type: exit
     vanilla: Lanayru Silent Realm - Entrance
-    req_index: 2000
+    req_index: 1988
     short_name: Lanayru Desert - Trial Gate Exit
   \Lanayru\Lanayru Silent Realm\Exit:
     type: exit
     vanilla: Lanayru Desert - Trial Gate Entrance
-    req_index: 2001
+    req_index: 1989
     short_name: Lanayru Silent Realm - Exit
   \Lanayru\Desert\North Part\Lightning Node\Present\Exit:
     type: exit
@@ -11413,7 +11404,7 @@ exits:
     stage: F300_2
     room: 0
     index: 0
-    req_index: 2002
+    req_index: 1990
     short_name: Lightning Node - Exit
   \Lanayru\Desert\East\Fire Node\Present\Exit:
     type: exit
@@ -11421,7 +11412,7 @@ exits:
     stage: F300_3
     room: 0
     index: 0
-    req_index: 2003
+    req_index: 1991
     short_name: Fire Node - Exit
   \Lanayru\Temple of Time\Shared Statue Exit:
     type: exit
@@ -11429,7 +11420,7 @@ exits:
     stage: F300_4
     room: 0
     index: 2
-    req_index: 2004
+    req_index: 1992
     short_name: Temple of Time - Shared Statue Exit
   \Lanayru\Temple of Time\South East\South Exit to Desert:
     type: exit
@@ -11437,7 +11428,7 @@ exits:
     stage: F300_4
     room: 0
     index: 0
-    req_index: 2005
+    req_index: 1993
     short_name: Temple of Time - South Exit to Desert
   \Lanayru\Temple of Time\North East\North Exit to Desert:
     type: exit
@@ -11445,7 +11436,7 @@ exits:
     stage: F300_4
     room: 0
     index: 1
-    req_index: 2006
+    req_index: 1994
     short_name: Temple of Time - North Exit to Desert
   \Lanayru\Temple of Time\Inside\Exit to Lanayru Mining Facility:
     type: exit
@@ -11453,7 +11444,7 @@ exits:
     stage: F300_4
     room: 0
     index: 4
-    req_index: 2007
+    req_index: 1995
     short_name: Temple of Time - Exit to Lanayru Mining Facility
   \Lanayru\Caves\Exit to Mine:
     type: exit
@@ -11461,7 +11452,7 @@ exits:
     stage: F303
     room: 0
     index: 0
-    req_index: 2008
+    req_index: 1996
     short_name: Lanayru Caves - Exit to Mine
   \Lanayru\Caves\Exit to Desert:
     type: exit
@@ -11469,7 +11460,7 @@ exits:
     stage: F303
     room: 0
     index: 1
-    req_index: 2009
+    req_index: 1997
     short_name: Lanayru Caves - Exit to Desert
   \Lanayru\Caves\Past Door to Lanayru Sand Sea\Exit to Lanayru Sand Sea:
     type: exit
@@ -11477,22 +11468,22 @@ exits:
     stage: F303
     room: 0
     index: 2
-    req_index: 2010
+    req_index: 1998
     short_name: Lanayru Caves - Exit to Lanayru Sand Sea
   \Lanayru\Caves\Past Crawlspace\Exit to Gorge:
     type: exit
     vanilla: Lanayru Gorge - Entrance
-    req_index: 2011
+    req_index: 1999
     short_name: Lanayru Caves - Exit to Gorge
   \Lanayru\Lanayru Sand Sea\Gorge\Exit:
     type: exit
     vanilla: Lanayru Caves - Entrance from Gorge
-    req_index: 2012
+    req_index: 2000
     short_name: Lanayru Gorge - Exit
   \Lanayru\Lanayru Sand Sea\Gorge\Statue Exit:
     type: exit
     vanilla: Sky - Lanayru Pillar - Entrance
-    req_index: 2013
+    req_index: 2001
     short_name: Lanayru Gorge - Statue Exit
   \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Exit:
     type: exit
@@ -11500,7 +11491,7 @@ exits:
     stage: F301_1
     room: 0
     index: 0
-    req_index: 2014
+    req_index: 2002
     short_name: Lanayru Sand Sea - Ancient Harbour Dock Exit
   \Lanayru\Lanayru Sand Sea\Sandship Dock Exit:
     type: exit
@@ -11508,7 +11499,7 @@ exits:
     stage: F301_1
     room: 0
     index: 1
-    req_index: 2015
+    req_index: 2003
     short_name: Lanayru Sand Sea - Sandship Dock Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Exit:
     type: exit
@@ -11516,7 +11507,7 @@ exits:
     stage: F301_1
     room: 0
     index: 2
-    req_index: 2016
+    req_index: 2004
     short_name: Lanayru Sand Sea - Skipper's Retreat Dock Exit
   \Lanayru\Lanayru Sand Sea\Shipyard Dock Exit:
     type: exit
@@ -11524,7 +11515,7 @@ exits:
     stage: F301_1
     room: 0
     index: 3
-    req_index: 2017
+    req_index: 2005
     short_name: Lanayru Sand Sea - Shipyard Dock Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Exit:
     type: exit
@@ -11532,7 +11523,7 @@ exits:
     stage: F301_1
     room: 0
     index: 4
-    req_index: 2018
+    req_index: 2006
     short_name: Lanayru Sand Sea - Pirate Stronghold Dock Exit
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Exit:
     type: exit
@@ -11540,7 +11531,7 @@ exits:
     stage: F301
     room: 0
     index: 3
-    req_index: 2019
+    req_index: 2007
     short_name: Lanayru Sand Sea Docks - Statue Exit
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Exit to Sandship:
     type: exit
@@ -11548,7 +11539,7 @@ exits:
     stage: F301
     room: 0
     index: 0
-    req_index: 2020
+    req_index: 2008
     short_name: Lanayru Sand Sea Docks - Exit to Sandship
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Exit to Caves:
     type: exit
@@ -11556,7 +11547,7 @@ exits:
     stage: F301
     room: 0
     index: 1
-    req_index: 2021
+    req_index: 2009
     short_name: Lanayru Sand Sea Docks - Exit to Caves
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Exit:
     type: exit
@@ -11564,7 +11555,7 @@ exits:
     stage: F301
     room: 0
     index: 2
-    req_index: 2022
+    req_index: 2010
     short_name: Lanayru Sand Sea Docks - Dock Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Exit:
     type: exit
@@ -11572,7 +11563,7 @@ exits:
     stage: F301_3
     room: 0
     index: 1
-    req_index: 2023
+    req_index: 2011
     short_name: Skipper's Retreat - Statue Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Exit:
     type: exit
@@ -11580,7 +11571,7 @@ exits:
     stage: F301_3
     room: 0
     index: 2
-    req_index: 2024
+    req_index: 2012
     short_name: Skipper's Retreat - Dock Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Exit:
     type: exit
@@ -11588,7 +11579,7 @@ exits:
     stage: F301_3
     room: 0
     index: 3
-    req_index: 2025
+    req_index: 2013
     short_name: Skipper's Retreat - Shack Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Exit:
     type: exit
@@ -11596,7 +11587,7 @@ exits:
     stage: F301_5
     room: 0
     index: 0
-    req_index: 2026
+    req_index: 2014
     short_name: Skipper's Retreat - Shack - Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Statue Exit:
     type: exit
@@ -11604,7 +11595,7 @@ exits:
     stage: F301_4
     room: 0
     index: 1
-    req_index: 2027
+    req_index: 2015
     short_name: Shipyard - Statue Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Dock Exit:
     type: exit
@@ -11612,7 +11603,7 @@ exits:
     stage: F301_4
     room: 0
     index: 2
-    req_index: 2028
+    req_index: 2016
     short_name: Shipyard - Dock Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Exit:
     type: exit
@@ -11620,7 +11611,7 @@ exits:
     stage: F301_4
     room: 0
     index: 3
-    req_index: 2029
+    req_index: 2017
     short_name: Shipyard - Construction Bay Upper Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Exit:
     type: exit
@@ -11628,7 +11619,7 @@ exits:
     stage: F301_4
     room: 0
     index: 4
-    req_index: 2030
+    req_index: 2018
     short_name: Shipyard - Construction Bay Lower Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Exit:
     type: exit
@@ -11636,7 +11627,7 @@ exits:
     stage: F301_7
     room: 0
     index: 0
-    req_index: 2031
+    req_index: 2019
     short_name: Shipyard - Construction Bay - Lower Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Exit:
     type: exit
@@ -11644,7 +11635,7 @@ exits:
     stage: F301_7
     room: 0
     index: 1
-    req_index: 2032
+    req_index: 2020
     short_name: Shipyard - Construction Bay - Upper Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Exit:
     type: exit
@@ -11652,7 +11643,7 @@ exits:
     stage: F301_6
     room: 0
     index: 3
-    req_index: 2033
+    req_index: 2021
     short_name: Pirate Stronghold - Statue Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Exit:
     type: exit
@@ -11660,7 +11651,7 @@ exits:
     stage: F301_6
     room: 0
     index: 0
-    req_index: 2034
+    req_index: 2022
     short_name: Pirate Stronghold - Dock Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Exit:
     type: exit
@@ -11668,7 +11659,7 @@ exits:
     stage: F301_6
     room: 0
     index: 1
-    req_index: 2035
+    req_index: 2023
     short_name: Pirate Stronghold - Side Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Exit:
     type: exit
@@ -11676,7 +11667,7 @@ exits:
     stage: F301_6
     room: 0
     index: 2
-    req_index: 2036
+    req_index: 2024
     short_name: Pirate Stronghold - Top Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Exit:
     type: exit
@@ -11684,7 +11675,7 @@ exits:
     stage: F301_2
     room: 1
     index: 0
-    req_index: 2037
+    req_index: 2025
     short_name: Pirate Stronghold - Inside - First Door Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Exit:
     type: exit
@@ -11692,63 +11683,63 @@ exits:
     stage: F301_2
     room: 1
     index: 2
-    req_index: 2038
+    req_index: 2026
     short_name: Pirate Stronghold - Inside - Second Door Exit
   \Lanayru Mining Facility\Main\First Room\Main Exit:
     type: exit
     vanilla: Lanayru Desert - Entrance from Lanayru Mining Facility
-    req_index: 2039
+    req_index: 2027
     short_name: Lanayru Mining Facility - Main Exit
   \Lanayru Mining Facility\Main\First Hub\Exit to Big Hub:
     type: exit
     vanilla: Lanayru Mining Facility - Big Hub - Entrance from First Hub
-    req_index: 2040
+    req_index: 2028
     short_name: Lanayru Mining Facility - First Hub - Exit to Big Hub
   \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Exit to Big Hub:
     type: exit
     vanilla: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes Room
-    req_index: 2041
+    req_index: 2029
     short_name: Lanayru Mining Facility - Hop Across Boxes Room - Exit to Big Hub
   \Lanayru Mining Facility\Main\Armos Fight Room\Exit to Big Hub:
     type: exit
     vanilla: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
-    req_index: 2042
+    req_index: 2030
     short_name: Lanayru Mining Facility - Armos Fight Room - Exit to Big Hub
   \Lanayru Mining Facility\Main\Big Hub\Entry\Exit to First Hub:
     type: exit
     vanilla: Lanayru Mining Facility - First Hub - Entrance from Big Hub
-    req_index: 2043
+    req_index: 2031
     short_name: Lanayru Mining Facility - Big Hub - Exit to First Hub
   \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Exit to Hop Across Boxes Room:
     type: exit
     vanilla: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big Hub
-    req_index: 2044
+    req_index: 2032
     short_name: Lanayru Mining Facility - Big Hub - Exit to Hop Across Boxes Room
   \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Exit to Armos Fight Room:
     type: exit
     vanilla: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
-    req_index: 2045
+    req_index: 2033
     short_name: Lanayru Mining Facility - Big Hub - Exit to Armos Fight Room
   \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Exit:
     type: exit
     vanilla: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
-    req_index: 2046
+    req_index: 2034
     short_name: Lanayru Mining Facility - Boss Door Exit
   \Lanayru Mining Facility\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Lanayru Mining Facility - Boss Door Entrance
-    req_index: 2047
+    req_index: 2035
     short_name: Lanayru Mining Facility - Boss Room - Exit to Dungeon
   \Lanayru Mining Facility\Boss Room\After Sand Drain\Exit to Hall of Ancient Robots:
     type: exit
     vanilla: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
       Room
-    req_index: 2048
+    req_index: 2036
     short_name: Lanayru Mining Facility - Boss Room - Exit to Hall of Ancient Robots
   \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Exit to Boss Room:
     type: exit
     vanilla: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient Robots
-    req_index: 2049
+    req_index: 2037
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Boss Room
   \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit to Temple of Time:
     type: exit
@@ -11757,23 +11748,23 @@ exits:
     stage: F300_5
     room: 0
     index: 1
-    req_index: 2050
+    req_index: 2038
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Temple
       of Time
   \Sandship\Main\Deck\Main Exit:
     type: exit
     vanilla: Lanayru Sand Sea - Sandship Dock Entrance
-    req_index: 2051
+    req_index: 2039
     short_name: Sandship - Main Exit
   \Sandship\Main\Before Boss Door\Boss Door one-way Exit:
     type: exit
     vanilla: Sandship - Boss Room - Entrance
-    req_index: 2052
+    req_index: 2040
     short_name: Sandship - Boss Door one-way Exit
   \Sky Keep\Main\First Room\Bottom Exit:
     type: exit
     vanilla: Skyloft - Entrance from Sky Keep
-    req_index: 2053
+    req_index: 2041
     short_name: Sky Keep - First Room - Bottom Exit
 entrances:
   \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Start Entrance:
@@ -11787,7 +11778,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2054
+    req_index: 2042
     short_name: Skyloft - Knight Academy - Start Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Chimney:
     type: entrance
@@ -11798,7 +11789,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2055
+    req_index: 2043
     short_name: Skyloft - Knight Academy - Chimney
   \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Entrance:
     type: entrance
@@ -11809,7 +11800,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2057
+    req_index: 2045
     short_name: Skyloft - Knight Academy - Lower Right Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Entrance:
     type: entrance
@@ -11820,7 +11811,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2059
+    req_index: 2047
     short_name: Skyloft - Knight Academy - Lower Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Entrance:
     type: entrance
@@ -11831,7 +11822,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2061
+    req_index: 2049
     short_name: Skyloft - Knight Academy - Upper Right Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Entrance:
     type: entrance
@@ -11842,7 +11833,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2063
+    req_index: 2051
     short_name: Skyloft - Knight Academy - Upper Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Entrance:
     type: entrance
@@ -11853,7 +11844,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2065
+    req_index: 2053
     short_name: Skyloft - Knight Academy Lower Right Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Entrance:
     type: entrance
@@ -11864,7 +11855,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2067
+    req_index: 2055
     short_name: Skyloft - Knight Academy Lower Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Entrance:
     type: entrance
@@ -11875,7 +11866,7 @@ entrances:
     entrance: 23
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2069
+    req_index: 2057
     short_name: Skyloft - Knight Academy Upper Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Entrance:
     type: entrance
@@ -11886,7 +11877,7 @@ entrances:
     entrance: 24
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2071
+    req_index: 2059
     short_name: Skyloft - Knight Academy Upper Right Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Right Door Entrance:
     type: entrance
@@ -11897,7 +11888,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2073
+    req_index: 2061
     short_name: Sparring Hall - Right Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Left Door Entrance:
     type: entrance
@@ -11908,7 +11899,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2075
+    req_index: 2063
     short_name: Sparring Hall - Left Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall Left Door Entrance:
     type: entrance
@@ -11919,7 +11910,7 @@ entrances:
     entrance: 21
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2077
+    req_index: 2065
     short_name: Skyloft - Sparring Hall Left Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall Right Door Entrance:
     type: entrance
@@ -11930,7 +11921,7 @@ entrances:
     entrance: 26
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2079
+    req_index: 2067
     short_name: Skyloft - Sparring Hall Right Door Entrance
   \Skyloft\Upper Skyloft\Goddess Statue\Entrance:
     type: entrance
@@ -11941,7 +11932,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2081
+    req_index: 2069
     short_name: Goddess Statue - Entrance
   \Skyloft\Upper Skyloft\Goddess Statue Entrance:
     type: entrance
@@ -11952,7 +11943,7 @@ entrances:
     entrance: 6
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2083
+    req_index: 2071
     short_name: Goddess Statue Entrance
   \Skyloft\Central Skyloft\Waterfall Cave\Upper Entrance:
     type: entrance
@@ -11963,7 +11954,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2085
+    req_index: 2073
     short_name: Waterfall Cave - Upper Entrance
   \Skyloft\Central Skyloft\Waterfall Cave\Lower Entrance:
     type: entrance
@@ -11974,7 +11965,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2087
+    req_index: 2075
     short_name: Waterfall Cave - Lower Entrance
   \Skyloft\Central Skyloft\Waterfall Cave Upper Entrance:
     type: entrance
@@ -11985,7 +11976,7 @@ entrances:
     entrance: 7
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2089
+    req_index: 2077
     short_name: Waterfall Cave Upper Entrance
   \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Entrance:
     type: entrance
@@ -11996,7 +11987,7 @@ entrances:
     entrance: 8
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2091
+    req_index: 2079
     short_name: Waterfall Cave Lower Entrance
   \Skyloft\Central Skyloft\Bazaar\North Entrance:
     type: entrance
@@ -12007,7 +11998,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2093
+    req_index: 2081
     short_name: Bazaar - North Entrance
   \Skyloft\Central Skyloft\Bazaar\South Entrance:
     type: entrance
@@ -12018,7 +12009,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2094
+    req_index: 2082
     short_name: Bazaar - South Entrance
   \Skyloft\Central Skyloft\Bazaar\West Entrance:
     type: entrance
@@ -12029,7 +12020,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2095
+    req_index: 2083
     short_name: Bazaar - West Entrance
   \Skyloft\Central Skyloft\Bazaar North Entrance:
     type: entrance
@@ -12040,7 +12031,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2096
+    req_index: 2084
     short_name: Bazaar North Entrance
   \Skyloft\Central Skyloft\Bazaar South Entrance:
     type: entrance
@@ -12051,7 +12042,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2098
+    req_index: 2086
     short_name: Bazaar South Entrance
   \Skyloft\Central Skyloft\Bazaar West Entrance:
     type: entrance
@@ -12062,7 +12053,7 @@ entrances:
     entrance: 20
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2100
+    req_index: 2088
     short_name: Bazaar West Entrance
   \Skyloft\Beedle's Shop\Day Entrance:
     type: entrance
@@ -12073,7 +12064,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2102
+    req_index: 2090
     short_name: Beedle's Shop - Day Entrance
   \Skyloft\Beedle's Shop\Night Entrance:
     type: entrance
@@ -12085,7 +12076,7 @@ entrances:
     entrance: 0
     tod: 1
     allowed_time_of_day: 2
-    req_index: 2104
+    req_index: 2092
     short_name: Beedle's Shop - Night Entrance
   \Skyloft\Central Skyloft\Entrance from Beedle's Shop:
     type: entrance
@@ -12096,7 +12087,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2105
+    req_index: 2093
     short_name: Skyloft - Entrance from Beedle's Shop
   \Skyloft\Skyloft Silent Realm\Entrance:
     type: entrance
@@ -12104,7 +12095,7 @@ entrances:
     can-start-at: false
     tod: 0
     allowed_time_of_day: 3
-    req_index: 2107
+    req_index: 2095
     short_name: Skyloft Silent Realm - Entrance
   \Skyloft\Central Skyloft\Trial Gate Entrance:
     type: entrance
@@ -12112,7 +12103,7 @@ entrances:
     can-start-at: false
     tod: 0
     allowed_time_of_day: 3
-    req_index: 2109
+    req_index: 2097
     short_name: Skyloft - Trial Gate Entrance
   \Skyloft\Central Skyloft\Near Temple Entrance\Entrance from Sky Keep:
     type: entrance
@@ -12124,7 +12115,7 @@ entrances:
     entrance: 53
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2111
+    req_index: 2099
     short_name: Skyloft - Entrance from Sky Keep
   \Skyloft\Central Skyloft\Orielle and Parrow's House\Entrance:
     type: entrance
@@ -12135,7 +12126,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2112
+    req_index: 2100
     short_name: Orielle and Parrow's House - Entrance
   \Skyloft\Central Skyloft\Orielle and Parrow's House Entrance:
     type: entrance
@@ -12146,7 +12137,7 @@ entrances:
     entrance: 30
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2114
+    req_index: 2102
     short_name: Orielle and Parrow's House Entrance
   \Skyloft\Central Skyloft\Peatrice's House\Entrance:
     type: entrance
@@ -12157,7 +12148,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2116
+    req_index: 2104
     short_name: Peatrice's House - Entrance
   \Skyloft\Central Skyloft\Peatrice's House Entrance:
     type: entrance
@@ -12168,7 +12159,7 @@ entrances:
     entrance: 38
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2118
+    req_index: 2106
     short_name: Peatrice's House Entrance
   \Skyloft\Central Skyloft\Wryna's House\Entrance:
     type: entrance
@@ -12179,7 +12170,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2120
+    req_index: 2108
     short_name: Wryna's House - Entrance
   \Skyloft\Central Skyloft\Wryna's House Entrance:
     type: entrance
@@ -12190,7 +12181,7 @@ entrances:
     entrance: 31
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2122
+    req_index: 2110
     short_name: Wryna's House Entrance
   \Skyloft\Skyloft Village\Bertie's House\Entrance:
     type: entrance
@@ -12201,7 +12192,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2124
+    req_index: 2112
     short_name: Bertie's House - Entrance
   \Skyloft\Skyloft Village\Bertie's House Entrance:
     type: entrance
@@ -12212,7 +12203,7 @@ entrances:
     entrance: 34
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2126
+    req_index: 2114
     short_name: Bertie's House Entrance
   \Skyloft\Skyloft Village\Sparrot's House\Entrance:
     type: entrance
@@ -12223,7 +12214,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2128
+    req_index: 2116
     short_name: Sparrot's House - Entrance
   \Skyloft\Skyloft Village\Sparrot's House Entrance:
     type: entrance
@@ -12234,7 +12225,7 @@ entrances:
     entrance: 33
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2130
+    req_index: 2118
     short_name: Sparrot's House Entrance
   \Skyloft\Skyloft Village\Mallara's House Entrance:
     type: entrance
@@ -12245,7 +12236,7 @@ entrances:
     entrance: 36
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2132
+    req_index: 2120
     short_name: Skyloft - Mallara's House Entrance
   \Skyloft\Skyloft Village\Mallara's House\Entrance:
     type: entrance
@@ -12256,7 +12247,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2134
+    req_index: 2122
     short_name: Mallara's House - Entrance
   \Skyloft\Skyloft Village\Batreaux's House\Entrance:
     type: entrance
@@ -12267,7 +12258,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2136
+    req_index: 2124
     short_name: Batreaux's House - Entrance
   \Skyloft\Skyloft Village\Batreaux's House Entrance:
     type: entrance
@@ -12278,7 +12269,7 @@ entrances:
     entrance: 29
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2138
+    req_index: 2126
     short_name: Batreaux's House Entrance
   \Skyloft\Skyloft Village\Gondo's House\Entrance:
     type: entrance
@@ -12289,7 +12280,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2140
+    req_index: 2128
     short_name: Gondo's House - Entrance
   \Skyloft\Skyloft Village\Gondo's House Entrance:
     type: entrance
@@ -12300,7 +12291,7 @@ entrances:
     entrance: 35
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2142
+    req_index: 2130
     short_name: Gondo's House Entrance
   \Skyloft\Skyloft Village\Rupin's House\Entrance:
     type: entrance
@@ -12311,7 +12302,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2144
+    req_index: 2132
     short_name: Rupin's House - Entrance
   \Skyloft\Skyloft Village\Rupin's House Entrance:
     type: entrance
@@ -12322,7 +12313,7 @@ entrances:
     entrance: 37
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2146
+    req_index: 2134
     short_name: Rupin's House Entrance
   \Skyloft\Central Skyloft\Piper's House\Entrance:
     type: entrance
@@ -12333,7 +12324,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2148
+    req_index: 2136
     short_name: Piper's House - Entrance
   \Skyloft\Central Skyloft\Piper's House Entrance:
     type: entrance
@@ -12344,7 +12335,7 @@ entrances:
     entrance: 32
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2150
+    req_index: 2138
     short_name: Piper's House Entrance
   \Skyloft\Central Skyloft\Entrance from Sky:
     type: entrance
@@ -12352,7 +12343,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2152
+    req_index: 2140
     short_name: Skyloft - Entrance from Sky
   \Sky\Around Skyloft\Entrance from Skyloft:
     type: entrance
@@ -12360,7 +12351,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2154
+    req_index: 2142
     short_name: Sky - Entrance from Skyloft
   \Sky\North East\Bamboo Island\Inside\Entrance:
     type: entrance
@@ -12371,7 +12362,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2155
+    req_index: 2143
     short_name: Bamboo Island - Inside - Entrance
   \Sky\North East\Bamboo Island\Entrance from Inside:
     type: entrance
@@ -12382,7 +12373,7 @@ entrances:
     entrance: 11
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2156
+    req_index: 2144
     short_name: Bamboo Island - Entrance from Inside
   \Sky\North East\Beedle's Island\Beedle's Ship Entrance:
     type: entrance
@@ -12394,7 +12385,7 @@ entrances:
     entrance: 0
     tod: 1
     allowed_time_of_day: 2
-    req_index: 2157
+    req_index: 2145
     short_name: Sky - Beedle's Island - Beedle's Ship Entrance
   \Sky\North East\Eldin Pillar\Entrance:
     type: entrance
@@ -12406,7 +12397,7 @@ entrances:
     entrance: 13
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2158
+    req_index: 2146
     short_name: Sky - Eldin Pillar - Entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Entrance:
     type: entrance
@@ -12417,7 +12408,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2159
+    req_index: 2147
     short_name: Lumpy Pumpkin Building - Main Right Door Entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Entrance:
     type: entrance
@@ -12428,7 +12419,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2161
+    req_index: 2149
     short_name: Lumpy Pumpkin Building - Main Left Door Entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Entrance:
     type: entrance
@@ -12439,7 +12430,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2163
+    req_index: 2151
     short_name: Lumpy Pumpkin Building - Back Door Entrance
   \Sky\South East\Lumpy Pumpkin\Main Left Door Entrance:
     type: entrance
@@ -12450,7 +12441,7 @@ entrances:
     entrance: 22
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2165
+    req_index: 2153
     short_name: Lumpy Pumpkin - Main Left Door Entrance
   \Sky\South East\Lumpy Pumpkin\Main Right Door Entrance:
     type: entrance
@@ -12461,7 +12452,7 @@ entrances:
     entrance: 23
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2167
+    req_index: 2155
     short_name: Lumpy Pumpkin - Main Right Door Entrance
   \Sky\South East\Lumpy Pumpkin\Back Door Entrance:
     type: entrance
@@ -12472,7 +12463,7 @@ entrances:
     entrance: 24
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2169
+    req_index: 2157
     short_name: Lumpy Pumpkin - Back Door Entrance
   \Sky\South East\Faron Pillar\Entrance:
     type: entrance
@@ -12484,7 +12475,7 @@ entrances:
     entrance: 12
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2171
+    req_index: 2159
     short_name: Sky - Faron Pillar - Entrance
   \Sky\South West\Lanayru Pillar\Entrance:
     type: entrance
@@ -12495,7 +12486,7 @@ entrances:
     entrance: 14
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2172
+    req_index: 2160
     short_name: Sky - Lanayru Pillar - Entrance
   \Sky\Around Skyloft\Entrance from Thunderhead:
     type: entrance
@@ -12507,7 +12498,7 @@ entrances:
     entrance: 28
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2173
+    req_index: 2161
     short_name: Sky - Entrance from Thunderhead
   \Sky\Thunderhead\Entrance:
     type: entrance
@@ -12519,7 +12510,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2174
+    req_index: 2162
     short_name: Thunderhead - Entrance
   \Sky\Thunderhead\Isle of Songs\Inside\Entrance:
     type: entrance
@@ -12531,7 +12522,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2175
+    req_index: 2163
     short_name: Isle of Songs - Entrance
   \Sky\Thunderhead\Isle of Songs\Entrance from Inside:
     type: entrance
@@ -12543,7 +12534,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2176
+    req_index: 2164
     short_name: Isle of Songs - Entrance from Inside
   \Faron\Sealed Grounds\Spiral\Upper Part\Statue Entrance:
     type: entrance
@@ -12556,7 +12547,7 @@ entrances:
     entrance: 8
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2177
+    req_index: 2165
     short_name: Sealed Grounds Spiral - Statue Entrance
   \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Entrance from Behind the Temple:
     type: entrance
@@ -12567,7 +12558,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2178
+    req_index: 2166
     short_name: Sealed Grounds Spiral - Shortcut Entrance from Behind the Temple
   \Faron\Sealed Grounds\Spiral\Door Entrance:
     type: entrance
@@ -12578,7 +12569,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2179
+    req_index: 2167
     short_name: Sealed Grounds Spiral - Door Entrance
   \Faron\Sealed Grounds\Sealed Temple\Main Entrance:
     type: entrance
@@ -12589,7 +12580,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2180
+    req_index: 2168
     short_name: Sealed Temple - Main Entrance
   \Faron\Sealed Grounds\Sealed Temple\Side Entrance:
     type: entrance
@@ -12600,7 +12591,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2181
+    req_index: 2169
     short_name: Sealed Temple - Side Entrance
   \Faron\Sealed Grounds\Sealed Temple\Gate of Time Entrance:
     type: entrance
@@ -12612,7 +12603,7 @@ entrances:
     entrance: 11
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2182
+    req_index: 2170
     short_name: Sealed Temple - Gate of Time Entrance
   \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Entrance:
     type: entrance
@@ -12624,7 +12615,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2183
+    req_index: 2171
     short_name: Hylia's Temple - Gate of Time Entrance
   \Faron\Sealed Grounds\Behind the Temple\Statue Entrance:
     type: entrance
@@ -12637,7 +12628,7 @@ entrances:
     entrance: 10
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2184
+    req_index: 2172
     short_name: Behind the Temple - Statue Entrance
   \Faron\Sealed Grounds\Behind the Temple\Door Entrance:
     type: entrance
@@ -12648,7 +12639,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2185
+    req_index: 2173
     short_name: Behind the Temple - Door Entrance
   \Faron\Sealed Grounds\Behind the Temple\Shortcut Entrance from Spiral:
     type: entrance
@@ -12660,7 +12651,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2186
+    req_index: 2174
     short_name: Behind the Temple - Shortcut Entrance from Spiral
   \Faron\Sealed Grounds\Behind the Temple\Entrance from Faron Woods:
     type: entrance
@@ -12671,7 +12662,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2187
+    req_index: 2175
     short_name: Behind the Temple - Entrance from Faron Woods
   \Faron\Faron Woods\Entry\Faron Woods Entry Statue Entrance:
     type: entrance
@@ -12684,7 +12675,7 @@ entrances:
     entrance: 50
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2188
+    req_index: 2176
     short_name: Faron Woods - Faron Woods Entry Statue Entrance
   \Faron\Faron Woods\In the Woods Statue Entrance:
     type: entrance
@@ -12697,7 +12688,7 @@ entrances:
     entrance: 51
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2189
+    req_index: 2177
     short_name: Faron Woods - In the Woods Statue Entrance
   \Faron\Faron Woods\Viewing Platform Statue Entrance:
     type: entrance
@@ -12710,7 +12701,7 @@ entrances:
     entrance: 52
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2190
+    req_index: 2178
     short_name: Faron Woods - Viewing Platform Statue Entrance
   \Faron\Faron Woods\Great Tree\Top\The Great Tree Statue Entrance:
     type: entrance
@@ -12723,7 +12714,7 @@ entrances:
     entrance: 53
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2191
+    req_index: 2179
     short_name: Great Tree - The Great Tree Statue Entrance
   \Faron\Faron Woods\Entry\Entrance from Behind the Temple:
     type: entrance
@@ -12734,7 +12725,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2192
+    req_index: 2180
     short_name: Faron Woods - Entrance from Behind the Temple
   \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Entrance from Floria Waterfall:
     type: entrance
@@ -12745,7 +12736,7 @@ entrances:
     entrance: 17
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2193
+    req_index: 2181
     short_name: Faron Woods - Shortcut Entrance from Floria Waterfall
   \Faron\Faron Woods\Ledge To Deep Woods\Entrance from Deep Woods:
     type: entrance
@@ -12756,7 +12747,7 @@ entrances:
     entrance: 45
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2194
+    req_index: 2182
     short_name: Faron Woods - Entrance from Deep Woods
   \Faron\Faron Woods\Trial Gate Entrance:
     type: entrance
@@ -12764,7 +12755,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2195
+    req_index: 2183
     short_name: Faron Woods - Trial Gate Entrance
   \Faron\Faron Silent Realm\Entrance:
     type: entrance
@@ -12772,7 +12763,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2196
+    req_index: 2184
     short_name: Faron Silent Realm - Entrance
   \Faron\Faron Woods\Great Tree\Platforms\Lower Entrance from Great Tree:
     type: entrance
@@ -12783,7 +12774,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2197
+    req_index: 2185
     short_name: Great Tree - Platforms - Lower Entrance from Great Tree
   \Faron\Faron Woods\Great Tree\Platforms\Upper Entrance from Great Tree:
     type: entrance
@@ -12794,7 +12785,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2198
+    req_index: 2186
     short_name: Great Tree - Platforms - Upper Entrance from Great Tree
   \Faron\Faron Woods\Great Tree\Top\Top Entrance from Great Tree:
     type: entrance
@@ -12805,7 +12796,7 @@ entrances:
     entrance: 6
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2199
+    req_index: 2187
     short_name: Great Tree - Top Entrance from Great Tree
   \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Entrance:
     type: entrance
@@ -12817,7 +12808,7 @@ entrances:
     entrance: 7
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2200
+    req_index: 2188
     short_name: Great Tree - Underwater Hole Entrance
   \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Entrance from Platforms:
     type: entrance
@@ -12828,7 +12819,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2201
+    req_index: 2189
     short_name: Great Tree - Lower Entrance from Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Upper Entrance from Platforms:
     type: entrance
@@ -12839,7 +12830,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2202
+    req_index: 2190
     short_name: Great Tree - Upper Entrance from Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Top:
     type: entrance
@@ -12850,7 +12841,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2203
+    req_index: 2191
     short_name: Great Tree - Entrance from Top
   \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Entrance:
     type: entrance
@@ -12862,7 +12853,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2204
+    req_index: 2192
     short_name: Great Tree - Underwater Tunnel Entrance
   \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Flooded Great Tree:
     type: entrance
@@ -12870,27 +12861,27 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2205
+    req_index: 2193
     short_name: Great Tree - Entrance from Flooded Great Tree
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2206
+    req_index: 2194
     short_name: Flooded Great Tree - Entrance
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Upper Flooded Faron Woods:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2207
+    req_index: 2195
     short_name: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Lower Flooded Faron Woods:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2208
+    req_index: 2196
     short_name: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
   \Faron\Flooded Faron Woods\Entrance from Upper Flooded Great Tree:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2209
+    req_index: 2197
     short_name: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
   \Faron\Flooded Faron Woods\Entrance from Lower Flooded Great Tree:
     type: entrance
@@ -12898,7 +12889,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2210
+    req_index: 2198
     short_name: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
   \Faron\Faron Woods\Deep Woods\Forest Temple Statue Entrance:
     type: entrance
@@ -12911,7 +12902,7 @@ entrances:
     entrance: 13
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2211
+    req_index: 2199
     short_name: Deep Woods - Forest Temple Statue Entrance
   \Faron\Faron Woods\Deep Woods\Deep Woods Statue Entrance:
     type: entrance
@@ -12924,7 +12915,7 @@ entrances:
     entrance: 14
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2212
+    req_index: 2200
     short_name: Deep Woods - Deep Woods Statue Entrance
   \Faron\Faron Woods\Deep Woods\Entry\Entrance from Faron Woods:
     type: entrance
@@ -12935,7 +12926,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2213
+    req_index: 2201
     short_name: Deep Woods - Entrance from Faron Woods
   \Faron\Faron Woods\Deep Woods\Entrance from Skyview Temple:
     type: entrance
@@ -12947,7 +12938,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2214
+    req_index: 2202
     short_name: Deep Woods - Entrance from Skyview Temple
   \Faron\Lake Floria\Below Rock\Emerged Area\Statue Entrance:
     type: entrance
@@ -12960,7 +12951,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2215
+    req_index: 2203
     short_name: Lake Floria - Below Rock - Statue Entrance
   \Faron\Lake Floria\Above Rock\Dive from Faron Woods:
     type: entrance
@@ -12972,7 +12963,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2216
+    req_index: 2204
     short_name: Lake Floria - Dive from Faron Woods
   \Faron\Lake Floria\Below Rock\Entrance from Farore's Lair:
     type: entrance
@@ -12984,7 +12975,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2217
+    req_index: 2205
     short_name: Lake Floria - Entrance from Farore's Lair
   \Faron\Lake Floria\Farore's Lair\Entrance from Lake Floria:
     type: entrance
@@ -12996,7 +12987,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2218
+    req_index: 2206
     short_name: Farore's Lair - Entrance from Lake Floria
   \Faron\Lake Floria\Farore's Lair\Entrance from Waterfall:
     type: entrance
@@ -13007,7 +12998,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2219
+    req_index: 2207
     short_name: Farore's Lair - Entrance from Waterfall
   \Faron\Lake Floria\Waterfall\Statue Entrance:
     type: entrance
@@ -13020,7 +13011,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2220
+    req_index: 2208
     short_name: Floria Waterfall - Statue Entrance
   \Faron\Lake Floria\Waterfall\Entrance from Farore's Lair:
     type: entrance
@@ -13031,7 +13022,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2221
+    req_index: 2209
     short_name: Floria Waterfall - Entrance from Farore's Lair
   \Faron\Lake Floria\Waterfall\Entrance from Ancient Cistern:
     type: entrance
@@ -13043,7 +13034,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2222
+    req_index: 2210
     short_name: Floria Waterfall - Entrance from Ancient Cistern
   \Faron\Lake Floria\Waterfall\Entrance from Faron Woods:
     type: entrance
@@ -13054,7 +13045,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2223
+    req_index: 2211
     short_name: Floria Waterfall - Entrance from Faron Woods
   \Skyview\Main\Entry\Main Entrance:
     type: entrance
@@ -13066,7 +13057,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2224
+    req_index: 2212
     short_name: Skyview Temple - Main Entrance
   \Skyview\Main\Last Room\After Rope\Boss Door Entrance:
     type: entrance
@@ -13074,7 +13065,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2225
+    req_index: 2213
     short_name: Skyview Temple - Boss Door Entrance
   \Skyview\Boss Room\Entrance from Dungeon:
     type: entrance
@@ -13082,7 +13073,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2226
+    req_index: 2214
     short_name: Skyview Temple - Boss Room - Entrance from Dungeon
   \Skyview\Boss Room\Entrance from Spring:
     type: entrance
@@ -13090,7 +13081,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2227
+    req_index: 2215
     short_name: Skyview Temple - Boss Room - Entrance from Spring
   \Skyview\Spring\Entrance:
     type: entrance
@@ -13098,7 +13089,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2228
+    req_index: 2216
     short_name: Skyview Temple - Spring - Entrance
   \Ancient Cistern\Main\Main Room\Main Entrance:
     type: entrance
@@ -13110,7 +13101,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2229
+    req_index: 2217
     short_name: Ancient Cistern - Main Entrance
   \Ancient Cistern\Main\Inside Statue\Boss Door Entrance:
     type: entrance
@@ -13118,7 +13109,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2230
+    req_index: 2218
     short_name: Ancient Cistern - Boss Door Entrance
   \Ancient Cistern\Boss Room\Entrance from Dungeon:
     type: entrance
@@ -13126,7 +13117,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2231
+    req_index: 2219
     short_name: Ancient Cistern - Boss Room - Entrance from Dungeon
   \Ancient Cistern\Boss Room\Entrance from Flame Room:
     type: entrance
@@ -13134,7 +13125,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2232
+    req_index: 2220
     short_name: Ancient Cistern - Boss Room - Entrance from Flame Room
   \Ancient Cistern\Flame Room\Entrance:
     type: entrance
@@ -13142,7 +13133,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2233
+    req_index: 2221
     short_name: Ancient Cistern - Flame Room - Entrance
   \Eldin\Volcano\Entry\First Time Entrance:
     type: entrance
@@ -13153,7 +13144,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2234
+    req_index: 2222
     short_name: Eldin Volcano - First Time Entrance
   \Eldin\Volcano\Entry\Volcano Entrance Statue Entrance:
     type: entrance
@@ -13166,7 +13157,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2235
+    req_index: 2223
     short_name: Eldin Volcano - Volcano Entrance Statue Entrance
   \Eldin\Volcano\East\Volcano East Statue Entrance:
     type: entrance
@@ -13179,7 +13170,7 @@ entrances:
     entrance: 6
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2236
+    req_index: 2224
     short_name: Eldin Volcano - Volcano East Statue Entrance
   \Eldin\Volcano\Ascent\Volcano Ascent Statue Entrance:
     type: entrance
@@ -13192,7 +13183,7 @@ entrances:
     entrance: 7
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2237
+    req_index: 2225
     short_name: Eldin Volcano - Volcano Ascent Statue Entrance
   \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Entrance:
     type: entrance
@@ -13205,7 +13196,7 @@ entrances:
     entrance: 7
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2238
+    req_index: 2226
     short_name: Eldin Volcano - Temple Entrance Statue Entrance
   \Eldin\Volcano\East\First Vent from Mogma Turf:
     type: entrance
@@ -13216,7 +13207,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2239
+    req_index: 2227
     short_name: Eldin Volcano - First Vent from Mogma Turf
   \Eldin\Volcano\Past Mogma Turf\Second Vent from Mogma Turf:
     type: entrance
@@ -13227,7 +13218,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2240
+    req_index: 2228
     short_name: Eldin Volcano - Second Vent from Mogma Turf
   \Eldin\Volcano\Near Temple Entrance\Entrance from Earth Temple:
     type: entrance
@@ -13238,7 +13229,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2241
+    req_index: 2229
     short_name: Eldin Volcano - Entrance from Earth Temple
   \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Entrance:
     type: entrance
@@ -13249,7 +13240,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2242
+    req_index: 2230
     short_name: Eldin Volcano - Thrill Digger Cave Entrance
   \Eldin\Volcano\Hot Cave\Entrance from Summit:
     type: entrance
@@ -13261,7 +13252,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2243
+    req_index: 2231
     short_name: Eldin Volcano - Entrance from Summit
   \Eldin\Volcano\Ascent\Trial Gate Entrance:
     type: entrance
@@ -13269,7 +13260,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2244
+    req_index: 2232
     short_name: Eldin Volcano - Trial Gate Entrance
   \Eldin\Volcano\Hot Cave\Vent Entrance near Hot Cave:
     type: entrance
@@ -13277,9 +13268,9 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2245
+    req_index: 2233
     short_name: Eldin Volcano - Vent Entrance near Hot Cave
-  \Eldin\Volcano\East\Entrance from Bokoblin Base:
+  \Eldin\Volcano\First Room\Entrance from Bokoblin Base:
     type: entrance
     province: Eldin Province
     stage: F200
@@ -13288,7 +13279,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2246
+    req_index: 2234
     short_name: Eldin Volcano - Entrance from Bokoblin Base
   \Eldin\Bokoblin Base\Prison\Entrance:
     type: entrance
@@ -13299,7 +13290,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2247
+    req_index: 2235
     short_name: Bokoblin Base - Entrance
   \Eldin\Mogma Turf\Pre Vent\Entrance:
     type: entrance
@@ -13310,7 +13301,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2248
+    req_index: 2236
     short_name: Mogma Turf - Entrance
   \Eldin\Volcano\Thrill Digger Cave\Entrance:
     type: entrance
@@ -13321,7 +13312,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2249
+    req_index: 2237
     short_name: Thrill Digger Cave - Entrance
   \Eldin\Eldin Silent Realm\Entrance:
     type: entrance
@@ -13329,7 +13320,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2250
+    req_index: 2238
     short_name: Eldin Silent Realm - Entrance
   \Eldin\Volcano Summit\Entrance from Outside Fire Sanctuary:
     type: entrance
@@ -13341,7 +13332,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2251
+    req_index: 2239
     short_name: Volcano Summit - Entrance from Outside Fire Sanctuary
   \Eldin\Volcano Summit\Entrance from Waterfall:
     type: entrance
@@ -13353,7 +13344,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2252
+    req_index: 2240
     short_name: Volcano Summit - Entrance from Waterfall
   \Eldin\Volcano Summit\Entrance from Eldin Volcano:
     type: entrance
@@ -13365,7 +13356,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2253
+    req_index: 2241
     short_name: Volcano Summit - Entrance from Eldin Volcano
   \Eldin\Volcano Summit\Waterfall\Entrance:
     type: entrance
@@ -13377,7 +13368,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2254
+    req_index: 2242
     short_name: Volcano Summit - Waterfall - Entrance
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Entrance:
     type: entrance
@@ -13390,7 +13381,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2255
+    req_index: 2243
     short_name: Outside Fire Sanctuary - Statue Entrance
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Entrance from Summit:
     type: entrance
@@ -13402,7 +13393,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2256
+    req_index: 2244
     short_name: Outside Fire Sanctuary - Entrance from Summit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Entrance from Fire Sanctuary:
     type: entrance
@@ -13414,7 +13405,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2257
+    req_index: 2245
     short_name: Outside Fire Sanctuary - Entrance from Fire Sanctuary
   \Earth Temple\Main\First Room\Main Entrance:
     type: entrance
@@ -13426,7 +13417,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2258
+    req_index: 2246
     short_name: Earth Temple - Main Entrance
   \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Entrance:
     type: entrance
@@ -13434,7 +13425,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2259
+    req_index: 2247
     short_name: Earth Temple - Boss Door Entrance
   \Earth Temple\Boss Room\Entry\Entrance from Dungeon:
     type: entrance
@@ -13442,7 +13433,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2260
+    req_index: 2248
     short_name: Earth Temple - Boss Room - Entrance from Dungeon
   \Earth Temple\Boss Room\Slope\Entrance from Spring:
     type: entrance
@@ -13450,7 +13441,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2261
+    req_index: 2249
     short_name: Earth Temple - Boss Room - Entrance from Spring
   \Earth Temple\Spring\Entrance:
     type: entrance
@@ -13458,7 +13449,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2262
+    req_index: 2250
     short_name: Earth Temple - Spring - Entrance
   \Fire Sanctuary\Main\Front of Boss Door\Statue Entrance:
     type: entrance
@@ -13472,7 +13463,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2263
+    req_index: 2251
     short_name: Fire Sanctuary - Statue Entrance
   \Fire Sanctuary\Main\First Room\Main Entrance:
     type: entrance
@@ -13484,7 +13475,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2264
+    req_index: 2252
     short_name: Fire Sanctuary - Main Entrance
   \Fire Sanctuary\Main\First Room\Past Water Plant\Entrance from Second Room:
     type: entrance
@@ -13492,7 +13483,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2265
+    req_index: 2253
     short_name: Fire Sanctuary - First Room - Entrance from Second Room
   \Fire Sanctuary\Main\Second Room\Outside Section\Entrance from First Room:
     type: entrance
@@ -13500,7 +13491,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2266
+    req_index: 2254
     short_name: Fire Sanctuary - Second Room - Entrance from First Room
   \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Entrance from West of Boss Door:
     type: entrance
@@ -13508,7 +13499,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2267
+    req_index: 2255
     short_name: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss
       Door
   \Fire Sanctuary\Main\West of Boss Door\Entry\Entrance from Magmanos Fight Room:
@@ -13517,7 +13508,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2268
+    req_index: 2256
     short_name: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight
       Room
   \Fire Sanctuary\Main\Front of Boss Door\Boss Door Entrance:
@@ -13526,7 +13517,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2269
+    req_index: 2257
     short_name: Fire Sanctuary - Boss Door Entrance
   \Fire Sanctuary\Boss Room\Entrance from Dungeon:
     type: entrance
@@ -13534,7 +13525,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2270
+    req_index: 2258
     short_name: Fire Sanctuary - Boss Room - Entrance from Dungeon
   \Fire Sanctuary\Boss Room\Entrance from Flame Room:
     type: entrance
@@ -13542,7 +13533,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2271
+    req_index: 2259
     short_name: Fire Sanctuary - Boss Room - Entrance from Flame Room
   \Fire Sanctuary\Flame Room\Entrance:
     type: entrance
@@ -13550,7 +13541,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2272
+    req_index: 2260
     short_name: Fire Sanctuary - Flame Room - Entrance
   \Lanayru\Mine\Entry\First Time Entrance:
     type: entrance
@@ -13561,7 +13552,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2273
+    req_index: 2261
     short_name: Lanayru Mine - First Time Entrance
   \Lanayru\Mine\Entry\Caves Entrance\Entrance from Caves:
     type: entrance
@@ -13572,7 +13563,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2274
+    req_index: 2262
     short_name: Lanayru Mine - Entrance from Caves
   \Lanayru\Mine\Entry\Statue Entrance:
     type: entrance
@@ -13585,7 +13576,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2275
+    req_index: 2263
     short_name: Lanayru Mine - Statue Entrance
   \Lanayru\Mine\End\In Minecart\Entrance from Desert:
     type: entrance
@@ -13596,7 +13587,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2276
+    req_index: 2264
     short_name: Lanayru Mine - Entrance from Desert
   \Lanayru\Desert\Entry\Desert Entrance Statue Entrance:
     type: entrance
@@ -13609,7 +13600,7 @@ entrances:
     entrance: 15
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2277
+    req_index: 2265
     short_name: Lanayru Desert - Desert Entrance Statue Entrance
   \Lanayru\Desert\West Part\West Desert Statue Entrance:
     type: entrance
@@ -13622,7 +13613,7 @@ entrances:
     entrance: 16
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2278
+    req_index: 2266
     short_name: Lanayru Desert - West Desert Statue Entrance
   \Lanayru\Desert\North Part\North Desert Statue Entrance:
     type: entrance
@@ -13635,7 +13626,7 @@ entrances:
     entrance: 17
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2279
+    req_index: 2267
     short_name: Lanayru Desert - North Desert Statue Entrance
   \Lanayru\Desert\East\Stone Cache Statue Entrance:
     type: entrance
@@ -13648,7 +13639,7 @@ entrances:
     entrance: 18
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2280
+    req_index: 2268
     short_name: Lanayru Desert - Stone Cache Statue Entrance
   \Lanayru\Desert\Near South Exit to Temple of Time\South Entrance from Temple of Time:
     type: entrance
@@ -13659,7 +13650,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2281
+    req_index: 2269
     short_name: Lanayru Desert - South Entrance from Temple of Time
   \Lanayru\Desert\North Part\North Entrance from Temple of Time:
     type: entrance
@@ -13670,7 +13661,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2282
+    req_index: 2270
     short_name: Lanayru Desert - North Entrance from Temple of Time
   \Lanayru\Desert\Entry\Entrance from Mine:
     type: entrance
@@ -13681,7 +13672,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2283
+    req_index: 2271
     short_name: Lanayru Desert - Entrance from Mine
   \Lanayru\Desert\East\Fire Node Entrance:
     type: entrance
@@ -13692,7 +13683,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2284
+    req_index: 2272
     short_name: Lanayru Desert - Fire Node Entrance
   \Lanayru\Desert\Top of LMF\Entrance from Lanayru Mining Facility:
     type: entrance
@@ -13704,7 +13695,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2285
+    req_index: 2273
     short_name: Lanayru Desert - Entrance from Lanayru Mining Facility
   \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Entrance from Caves:
     type: entrance
@@ -13715,7 +13706,7 @@ entrances:
     entrance: 6
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2286
+    req_index: 2274
     short_name: Lanayru Desert - Entrance from Caves
   \Lanayru\Desert\North Part\Lightning Node Entrance:
     type: entrance
@@ -13726,7 +13717,7 @@ entrances:
     entrance: 7
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2287
+    req_index: 2275
     short_name: Lanayru Desert - Lightning Node Entrance
   \Lanayru\Desert\North Part\Trial Gate Entrance:
     type: entrance
@@ -13734,7 +13725,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2288
+    req_index: 2276
     short_name: Lanayru Desert - Trial Gate Entrance
   \Lanayru\Lanayru Silent Realm\Entrance:
     type: entrance
@@ -13742,7 +13733,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2289
+    req_index: 2277
     short_name: Lanayru Silent Realm - Entrance
   \Lanayru\Desert\North Part\Lightning Node\Present\Entrance:
     type: entrance
@@ -13753,7 +13744,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2290
+    req_index: 2278
     short_name: Lightning Node - Entrance
   \Lanayru\Desert\East\Fire Node\Present\Entrance:
     type: entrance
@@ -13764,7 +13755,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2291
+    req_index: 2279
     short_name: Fire Node - Entrance
   \Lanayru\Temple of Time\South East\Desert Gorge Statue Entrance:
     type: entrance
@@ -13777,7 +13768,7 @@ entrances:
     entrance: 16
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2292
+    req_index: 2280
     short_name: Temple of Time - Desert Gorge Statue Entrance
   \Lanayru\Temple of Time\Inside\Temple of Time Statue Entrance:
     type: entrance
@@ -13790,7 +13781,7 @@ entrances:
     entrance: 17
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2293
+    req_index: 2281
     short_name: Temple of Time - Temple of Time Statue Entrance
   \Lanayru\Temple of Time\South East\South Entrance from Desert:
     type: entrance
@@ -13801,7 +13792,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2294
+    req_index: 2282
     short_name: Temple of Time - South Entrance from Desert
   \Lanayru\Temple of Time\North East\North Entrance from Desert:
     type: entrance
@@ -13812,7 +13803,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2295
+    req_index: 2283
     short_name: Temple of Time - North Entrance from Desert
   \Lanayru\Temple of Time\Inside\Entrance from Lanayru Mining Facility:
     type: entrance
@@ -13825,7 +13816,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2296
+    req_index: 2284
     short_name: Temple of Time - Entrance from Lanayru Mining Facility
   \Lanayru\Caves\Entrance from Mine:
     type: entrance
@@ -13836,7 +13827,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2297
+    req_index: 2285
     short_name: Lanayru Caves - Entrance from Mine
   \Lanayru\Caves\Entrance from Desert:
     type: entrance
@@ -13847,7 +13838,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2298
+    req_index: 2286
     short_name: Lanayru Caves - Entrance from Desert
   \Lanayru\Caves\Past Door to Lanayru Sand Sea\Entrance from Lanayru Sand Sea:
     type: entrance
@@ -13859,7 +13850,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2299
+    req_index: 2287
     short_name: Lanayru Caves - Entrance from Lanayru Sand Sea
   \Lanayru\Caves\Past Crawlspace\Entrance from Gorge:
     type: entrance
@@ -13870,7 +13861,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2300
+    req_index: 2288
     short_name: Lanayru Caves - Entrance from Gorge
   \Lanayru\Lanayru Sand Sea\Gorge\Entrance:
     type: entrance
@@ -13881,7 +13872,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2301
+    req_index: 2289
     short_name: Lanayru Gorge - Entrance
   \Lanayru\Lanayru Sand Sea\Gorge\Statue Entrance:
     type: entrance
@@ -13894,7 +13885,7 @@ entrances:
     entrance: 12
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2302
+    req_index: 2290
     short_name: Lanayru Gorge - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Entrance:
     type: entrance
@@ -13905,7 +13896,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2303
+    req_index: 2291
     short_name: Lanayru Sand Sea - Ancient Harbour Dock Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Entrance:
     type: entrance
@@ -13916,7 +13907,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2304
+    req_index: 2292
     short_name: Lanayru Sand Sea - Skipper's Retreat Dock Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard Dock Entrance:
     type: entrance
@@ -13927,7 +13918,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2305
+    req_index: 2293
     short_name: Lanayru Sand Sea - Shipyard Dock Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Entrance:
     type: entrance
@@ -13938,7 +13929,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2306
+    req_index: 2294
     short_name: Lanayru Sand Sea - Pirate Stronghold Dock Entrance
   \Lanayru\Lanayru Sand Sea\Sandship Dock Entrance:
     type: entrance
@@ -13950,7 +13941,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2307
+    req_index: 2295
     short_name: Lanayru Sand Sea - Sandship Dock Entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Entrance:
     type: entrance
@@ -13963,7 +13954,7 @@ entrances:
     entrance: 10
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2308
+    req_index: 2296
     short_name: Lanayru Sand Sea Docks - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Entrance from Caves:
     type: entrance
@@ -13975,7 +13966,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2309
+    req_index: 2297
     short_name: Lanayru Sand Sea Docks - Entrance from Caves
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Entrance:
     type: entrance
@@ -13986,7 +13977,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2310
+    req_index: 2298
     short_name: Lanayru Sand Sea Docks - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Entrance:
     type: entrance
@@ -13999,7 +13990,7 @@ entrances:
     entrance: 10
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2311
+    req_index: 2299
     short_name: Skipper's Retreat - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Entrance:
     type: entrance
@@ -14010,7 +14001,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2312
+    req_index: 2300
     short_name: Skipper's Retreat - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Entrance:
     type: entrance
@@ -14021,7 +14012,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2313
+    req_index: 2301
     short_name: Skipper's Retreat - Shack Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Entrance:
     type: entrance
@@ -14032,7 +14023,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2314
+    req_index: 2302
     short_name: Skipper's Retreat - Shack - Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Statue Entrance:
     type: entrance
@@ -14045,7 +14036,7 @@ entrances:
     entrance: 10
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2315
+    req_index: 2303
     short_name: Shipyard - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Dock Entrance:
     type: entrance
@@ -14056,7 +14047,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2316
+    req_index: 2304
     short_name: Shipyard - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Entrance:
     type: entrance
@@ -14068,7 +14059,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2317
+    req_index: 2305
     short_name: Shipyard - Construction Bay Lower Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Entrance:
     type: entrance
@@ -14080,7 +14071,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2318
+    req_index: 2306
     short_name: Shipyard - Construction Bay Upper Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Entrance:
     type: entrance
@@ -14092,7 +14083,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2319
+    req_index: 2307
     short_name: Shipyard - Construction Bay - Upper Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Entrance:
     type: entrance
@@ -14104,7 +14095,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2320
+    req_index: 2308
     short_name: Shipyard - Construction Bay - Lower Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Entrance:
     type: entrance
@@ -14117,7 +14108,7 @@ entrances:
     entrance: 10
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2321
+    req_index: 2309
     short_name: Pirate Stronghold - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Entrance:
     type: entrance
@@ -14128,7 +14119,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2322
+    req_index: 2310
     short_name: Pirate Stronghold - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Entrance:
     type: entrance
@@ -14139,7 +14130,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2323
+    req_index: 2311
     short_name: Pirate Stronghold - Side Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Entrance:
     type: entrance
@@ -14151,7 +14142,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2324
+    req_index: 2312
     short_name: Pirate Stronghold - Top Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Entrance:
     type: entrance
@@ -14162,7 +14153,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2325
+    req_index: 2313
     short_name: Pirate Stronghold - Inside - First Door Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Entrance:
     type: entrance
@@ -14174,7 +14165,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2326
+    req_index: 2314
     short_name: Pirate Stronghold - Inside - Second Door Entrance
   \Lanayru Mining Facility\Main\First Room\Main Entrance:
     type: entrance
@@ -14186,7 +14177,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2327
+    req_index: 2315
     short_name: Lanayru Mining Facility - Main Entrance
   \Lanayru Mining Facility\Main\First Hub\Entrance from Big Hub:
     type: entrance
@@ -14194,7 +14185,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2328
+    req_index: 2316
     short_name: Lanayru Mining Facility - First Hub - Entrance from Big Hub
   \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Entrance from Big Hub:
     type: entrance
@@ -14202,7 +14193,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2329
+    req_index: 2317
     short_name: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big
       Hub
   \Lanayru Mining Facility\Main\Armos Fight Room\Entrance from Big Hub:
@@ -14211,7 +14202,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2330
+    req_index: 2318
     short_name: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
   \Lanayru Mining Facility\Main\Big Hub\Entry\Entrance from First Hub:
     type: entrance
@@ -14219,7 +14210,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2331
+    req_index: 2319
     short_name: Lanayru Mining Facility - Big Hub - Entrance from First Hub
   \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Entrance from Hop Across Boxes Room:
     type: entrance
@@ -14227,7 +14218,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2332
+    req_index: 2320
     short_name: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes
       Room
   \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Entrance from Armos Fight Room:
@@ -14236,7 +14227,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2333
+    req_index: 2321
     short_name: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
   \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Entrance:
     type: entrance
@@ -14244,7 +14235,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2334
+    req_index: 2322
     short_name: Lanayru Mining Facility - Boss Door Entrance
   \Lanayru Mining Facility\Boss Room\Entrance from Dungeon:
     type: entrance
@@ -14252,7 +14243,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2335
+    req_index: 2323
     short_name: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
   \Lanayru Mining Facility\Boss Room\After Sand Drain\Entrance from Hall of Ancient Robots:
     type: entrance
@@ -14260,7 +14251,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2336
+    req_index: 2324
     short_name: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient
       Robots
   \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Entrance from Boss Room:
@@ -14269,7 +14260,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2337
+    req_index: 2325
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
       Room
   \Lanayru Mining Facility\Hall of Ancient Robots\End\Entrance from Temple of Time:
@@ -14283,7 +14274,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2338
+    req_index: 2326
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Temple
       of Time
   \Sandship\Main\Deck\Main Entrance:
@@ -14296,7 +14287,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2339
+    req_index: 2327
     short_name: Sandship - Main Entrance
   \Sandship\Boss Room\Entrance:
     type: entrance
@@ -14304,7 +14295,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2340
+    req_index: 2328
     short_name: Sandship - Boss Room - Entrance
   \Sky Keep\Main\First Room\Bottom Entrance:
     type: entrance
@@ -14316,7 +14307,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2341
+    req_index: 2329
     short_name: Sky Keep - First Room - Bottom Entrance
 linked_entrances:
   silent_realms:

--- a/dump.yaml
+++ b/dump.yaml
@@ -1,0 +1,20303 @@
+areas: !!python/object:logic.logic_input.Area
+  abstract: true
+  allowed_time_of_day: &id002 !!python/object/apply:logic.logic_input.AllowedTimeOfDay
+  - 3
+  can_save: false
+  can_sleep: false
+  entrances: !!set {}
+  exits:
+    Start: !!python/object:logic.logic_expression.BasicTextAtom
+      text: 'True'
+  hint_region: null
+  locations:
+    1 Extra Wallet: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Extra Wallet
+    1 Gratitude Crystal Pack: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack
+    10 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 10
+    10 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \10 Single Gratitude Crystals
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \5 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \1 Gratitude Crystal Pack
+        opaque: false
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \2 Gratitude Crystal Packs
+      opaque: false
+    10 Single Gratitude Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Gratitude Crystal x 10
+    11 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 11
+    12 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 12
+    13 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 13
+    15 Single Gratitude Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Gratitude Crystal x 15
+    2 Extra Wallets: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Extra Wallet x 2
+    2 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 2
+    3 Extra Wallets: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Extra Wallet x 3
+    3 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 3
+    30 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \15 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \3 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \10 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \4 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \5 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \5 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \6 Gratitude Crystal Packs
+      opaque: false
+    4 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 4
+    40 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \15 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \5 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \10 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \6 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \5 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \7 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \8 Gratitude Crystal Packs
+      opaque: false
+    5 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 5
+    5 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \5 Single Gratitude Crystals
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \1 Gratitude Crystal Pack
+      opaque: false
+    5 Single Gratitude Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Gratitude Crystal x 5
+    50 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \15 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \7 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \10 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \8 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \5 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \9 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \10 Gratitude Crystal Packs
+      opaque: false
+    6 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 6
+    7 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 7
+    70 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \15 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \11 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \10 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \12 Gratitude Crystal Packs
+        opaque: false
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \5 Single Gratitude Crystals
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \13 Gratitude Crystal Packs
+        opaque: false
+      opaque: false
+    8 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 8
+    80 Gratitude Crystals: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \15 Single Gratitude Crystals
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \13 Gratitude Crystal Packs
+      opaque: false
+    9 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Gratitude Crystal Pack x 9
+    Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
+      text: 'False'
+    Beetle: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Progressive Beetle
+    Big Wallet: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Progressive Wallet x 2
+    Bottle: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Pouch
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Skyloft\Central Skyloft\Bazaar\Item Check Access
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Empty Bottle_
+      opaque: false
+    Bow: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Progressive Bow
+    Bug Net: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Progressive Bug Net
+    Can Afford 100 Rupees: !!python/object:logic.logic_expression.BasicTextAtom
+      text: 'True'
+    Can Afford 1000 Rupees: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Can High Rupee Farm
+      - !!python/object:logic.logic_expression.OrCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \3 Extra Wallets
+        - !!python/object:logic.logic_expression.AndCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Medium Wallet
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \2 Extra Wallets
+          opaque: false
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \Big Wallet
+        opaque: false
+      opaque: false
+    Can Afford 1200 Rupees: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Can High Rupee Farm
+      - !!python/object:logic.logic_expression.OrCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \3 Extra Wallets
+        - !!python/object:logic.logic_expression.AndCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Medium Wallet
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \3 Extra Wallets
+          opaque: false
+        - !!python/object:logic.logic_expression.AndCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Big Wallet
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \1 Extra Wallet
+          opaque: false
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \Giant Wallet
+        opaque: false
+      opaque: false
+    Can Afford 1600 Rupees: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Can High Rupee Farm
+      - !!python/object:logic.logic_expression.OrCombination
+        arguments:
+        - !!python/object:logic.logic_expression.AndCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Big Wallet
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \2 Extra Wallets
+          opaque: false
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \Giant Wallet
+        opaque: false
+      opaque: false
+    Can Afford 300 Rupees: !!python/object:logic.logic_expression.BasicTextAtom
+      text: \Can Medium Rupee Farm
+    Can Afford 50 Rupees: !!python/object:logic.logic_expression.BasicTextAtom
+      text: 'True'
+    Can Afford 600 Rupees: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Can High Rupee Farm
+      - !!python/object:logic.logic_expression.OrCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \1 Extra Wallet
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \Big Wallet
+        opaque: false
+      opaque: false
+    Can Afford 800 Rupees: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Can High Rupee Farm
+      - !!python/object:logic.logic_expression.OrCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \2 Extra Wallets
+        - !!python/object:logic.logic_expression.AndCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Medium Wallet
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \1 Extra Wallet
+          opaque: false
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \Big Wallet
+        opaque: false
+      opaque: false
+    Can Collect Water: !!python/object:logic.logic_expression.BasicTextAtom
+      text: 'False'
+    Can Cut Tree: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Bomb Bag
+      opaque: false
+    Can Defeat Ampilus: !!python/object:logic.logic_expression.BasicTextAtom
+      text: \Damaging Item
+    Can Defeat Armos: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Gust Bellows
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      opaque: false
+    Can Defeat Beamos: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Bow
+      opaque: false
+    Can Defeat Bokoblins: !!python/object:logic.logic_expression.BasicTextAtom
+      text: \Damaging Item
+    Can Defeat Cursed Bokoblins: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Bomb Bag
+      opaque: false
+    Can Defeat Keeses: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Slingshot
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Beetle
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Whip
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Clawshots
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Bow
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Bomb Bag
+      opaque: false
+    Can Defeat Lizalfos: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: Advanced Lizalfos Combat Trick
+        - !!python/object:logic.logic_expression.OrCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Bomb Bag
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Bow
+          opaque: false
+        opaque: false
+      opaque: false
+    Can Defeat Moblins: !!python/object:logic.logic_expression.BasicTextAtom
+      text: \Damaging Item
+    Can Defeat Scervo/Dreadfuse: !!python/object:logic.logic_expression.BasicTextAtom
+      text: \Sword
+    Can Defeat Stalfos: !!python/object:logic.logic_expression.BasicTextAtom
+      text: \Sword
+    Can Defeat Stalmaster: !!python/object:logic.logic_expression.BasicTextAtom
+      text: \Sword
+    Can High Rupee Farm: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sky\South West\Fun Fun Island\Fun Fun Island Minigame
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Eldin\Volcano\Thrill Digger Cave\Thrill Digger Minigame
+      opaque: false
+    Can Hit Switch: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Bomb Bag
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Whip
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Distance Activator
+      opaque: false
+    Can Hit Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Bomb Bag
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Whip
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Distance Activator
+      opaque: false
+    Can Hit Timeshift Stone in Minecart: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Bomb Bag
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Distance Activator
+      opaque: false
+    Can Medium Rupee Farm: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sky\North East\Bamboo Island\Inside\Clean Cut Minigame
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Can High Rupee Farm
+      opaque: false
+    Can Unlock Combination Lock: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Whip
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Clawshots
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Slingshot
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Bow
+      opaque: false
+    Can bypass Boko Base Watch Tower: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Bow
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Bomb Bag
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Slingshot
+      opaque: false
+    Complete Triforce: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Triforce of Courage
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Triforce of Wisdom
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Triforce of Power
+      opaque: false
+    Damaging Item: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Sword
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Bomb Bag
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Bow
+      opaque: false
+    Digging Mitts: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Progressive Mitts
+    Distance Activator: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Slingshot
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Beetle
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Clawshots
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Bow
+      opaque: false
+    Early Lake Floria Tricks: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: Early Lake Floria - Fence Hop Trick
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \Practice Sword
+        opaque: false
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Early Lake Floria - Swordless Rope Floria Trick
+      opaque: false
+    Empty Bottle_: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Empty Bottle
+    Giant Wallet: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Progressive Wallet x 3
+    Goddess Longsword: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Progressive Sword x 3
+    Goddess Sword: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Progressive Sword x 2
+    Goddess White Sword: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Progressive Sword x 4
+    Hook Beetle: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Progressive Beetle x 2
+    Long Range Skyward Strike: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.AndCombination
+        arguments:
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: \Goddess Sword
+        - !!python/object:logic.logic_expression.BasicTextAtom
+          text: Upgraded Skyward Strike option
+        opaque: false
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \True Master Sword
+      opaque: false
+    Master Sword: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Progressive Sword x 5
+    Medium Wallet: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Progressive Wallet
+    Mogma Mitts: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Progressive Mitts x 2
+    Pouch: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Progressive Pouch
+    Practice Sword: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Progressive Sword
+    Projectile Item: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Slingshot
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Beetle
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Bow
+      opaque: false
+    Quick Beetle: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Three Beetles
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades\Upgrade to Quick Beetle
+      opaque: true
+    Slingshot: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Progressive Slingshot
+    Song of the Hero: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Faron Song of the Hero Part
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Eldin Song of the Hero Part
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Lanayru Song of the Hero Part
+      opaque: false
+    Sword: !!python/object:logic.logic_expression.BasicTextAtom
+      text: \Practice Sword
+    Three Beetles: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Progressive Beetle x 3
+    Tough Beetle: !!python/object:logic.logic_expression.OrCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: Progressive Beetle x 4
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades\Upgrade to Tough Beetle
+      opaque: true
+    True Master Sword: !!python/object:logic.logic_expression.BasicTextAtom
+      opaque: true
+      text: Progressive Sword x 6
+    Tycoon Wallet: !!python/object:logic.logic_expression.BasicTextAtom
+      text: Progressive Wallet x 4
+    Water Bottle: !!python/object:logic.logic_expression.AndCombination
+      arguments:
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Bottle
+      - !!python/object:logic.logic_expression.BasicTextAtom
+        text: \Can Collect Water
+      opaque: false
+  name: ''
+  sub_areas:
+    Ancient Cistern: !!python/object:logic.logic_input.Area
+      abstract: true
+      allowed_time_of_day: &id001 !!python/object/apply:logic.logic_input.AllowedTimeOfDay
+      - 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Ancient Cistern
+      locations:
+        Can Freely Raise and Lower Statue: !!python/object:logic.logic_expression.BasicTextAtom
+          text: 'False'
+        Can Lower Statue: !!python/object:logic.logic_expression.BasicTextAtom
+          text: \Ancient Cistern\Can Freely Raise and Lower Statue
+      name: \Ancient Cistern
+      sub_areas:
+        Boss Room: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Dungeon: null
+            Entrance from Flame Room: null
+          exits:
+            Exit to Dungeon: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Ancient Cistern\Boss Room\Beat Koloktos
+            Exit to Flame Room: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Ancient Cistern\Boss Room\Beat Koloktos
+          hint_region: Ancient Cistern
+          locations:
+            Beat Koloktos: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Whip
+              - !!python/object:logic.logic_expression.OrCombination
+                arguments:
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sword
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Bomb Bag
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Bow
+                opaque: false
+              opaque: false
+            Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Ancient Cistern\Boss Room\Beat Koloktos
+          name: \Ancient Cistern\Boss Room
+          sub_areas: {}
+          toplevel_alias: null
+        Flame Room: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Ancient Cistern
+          locations:
+            Farore's Flame: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Goddess Sword
+          name: \Ancient Cistern\Flame Room
+          sub_areas: {}
+          toplevel_alias: null
+        Main: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Ancient Cistern
+          locations: {}
+          name: \Ancient Cistern\Main
+          sub_areas:
+            Basement: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Ancient Cistern\Main\Basement\Rotating Vines: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Ancient Cistern\Main\Basement\Blow Rock
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  opaque: false
+                \Ancient Cistern\Main\Basement\Spider Thread: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Ancient Cistern\Main\Basement\Spider Thread\Activate Water
+                      Geyser
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ancient Cistern - Basement Highflip Trick
+                  opaque: false
+                \Ancient Cistern\Main\Basement\Under the Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Ancient Cistern - Basement Highflip Trick
+                \Ancient Cistern\Main\Inside Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Ancient Cistern
+              locations:
+                Blow Rock: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Bomb Bag
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Bomb Throws Trick
+                    opaque: false
+                  opaque: false
+                Stop Cursed Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+              name: \Ancient Cistern\Main\Basement
+              sub_areas:
+                Rotating Vines: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Ancient Cistern\Main\Basement\Spider Thread: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                  hint_region: Ancient Cistern
+                  locations: {}
+                  name: \Ancient Cistern\Main\Basement\Rotating Vines
+                  sub_areas: {}
+                  toplevel_alias: null
+                Spider Thread: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Ancient Cistern\Main\Basement\Under the Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Ancient Cistern\Can Freely Raise and Lower Statue
+                    \Ancient Cistern\Main\Main Room\Spider Thread Area: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Ancient Cistern
+                  locations:
+                    Activate Water Geyser: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                  name: \Ancient Cistern\Main\Basement\Spider Thread
+                  sub_areas: {}
+                  toplevel_alias: null
+                Under the Statue: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Ancient Cistern
+                  locations:
+                    Boss Key Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Ancient Cistern\Can Lower Statue
+                    \Ancient Cistern\Can Lower Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Ancient Cistern\Main\Basement\Under the Statue
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Basement Gutters: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Ancient Cistern\Main\Basement Gutters\Past Skulltula: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Ancient Cistern\Main\Basement Gutters\Can Get Past Skulltula
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Water Dragon's Scale
+                  opaque: false
+              hint_region: Ancient Cistern
+              locations:
+                Can Get Past Skulltula: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Beetle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  opaque: false
+              name: \Ancient Cistern\Main\Basement Gutters
+              sub_areas:
+                Past Skulltula: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement Gutters: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Water Dragon's Scale
+                    \Ancient Cistern\Main\Main Room\After Gutters: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Ancient Cistern Small Key x 2
+                  hint_region: Ancient Cistern
+                  locations:
+                    Bokoblin: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                  name: \Ancient Cistern\Main\Basement Gutters\Past Skulltula
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            East Part: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Ancient Cistern\Main\East Part\Second Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Ancient Cistern\Main\East Part\Unlock Combination Lock Door
+                \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Ancient Cistern
+              locations:
+                Unlock Combination Lock Door: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Unlock Combination Lock
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Ancient Cistern\Main\Main Room\Lock Combination Knowledge
+                  opaque: false
+              name: \Ancient Cistern\Main\East Part
+              sub_areas:
+                Chest Ledge: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Ancient Cistern
+                  locations:
+                    Chest in East Part: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Ancient Cistern\Main\East Part\Chest Ledge
+                  sub_areas: {}
+                  toplevel_alias: null
+                Second Room: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\East Part: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Ancient Cistern\Main\East Part\Chest Ledge: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\East Part\Second Room\Flip Main
+                          Lilypad
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Water Dragon's Scale
+                      opaque: false
+                  hint_region: Ancient Cistern
+                  locations:
+                    First Rupee in East Part in Short Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Water Dragon's Scale
+                    Flip Main Lilypad: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Flip Side Lilypad: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Rupee in East Part in Cubby: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\East Part\Second Room\Flip Side
+                          Lilypad
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Water Dragon's Scale
+                      opaque: false
+                    Rupee in East Part in Main Tunnel: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\East Part\Second Room\Flip Main
+                          Lilypad
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Water Dragon's Scale
+                      opaque: false
+                    Second Rupee in East Part in Short Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Water Dragon's Scale
+                    Third Rupee in East Part in Short Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Water Dragon's Scale
+                  name: \Ancient Cistern\Main\East Part\Second Room
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Inside Statue: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Boss Door Entrance: null
+              exits:
+                Boss Door Exit: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ancient Cistern Boss Key
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Ancient Cistern\Main\Inside Statue\Activate Water Geysers
+                  opaque: false
+                \Ancient Cistern\Main\Basement: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Ancient Cistern\Can Lower Statue
+                \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ancient Cistern Small Key x 2
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Can Defeat Stalmaster
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Ancient Cistern\Can Lower Statue
+                    opaque: false
+                  opaque: false
+                \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Ancient Cistern\Main\Inside Statue\Activate Water Geysers
+              hint_region: Ancient Cistern
+              locations:
+                Activate Water Geysers: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Whip
+              name: \Ancient Cistern\Main\Inside Statue
+              sub_areas:
+                Key Locked Room with Chest: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Inside Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Ancient Cistern Small Key x 2
+                  hint_region: Ancient Cistern
+                  locations:
+                    Chest in Key Locked Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Main Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Ancient Cistern\Main\Basement\Under the Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Ancient Cistern - Cistern Clip Trick
+                \Ancient Cistern\Main\East Part: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Ancient Cistern\Main\Main Room\Lever to East Part
+                \Ancient Cistern\Main\Inside Statue: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Ancient Cistern\Can Lower Statue
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ancient Cistern Small Key x 2
+                  opaque: false
+                \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ancient Cistern - Cistern Clip Trick
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ancient Cistern - Cistern Whip Room Clip Trick
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Water Dragon's Scale
+                  opaque: false
+                \Ancient Cistern\Main\Main Room\After Whip Hooks: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Whip
+                \Ancient Cistern\Main\Main Room\Behind the Waterfall: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Ancient Cistern\Main\Main Room\Lever to Block Waterfall
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Water Dragon's Scale
+                  opaque: false
+                \Ancient Cistern\Main\Main Room\Vines Area: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Ancient Cistern\Main\Main Room\Vines Area\Activate Water
+                      Geyser
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                    opaque: false
+                  opaque: false
+              hint_region: Ancient Cistern
+              locations:
+                Lever to Block Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Whip
+                Lever to East Part: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Lock Combination Knowledge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Rupee in East Hand: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                Rupee in West Hand: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+              name: \Ancient Cistern\Main\Main Room
+              sub_areas:
+                After Gutters: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\Main Room\After Gutters\Flip First
+                          Lilypad
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\Main Room\After Gutters\Activate
+                          Water Geyser
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\Main Room\After Gutters\Flip Second
+                          Lilypad 2
+                      opaque: false
+                    \Ancient Cistern\Main\Main Room\After Whip Hooks: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Ancient Cistern
+                  locations:
+                    Activate Water Geyser: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\Main Room\After Gutters\Flip Second
+                          Lilypad 1
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Water Dragon's Scale
+                      opaque: false
+                    Flip First Lilypad: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Water Dragon's Scale
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Whip
+                      opaque: false
+                    Flip Second Lilypad 1: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Ancient Cistern\Main\Main Room\After Gutters\Flip First
+                        Lilypad
+                    Flip Second Lilypad 2: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\Main Room\After Gutters\Flip First
+                          Lilypad
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\Main Room\After Gutters\Activate
+                          Water Geyser
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Whip
+                      opaque: false
+                    Lower Lever: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Rupee under Lilypad: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\Main Room\After Gutters\Flip Second
+                          Lilypad 1
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Water Dragon's Scale
+                      opaque: false
+                  name: \Ancient Cistern\Main\Main Room\After Gutters
+                  sub_areas:
+                    Upper Area: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Ancient Cistern\Main\Main Room\After Gutters: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        \Ancient Cistern\Main\Main Room\Vines Area: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Ancient Cistern\Main\Main Room\After Gutters\Upper
+                            Area\Upper Lever
+                      hint_region: Ancient Cistern
+                      locations:
+                        Upper Lever: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Whip
+                      name: \Ancient Cistern\Main\Main Room\After Gutters\Upper Area
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+                After Whip Hooks: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Ancient Cistern\Main\Main Room\After Gutters: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Ancient Cistern\Main\Main Room\After Gutters\Lower Lever
+                    \Ancient Cistern\Main\Main Room\Vines Area: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                  hint_region: Ancient Cistern
+                  locations:
+                    Chest after Whip Hooks: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Ancient Cistern\Main\Main Room\After Whip Hooks
+                  sub_areas: {}
+                  toplevel_alias: null
+                Behind the Waterfall: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement Gutters: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Ancient Cistern\Main\Main Room\Behind the Waterfall\Toilet
+                        Flush
+                  hint_region: Ancient Cistern
+                  locations:
+                    Chest behind the Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    First Lever: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                    Second Lever: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\Main Room\Behind the Waterfall\First
+                          Lever
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Whip
+                      opaque: false
+                    Toilet Flush: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\Main Room\Behind the Waterfall\First
+                          Lever
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Cistern\Main\Main Room\Behind the Waterfall\Second
+                          Lever
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Whip
+                      opaque: false
+                  name: \Ancient Cistern\Main\Main Room\Behind the Waterfall
+                  sub_areas: {}
+                  toplevel_alias: null
+                Spider Thread Area: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Ancient Cistern\Main\Main Room\Vines Area: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Ancient Cistern\Main\Main Room\Spider Thread Area\Extend
+                        Platform
+                  hint_region: Ancient Cistern
+                  locations:
+                    Extend Platform: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Ancient Cistern\Can Freely Raise and Lower Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                  name: \Ancient Cistern\Main\Main Room\Spider Thread Area
+                  sub_areas: {}
+                  toplevel_alias: null
+                Vines Area: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Ancient Cistern\Main\Main Room\After Gutters\Upper Area\Upper
+                        Lever
+                    \Ancient Cistern\Main\Main Room\After Whip Hooks: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sword
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Ancient Cistern - Map Chest Jump Trick
+                      opaque: false
+                    \Ancient Cistern\Main\Main Room\Spider Thread Area: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Ancient Cistern\Main\Main Room\Spider Thread Area\Extend
+                        Platform
+                  hint_region: Ancient Cistern
+                  locations:
+                    Activate Water Geyser: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                    Chest near Vines: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Ancient Cistern\Can Lower Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                    \Ancient Cistern\Main\Main Room\Lever to Block Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Ancient Cistern - Lever Jump Trick
+                  name: \Ancient Cistern\Main\Main Room\Vines Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Earth Temple: !!python/object:logic.logic_input.Area
+      abstract: false
+      allowed_time_of_day: *id001
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Earth Temple
+      locations: {}
+      name: \Earth Temple
+      sub_areas:
+        Boss Room: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Earth Temple
+          locations: {}
+          name: \Earth Temple\Boss Room
+          sub_areas:
+            Entry: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Dungeon: null
+              exits:
+                Exit to Dungeon: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Boss Room\Slope\Beat Scaldera
+                \Earth Temple\Boss Room\Slope: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Earth Temple
+              locations: {}
+              name: \Earth Temple\Boss Room\Entry
+              sub_areas: {}
+              toplevel_alias: null
+            Slope: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Spring: null
+              exits:
+                Exit to Spring: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Boss Room\Slope\Beat Scaldera
+              hint_region: Earth Temple
+              locations:
+                Beat Scaldera: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Bomb Bag
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sword
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Earth Temple\Boss Room\Slope\Bomb Flower Scaldera
+                  opaque: false
+                Bomb Flower Scaldera: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Earth Temple - Bomb Flower Scaldera Trick
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Earth Temple\Boss Room\Slope\Goddess Sword Strat
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Earth Temple\Boss Room\Slope\Longsword Strat
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Earth Temple\Boss Room\Slope\Master Sword Strat
+                    opaque: false
+                  opaque: false
+                Goddess Sword Strat: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Upgraded Skyward Strike option
+                  opaque: false
+                Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Boss Room\Slope\Beat Scaldera
+                Longsword Strat: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Longsword
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Upgraded Skyward Strike option
+                  opaque: false
+                Master Sword Strat: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Master Sword
+              name: \Earth Temple\Boss Room\Slope
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Main: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Earth Temple
+          locations: {}
+          name: \Earth Temple\Main
+          sub_areas:
+            East Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Earth Temple\Main\Hub Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Earth Temple
+              locations:
+                Chest after Double Lizalfos Fight: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Defeat Lizalfos
+              name: \Earth Temple\Main\East Room
+              sub_areas: {}
+              toplevel_alias: null
+            First Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Earth Temple\Main\Hub Room: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Earth Temple\Main\First Room\Lower Drawbridge
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Earth Temple\Main\First Room\Dislodge Boulder
+                  opaque: false
+              hint_region: Earth Temple
+              locations:
+                Dislodge Boulder: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Slingshot
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Beetle
+                    - !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Advanced Lizalfos Combat Trick
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Can Defeat Lizalfos
+                      opaque: false
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Long Range Skyward Strike
+                  opaque: false
+                Lower Drawbridge: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Beetle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Long Range Skyward Strike
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Earth Temple - Keese Yeet Trick
+                    opaque: false
+                  opaque: false
+                Rupee above Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Vent Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Digging Mitts
+              name: \Earth Temple\Main\First Room
+              sub_areas: {}
+              toplevel_alias: null
+            Hub Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Earth Temple\Main\East Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Main\Hub Room\Access to Boulder
+                \Earth Temple\Main\Hub Room\Past Lava Section: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Earth Temple\Main\Hub Room\Access to Boulder
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Earth Temple\Main\Hub Room\Wall to Lava Section
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Earth Temple\Main\Hub Room\Lower Lava Section Portcullis
+                      opaque: false
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Earth Temple\Main\Hub Room\Raise Bridge
+                    opaque: false
+                  opaque: false
+                \Earth Temple\Main\Room with Slopes: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Main\Hub Room\Raise Bridge
+                \Earth Temple\Main\West Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Main\Hub Room\Rock to West Room
+              hint_region: Earth Temple
+              locations:
+                Access to Boulder: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Main\First Room\Dislodge Boulder
+                Chest Left of Main Room Bridge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Main\Hub Room\Access to Boulder
+                Chest behind Bombable Rock: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Main\Hub Room\Access to Boulder
+                Ledd's Gift: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Defeat Lizalfos
+                Left Peg: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Main\Hub Room\Access to Boulder
+                Lower Lava Section Portcullis: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Earth Temple\Main\Hub Room\Wall to Lava Section
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Beetle
+                  opaque: false
+                Raise Bridge: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Earth Temple\Main\Hub Room\Left Peg
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Earth Temple\Main\Hub Room\Past Lava Section\Right Peg
+                  opaque: false
+                Rock to West Room: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  opaque: false
+                Rupee in Lava Tunnel: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Earth Temple\Main\Hub Room\Wall to Lava Section
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Beetle
+                  opaque: false
+                Wall to Lava Section: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Hook Beetle
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Earth Temple\Main\Hub Room\Access to Boulder
+                    opaque: false
+                  opaque: false
+                \Earth Temple\Main\First Room\Rupee above Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+              name: \Earth Temple\Main\Hub Room
+              sub_areas:
+                Past Lava Section: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Earth Temple\Main\Hub Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Earth Temple
+                  locations:
+                    Chest Guarded by Lizalfos: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Right Peg: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Earth Temple\Main\Hub Room\Past Lava Section
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Room with Slopes: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Earth Temple\Main\Hub Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Earth Temple\Main\Room with Slopes\Front of Boss Door: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Earth Temple\Main\Room with Slopes\Rock in Second Slope
+                      Resting Area
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Earth Temple - Slope Stuttersprint Trick
+                  opaque: false
+              hint_region: Earth Temple
+              locations:
+                Rock in Second Slope Resting Area: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Digging Mitts
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Bomb Bag
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  opaque: false
+              name: \Earth Temple\Main\Room with Slopes
+              sub_areas:
+                Front of Boss Door: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Boss Door Entrance: null
+                  exits:
+                    Boss Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Earth Temple\Main\Room with Slopes\Front of Boss Door\Open
+                        Boss Door
+                    \Earth Temple\Main\Room with Slopes: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Earth Temple
+                  locations:
+                    Boss Key Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Open Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Earth Temple Boss Key
+                  name: \Earth Temple\Main\Room with Slopes\Front of Boss Door
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            West Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Earth Temple\Main\Hub Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Earth Temple\Main\West Room\Rock to Hub Room
+              hint_region: Earth Temple
+              locations:
+                Chest in West Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Rock to Hub Room: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  opaque: false
+              name: \Earth Temple\Main\West Room
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Spring: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Earth Temple
+          locations:
+            Strike Crest: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Goddess Sword
+          name: \Earth Temple\Spring
+          sub_areas: {}
+          toplevel_alias: null
+      toplevel_alias: null
+    Eldin: !!python/object:logic.logic_input.Area
+      abstract: true
+      allowed_time_of_day: *id001
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: null
+      locations:
+        Can Survive Hot Cave: !!python/object:logic.logic_expression.OrCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Nonlethal Hot Cave
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Fireshield Earrings
+          opaque: false
+      name: \Eldin
+      sub_areas:
+        Bokoblin Base: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Bokoblin Base
+          locations: {}
+          name: \Eldin\Bokoblin Base
+          sub_areas:
+            After Drawbridge: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Before Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+                \Eldin\Bokoblin Base\Lower Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Bokoblin Base\Outside Earth Temple: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Bokoblin Base\Volcano East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Bokoblin Base
+              locations: {}
+              name: \Eldin\Bokoblin Base\After Drawbridge
+              sub_areas: {}
+              toplevel_alias: null
+            Before Drawbridge: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\After Drawbridge: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Whip
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  opaque: false
+                \Eldin\Bokoblin Base\Volcano East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Bokoblin Base
+              locations:
+                Chest near Drawbridge: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can bypass Boko Base Watch Tower
+                  opaque: false
+              name: \Eldin\Bokoblin Base\Before Drawbridge
+              sub_areas: {}
+              toplevel_alias: null
+            Bokoblin Base Summit: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Fire Dragon's Lair: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Fireshield Earrings
+                \Eldin\Bokoblin Base\Hot Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Fireshield Earrings
+              hint_region: Bokoblin Base
+              locations:
+                Chest in Volcano Summit Alcove: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Fireshield Earrings
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Practice Sword
+                  opaque: false
+                First Chest in Volcano Summit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Fireshield Earrings
+                Goddess Cube inside Volcano Summit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Fireshield Earrings
+                Raised Chest in Volcano Summit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Fireshield Earrings
+              name: \Eldin\Bokoblin Base\Bokoblin Base Summit
+              sub_areas: {}
+              toplevel_alias: null
+            Fire Dragon's Lair: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Bokoblin Base Summit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Bokoblin Base
+              locations:
+                Beaten Boko Base: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Beetle
+                  opaque: false
+                Fire Dragon's Reward: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
+              name: \Eldin\Bokoblin Base\Fire Dragon's Lair
+              sub_areas: {}
+              toplevel_alias: null
+            Hot Cave: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\After Drawbridge: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Fireshield Earrings
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  opaque: false
+                \Eldin\Bokoblin Base\Bokoblin Base Summit: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Fireshield Earrings
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  opaque: false
+              hint_region: Bokoblin Base
+              locations: {}
+              name: \Eldin\Bokoblin Base\Hot Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Lower Platform Cave: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\After Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+                \Eldin\Bokoblin Base\Before Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Bokoblin Base\Volcano East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Bokoblin Base
+              locations:
+                Gossip Stone in Lower Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Bokoblin Base\Lower Platform Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Outside Earth Temple: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Hot Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Bokoblin Base\Upper Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Bokoblin Base
+              locations:
+                Chest East of Earth Temple Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Chest West of Earth Temple Entrance: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Slingshot
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Bow
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Bomb Bag
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Goddess Sword
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can bypass Boko Base Watch Tower
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Mogma Mitts
+                  opaque: false
+                Goddess Cube East of Earth Temple Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                Goddess Cube West of Earth Temple Entrance: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can bypass Boko Base Watch Tower
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Mogma Mitts
+                  opaque: false
+              name: \Eldin\Bokoblin Base\Outside Earth Temple
+              sub_areas: {}
+              toplevel_alias: null
+            Prison: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Bokoblin Base\Volcano East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Mogma Mitts
+              hint_region: Bokoblin Base
+              locations:
+                Plats' Gift: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Bokoblin Base\Prison
+              sub_areas: {}
+              toplevel_alias: null
+            Upper Platform Cave: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Outside Earth Temple: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Bokoblin Base
+              locations:
+                Gossip Stone in Upper Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Bokoblin Base\Upper Platform Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Volcano East: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\After Drawbridge: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  opaque: false
+                \Eldin\Bokoblin Base\Before Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Bokoblin Base\Prison: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Mogma Mitts
+              hint_region: Bokoblin Base
+              locations:
+                Chest near Bone Bridge: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can bypass Boko Base Watch Tower
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Mogma Mitts
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Gust Bellows
+                  opaque: false
+                Chest on Cliff: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Can bypass Boko Base Watch Tower
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Mogma Mitts
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Gust Bellows
+                  opaque: false
+                Goddess Cube near Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+              name: \Eldin\Bokoblin Base\Volcano East
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Bokoblin Base
+        Eldin Silent Realm: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Eldin Silent Realm
+          locations:
+            Relic 1: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 10: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 2: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 3: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 4: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 5: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 6: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 7: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 8: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 9: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Trial Reward: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          name: \Eldin\Eldin Silent Realm
+          sub_areas: {}
+          toplevel_alias: null
+        Mogma Turf: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Mogma Turf
+          locations: {}
+          name: \Eldin\Mogma Turf
+          sub_areas:
+            Past Vent: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                Second Vent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Mogma Turf\Pre Vent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Mogma Turf\Sand Slide Platform: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Mogma Turf
+              locations:
+                Chest behind Bombable Wall in Fire Maze: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Mogma Turf\Past Vent
+              sub_areas: {}
+              toplevel_alias: null
+            Pre Vent: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                First Vent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Mogma Turf\Past Vent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Mogma Turf\Pre Vent\Open Vent
+              hint_region: Mogma Turf
+              locations:
+                Chest behind Bombable Wall at Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Defeat Bokoblins: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Defeat Bokoblins
+                Free Fall Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Goddess Cube in Mogma Turf: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                Open Vent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Digging Mitts
+                Pick up Guld: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sky\South East\Lumpy Pumpkin\Start Kina's Quest
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Scrapper
+                  opaque: false
+              name: \Eldin\Mogma Turf\Pre Vent
+              sub_areas: {}
+              toplevel_alias: null
+            Sand Slide Platform: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Mogma Turf\Pre Vent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Mogma Turf
+              locations:
+                Sand Slide Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Mogma Turf\Sand Slide Platform
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Volcano: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Eldin Volcano
+          locations: {}
+          name: \Eldin\Volcano
+          sub_areas:
+            Ascent: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Trial Gate Entrance: null
+                Volcano Ascent Statue Entrance: null
+              exits:
+                Trial Gate Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Ascent\Open Trial Gate
+                \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Ascent\Unlock Statue
+                \Eldin\Volcano\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
+                \Eldin\Volcano\Near Thrill Digger Cave: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Eldin\Volcano\Ascent\Defeat Slope Bokoblins
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Stuttersprint Trick
+                  opaque: false
+                \Eldin\Volcano\Past Slide: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Past Slide\Unlock Shortcut to Ascent
+              hint_region: Eldin Volcano
+              locations:
+                Chest behind Bombable Wall near Volcano Ascent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Defeat Slope Bokoblins: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Slingshot
+                  opaque: false
+                Open Trial Gate: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Goddess's Harp
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Din's Power
+                  opaque: false
+                Unlock Shortcut to Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Volcano\Past Slide\Unlock Shortcut to Ascent: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  opaque: false
+              name: \Eldin\Volcano\Ascent
+              sub_areas: {}
+              toplevel_alias: null
+            East: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Bokoblin Base: null
+                First Vent from Mogma Turf: null
+                Volcano East Statue Entrance: null
+              exits:
+                Dive to Mogma Turf: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\East\Drain Lava
+                Exit to Bokoblin Base: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Volcano East / Volcano Ascent Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\East\Unlock Statue
+                \Eldin\Volcano\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+                \Eldin\Volcano\First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\First Room\Blow up Rock to East
+                \Eldin\Volcano\Past Mogma Turf: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf
+              hint_region: Eldin Volcano
+              locations:
+                Chest after Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Chest behind Bombable Wall near Cliff: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Drain Lava: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Goddess Cube near Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                Item on Cliff: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                North Rupee above Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Southeast Rupee above Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Volcano\First Room\Blow up Rock to East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Bomb Bag
+                \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  opaque: false
+              name: \Eldin\Volcano\East
+              sub_areas: {}
+              toplevel_alias: null
+            Entry: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                First Time Entrance: null
+                Volcano Entrance Statue Entrance: null
+              exits:
+                Volcano Entrance Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Entry\Unlock Statue
+                \Eldin\Volcano\Ascent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
+                \Eldin\Volcano\First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Eldin Volcano
+              locations:
+                Goddess Cube at Eldin Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                Rupee on Ledge before First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Volcano\Ascent\Unlock Shortcut to Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Bomb Bag
+              name: \Eldin\Volcano\Entry
+              sub_areas: {}
+              toplevel_alias: null
+            First Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Volcano\East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\First Room\Blow up Rock to East
+              hint_region: Eldin Volcano
+              locations:
+                Blow up Rock to East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Chest behind Bombable Wall in First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Rupee behind Bombable Wall in First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Rupee in Crawlspace in First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Volcano\First Room
+              sub_areas: {}
+              toplevel_alias: null
+            Hot Cave: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Summit: null
+                Vent Entrance near Hot Cave: null
+              exits:
+                Exit to Summit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Fireshield Earrings
+                \Eldin\Volcano\Near Temple Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Near Temple Entrance\Blow down Watchtower to
+                    Hot Cave
+                \Eldin\Volcano\Sand Slide: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Can Survive Hot Cave
+              hint_region: Eldin Volcano
+              locations:
+                \Eldin\Volcano\Near Temple Entrance\Blow down Watchtower to Hot Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'False'
+              name: \Eldin\Volcano\Hot Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Lower Platform Cave: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Volcano\East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
+                \Eldin\Volcano\Past Mogma Turf: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
+                \Eldin\Volcano\Past Slide: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+              hint_region: Eldin Volcano
+              locations:
+                Gossip Stone in Lower Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Volcano\Lower Platform Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Near Temple Entrance: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Earth Temple: null
+                Temple Entrance Statue Entrance: null
+              exits:
+                Exit to Earth Temple: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Open ET option
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Key Piece x 5
+                  opaque: false
+                Temple Entrance Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Near Temple Entrance\Unlock Statue
+                \Eldin\Volcano\Hot Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Near Temple Entrance\Blow down Watchtower to
+                    Hot Cave
+                \Eldin\Volcano\Near Thrill Digger Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Near Thrill Digger Cave\Blow down Watchtower
+                \Eldin\Volcano\Upper Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
+              hint_region: Eldin Volcano
+              locations:
+                Blow down Watchtower to Hot Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Digging Spot behind Boulder on Sandy Slope: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Digging Mitts
+                Digging Spot below Tower: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Digging Mitts
+                Digging Spot in front of Earth Temple: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Digging Mitts
+                Goddess Cube East of Earth Temple Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                Goddess Cube West of Earth Temple Entrance: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Digging Mitts
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  opaque: false
+                Gossip Stone next to Earth Temple: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Digging Mitts
+                Retrieve Crystal Ball: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Scrapper
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyloft\Skyloft Village\Sparrot's House\Start Sparrot's
+                      Quest
+                  opaque: false
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Volcano\Near Temple Entrance
+              sub_areas: {}
+              toplevel_alias: null
+            Near Thrill Digger Cave: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Thrill Digger Cave Entrance: null
+              exits:
+                Thrill Digger Cave Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Volcano\Ascent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Volcano\Near Temple Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Near Thrill Digger Cave\Blow down Watchtower
+              hint_region: Eldin Volcano
+              locations:
+                Blow down Watchtower: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Left Rupee behind Bombable Wall on First Slope: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Right Rupee behind Bombable Wall on First Slope: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Volcano\Near Thrill Digger Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Past Mogma Turf: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Second Vent from Mogma Turf: null
+              exits:
+                \Eldin\Volcano\Ascent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Past Mogma Turf\Watch Bridge Cutscene
+                \Eldin\Volcano\East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf
+              hint_region: Eldin Volcano
+              locations:
+                Goddess Cube near Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                North Rupee above Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Southeast Rupee above Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Unlock Shortcut to Pre Turf: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Watch Bridge Cutscene: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Volcano\Past Mogma Turf
+              sub_areas: {}
+              toplevel_alias: null
+            Past Slide: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                Vent Exit near Ascent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Volcano\Ascent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Past Slide\Unlock Shortcut to Ascent
+                \Eldin\Volcano\Lower Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
+              hint_region: Eldin Volcano
+              locations:
+                Digging Spot after Draining Lava: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Digging Mitts
+                Unlock Shortcut to Ascent: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Volcano\Past Slide
+              sub_areas: {}
+              toplevel_alias: null
+            Sand Slide: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Volcano\Past Slide: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Eldin Volcano
+              locations:
+                Digging Spot after Vents: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Digging Mitts
+                Goddess Cube on Sand Slide: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+              name: \Eldin\Volcano\Sand Slide
+              sub_areas: {}
+              toplevel_alias: null
+            Thrill Digger Cave: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Eldin Volcano
+              locations:
+                Gossip Stone in Thrill Digger Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Thrill Digger Minigame: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Digging Mitts
+              name: \Eldin\Volcano\Thrill Digger Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Upper Platform Cave: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Volcano\Near Temple Entrance: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  opaque: false
+              hint_region: Eldin Volcano
+              locations:
+                Gossip Stone in Upper Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Volcano\Upper Platform Cave
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Eldin Volcano
+        Volcano Summit: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Eldin Volcano: null
+            Entrance from Outside Fire Sanctuary: null
+            Entrance from Waterfall: null
+          exits:
+            Exit to Eldin Volcano: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Fireshield Earrings
+            Exit to Outside Fire Sanctuary: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Fireshield Earrings
+            Exit to Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Fireshield Earrings
+          hint_region: Volcano Summit
+          locations:
+            Goddess Cube inside Volcano Summit: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Fireshield Earrings
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Long Range Skyward Strike
+              opaque: false
+          name: \Eldin\Volcano Summit
+          sub_areas:
+            Outside Fire Sanctuary: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Fire Sanctuary: null
+                Statue Entrance: null
+              exits:
+                Exit to Fire Sanctuary: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Hydrate Giant
+                    Frog
+                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
+                \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty
+                    Frogs\Hydrate Second Frog
+              hint_region: Volcano Summit
+              locations:
+                Goddess Cube near Fire Sanctuary Entrance: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  opaque: false
+                Hydrate Giant Frog: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Volcano Summit\Outside Fire Sanctuary
+              sub_areas:
+                Before Thirsty Frogs: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Summit: null
+                  exits:
+                    Exit to Summit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty
+                        Frogs\Hydrate First Frog
+                  hint_region: Volcano Summit
+                  locations:
+                    Hydrate First Frog: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Water Bottle
+                  name: \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty
+                    Frogs
+                  sub_areas: {}
+                  toplevel_alias: null
+                Between Thirsty Frogs: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Eldin\Volcano Summit\Outside Fire Sanctuary: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty
+                        Frogs\Hydrate Second Frog
+                    \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty
+                        Frogs\Hydrate First Frog
+                  hint_region: Volcano Summit
+                  locations:
+                    Gossip Stone near Second Thirsty Frog: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Hydrate Second Frog: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Water Bottle
+                      opaque: false
+                    Item behind Digging: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Mogma Mitts
+                  name: \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty
+                    Frogs
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Waterfall: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Eldin\Volcano Summit\Waterfall\Higher Area: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+              hint_region: Volcano Summit
+              locations:
+                Goddess Cube in Summit Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                \Can Collect Water: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Eldin\Volcano Summit\Waterfall
+              sub_areas:
+                Higher Area: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Eldin\Volcano Summit\Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Volcano Summit
+                  locations:
+                    Chest behind Bombable Wall in Waterfall Area: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Gossip Stone in Waterfall Area: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Eldin\Volcano Summit\Waterfall\Higher Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Faron: !!python/object:logic.logic_input.Area
+      abstract: false
+      allowed_time_of_day: *id001
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: null
+      locations: {}
+      name: \Faron
+      sub_areas:
+        Faron Silent Realm: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Faron Silent Realm
+          locations:
+            Relic 1: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 10: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 2: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 3: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 4: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 5: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 6: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 7: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 8: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 9: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Trial Reward: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          name: \Faron\Faron Silent Realm
+          sub_areas: {}
+          toplevel_alias: null
+        Faron Woods: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            In the Woods Statue Entrance: null
+            Trial Gate Entrance: null
+            Viewing Platform Statue Entrance: null
+          exits:
+            Lake Floria Dive: !!python/object:logic.logic_expression.OrCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Faron\Faron Woods\Open Door to Lake Floria
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Early Lake Floria Tricks
+              opaque: false
+            Shared Statue Exit: !!python/object:logic.logic_expression.OrCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Faron\Faron Woods\Unlock In the Woods Statue
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Faron\Faron Woods\Unlock Viewing Platform Statue
+              opaque: false
+            Trial Gate Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Faron\Faron Woods\Open Trial Gate
+            \Faron\Faron Woods\Behind the Crawlspace and Rope: !!python/object:logic.logic_expression.OrCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Bomb Bag
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Faron\Faron Woods\Ledge to Lake Floria\Push Log
+              opaque: false
+            \Faron\Faron Woods\Clawshot Target Branch: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Clawshots
+            \Faron\Faron Woods\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Faron\Faron Woods\Great Tree\Near Underwater Hole: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            \Faron\Faron Woods\Great Tree\Platforms: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Clawshots
+            \Faron\Faron Woods\Ledge To Deep Woods: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Faron\Faron Woods\Hit Vine to Deep Woods
+            \Faron\Faron Woods\Ledge to Lake Floria: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Faron\Faron Woods\Ledge to Lake Floria\Push Log
+          hint_region: Faron Woods
+          locations:
+            All Kikwis Saved: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.OrCombination
+                arguments:
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sword
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                opaque: false
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Can Defeat Bokoblins
+              opaque: false
+            Amber Relic Farming: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Chest behind Upper Bombable Rock: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Bomb Bag
+            Hit Vine to Deep Woods: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Distance Activator
+            Item behind Lower Bombable Rock: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Bomb Bag
+            Item on Tree: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Kikwi Elder's Reward: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Faron\Faron Woods\All Kikwis Saved
+            Open Door to Lake Floria: !!python/object:logic.logic_expression.OrCombination
+              arguments:
+              - !!python/object:logic.logic_expression.AndCombination
+                arguments:
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Open Lake Floria option
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                opaque: false
+              - !!python/object:logic.logic_expression.AndCombination
+                arguments:
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Faron Woods\Great Tree\Top\Talk to Yerbal
+                - !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Talk to Yerbal option
+                  opaque: false
+                opaque: false
+              opaque: false
+            Open Trial Gate: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Goddess's Harp
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Farore's Courage
+              opaque: false
+            Push Log to Sealed Grounds: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Rupee on Hollow Tree Branch: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Beetle
+            Rupee on Hollow Tree Root: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Rupee on Platform near Floria Door: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Beetle
+            Unlock In the Woods Statue: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Unlock Viewing Platform Statue: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          name: \Faron\Faron Woods
+          sub_areas:
+            Behind the Crawlspace and Rope: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Faron Woods
+              locations:
+                Push Log: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Retrieve Oolo: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Scrapper
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyloft\Upper Skyloft\Knight Academy\Start Owlan's Quest
+                  opaque: false
+              name: \Faron\Faron Woods\Behind the Crawlspace and Rope
+              sub_areas: {}
+              toplevel_alias: null
+            Clawshot Target Branch: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Faron Woods
+              locations:
+                Goddess Cube on East Great Tree with Clawshots Target: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+              name: \Faron\Faron Woods\Clawshot Target Branch
+              sub_areas: {}
+              toplevel_alias: null
+            Deep Woods: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Deep Woods Statue Entrance: null
+                Entrance from Skyview Temple: null
+                Forest Temple Statue Entrance: null
+              exits:
+                Exit to Skyview Temple: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Distance Activator
+                Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Faron\Faron Woods\Deep Woods\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Faron Woods
+              locations:
+                Deep Woods Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Goddess Cube in Deep Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                Goddess Cube on top of Skyview: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  opaque: false
+                Gossip Stone in Deep Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Initial Goddess Cube: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                Push Shortcut Logs: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Unlock Deep Woods Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Unlock Forest Temple Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Faron\Faron Woods\Deep Woods
+              sub_areas:
+                Entry: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Faron Woods: null
+                  exits:
+                    Exit to Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Faron\Faron Woods\Deep Woods: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Faron\Faron Woods\Deep Woods\Push Shortcut Logs
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Distance Activator
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Goddess Sword
+                      opaque: false
+                  hint_region: Faron Woods
+                  locations:
+                    Hornet Larvae Farming: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Faron\Faron Woods\Deep Woods\Entry
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Entry: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Behind the Temple: null
+                Faron Woods Entry Statue Entrance: null
+              exits:
+                Exit to Behind the Temple: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Faron\Faron Woods: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Faron Woods\Push Log to Sealed Grounds
+                  opaque: false
+                \Faron\Faron Woods\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Faron Woods\Entry\Unlock Statue
+              hint_region: Faron Woods
+              locations:
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Faron\Faron Woods\Entry
+              sub_areas: {}
+              toplevel_alias: null
+            Great Tree: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Faron Woods
+              locations: {}
+              name: \Faron\Faron Woods\Great Tree
+              sub_areas:
+                Lower Area: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Underwater Tunnel Entrance: null
+                  exits:
+                    Underwater Tunnel Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Water Dragon's Scale
+                    \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                  hint_region: Faron Woods
+                  locations: {}
+                  name: \Faron\Faron Woods\Great Tree\Lower Area
+                  sub_areas:
+                    Near Exit: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set
+                        Lower Entrance from Platforms: null
+                      exits:
+                        Lower Exit to Platforms: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        \Faron\Faron Woods\Great Tree\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Faron Woods
+                      locations: {}
+                      name: \Faron\Faron Woods\Great Tree\Lower Area\Near Exit
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Path to Chest: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Faron\Faron Woods\Great Tree\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Faron Woods
+                      locations:
+                        Chest inside Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      name: \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+                Near Underwater Hole: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Underwater Hole Entrance: null
+                  exits:
+                    Underwater Hole Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Water Dragon's Scale
+                    \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Faron Woods
+                  locations: {}
+                  name: \Faron\Faron Woods\Great Tree\Near Underwater Hole
+                  sub_areas: {}
+                  toplevel_alias: null
+                Platforms: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Lower Entrance from Great Tree: null
+                    Upper Entrance from Great Tree: null
+                  exits:
+                    Lower Exit to Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Upper Exit to Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Faron\Faron Woods\West Branch: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Faron Woods
+                  locations: {}
+                  name: \Faron\Faron Woods\Great Tree\Platforms
+                  sub_areas: {}
+                  toplevel_alias: null
+                Top: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    The Great Tree Statue Entrance: null
+                    Top Entrance from Great Tree: null
+                  exits:
+                    Top Exit to Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Faron\Faron Woods\Clawshot Target Branch: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Faron\Faron Woods\Great Tree\Platforms: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Faron\Faron Woods\Rope Branch: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Faron\Faron Woods\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Faron\Faron Woods\Great Tree\Top\Unlock Statue
+                  hint_region: Faron Woods
+                  locations:
+                    Rupee on Great Tree North Branch: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Beetle
+                    Rupee on Great Tree West Branch: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Beetle
+                    Talk to Yerbal: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Water Dragon's Scale
+                      - !!python/object:logic.logic_expression.OrCombination
+                        arguments:
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Slingshot
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Beetle
+                        opaque: false
+                      opaque: false
+                    Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Faron\Faron Woods\Great Tree\Top
+                  sub_areas: {}
+                  toplevel_alias: null
+                Upper Area: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Flooded Great Tree: null
+                    Entrance from Top: null
+                    Upper Entrance from Platforms: null
+                  exits:
+                    Exit to Flooded Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Exit to Top: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Upper Exit to Platforms: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Faron\Faron Woods\Great Tree\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Faron\Faron Woods\Great Tree\Upper Area\Remove Void Plane
+                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Faron\Faron Woods\Great Tree\Upper Area\Remove Void Plane
+                  hint_region: Faron Woods
+                  locations:
+                    Remove Void Plane: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Can Defeat Moblins
+                  name: \Faron\Faron Woods\Great Tree\Upper Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Ledge To Deep Woods: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Deep Woods: null
+              exits:
+                Exit to Deep Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Faron Woods
+              locations: {}
+              name: \Faron\Faron Woods\Ledge To Deep Woods
+              sub_areas: {}
+              toplevel_alias: null
+            Ledge to Lake Floria: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Shortcut Entrance from Floria Waterfall: null
+              exits:
+                Shortcut Exit to Floria Waterfall: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Faron Woods\Open Door to Lake Floria
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Early Lake Floria Tricks
+                  opaque: false
+                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Faron Woods
+              locations:
+                Push Log: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Faron\Faron Woods\Ledge to Lake Floria
+              sub_areas: {}
+              toplevel_alias: null
+            Rope Branch: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Faron Woods
+              locations:
+                Goddess Cube on East Great Tree with Rope: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+              name: \Faron\Faron Woods\Rope Branch
+              sub_areas: {}
+              toplevel_alias: null
+            West Branch: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Faron Woods
+              locations:
+                Goddess Cube on West Great Tree near Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+              name: \Faron\Faron Woods\West Branch
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Faron Woods
+        Flooded Faron Woods: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Lower Flooded Great Tree: null
+            Entrance from Upper Flooded Great Tree: null
+          exits:
+            Exit to Lower Flooded Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            Exit to Upper Flooded Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Flooded Faron Woods
+          locations:
+            16 Dark Blue Tadtones in the South West: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            2 Dark Blue Tadtones in Grass West of Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            2 Red Tadtones in Grass near Lower Bombable Rock: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            4 Light Blue Moving Tadtones under Kikwi Elder: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            4 Purple Moving Tadtones near Floria Gate: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            4 Purple Tadtones under Viewing Platform: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            4 Red Moving Tadtones North West of Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            4 Yellow Tadtones under Small Hollow Tree: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            8 Green Tadtones in West Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            8 Light Blue Tadtones near Viewing Platform: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            8 Purple Tadtones in Clearing after Small Hollow Tree: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            8 Yellow Tadtones near Kikwi Elder: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            Can Watch Completed Tadtones Cutscene: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Dark Blue Moving Tadtone inside Small Hollow Tree: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            Green Tadtone behind Upper Bombable Rock: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            Light Blue Tadtone under Great Tree Root: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            Red Moving Tadtone near Viewing Platform: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            Yellow Tadtone under Lilypad: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            \Faron\Faron Woods\Behind the Crawlspace and Rope\Retrieve Oolo: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Scrapper
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Skyloft\Upper Skyloft\Knight Academy\Start Owlan's Quest
+              opaque: false
+          name: \Faron\Flooded Faron Woods
+          sub_areas:
+            Flooded Great Tree: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+                Entrance from Lower Flooded Faron Woods: null
+                Entrance from Upper Flooded Faron Woods: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Exit to Lower Flooded Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                Exit to Upper Flooded Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Flooded Faron Woods
+              locations:
+                Water Dragon's Reward: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Group of Tadtones x 17
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Flooded Faron Woods\Can Watch Completed Tadtones
+                      Cutscene
+                  opaque: false
+              name: \Faron\Flooded Faron Woods\Flooded Great Tree
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Flooded Faron Woods
+        Lake Floria: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Lake Floria
+          locations: {}
+          name: \Faron\Lake Floria
+          sub_areas:
+            Above Rock: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Dive from Faron Woods: null
+              exits:
+                \Faron\Lake Floria\Below Rock: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Lake Floria\Above Rock\Blow Rock
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Water Dragon's Scale
+                  opaque: false
+              hint_region: Lake Floria
+              locations:
+                Blow Rock: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                Left Rupee behind Northwest Boulder: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                Right Rupee behind Northwest Boulder: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                Rupee behind Southwest Boulder: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                Rupee under Central Boulder: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+              name: \Faron\Lake Floria\Above Rock
+              sub_areas: {}
+              toplevel_alias: null
+            Below Rock: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Farore's Lair: null
+              exits:
+                Exit to Farore's Lair: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                \Faron\Lake Floria\Above Rock: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                \Faron\Lake Floria\Below Rock\Emerged Area: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+              hint_region: Lake Floria
+              locations: {}
+              name: \Faron\Lake Floria\Below Rock
+              sub_areas:
+                Emerged Area: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Statue Entrance: null
+                  exits:
+                    Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Faron\Lake Floria\Below Rock\Emerged Area\Unlock Statue
+                    \Faron\Lake Floria\Below Rock: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Water Dragon's Scale
+                  hint_region: Lake Floria
+                  locations:
+                    Goddess Cube in Lake Floria: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Goddess Sword
+                    Lake Floria Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Faron\Lake Floria\Below Rock\Emerged Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Farore's Lair: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Lake Floria: null
+                Entrance from Waterfall: null
+              exits:
+                Exit to Lake Floria: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                Exit to Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Lake Floria
+              locations:
+                Dragon Lair East Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Dragon Lair South Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                Talk to Farore: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Faron\Lake Floria\Farore's Lair
+              sub_areas: {}
+              toplevel_alias: null
+            Waterfall: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Ancient Cistern: null
+                Entrance from Faron Woods: null
+                Entrance from Farore's Lair: null
+                Statue Entrance: null
+              exits:
+                Exit to Ancient Cistern: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Water Dragon's Scale
+                Exit to Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Exit to Farore's Lair: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Lake Floria\Waterfall\Unlock Statue
+              hint_region: Lake Floria
+              locations:
+                Goddess Cube in Floria Waterfall: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  opaque: false
+                Gossip Stone outside Ancient Cistern: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Rupee on High Ledge outside Ancient Cistern Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Faron\Lake Floria\Waterfall
+              sub_areas: {}
+              toplevel_alias: Floria Waterfall
+          toplevel_alias: null
+        Sealed Grounds: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Sealed Grounds
+          locations: {}
+          name: \Faron\Sealed Grounds
+          sub_areas:
+            Behind the Temple: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Door Entrance: null
+                Entrance from Faron Woods: null
+                Shortcut Entrance from Spiral: null
+                Statue Entrance: null
+              exits:
+                Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Exit to Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Shortcut Exit to Spiral: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
+              hint_region: Sealed Grounds
+              locations:
+                Gorko's Goddess Wall Reward: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Goddess's Harp
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ballad of the Goddess
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  opaque: false
+                Gossip Stone behind the Temple: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Faron\Sealed Grounds\Behind the Temple
+              sub_areas: {}
+              toplevel_alias: null
+            Hylia's Temple: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Gate of Time Entrance: null
+              exits:
+                Gate of Time Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Sealed Grounds
+              locations:
+                Defeat Demise: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Horde Door Requirement
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  opaque: false
+                Zelda's Blessing: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Faron\Sealed Grounds\Hylia's Temple
+              sub_areas: {}
+              toplevel_alias: null
+            Sealed Temple: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Gate of Time Entrance: null
+                Main Entrance: null
+                Side Entrance: null
+              exits:
+                Gate of Time Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Sealed Grounds\Sealed Temple\Open Gate of Time
+                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Side Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Sealed Grounds
+              locations:
+                Chest inside Sealed Temple: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Open Gate of Time: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Sealed Grounds\Sealed Temple\Raise Gate of Time
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: GoT Opening Requirement
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Sealed Grounds\Spiral\Defeat Imprisoned 2
+                  opaque: false
+                Raise Gate of Time: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: GoT Raising Requirement
+                Song from Impa: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Goddess's Harp
+                Start Imprisoned 2: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Sealed Grounds\Sealed Temple\Raise Gate of Time
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: GoT Opening Requirement
+                  opaque: false
+              name: \Faron\Sealed Grounds\Sealed Temple
+              sub_areas: {}
+              toplevel_alias: null
+            Spiral: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Door Entrance: null
+              exits:
+                Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Faron\Sealed Grounds\Spiral\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Sealed Grounds\Spiral\Defeat Imprisoned 2
+              hint_region: Sealed Grounds
+              locations:
+                Defeat Imprisoned 2: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Sealed Grounds\Sealed Temple\Start Imprisoned 2
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  opaque: false
+              name: \Faron\Sealed Grounds\Spiral
+              sub_areas:
+                Upper Part: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Statue Entrance: null
+                  exits:
+                    Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Faron\Sealed Grounds\Spiral\Upper Part\Unlock Statue
+                    \Faron\Sealed Grounds\Spiral: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Sealed Grounds
+                  locations:
+                    Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Faron\Sealed Grounds\Spiral\Upper Part
+                  sub_areas:
+                    From Behind the Temple: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set
+                        Shortcut Entrance from Behind the Temple: null
+                      exits:
+                        Shortcut Exit to Behind the Temple: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        \Faron\Sealed Grounds\Spiral\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Sealed Grounds
+                      locations: {}
+                      name: \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the
+                        Temple
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+              toplevel_alias: Sealed Grounds Spiral
+          toplevel_alias: null
+      toplevel_alias: null
+    Fire Sanctuary: !!python/object:logic.logic_input.Area
+      abstract: false
+      allowed_time_of_day: *id001
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Fire Sanctuary
+      locations: {}
+      name: \Fire Sanctuary
+      sub_areas:
+        Boss Room: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Dungeon: null
+            Entrance from Flame Room: null
+          exits:
+            Exit to Dungeon: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Fire Sanctuary\Boss Room\Beat Ghirahim
+            Exit to Flame Room: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Fire Sanctuary\Boss Room\Beat Ghirahim
+          hint_region: Fire Sanctuary
+          locations:
+            Beat Ghirahim: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Sword
+            Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Fire Sanctuary\Boss Room\Beat Ghirahim
+          name: \Fire Sanctuary\Boss Room
+          sub_areas: {}
+          toplevel_alias: null
+        Flame Room: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Fire Sanctuary
+          locations:
+            Din's Flame: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Goddess Sword
+          name: \Fire Sanctuary\Flame Room
+          sub_areas: {}
+          toplevel_alias: null
+        Main: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Fire Sanctuary
+          locations: {}
+          name: \Fire Sanctuary\Main
+          sub_areas:
+            Boss Key Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Front of Boss Door\Past Bars: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Fire Sanctuary\Main\Staircase Room\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Fire Sanctuary
+              locations:
+                Boss Key Chest: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Boss Key Room\Solve Puzzle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Boss Key Room\Defeat Moldorm
+                  opaque: false
+                Defeat Moldorm: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Boss Key Room\Solve Puzzle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Mogma Mitts
+                  opaque: false
+                Solve Puzzle: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Mogma Mitts
+              name: \Fire Sanctuary\Main\Boss Key Room
+              sub_areas: {}
+              toplevel_alias: null
+            First Bridge: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Room with Water Plant: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\First Bridge\Lizalfos Fight
+                \Fire Sanctuary\Main\Second Bridge\Left: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\Second Bridge\Left\Unlock Shortcut to
+                    First Bridge
+                \Fire Sanctuary\Main\Second Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\First Bridge\Lizalfos Fight
+              hint_region: Fire Sanctuary
+              locations:
+                Lizalfos Fight: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Defeat Lizalfos
+              name: \Fire Sanctuary\Main\First Bridge
+              sub_areas: {}
+              toplevel_alias: null
+            First Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Fire Sanctuary\Main\First Room\Past Water Plant: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\First Room\Hit Water Plant
+              hint_region: Fire Sanctuary
+              locations:
+                Hit Water Plant: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Distance Activator
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  opaque: false
+              name: \Fire Sanctuary\Main\First Room
+              sub_areas:
+                Past Water Plant: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Second Room: null
+                  exits:
+                    Exit to Second Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Fire Sanctuary Small Key
+                    \Fire Sanctuary\Main\First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\First Room\Hit Water Plant
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Chest in First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\First Room\Past Water Plant\Defeat
+                        Last Bokoblin
+                    Defeat Last Bokoblin: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Can Defeat Bokoblins
+                    \Fire Sanctuary\Main\First Room\Hit Water Plant: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Distance Activator
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      opaque: false
+                  name: \Fire Sanctuary\Main\First Room\Past Water Plant
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            First Trapped Mogma Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos
+                    Fight
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Fire Sanctuary
+              locations:
+                Chest near First Trapped Mogma: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Gust Bellows
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  opaque: false
+              name: \Fire Sanctuary\Main\First Trapped Mogma Room
+              sub_areas:
+                Lower Area: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\First Trapped Mogma Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos
+                        Fight
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Mogma Mitts
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Fire Sanctuary\Main\First Trapped Mogma Room\Lower
+                          Area\Blow up Rock in Tunnel
+                      opaque: false
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos
+                        Fight
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Blow up Rock in Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Mogma Mitts
+                    Rescue First Trapped Mogma: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Front of Boss Door: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Boss Door Entrance: null
+                Statue Entrance: null
+              exits:
+                Boss Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Fire Sanctuary Boss Key
+                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
+                \Fire Sanctuary\Main\Front of Boss Door\Past Bars: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\Front of Boss Door\Past Bars\Unlock Way
+                    to Front
+                \Fire Sanctuary\Main\Lizalfos Fight Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Fire Sanctuary
+              locations:
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Fire Sanctuary\Main\Front of Boss Door
+              sub_areas:
+                Past Bars: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Boss Key Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Fire Sanctuary\Main\Front of Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Front of Boss Door\Past Bars\Unlock
+                        Way to Front
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Unlock Way to Front: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Fire Sanctuary\Main\Front of Boss Door\Past Bars
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Lizalfos Fight Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Staircase Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\Lizalfos Fight Room\Fight
+              hint_region: Fire Sanctuary
+              locations:
+                Fight: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Defeat Lizalfos
+              name: \Fire Sanctuary\Main\Lizalfos Fight Room
+              sub_areas: {}
+              toplevel_alias: null
+            Magmanos Fight Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Fire Sanctuary
+              locations: {}
+              name: \Fire Sanctuary\Main\Magmanos Fight Room
+              sub_areas:
+                Lower Part: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from West of Boss Door: null
+                  exits:
+                    Exit to West of Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Unlock
+                        Key Door
+                    \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Mogma Mitts
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Fire Sanctuary\Main\First Trapped Mogma Room\Lower
+                          Area\Blow up Rock in Tunnel
+                      opaque: false
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Past Sliding Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Move
+                        Sliding Door
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Move Sliding Door: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Uncover
+                          Dig Spot
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Mogma Mitts
+                      opaque: false
+                    Uncover Dig Spot: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                    Unlock Key Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Fire Sanctuary Small Key x 3
+                  name: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part
+                  sub_areas:
+                    Past Sliding Door: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Move
+                            Sliding Door
+                        \Fire Sanctuary\Main\Second Bridge\Left: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Fire Sanctuary
+                      locations: {}
+                      name: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Past
+                        Sliding Door
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+                Upper Part: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\First Trapped Mogma Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos
+                        Fight
+                    \Fire Sanctuary\Main\Water Fruit Room\After Frog: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos
+                        Fight
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Magmanos Fight: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sword
+                  name: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Room with Water Plant: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\First Bridge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Room with Water Plant\Blow up Rock
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Room with Water Plant\Hit Water Plant
+                  opaque: false
+              hint_region: Fire Sanctuary
+              locations:
+                Blow up Rock: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Hook Beetle
+                Hit Water Plant: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Distance Activator
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  opaque: false
+              name: \Fire Sanctuary\Main\Room with Water Plant
+              sub_areas:
+                Past Lava: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\First Trapped Mogma Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Fire Sanctuary\Main\Room with Water Plant: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Fire Sanctuary\Main\Room with Water Plant\Blow up Rock
+                      opaque: false
+                    \Fire Sanctuary\Main\Water Fruit Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Room with Water Plant\Past Lava\Unlock
+                        Key Door
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Unlock Key Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Fire Sanctuary Small Key x 2
+                  name: \Fire Sanctuary\Main\Room with Water Plant\Past Lava
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Second Bridge: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Fire Sanctuary
+              locations: {}
+              name: \Fire Sanctuary\Main\Second Bridge
+              sub_areas:
+                Bottom Part: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Second Bridge\Left: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                    \Fire Sanctuary\Main\Second Bridge\Right: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                  hint_region: Fire Sanctuary
+                  locations: {}
+                  name: \Fire Sanctuary\Main\Second Bridge\Bottom Part
+                  sub_areas: {}
+                  toplevel_alias: null
+                Left: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\First Bridge: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Second Bridge\Left\Unlock Shortcut
+                        to First Bridge
+                    \Fire Sanctuary\Main\Second Bridge\Bottom Part: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Fire Sanctuary\Main\Second Bridge\Right: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Unlock Shortcut to First Bridge: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Fire Sanctuary\Main\Second Bridge\Left
+                  sub_areas: {}
+                  toplevel_alias: null
+                Right: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Second Bridge\Bottom Part: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Fire Sanctuary\Main\Second Bridge\Left: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                    \Fire Sanctuary\Main\Second Trapped Mogma Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Fire Sanctuary
+                  locations: {}
+                  name: \Fire Sanctuary\Main\Second Bridge\Right
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Second Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\First Bridge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Fire Sanctuary\Main\Second Room\Balcony: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\Second Room\Defeat Magmanos
+                \Fire Sanctuary\Main\Second Room\Outside Section: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Fire Sanctuary
+              locations:
+                Chest in Second Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Defeat Magmanos: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Second Room\Open Doors to Water Fruit
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  opaque: false
+                Open Doors to Water Fruit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Mogma Mitts
+              name: \Fire Sanctuary\Main\Second Room
+              sub_areas:
+                Balcony: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Second Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Second Room\Defeat Magmanos
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Chest on Balcony: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Fire Sanctuary\Main\Second Room\Balcony
+                  sub_areas: {}
+                  toplevel_alias: null
+                Outside Section: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from First Room: null
+                  exits:
+                    Exit to First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Fire Sanctuary\Main\Second Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Fire Sanctuary
+                  locations: {}
+                  name: \Fire Sanctuary\Main\Second Room\Outside Section
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Second Trapped Mogma Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Second Bridge\Right: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Hydrate Frog
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Blow up Wall
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Mogma Mitts
+                  opaque: false
+              hint_region: Fire Sanctuary
+              locations:
+                Blow up Wall: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Hydrate Frog
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  opaque: false
+                Hydrate Frog: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Move Sliding
+                      Doors Correctly
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  opaque: false
+                Move Sliding Doors Correctly: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Mogma Mitts
+                Rescue Mogma: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Hydrate Frog
+                Rescue Second Trapped Mogma: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Mogma
+              name: \Fire Sanctuary\Main\Second Trapped Mogma Room
+              sub_areas:
+                Past Bombable Wall: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Second Trapped Mogma Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Chest after Bombable Wall: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable
+                    Wall
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Staircase Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Staircase Room\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+              hint_region: Fire Sanctuary
+              locations:
+                Chest in Staircase Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+              name: \Fire Sanctuary\Main\Staircase Room
+              sub_areas:
+                Upper Part: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Boss Key Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Fire Sanctuary\Main\Staircase Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Fire Sanctuary
+                  locations: {}
+                  name: \Fire Sanctuary\Main\Staircase Room\Upper Part
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Water Fruit Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\Room with Water Plant\Past Lava\Unlock
+                    Key Door
+                \Fire Sanctuary\Main\Water Fruit Room\After Frog: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\Water Fruit Room\Hydrate Frog
+              hint_region: Fire Sanctuary
+              locations:
+                First Chest in Water Fruit Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Hydrate Frog: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sword
+                Second Chest in Water Fruit Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava\Unlock Key Door: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Fire Sanctuary Small Key x 2
+              name: \Fire Sanctuary\Main\Water Fruit Room
+              sub_areas:
+                After Frog: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Fire Sanctuary\Main\Water Fruit Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\Water Fruit Room\Hydrate Frog
+                  hint_region: Fire Sanctuary
+                  locations: {}
+                  name: \Fire Sanctuary\Main\Water Fruit Room\After Frog
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            West of Boss Door: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Front of Boss Door: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\West of Boss Door\Past Plats\Release
+                      Lava
+                  opaque: false
+                \Fire Sanctuary\Main\West of Boss Door\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant
+                \Fire Sanctuary\Main\West of Boss Door\Past Plats: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\West of Boss Door\Catch Plats
+                    - !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Distance Activator
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      opaque: false
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\West of Boss Door\Past Plats\Unlock
+                      Shortcut to Pre Plats
+                  opaque: false
+              hint_region: Fire Sanctuary
+              locations:
+                Catch Plats: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Mogma Mitts
+                Hit Water Plant: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Distance Activator
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  opaque: false
+                Plats' Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Fire Sanctuary\Main\West of Boss Door\Catch Plats
+              name: \Fire Sanctuary\Main\West of Boss Door
+              sub_areas:
+                Entry: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Magmanos Fight Room: null
+                  exits:
+                    Exit to Magmanos Fight Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Fire Sanctuary\Main\Front of Boss Door: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Fire Sanctuary\Main\West of Boss Door\Past Plats\Release
+                          Lava
+                      opaque: false
+                    \Fire Sanctuary\Main\West of Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant
+                  hint_region: Fire Sanctuary
+                  locations:
+                    \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Distance Activator
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      opaque: false
+                  name: \Fire Sanctuary\Main\West of Boss Door\Entry
+                  sub_areas: {}
+                  toplevel_alias: null
+                Past Plats: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: true
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\West of Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Fire Sanctuary\Main\West of Boss Door\Past Plats\Unlock
+                        Shortcut to Pre Plats
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Release Lava: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Mogma Mitts
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: FS Lava Flow option
+                      opaque: false
+                    Unlock Shortcut to Pre Plats: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Fire Sanctuary\Main\West of Boss Door\Past Plats
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Lanayru: !!python/object:logic.logic_input.Area
+      abstract: true
+      allowed_time_of_day: *id001
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: null
+      locations:
+        All Three Nodes: !!python/object:logic.logic_expression.OrCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: LMF Nodes On option
+          - !!python/object:logic.logic_expression.AndCombination
+            arguments:
+            - !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Lanayru\Desert\North Part\Water Node
+            - !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Lanayru\Desert\North Part\Lightning Node\Past\Lightning Node
+            - !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Lanayru\Desert\East\Fire Node\Past after Grate\Fire Node
+            opaque: false
+          opaque: false
+        Can Navigate in Oasis: !!python/object:logic.logic_expression.OrCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Can Defeat Ampilus
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Hook Beetle
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Brakeslide Trick
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Stuttersprint Trick
+          opaque: false
+        Raise Lanayru Mining Facility: !!python/object:logic.logic_expression.OrCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Open LMF option
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Lanayru\Desert\North Part\Activate Main Node
+          opaque: false
+      name: \Lanayru
+      sub_areas:
+        Caves: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Desert: null
+            Entrance from Mine: null
+          exits:
+            Exit to Desert: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Exit to Mine: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Lanayru\Caves\Past Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Lanayru\Caves\Past Door to Lanayru Sand Sea: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Clawshots
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Lanayru Caves Small Key
+              opaque: false
+          hint_region: Lanayru Caves
+          locations:
+            Chest: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Golo's Gift: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Gossip Stone in Center: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          name: \Lanayru\Caves
+          sub_areas:
+            Past Crawlspace: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Gorge: null
+              exits:
+                Exit to Gorge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Caves: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Bomb Bag
+              hint_region: Lanayru Caves
+              locations:
+                Gossip Stone towards Lanayru Gorge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Caves\Past Crawlspace
+              sub_areas: {}
+              toplevel_alias: null
+            Past Door to Lanayru Sand Sea: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Lanayru Sand Sea: null
+              exits:
+                Exit to Lanayru Sand Sea: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Caves: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Lanayru Caves Small Key
+              hint_region: Lanayru Caves
+              locations: {}
+              name: \Lanayru\Caves\Past Door to Lanayru Sand Sea
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Lanayru Caves
+        Desert: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits:
+            Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'False'
+          hint_region: Lanayru Desert
+          locations: {}
+          name: \Lanayru\Desert
+          sub_areas:
+            East: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Fire Node Entrance: null
+                Stone Cache Statue Entrance: null
+              exits:
+                Fire Node Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Near Caged Robot: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\East\Open Wall Shortcut
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Temple of Time Skip - Brakeslide Trick
+                  opaque: false
+                \Lanayru\Desert\North Part: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Top of LMF: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Raise Lanayru Mining Facility
+              hint_region: Lanayru Desert
+              locations:
+                Chest on Platform near Fire Node: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+                Open Wall Shortcut: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Desert\East
+              sub_areas:
+                Fire Node: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits: {}
+                  hint_region: Lanayru Desert
+                  locations: {}
+                  name: \Lanayru\Desert\East\Fire Node
+                  sub_areas:
+                    Past: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\East\Fire Node\Past after Void: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Lanayru\Desert\East\Fire Node\Present after Sand\Push
+                            Box
+                        \Lanayru\Desert\East\Fire Node\Present: !!python/object:logic.logic_expression.OrCombination
+                          arguments:
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Projectile Item
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: Bomb Bag
+                          opaque: false
+                        \Lanayru\Desert\East\Fire Node\Present\Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Lanayru Desert
+                      locations:
+                        First Small Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        Second Small Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      name: \Lanayru\Desert\East\Fire Node\Past
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Past after Grate: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\East\Fire Node\Past after Void: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Lanayru Desert
+                      locations:
+                        Fire Node: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Sword
+                        Left Ending Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        Right Ending Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      name: \Lanayru\Desert\East\Fire Node\Past after Grate
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Past after Void: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\East\Fire Node\Past: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        \Lanayru\Desert\East\Fire Node\Past after Grate: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Lanayru\Desert\East\Fire Node\Past after Void\Open
+                            Grate
+                      hint_region: Lanayru Desert
+                      locations:
+                        Open Grate: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Hook Beetle
+                      name: \Lanayru\Desert\East\Fire Node\Past after Void
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Present: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set
+                        Entrance: null
+                      exits:
+                        Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        \Lanayru\Desert\East\Fire Node\Past: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Lanayru\Desert\East\Fire Node\Present\Timeshift Stone
+                        \Lanayru\Desert\East\Fire Node\Present after Sand: !!python/object:logic.logic_expression.OrCombination
+                          arguments:
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Can Defeat Ampilus
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: Brakeslide Trick
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Lanayru\Desert\East\Fire Node\Present after Sand\Push
+                              Box
+                          opaque: false
+                      hint_region: Lanayru Desert
+                      locations:
+                        Blow up Rock for Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Bomb Bag
+                        Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
+                          arguments:
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Lanayru\Desert\East\Fire Node\Present\Blow up Rock
+                              for Timeshift Stone
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Can Hit Timeshift Stone
+                          opaque: false
+                      name: \Lanayru\Desert\East\Fire Node\Present
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Present after Sand: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\East\Fire Node\Past after Void: !!python/object:logic.logic_expression.AndCombination
+                          arguments:
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Lanayru\Desert\East\Fire Node\Present\Timeshift
+                              Stone
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Projectile Item
+                          opaque: false
+                        \Lanayru\Desert\East\Fire Node\Present: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Lanayru Desert
+                      locations:
+                        Push Box: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        Shortcut Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      name: \Lanayru\Desert\East\Fire Node\Present after Sand
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+              toplevel_alias: null
+            Entry: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Desert Entrance Statue Entrance: null
+                Entrance from Mine: null
+              exits:
+                Exit to Mine: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\Entry\Timeshift Stone
+                \Lanayru\Desert\Entry\High Ledge after Vines: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\Entry\Timeshift Stone
+                \Lanayru\Desert\Near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\Entry\Unlock Statue
+              hint_region: Lanayru Desert
+              locations:
+                Blow up Rock for Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Bomb Bag
+                Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\Entry\Blow up Rock for Timeshift Stone
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Hit Timeshift Stone
+                  opaque: false
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Desert\Entry
+              sub_areas:
+                High Ledge after Vines: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits: {}
+                  hint_region: Lanayru Desert
+                  locations:
+                    Chest near Party Wheel: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Retrieve Party Wheel: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Scrapper
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sky\South West\Fun Fun Island\Start Dodoh's Quest
+                      opaque: false
+                    \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Lanayru\Desert\Entry\High Ledge after Vines
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Near Caged Robot: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Desert\East: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Temple of Time Skip - Brakeslide Trick
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\East\Open Wall Shortcut
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
+                  opaque: false
+                \Lanayru\Desert\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Sand Oasis: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\Near Caged Robot\Get Past Spume to Sand Oasis
+                \Lanayru\Desert\Top of LMF: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Raise Lanayru Mining Facility
+                \Lanayru\Desert\Top of West Wall: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+              hint_region: Lanayru Desert
+              locations:
+                Blow Statues to Sand Oasis Down: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Hook Beetle
+                Blow up Rock for Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Lanayru Desert - Ampilus Bomb Toss Trick
+                  opaque: false
+                Chest near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Get Past Spume to Sand Oasis: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\Near Caged Robot\Blow Statues to Sand Oasis
+                      Down
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Brakeslide Trick
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Stuttersprint Trick
+                    - !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Long Range Skyward Strike
+                      opaque: false
+                    opaque: false
+                  opaque: false
+                Goddess Cube near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Long Range Skyward Strike
+                Rescue Caged Robot: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\Near Caged Robot\Blow up Rock for Timeshift
+                      Stone
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Defeat Bokoblins
+                  opaque: false
+              name: \Lanayru\Desert\Near Caged Robot
+              sub_areas: {}
+              toplevel_alias: null
+            Near South Exit to Temple of Time: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                South Entrance from Temple of Time: null
+              exits:
+                South Exit to Temple of Time: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+                \Lanayru\Desert\West Part: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Lanayru Desert
+              locations:
+                Push Minecart: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Desert\Near South Exit to Temple of Time
+              sub_areas:
+                Ledge to Caves: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Caves: null
+                  exits:
+                    Exit to Caves: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru\Desert\Near South Exit to Temple of Time: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Lanayru Desert
+                  locations: {}
+                  name: \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to
+                    Caves
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            North Part: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Lightning Node Entrance: null
+                North Desert Statue Entrance: null
+                North Entrance from Temple of Time: null
+                Trial Gate Entrance: null
+              exits:
+                Lightning Node Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\North Part\Open Lightning Node
+                North Exit to Temple of Time: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Trial Gate Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\North Part\Open Trial Gate
+                \Lanayru\Desert\East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\North Part\Secret Passageway: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\North Part\Open Secret Passageway
+                \Lanayru\Desert\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\North Part\Unlock Statue
+                \Lanayru\Desert\Top of LMF: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Raise Lanayru Mining Facility
+              hint_region: Lanayru Desert
+              locations:
+                Activate Main Node: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\All Three Nodes
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\North Part\Main Node Timeshift Stone
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  opaque: false
+                Blow up Main Node Timeshift Stone Rock: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  opaque: false
+                Chest on Platform near Lightning Node: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+                Main Node Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\North Part\Blow up Main Node Timeshift Stone
+                      Rock
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Hit Timeshift Stone
+                  opaque: false
+                Open Lightning Node: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Open Secret Passageway: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Hook Beetle
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Secret Passageway Hook Beetle Opening Trick
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Tough Beetle
+                  opaque: false
+                Open Trial Gate: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Nayru's Wisdom
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Goddess's Harp
+                  opaque: false
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Water Node: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Bomb Bag
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Hook Beetle
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  opaque: false
+                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\North Part\Main Node Timeshift Stone
+              name: \Lanayru\Desert\North Part
+              sub_areas:
+                Lightning Node: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits: {}
+                  hint_region: Lanayru Desert
+                  locations: {}
+                  name: \Lanayru\Desert\North Part\Lightning Node
+                  sub_areas:
+                    Past: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\North Part\Lightning Node\Present: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Projectile Item
+                        \Lanayru\Desert\North Part\Lightning Node\Present from afar: !!python/object:logic.logic_expression.OrCombination
+                          arguments:
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Beetle
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Bow
+                          - !!python/object:logic.logic_expression.AndCombination
+                            arguments:
+                            - !!python/object:logic.logic_expression.BasicTextAtom
+                              text: Lightning Node End with Bombs Trick
+                            - !!python/object:logic.logic_expression.BasicTextAtom
+                              text: Bomb Bag
+                            opaque: false
+                          opaque: false
+                        \Lanayru\Desert\North Part\Lightning Node\Present\Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Lanayru Desert
+                      locations:
+                        First Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        Lightning Node: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Sword
+                        Second Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      name: \Lanayru\Desert\North Part\Lightning Node\Past
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Present: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set
+                        Entrance: null
+                      exits:
+                        Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        \Lanayru\Desert\North Part\Lightning Node\Past: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Lanayru\Desert\North Part\Lightning Node\Present\Timeshift
+                            Stone
+                      hint_region: Lanayru Desert
+                      locations:
+                        Blow up Rock for Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Bomb Bag
+                        Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
+                          arguments:
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Lanayru\Desert\North Part\Lightning Node\Present\Blow
+                              up Rock for Timeshift Stone
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Can Hit Timeshift Stone
+                          opaque: false
+                      name: \Lanayru\Desert\North Part\Lightning Node\Present
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Present from afar: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\North Part\Lightning Node\Past: !!python/object:logic.logic_expression.OrCombination
+                          arguments:
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Beetle
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Bow
+                          opaque: false
+                        \Lanayru\Desert\North Part\Lightning Node\Present: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Lanayru Desert
+                      locations:
+                        Raised Chest near Generator: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      name: \Lanayru\Desert\North Part\Lightning Node\Present from
+                        afar
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+                Secret Passageway: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru\Desert\North Part: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Lanayru Desert
+                  locations:
+                    Goddess Cube in Secret Passageway: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Goddess Sword
+                      opaque: false
+                    Secret Passageway Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Lanayru\Desert\North Part\Secret Passageway
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Sand Oasis: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Desert\Near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Top of West Wall: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\Top of West Wall\Push Minecart
+                  opaque: false
+                \Lanayru\Desert\West Part: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Can Navigate in Oasis
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\West Part\Push Minecart
+                  opaque: false
+              hint_region: Lanayru Desert
+              locations:
+                Goddess Cube in Sand Oasis: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Can Navigate in Oasis
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  opaque: false
+              name: \Lanayru\Desert\Sand Oasis
+              sub_areas: {}
+              toplevel_alias: null
+            Top of LMF: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Lanayru Mining Facility: null
+              exits:
+                Exit to Lanayru Mining Facility: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\North Part: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Lanayru Desert
+              locations:
+                Chest on top of Lanayru Mining Facility: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Desert\Top of LMF
+              sub_areas: {}
+              toplevel_alias: null
+            Top of West Wall: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Desert\Near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Sand Oasis: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\West Part: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Lanayru Desert
+              locations:
+                Chest near Sand Oasis: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Push Minecart: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Near Caged Robot\Goddess Cube near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+              name: \Lanayru\Desert\Top of West Wall
+              sub_areas: {}
+              toplevel_alias: null
+            West Part: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                West Desert Statue Entrance: null
+              exits:
+                \Lanayru\Desert\Near South Exit to Temple of Time: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Can Navigate in Oasis
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\Near South Exit to Temple of Time\Push Minecart
+                  opaque: false
+                \Lanayru\Desert\Sand Oasis: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\West Part\Unlock Statue
+                \Lanayru\Desert\Top of West Wall: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+              hint_region: Lanayru Desert
+              locations:
+                Push Minecart: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Desert\Sand Oasis\Goddess Cube in Sand Oasis: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+              name: \Lanayru\Desert\West Part
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Lanayru Desert
+        Lanayru Sand Sea: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Ancient Harbour Dock Entrance: null
+            Pirate Stronghold Dock Entrance: null
+            Sandship Dock Entrance: null
+            Shipyard Dock Entrance: null
+            Skipper's Retreat Dock Entrance: null
+          exits:
+            Ancient Harbour Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Pirate Stronghold Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Sandship Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
+            Shipyard Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Skipper's Retreat Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Lanayru Sand Sea
+          locations:
+            Shoot down Sandship: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Sea Chart
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Sword
+              opaque: false
+          name: \Lanayru\Lanayru Sand Sea
+          sub_areas:
+            Ancient Harbour: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Dock Entrance: null
+                Statue Entrance: null
+              exits:
+                Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Ship Timeshift Stone
+                Exit to Sandship: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
+                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Unlock Statue
+                \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+              hint_region: Lanayru Sand Sea
+              locations:
+                Goddess Cube in Ancient Harbour: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Goddess Sword
+                  opaque: false
+                Ship Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Distance Activator
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  opaque: false
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Lanayru Sand Sea\Ancient Harbour
+              sub_areas:
+                Near Exit to Caves: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Caves: null
+                  exits:
+                    Exit to Caves: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru\Lanayru Sand Sea\Ancient Harbour: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Left Rupee on Entrance Crown: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Quick Beetle
+                    Right Rupee on Entrance Crown: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Quick Beetle
+                    Rupee on First Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Beetle
+                  name: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: Lanayru Sand Sea Docks
+            Gorge: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+                Statue Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Gorge\Unlock Statue
+                \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Gorge\Activate Timeshift Stone
+              hint_region: Lanayru Gorge
+              locations:
+                Activate Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Hit Timeshift Stone in Minecart
+                Boss Rush -- 4 Bosses: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: 'False'
+                  opaque: false
+                Boss Rush -- 8 Bosses: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: 'False'
+                  opaque: false
+                Item on Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Thunder Dragon's Reward: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Gorge\Activate Timeshift Stone
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Life Tree Fruit
+                  opaque: false
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Lanayru Sand Sea\Gorge
+              sub_areas:
+                Beyond Bridge: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru\Lanayru Sand Sea\Gorge: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      opaque: false
+                  hint_region: Lanayru Gorge
+                  locations:
+                    Activate Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Gust Bellows
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Can Hit Timeshift Stone
+                      opaque: false
+                    Digging Spot: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Activate
+                          Timeshift Stone
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Digging Mitts
+                      opaque: false
+                    Goddess Cube in Lanayru Gorge: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Goddess Sword
+                    \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Activate
+                        Timeshift Stone
+                  name: \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: Lanayru Gorge
+            Pirate Stronghold: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Dock Entrance: null
+                Side Entrance: null
+                Statue Entrance: null
+              exits:
+                Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Side Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
+                \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
+                    Minidungeon
+              hint_region: Lanayru Sand Sea
+              locations:
+                Rupee on Bird Statue Pillar or Nose: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Rupee on East Sea Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Quick Beetle
+                Rupee on West Sea Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Quick Beetle
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold
+              sub_areas:
+                Inside: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    First Door Entrance: null
+                    Second Door Entrance: null
+                  exits:
+                    First Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Second Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
+                        Minidungeon
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Finish Minidungeon: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Can Defeat Beamos
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Can Defeat Armos
+                      opaque: false
+                    First Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Second Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Third Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside
+                  sub_areas: {}
+                  toplevel_alias: null
+                Inside the Shark Head: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Top Entrance: null
+                  exits:
+                    Top Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
+                          Minidungeon
+                      opaque: false
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Goddess Cube in Pirate Stronghold: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Goddess Sword
+                      opaque: false
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Beetle
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Quick Beetle
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Quick Beetle
+                  name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark
+                    Head
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Shipyard: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Construction Bay Lower Entrance: null
+                Construction Bay Upper Entrance: null
+                Dock Entrance: null
+                Statue Entrance: null
+              exits:
+                Construction Bay Lower Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
+                    Moldarach
+                Construction Bay Upper Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
+              hint_region: Lanayru Sand Sea
+              locations:
+                Gossip Stone in Shipyard: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Rickety Coaster -- Heart Stopping Track in 1'05: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
+                    Moldarach
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Lanayru Sand Sea\Shipyard
+              sub_areas:
+                Construction Bay: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Lower Entrance: null
+                    Upper Entrance: null
+                  exits:
+                    Lower Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
+                        Moldarach
+                    Upper Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Defeat Moldarach: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Gust Bellows
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sword
+                      opaque: false
+                  name: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Skipper's Retreat: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Dock Entrance: null
+                Statue Entrance: null
+              exits:
+                Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Unlock Statue
+                \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Blow up Rock
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  opaque: false
+              hint_region: Lanayru Sand Sea
+              locations:
+                Blow up Rock: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Cactus Bomb Whip Trick
+                    opaque: false
+                  opaque: false
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat
+              sub_areas:
+                Past Rock: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Whip
+                          Peahat
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Deal
+                          with Deku Baba
+                      opaque: false
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Chest after Moblin: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Deal with Deku Baba: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Projectile Item
+                      - !!python/object:logic.logic_expression.AndCombination
+                        arguments:
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Skipper's Retreat Fast Clawshots Trick
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Clawshots
+                        opaque: false
+                      opaque: false
+                    Goddess Cube in Skipper's Retreat: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Goddess Sword
+                      opaque: false
+                    Whip Peahat: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Whip
+                      opaque: false
+                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock
+                  sub_areas: {}
+                  toplevel_alias: null
+                Shack: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance: null
+                  exits:
+                    Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Chest in Shack: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack
+                  sub_areas: {}
+                  toplevel_alias: null
+                Skydive Platform: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Skydive Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform
+                  sub_areas: {}
+                  toplevel_alias: null
+                Top Part: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Shack Entrance: null
+                  exits:
+                    Shack Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Chest on top of Cacti Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: Lanayru Sand Sea
+        Lanayru Silent Realm: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Lanayru Silent Realm
+          locations:
+            Relic 1: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 10: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 2: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 3: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 4: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 5: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 6: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 7: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 8: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 9: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Trial Reward: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          name: \Lanayru\Lanayru Silent Realm
+          sub_areas: {}
+          toplevel_alias: null
+        Mine: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Lanayru Mine
+          locations: {}
+          name: \Lanayru\Mine
+          sub_areas:
+            End: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Mine\End\In Minecart: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Mine\End\Blow up Rock on Track
+                \Lanayru\Mine\Statues Area: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Mine\Statues Area\Blow Statues Down
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Brakeslide Trick
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
+                  opaque: false
+              hint_region: Lanayru Mine
+              locations:
+                Blow up Rock on Track: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Chest at the End of Mine: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Hit Timeshift Stone
+              name: \Lanayru\Mine\End
+              sub_areas:
+                In Minecart: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Desert: null
+                  exits:
+                    Exit to Desert: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Lanayru Mine
+                  locations:
+                    Blow up Rock on Track: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Lanayru Mine - Quick Bomb Trick
+                      opaque: false
+                  name: \Lanayru\Mine\End\In Minecart
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Entry: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                First Time Entrance: null
+                Statue Entrance: null
+              exits:
+                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Mine\Entry\Unlock Statue
+                \Lanayru\Mine\Entry\Higher Area: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+                \Lanayru\Mine\Statues Area: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Mine\Entry\Timeshift Stone
+              hint_region: Lanayru Mine
+              locations:
+                Chest near First Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Mine\Entry\Timeshift Stone
+                Goddess Cube at Lanayru Mine Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Hit Timeshift Stone
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Itemless First Timeshift Stone Trick
+                  opaque: false
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Mine\Entry\Timeshift Stone
+              name: \Lanayru\Mine\Entry
+              sub_areas:
+                Caves Entrance: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Caves: null
+                  exits:
+                    Exit to Caves: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru\Mine\Entry\Higher Area: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                  hint_region: Lanayru Mine
+                  locations: {}
+                  name: \Lanayru\Mine\Entry\Caves Entrance
+                  sub_areas: {}
+                  toplevel_alias: null
+                Higher Area: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru\Mine\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru\Mine\Entry\Caves Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                  hint_region: Lanayru Mine
+                  locations:
+                    Chest behind First Landing: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Lanayru\Mine\Entry\Higher Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Statues Area: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Mine\End: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Mine\Statues Area\Blow Statues Down
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Brakeslide Trick
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
+                  opaque: false
+                \Lanayru\Mine\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Lanayru Mine
+              locations:
+                Blow Statues Down: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  opaque: false
+                Chest behind Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Mine\Statues Area\Blow Statues Down
+              name: \Lanayru\Mine\Statues Area
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Lanayru Mine
+        Temple of Time: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits:
+            Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'False'
+          hint_region: null
+          locations: {}
+          name: \Lanayru\Temple of Time
+          sub_areas:
+            Front: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Temple of Time\Inside: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Temple of Time\Near Goddess Cube: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Temple of Time\Near Goddess Cube\Timeshift Stone
+              hint_region: null
+              locations:
+                Blow up Rock for Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Bomb Throws Trick
+                    - !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      - !!python/object:logic.logic_expression.AndCombination
+                        arguments:
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Cactus Bomb Whip Trick
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Whip
+                        opaque: false
+                      opaque: false
+                    opaque: false
+                  opaque: false
+                Gossip Stone in Temple of Time Area: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Save Robot: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Temple of Time\Front\Timeshift Stone
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Defeat Bokoblins
+                  opaque: false
+                Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Temple of Time\Front\Blow up Rock for Timeshift
+                      Stone
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Distance Activator
+                  opaque: false
+                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Hook Beetle
+                \Lanayru\Temple of Time\Near Goddess Cube\Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Long Range Skyward Strike
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Distance Activator
+                  opaque: false
+              name: \Lanayru\Temple of Time\Front
+              sub_areas: {}
+              toplevel_alias: null
+            Inside: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Lanayru Mining Facility: null
+                Temple of Time Statue Entrance: null
+              exits:
+                Exit to Lanayru Mining Facility: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Temple of Time\Front: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Temple of Time\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Temple of Time\Inside\Unlock Statue
+              hint_region: null
+              locations:
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru\Temple of Time\Inside
+              sub_areas: {}
+              toplevel_alias: null
+            Near Goddess Cube: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Temple of Time\North East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: null
+              locations:
+                Goddess Cube at Ride near Temple of Time: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Goddess Sword
+                Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'False'
+              name: \Lanayru\Temple of Time\Near Goddess Cube
+              sub_areas: {}
+              toplevel_alias: null
+            North East: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                North Entrance from Desert: null
+              exits:
+                North Exit to Desert: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Distance Activator
+                \Lanayru\Temple of Time\South East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Distance Activator
+              hint_region: null
+              locations: {}
+              name: \Lanayru\Temple of Time\North East
+              sub_areas: {}
+              toplevel_alias: null
+            South East: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Desert Gorge Statue Entrance: null
+                South Entrance from Desert: null
+              exits:
+                South Exit to Desert: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru\Temple of Time\Front: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Slingshot
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Temple of Time - Slingshot Shot Trick
+                    opaque: false
+                  opaque: false
+                \Lanayru\Temple of Time\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Temple of Time\South East\Unlock Statue
+              hint_region: null
+              locations:
+                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Distance Activator
+              name: \Lanayru\Temple of Time\South East
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Lanayru Mining Facility: !!python/object:logic.logic_input.Area
+      abstract: true
+      allowed_time_of_day: *id001
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Lanayru Mining Facility
+      locations:
+        Can Activate Minecart Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Sword
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Whip
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Bomb Bag
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Distance Activator
+          opaque: false
+      name: \Lanayru Mining Facility
+      sub_areas:
+        Boss Room: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Dungeon: null
+          exits:
+            Exit to Dungeon: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat Moldarach
+            \Lanayru Mining Facility\Boss Room\After Sand Drain: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Lanayru Mining Facility
+          locations: {}
+          name: \Lanayru Mining Facility\Boss Room
+          sub_areas:
+            After Sand Drain: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Hall of Ancient Robots: null
+              exits:
+                Exit to Hall of Ancient Robots: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat Moldarach
+              hint_region: Lanayru Mining Facility
+              locations:
+                Beat Moldarach: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: LMF - Moldarach without Gust Bellows Trick
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  opaque: false
+                Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat Moldarach
+              name: \Lanayru Mining Facility\Boss Room\After Sand Drain
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Hall of Ancient Robots: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Lanayru Mining Facility
+          locations: {}
+          name: \Lanayru Mining Facility\Hall of Ancient Robots
+          sub_areas:
+            End: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Temple of Time: null
+              exits:
+                Exit to Temple of Time: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Lanayru Mining Facility
+              locations:
+                Exit Hall of Ancient Robots: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru Mining Facility\Hall of Ancient Robots\End
+              sub_areas: {}
+              toplevel_alias: null
+            Entry: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Boss Room: null
+              exits:
+                Exit to Boss Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru Mining Facility\Hall of Ancient Robots\End: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Hit
+                    Timeshift Stone
+              hint_region: Lanayru Mining Facility
+              locations:
+                Hit Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Beetle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  opaque: false
+              name: \Lanayru Mining Facility\Hall of Ancient Robots\Entry
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Main: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Lanayru Mining Facility
+          locations: {}
+          name: \Lanayru Mining Facility\Main
+          sub_areas:
+            Armos Fight Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Big Hub: null
+              exits:
+                Exit to Big Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\Armos Fight Room\Defeat Armos
+              hint_region: Lanayru Mining Facility
+              locations:
+                Activate Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Gust Bellows
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Slingshot
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Bow
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Goddess Sword
+                    - !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: LMF - Whip Armos Room Timeshift Stone Trick
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Whip
+                      opaque: false
+                    opaque: false
+                  opaque: false
+                Chest after Armos Fight: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\Armos Fight Room\Defeat Armos
+                Defeat Armos: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru Mining Facility\Main\Armos Fight Room\Activate
+                      Timeshift Stone
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Defeat Armos
+                  opaque: false
+              name: \Lanayru Mining Facility\Main\Armos Fight Room
+              sub_areas: {}
+              toplevel_alias: null
+            Big Hub: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Lanayru Mining Facility
+              locations: {}
+              name: \Lanayru Mining Facility\Main\Big Hub
+              sub_areas:
+                After Wooden Boxes: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru Mining Facility\Main\Big Hub\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop
+                        Across Boxes Room\Push Box
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    First Chest in Hub Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes
+                  sub_areas: {}
+                  toplevel_alias: null
+                Between Wind Gates: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru Mining Facility\Main\Big Hub\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Open
+                        First Wind Gate
+                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Activate
+                        Minecart Stone to Boss Key Room
+                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room
+                        Second Exit\Push Box
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Activate Minecart Stone to Boss Key Room: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Gust Bellows
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Lanayru Mining Facility\Can Activate Minecart Timeshift
+                          Stone
+                      opaque: false
+                    Get Minecart: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Near Boss Door\Open Second
+                        Wind Gate
+                    Open First Wind Gate: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Get
+                          Minecart
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Lanayru Mining Facility\Can Activate Minecart Timeshift
+                          Stone
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Gust Bellows
+                      opaque: false
+                    Unlock Exit to Boss Key Room: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Activate
+                          Minecart Stone to Boss Key Room
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Gust Bellows
+                      opaque: false
+                  name: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates
+                  sub_areas: {}
+                  toplevel_alias: null
+                Entry: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from First Hub: null
+                  exits:
+                    Exit to First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Entry\Blow Up Boxes
+                    \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Open
+                        First Wind Gate
+                    \Lanayru Mining Facility\Main\Big Hub\Past West Gate: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Open
+                        Gate
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Blow Up Boxes: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Hook Beetle
+                      opaque: false
+                  name: \Lanayru Mining Facility\Main\Big Hub\Entry
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near Boss Key Room First Exit: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru Mining Facility\Main\Boss Key Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Unlock
+                        Exit to Boss Key Room
+                  hint_region: Lanayru Mining Facility
+                  locations: {}
+                  name: \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First
+                    Exit
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near Boss Key Room Second Exit: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru Mining Facility\Main\Near Boss Door: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Gust Bellows
+                      - !!python/object:logic.logic_expression.AndCombination
+                        arguments:
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: LMF - Minecart Jump Trick
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Sword
+                        - !!python/object:logic.logic_expression.OrCombination
+                          arguments:
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: Bomb Bag
+                          - !!python/object:logic.logic_expression.BasicTextAtom
+                            text: \Beetle
+                          opaque: false
+                        opaque: false
+                      opaque: false
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Push Box: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Shortcut Chest in Main Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second
+                    Exit
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near Exit to Hop Across Boxes Room: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Hop Across Boxes Room: null
+                  exits:
+                    Exit to Hop Across Boxes Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Push Box: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across
+                    Boxes Room
+                  sub_areas: {}
+                  toplevel_alias: null
+                Past West Gate: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Armos Fight Room: null
+                  exits:
+                    Exit to Armos Fight Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Open
+                        Gate
+                    \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Blow
+                        Off Pile for Second Crawlspace
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Blow Off Pile for First Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                    Blow Off Pile for Second Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                    Chest behind First Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Blow
+                        Off Pile for First Crawlspace
+                    Open Gate: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Lanayru Mining Facility\Main\Big Hub\Past West Gate
+                  sub_areas: {}
+                  toplevel_alias: null
+                Sand Spike Maze: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru Mining Facility\Main\Near Boss Door: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Switch
+                          under Sand
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Lanayru Mining Facility\Can Activate Minecart Timeshift
+                          Stone
+                      opaque: false
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Chest in Spike Maze: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                    Switch under Sand: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                  name: \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Boss Key Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\Boss Key Room\Can Beat Room
+              hint_region: Lanayru Mining Facility
+              locations:
+                Boss Key Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\Boss Key Room\Can Beat Room
+                Can Beat Room: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Gust Bellows
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  opaque: false
+              name: \Lanayru Mining Facility\Main\Boss Key Room
+              sub_areas: {}
+              toplevel_alias: null
+            First Hub: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Big Hub: null
+              exits:
+                Exit to Big Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru Mining Facility\Main\First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru Mining Facility\Main\First West Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\First Hub\Push Box on Switch
+                \Lanayru Mining Facility\Main\Key Locked Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Lanayru Mining Facility Small Key
+              hint_region: Lanayru Mining Facility
+              locations:
+                Push Box on Switch: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Gust Bellows
+              name: \Lanayru Mining Facility\Main\First Hub
+              sub_areas: {}
+              toplevel_alias: null
+            First Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru Mining Facility\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\First Room\Left Lever
+              hint_region: Lanayru Mining Facility
+              locations:
+                Chest behind Bars: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\First Room\Right Lever
+                Left Lever: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Whip
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: LMF - Whip First Room Switch Trick
+                    opaque: false
+                  opaque: false
+                Right Lever: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Lanayru Mining Facility\Main\First Room
+              sub_areas: {}
+              toplevel_alias: null
+            First West Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru Mining Facility\Main\Armos Fight Room: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Gust Bellows
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Defeat Beamos
+                  opaque: false
+                \Lanayru Mining Facility\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Lanayru Mining Facility
+              locations:
+                Chest in First West Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Gust Bellows
+              name: \Lanayru Mining Facility\Main\First West Room
+              sub_areas: {}
+              toplevel_alias: null
+            Hop Across Boxes Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Blow
+                      Up Rocks
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near
+                      Exit\Push Shortcut Box
+                  opaque: false
+              hint_region: Lanayru Mining Facility
+              locations:
+                Blow Up Rocks: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Slingshot
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Beetle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Gust Bellows
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Whip
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  opaque: false
+                Lower Chest in Hop across Boxes Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Blow Up
+                    Rocks
+                Raised Chest in Hop across Boxes Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Blow Up
+                    Rocks
+              name: \Lanayru Mining Facility\Main\Hop Across Boxes Room
+              sub_areas:
+                Near Exit: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Big Hub: null
+                  exits:
+                    Exit to Big Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near
+                        Exit\Remove Dust Pile at Door
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Push Shortcut Box: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Remove Dust Pile at Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Key Locked Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru Mining Facility\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Lanayru Mining Facility\Main\Hop Across Boxes Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\Key Locked Room\Activate Timeshift
+                    Stone
+              hint_region: Lanayru Mining Facility
+              locations:
+                Activate Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru Mining Facility\Main\Key Locked Room\Blow Up Boxes
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Bow
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Beetle
+                    - !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Slingshot
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: LMF - Keylocked Slingshot Trickshot Trick
+                      opaque: false
+                    opaque: false
+                  opaque: false
+                Blow Up Boxes: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Hook Beetle
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Bomb Bag
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Bomb Throws Trick
+                    opaque: false
+                  opaque: false
+                Chest in Key Locked Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru Mining Facility\Main\Key Locked Room\Activate Timeshift
+                    Stone
+              name: \Lanayru Mining Facility\Main\Key Locked Room
+              sub_areas: {}
+              toplevel_alias: null
+            Near Boss Door: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Boss Door Entrance: null
+              exits:
+                Boss Door Exit: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Lanayru Mining Facility Boss Key
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru Mining Facility\Can Activate Minecart Timeshift
+                      Stone
+                  opaque: false
+                \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru Mining Facility\Main\Near Boss Door\Open Second
+                      Wind Gate
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Defeat Beamos
+                  opaque: false
+                \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: LMF - Minecart Jump Trick
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sword
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Bomb Bag
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Beetle
+                    opaque: false
+                  opaque: false
+              hint_region: Lanayru Mining Facility
+              locations:
+                Get Minecart to Wind Gate: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Gust Bellows
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru Mining Facility\Can Activate Minecart Timeshift
+                      Stone
+                  opaque: false
+                Open Second Wind Gate: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru Mining Facility\Main\Near Boss Door\Get Minecart
+                      to Wind Gate
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Gust Bellows
+                  opaque: false
+              name: \Lanayru Mining Facility\Main\Near Boss Door
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Sandship: !!python/object:logic.logic_input.Area
+      abstract: true
+      allowed_time_of_day: *id001
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Sandship
+      locations:
+        Pass Spume: !!python/object:logic.logic_expression.OrCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Goddess Sword
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Bow
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Bomb Bag
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Slingshot
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Sandship - Itemless Spume Skip Trick
+          opaque: false
+      name: \Sandship
+      sub_areas:
+        Boss Room: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits: {}
+          hint_region: Sandship
+          locations:
+            Beat Tentalus: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Bow
+            Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Sandship\Boss Room\Beat Tentalus
+            Nayru's Flame: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Sandship\Boss Room\Beat Tentalus
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Goddess Sword
+              opaque: false
+          name: \Sandship\Boss Room
+          sub_areas: {}
+          toplevel_alias: null
+        Main: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Sandship
+          locations: {}
+          name: \Sandship\Main
+          sub_areas:
+            Before Boss Door: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                Boss Door one-way Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sandship\Main\Before Boss Door\Open Boss Door
+                \Sandship\Main\Corridor: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Sandship
+              locations:
+                Chest behind Combination Lock: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sandship\Main\Before Boss Door\Combination Lock
+                Combination Lock: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Sandship - No Combination Hint Trick
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Unlock Combination Lock
+                  opaque: false
+                Open Boss Door: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Sandship Boss Key
+                  opaque: false
+              name: \Sandship\Main\Before Boss Door
+              sub_areas: {}
+              toplevel_alias: null
+            Before Ship's Bow: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Corridor: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Pass Spume
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                  opaque: false
+                \Sandship\Main\Ship's Bow: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Sandship Small Key x 2
+              hint_region: Sandship
+              locations:
+                Chest before 4-Door Corridor: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+              name: \Sandship\Main\Before Ship's Bow
+              sub_areas: {}
+              toplevel_alias: null
+            Brig: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Brig Prison: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Starboard Rooms\Generator
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Whip
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Port Rooms\Generator
+                  opaque: false
+                \Sandship\Main\Starboard Rooms: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sandship\Main\Starboard Rooms\Switch
+                \Sandship\Main\Treasure Room: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Starboard Rooms\Generator
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Whip
+                  opaque: false
+              hint_region: Sandship
+              locations: {}
+              name: \Sandship\Main\Brig
+              sub_areas: {}
+              toplevel_alias: null
+            Brig Prison: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Brig: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Sandship
+              locations:
+                Robot in Brig's Reward: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Sandship\Main\Brig Prison
+              sub_areas: {}
+              toplevel_alias: null
+            Corridor: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Before Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Sandship\Main\Before Ship's Bow: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Pass Spume
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                  opaque: false
+                \Sandship\Main\Port Rooms: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sandship\Main\Port Rooms\Switch
+                \Sandship\Main\Starboard Rooms: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+              hint_region: Sandship
+              locations:
+                \Sandship\Main\Port Rooms\Switch: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Bow
+              name: \Sandship\Main\Corridor
+              sub_areas: {}
+              toplevel_alias: null
+            Deck: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Sandship\Main\Before Ship's Bow: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Sandship\Main\Deck\Captain's Cabin: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Sandship Small Key x 2
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sandship\Main\Deck\Start Mast Sequence
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                    opaque: false
+                  opaque: false
+                \Sandship\Main\Deck\Mast: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Deck\Start Mast Sequence
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                  opaque: false
+                \Sandship\Main\Starboard Rooms: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Starboard Rooms\Switch
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  opaque: false
+              hint_region: Sandship
+              locations:
+                Freely Usable Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Deck\Mast\Finish Mast Sequence
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  opaque: false
+                Raise Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Bow
+                Start Mast Sequence: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Deck\Raise Timeshift Stone
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  opaque: false
+              name: \Sandship\Main\Deck
+              sub_areas:
+                Captain's Cabin: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sandship\Main\Deck: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Sandship Small Key x 2
+                  hint_region: Sandship
+                  locations:
+                    Bars: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Can Defeat Beamos
+                    Boss Key Chest: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sandship\Main\Deck\Captain's Cabin\Switch
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sandship\Main\Deck\Captain's Cabin\Bars
+                      opaque: false
+                    Switch: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                      opaque: false
+                  name: \Sandship\Main\Deck\Captain's Cabin
+                  sub_areas: {}
+                  toplevel_alias: null
+                Mast: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sandship\Main\Deck: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    \Sandship\Main\Deck\Stern: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      - !!python/object:logic.logic_expression.OrCombination
+                        arguments:
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Clawshots
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Sandship - Mast Jump Trick
+                        opaque: false
+                      opaque: false
+                  hint_region: Sandship
+                  locations:
+                    Finish Mast Sequence: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sword
+                      opaque: false
+                  name: \Sandship\Main\Deck\Mast
+                  sub_areas: {}
+                  toplevel_alias: null
+                Stern: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sandship\Main\Deck: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                  hint_region: Sandship
+                  locations:
+                    Chest at the Stern: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Sandship\Main\Deck\Stern
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Port Rooms: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Corridor: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sandship\Main\Port Rooms\Switch
+              hint_region: Sandship
+              locations:
+                Generator: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                  opaque: false
+                Switch: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Bow
+              name: \Sandship\Main\Port Rooms
+              sub_areas: {}
+              toplevel_alias: null
+            Ship's Bow: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Before Ship's Bow: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Caves\Chest
+              hint_region: Sandship
+              locations:
+                Chest after Scervo Fight: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Defeat Scervo/Dreadfuse
+              name: \Sandship\Main\Ship's Bow
+              sub_areas: {}
+              toplevel_alias: null
+            Starboard Rooms: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Brig: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sandship\Main\Starboard Rooms\Switch
+                \Sandship\Main\Corridor: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                \Sandship\Main\Deck: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Starboard Rooms\Switch
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  opaque: false
+              hint_region: Sandship
+              locations:
+                Generator: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                  opaque: false
+                Switch: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Sandship\Main\Starboard Rooms
+              sub_areas: {}
+              toplevel_alias: null
+            Treasure Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Brig: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Sandship
+              locations:
+                Treasure Room Fifth Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Treasure Room First Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Treasure Room Fourth Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Treasure Room Second Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Treasure Room Third Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Sandship\Main\Treasure Room
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Sky: !!python/object:logic.logic_input.Area
+      abstract: false
+      allowed_time_of_day: *id001
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Sky
+      locations: {}
+      name: \Sky
+      sub_areas:
+        Around Skyloft: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Skyloft: null
+            Entrance from Thunderhead: null
+          exits:
+            Exit to Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Exit to Thunderhead: !!python/object:logic.logic_expression.OrCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Open Thunderhead option
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Ballad of the Goddess
+              opaque: false
+            \Sky\North East: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South East: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Sky
+          locations: {}
+          name: \Sky\Around Skyloft
+          sub_areas: {}
+          toplevel_alias: null
+        North East: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits:
+            \Sky\Around Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\North East\Bamboo Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\North East\Beedle's Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\North East\Beedle's Island\Cage: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Sky - Beedle's Island Cage Chest Dive Trick
+            \Sky\North East\Beedle's Island\Top: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\North East\Eldin Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South East: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Sky
+          locations:
+            Goddess Chest in Cave on Island next to Bamboo Island: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Lanayru\Desert\North Part\Secret Passageway\Goddess Cube in
+                  Secret Passageway
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Water Dragon's Scale
+              opaque: false
+            Goddess Chest on Island next to Bamboo Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Eldin\Volcano\East\Goddess Cube near Mogma Turf Entrance
+            Northeast Island Cage Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Eldin\Volcano\Near Temple Entrance\Goddess Cube East of Earth
+                Temple Entrance
+            Northeast Island Goddess Chest behind Bombable Rocks: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Lanayru\Mine\Entry\Goddess Cube at Lanayru Mine Entrance
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Bomb Bag
+              opaque: false
+          name: \Sky\North East
+          sub_areas:
+            Bamboo Island: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Inside: null
+              exits:
+                Exit to Inside: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Sky\North East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Sky
+              locations:
+                Bamboo Island Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Near Temple Entrance\Goddess Cube West of Earth
+                    Temple Entrance
+              name: \Sky\North East\Bamboo Island
+              sub_areas:
+                Inside: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance: null
+                  exits:
+                    Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Sky
+                  locations:
+                    Clean Cut Minigame: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sword
+                    Gossip Stone on Bamboo Island: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Sky\North East\Bamboo Island\Inside
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Beedle's Island: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Beedle's Ship Entrance: null
+              exits:
+                Beedle's Ship Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Night
+                \Sky\North East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+                \Sky\North East\Beedle's Island\Cage: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Night
+              hint_region: Sky
+              locations:
+                Beedle's Crystals: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Horned Colossus Beetle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Night
+                  opaque: false
+                Crystal on Beedle's Ship: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Night
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Beetle
+                  opaque: false
+              name: \Sky\North East\Beedle's Island
+              sub_areas:
+                Cage: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id002
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky\North East\Beedle's Island: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Sky
+                  locations:
+                    Beedle's Island Cage Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Faron\Faron Woods\Deep Woods\Goddess Cube on top of Skyview
+                  name: \Sky\North East\Beedle's Island\Cage
+                  sub_areas: {}
+                  toplevel_alias: null
+                Top: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id002
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky\North East\Beedle's Island: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Sky
+                  locations:
+                    Beedle's Island Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Lanayru\Temple of Time\Near Goddess Cube\Goddess Cube
+                        at Ride near Temple of Time
+                  name: \Sky\North East\Beedle's Island\Top
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Eldin Pillar: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Fire Sanctuary Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ruby Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
+                  opaque: false
+                First Time Dive: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Ruby Tablet
+                Inside the Volcano Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ruby Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
+                  opaque: false
+                Temple Entrance Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ruby Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Eldin\Volcano\Near Temple Entrance\Unlock Statue
+                  opaque: false
+                Volcano Ascent Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ruby Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Eldin\Volcano\Ascent\Unlock Statue
+                  opaque: false
+                Volcano East Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ruby Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Eldin\Volcano\East\Unlock Statue
+                  opaque: false
+                Volcano Entrance Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ruby Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Eldin\Volcano\Entry\Unlock Statue
+                  opaque: false
+                \Sky\North East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Sky
+              locations: {}
+              name: \Sky\North East\Eldin Pillar
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        South East: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits:
+            \Sky\Around Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\North East: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South East\Faron Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South East\Lumpy Pumpkin: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Sky
+          locations:
+            Chest in Breakable Boulder near Lumpy Pumpkin: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Spiral Charge
+            Goddess Chest on Island Closest to Faron Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Faron\Faron Woods\Deep Woods\Goddess Cube in Deep Woods
+          name: \Sky\South East
+          sub_areas:
+            Faron Pillar: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Behind the Temple Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Emerald Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
+                  opaque: false
+                Deep Woods Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Emerald Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Faron Woods\Deep Woods\Unlock Deep Woods Statue
+                  opaque: false
+                Faron Woods Entry Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Emerald Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Faron Woods\Entry\Unlock Statue
+                  opaque: false
+                First Time Dive: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Emerald Tablet
+                Floria Waterfall Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Emerald Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Lake Floria\Waterfall\Unlock Statue
+                  opaque: false
+                Forest Temple Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Emerald Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Faron Woods\Deep Woods\Unlock Forest Temple Statue
+                  opaque: false
+                In the Woods Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Emerald Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Faron Woods\Unlock In the Woods Statue
+                  opaque: false
+                Lake Floria Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Emerald Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Lake Floria\Below Rock\Emerged Area\Unlock Statue
+                  opaque: false
+                Sealed Grounds Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Emerald Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Sealed Grounds\Spiral\Upper Part\Unlock Statue
+                  opaque: false
+                The Great Tree Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Emerald Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Faron Woods\Great Tree\Top\Unlock Statue
+                  opaque: false
+                Viewing Platform Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Emerald Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Faron Woods\Unlock Viewing Platform Statue
+                  opaque: false
+                \Sky\South East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Sky
+              locations: {}
+              name: \Sky\South East\Faron Pillar
+              sub_areas: {}
+              toplevel_alias: null
+            Lumpy Pumpkin: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Back Door Entrance: null
+                Main Left Door Entrance: null
+                Main Right Door Entrance: null
+              exits:
+                Back Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Main Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Main Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Sky\South East: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Sky
+              locations:
+                Crystal outside Lumpy Pumpkin: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Night
+                Goddess Chest on the Roof: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyview\Spring\Goddess Cube in Skyview Spring
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Day
+                  opaque: false
+                Gossip Stone on Lumpy Pumpkin: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Kina's Crystals: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Eldin\Mogma Turf\Pre Vent\Pick up Guld
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Day
+                  opaque: false
+                Outside Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Faron Woods\Deep Woods\Initial Goddess Cube
+                Pumpkin Carrying: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Complete
+                      Hot Soup Delivery
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Day
+                  opaque: false
+                Start Kina's Quest: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Complete
+                      Hot Soup Delivery
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Day
+                  opaque: false
+              name: \Sky\South East\Lumpy Pumpkin
+              sub_areas:
+                Lumpy Pumpkin Building: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id002
+                  can_save: false
+                  can_sleep: true
+                  entrances: !!set
+                    Back Door Entrance: null
+                    Main Left Door Entrance: null
+                    Main Right Door Entrance: null
+                  exits:
+                    Back Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Main Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Main Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Sky
+                  locations:
+                    Break the Chandelier: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Chandelier: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Break
+                        the Chandelier
+                    Complete Hot Soup Delivery: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyloft\Upper Skyloft\Sparring Hall\Delivered Hot Soup
+                    Crystal inside Lumpy Pumpkin: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Night
+                    Harp Minigame: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Play
+                        the Harp with Kina
+                    Pick up Levias' Soup: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Spiral Charge
+                    Play the Harp with Kina: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sky\South East\Lumpy Pumpkin\Pumpkin Carrying
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Goddess's Harp
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Night
+                      opaque: false
+                    Start Hot Soup Delivery: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Break
+                          the Chandelier
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bottle
+                      opaque: false
+                  name: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+        South West: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits:
+            \Sky\Around Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South East: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South West\Fun Fun Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South West\Lanayru Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South West\Orielle's Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South West\Triple Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\South West\Volcanic Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Sky
+          locations:
+            Chest in Breakable Boulder near Fun Fun Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Spiral Charge
+          name: \Sky\South West
+          sub_areas:
+            Fun Fun Island: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Sky
+              locations:
+                Dodoh's Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve Party
+                    Wheel
+                Fun Fun Island Minigame: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve Party
+                    Wheel
+                Fun Fun Island Minigame -- 500 Rupees: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky\South West\Fun Fun Island\Fun Fun Island Minigame
+                Goddess Chest under Fun Fun Island: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Lake Floria\Waterfall\Goddess Cube in Floria Waterfall
+                Start Dodoh's Quest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Sky\South West\Fun Fun Island
+              sub_areas: {}
+              toplevel_alias: null
+            Lanayru Pillar: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Ancient Harbour Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Unlock Statue
+                  opaque: false
+                Desert Entrance Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\Entry\Unlock Statue
+                  opaque: false
+                Desert Gorge Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Temple of Time\South East\Unlock Statue
+                  opaque: false
+                First Time Dive: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Amber Tablet
+                Lanayru Gorge Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Gorge\Unlock Statue
+                  opaque: false
+                Lanayru Mine Entry Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Mine\Entry\Unlock Statue
+                  opaque: false
+                North Desert Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\North Part\Unlock Statue
+                  opaque: false
+                Pirate Stronghold Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
+                  opaque: false
+                Shipyard Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
+                  opaque: false
+                Skipper's Retreat Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Unlock Statue
+                  opaque: false
+                Stone Cache Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\East\Unlock Statue
+                  opaque: false
+                Temple of Time Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Temple of Time\Inside\Unlock Statue
+                  opaque: false
+                West Desert Statue Dive: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Amber Tablet
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Desert\West Part\Unlock Statue
+                  opaque: false
+                \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Sky
+              locations: {}
+              name: \Sky\South West\Lanayru Pillar
+              sub_areas: {}
+              toplevel_alias: null
+            Orielle's Island: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Sky
+              locations:
+                Orielle's Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky\South West\Orielle's Island\Save Orielle
+                Save Orielle: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Bottle
+                Talk to Orielle: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Sky\South West\Orielle's Island
+              sub_areas: {}
+              toplevel_alias: null
+            Triple Island: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Sky
+              locations:
+                Southwest Triple Island Cage Goddess Chest: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Goddess
+                      Cube in Skipper's Retreat
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  opaque: false
+                Southwest Triple Island Lower Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\Near Caged Robot\Goddess Cube near Caged Robot
+                Southwest Triple Island Upper Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Entry\Goddess Cube at Eldin Entrance
+              name: \Sky\South West\Triple Island
+              sub_areas: {}
+              toplevel_alias: null
+            Volcanic Island: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Sky
+              locations:
+                Goddess Chest inside Volcanic Island: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Faron Woods\Clawshot Target Branch\Goddess Cube on
+                      East Great Tree with Clawshots Target
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Sky - Volcanic Island Dive Trick
+                    opaque: false
+                  opaque: false
+                Goddess Chest outside Volcanic Island: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Desert\Sand Oasis\Goddess Cube in Sand Oasis
+                Gossip Stone on Volcanic Island: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Sky\South West\Volcanic Island
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Thunderhead: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\Thunderhead\Bug Heaven: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\Thunderhead\East Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\Thunderhead\Isle of Songs: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Sky\Thunderhead\Mogma Mitts Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Thunderhead
+          locations:
+            Song from Levias: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Pick up
+                  Levias' Soup
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Spiral Charge
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Scrapper
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Sword
+              opaque: false
+          name: \Sky\Thunderhead
+          sub_areas:
+            Bug Heaven: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\Thunderhead: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Thunderhead
+              locations:
+                Bug Heaven -- 10 Bugs in 3 Minutes: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Bug Net
+                Bug Heaven Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano Summit\Waterfall\Goddess Cube in Summit Waterfall
+                Gossip Stone near Bug Heaven: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Sky\Thunderhead\Bug Heaven
+              sub_areas: {}
+              toplevel_alias: null
+            East Island: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\Thunderhead: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Thunderhead
+              locations:
+                East Island Chest: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Digging Mitts
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Thunderhead - East Island Dive Trick
+                  opaque: false
+                East Island Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Faron Woods\Rope Branch\Goddess Cube on East Great
+                    Tree with Rope
+              name: \Sky\Thunderhead\East Island
+              sub_areas: {}
+              toplevel_alias: null
+            Isle of Songs: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Inside: null
+              exits:
+                Exit to Inside: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky\Thunderhead\Isle of Songs\Puzzle Solved
+                \Sky\Thunderhead: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Thunderhead
+              locations:
+                Goddess Chest on top of Isle of Songs: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Goddess Cube
+                    near Fire Sanctuary Entrance
+                Goddess Chest outside Isle of Songs: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Mogma Turf\Pre Vent\Goddess Cube in Mogma Turf
+                Puzzle Solved: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Sky\Thunderhead\Isle of Songs
+              sub_areas:
+                Inside: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance: null
+                  exits:
+                    Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Thunderhead
+                  locations:
+                    Strike Crest with Goddess Sword: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Goddess Sword
+                    Strike Crest with Longsword: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Goddess Longsword
+                    Strike Crest with White Sword: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Goddess White Sword
+                  name: \Sky\Thunderhead\Isle of Songs\Inside
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Mogma Mitts Island: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\Thunderhead: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Thunderhead
+              locations:
+                First Goddess Chest on Mogma Mitts Island: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Eldin\Volcano Summit\Goddess Cube inside Volcano Summit
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Mogma Mitts
+                  opaque: false
+                Second Goddess Chest on Mogma Mitts Island: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Goddess Cube
+                      in Lanayru Gorge
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Mogma Mitts
+                  opaque: false
+              name: \Sky\Thunderhead\Mogma Mitts Island
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Sky Keep: !!python/object:logic.logic_input.Area
+      abstract: false
+      allowed_time_of_day: *id001
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Sky Keep
+      locations: {}
+      name: \Sky Keep
+      sub_areas:
+        Main: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Sky Keep
+          locations: {}
+          name: \Sky Keep\Main
+          sub_areas:
+            Ancient Cistern Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky Keep\Main\Ancient Cistern Room\After Key: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky Keep\Main\Ancient Cistern Room\Unlock Key Door
+                \Sky Keep\Main\Ancient Cistern Room\Triforce Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Lever
+              hint_region: Sky Keep
+              locations:
+                Bottom Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Right Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Unlock Key Door: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Sky Keep Small Key
+              name: \Sky Keep\Main\Ancient Cistern Room
+              sub_areas:
+                After Key: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Ancient Cistern Room\Triforce Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Ancient Cistern Room\After Key\Beat Trial
+                  hint_region: Sky Keep
+                  locations:
+                    Beat Trial: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Can Defeat Moblins
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Can Defeat Bokoblins
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Can Defeat Stalfos
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Can Defeat Cursed Bokoblins
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Can Defeat Stalmaster
+                      opaque: false
+                  name: \Sky Keep\Main\Ancient Cistern Room\After Key
+                  sub_areas: {}
+                  toplevel_alias: null
+                Triforce Room: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Ancient Cistern Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Lever
+                    \Sky Keep\Main\Ancient Cistern Room\After Key: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Sky Keep
+                  locations:
+                    Lever: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Sacred Power of Farore: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Sky Keep\Main\Ancient Cistern Room\Triforce Room
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Earth Temple Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Sky Keep
+              locations:
+                Right Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'False'
+                Top Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'False'
+              name: \Sky Keep\Main\Earth Temple Room
+              sub_areas: {}
+              toplevel_alias: null
+            Fire Sanctuary Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Sky Keep
+              locations: {}
+              name: \Sky Keep\Main\Fire Sanctuary Room
+              sub_areas:
+                First Platform: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      opaque: false
+                  hint_region: Sky Keep
+                  locations:
+                    Lever: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Rupee in Fire Sanctuary Room in Alcove: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Beetle
+                  name: \Sky Keep\Main\Fire Sanctuary Room\First Platform
+                  sub_areas: {}
+                  toplevel_alias: null
+                From Left: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Lower
+                        Lever
+                  hint_region: Sky Keep
+                  locations:
+                    Left Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Sky Keep\Main\Fire Sanctuary Room\From Left
+                  sub_areas: {}
+                  toplevel_alias: null
+                From Right: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Fire Sanctuary Room\First Platform: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sky Keep\Main\Fire Sanctuary Room\First Platform\Lever
+                      opaque: false
+                    \Sky Keep\Main\Fire Sanctuary Room\OoB: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Sky Keep - FS Room Clawshots Vine Clip Trick
+                      opaque: false
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Upper
+                        Lever
+                  hint_region: Sky Keep
+                  locations:
+                    Right Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Sky Keep\Main\Fire Sanctuary Room\From Right
+                  sub_areas: {}
+                  toplevel_alias: null
+                OoB: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Clawshots
+                  hint_region: Sky Keep
+                  locations: {}
+                  name: \Sky Keep\Main\Fire Sanctuary Room\OoB
+                  sub_areas: {}
+                  toplevel_alias: null
+                Triforce Room: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Fire Sanctuary Room\From Left: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Lower
+                        Lever
+                    \Sky Keep\Main\Fire Sanctuary Room\From Right: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Upper
+                        Lever
+                  hint_region: Sky Keep
+                  locations:
+                    Lower Lever: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Sacred Power of Din: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Upper Lever: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            First Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Bottom Entrance: null
+              exits:
+                Bottom Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Sky Keep\Main\Puzzle Solving Meta Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Sky Keep
+              locations:
+                First Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Right Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Sky Keep\Main\First Room
+              sub_areas: {}
+              toplevel_alias: null
+            LMF Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Sky Keep
+              locations:
+                Bottom Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Finish Room: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Gust Bellows
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Sky Keep - Shooting LMF Bow Switches in Present Trick
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  opaque: false
+                Top Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky Keep\Main\LMF Room\Finish Room
+              name: \Sky Keep\Main\LMF Room
+              sub_areas: {}
+              toplevel_alias: null
+            Mini Boss Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Sky Keep
+              locations: {}
+              name: \Sky Keep\Main\Mini Boss Room
+              sub_areas:
+                From Bottom: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Mini Boss Room\Near Chest: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat Dreadfuse
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Clawshots
+                      opaque: false
+                  hint_region: Sky Keep
+                  locations:
+                    Bottom Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat Dreadfuse
+                    Defeat Dreadfuse: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Can Defeat Scervo/Dreadfuse
+                  name: \Sky Keep\Main\Mini Boss Room\From Bottom
+                  sub_areas: {}
+                  toplevel_alias: null
+                From Left: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Mini Boss Room\Near Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Mini Boss Room\Near Chest\Unlock Door
+                  hint_region: Sky Keep
+                  locations:
+                    Left Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Sky Keep\Main\Mini Boss Room\From Left
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near Chest: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Mini Boss Room\From Left: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Mini Boss Room\Near Chest\Unlock Door
+                  hint_region: Sky Keep
+                  locations:
+                    Chest after Dreadfuse: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Unlock Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat Dreadfuse
+                  name: \Sky Keep\Main\Mini Boss Room\Near Chest
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Puzzle Solving Meta Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky Keep\Main\Ancient Cistern Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky Keep\Main\LMF Room\Top Exit
+                \Sky Keep\Main\Earth Temple Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky Keep\Main\LMF Room\Top Exit
+                \Sky Keep\Main\Fire Sanctuary Room\From Right: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky Keep\Main\Ancient Cistern Room\Bottom Exit
+                \Sky Keep\Main\LMF Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky Keep\Main\Skyview Room\End\Top Exit
+                \Sky Keep\Main\Mini Boss Room\From Bottom: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky Keep\Main\Fire Sanctuary Room\From Left\Left Exit
+                \Sky Keep\Main\Sandship Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky Keep\Main\Fire Sanctuary Room\From Left\Left Exit
+                \Sky Keep\Main\Skyview Room\Beginning: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky Keep\Main\First Room\Right Exit
+              hint_region: Sky Keep
+              locations: {}
+              name: \Sky Keep\Main\Puzzle Solving Meta Room
+              sub_areas: {}
+              toplevel_alias: null
+            Sandship Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky Keep\Main\Sandship Room\Triforce Area: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sky Keep\Main\Sandship Room\Lower Eye
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  opaque: false
+              hint_region: Sky Keep
+              locations:
+                Higher Eye: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Bow
+                Left Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Lower Eye: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sky Keep\Main\Sandship Room\Higher Eye
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bow
+                  opaque: false
+              name: \Sky Keep\Main\Sandship Room
+              sub_areas:
+                Triforce Area: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Sandship Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Sky Keep
+                  locations:
+                    Sacred Power of Nayru: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Sky Keep\Main\Sandship Room\Triforce Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Skyview Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Sky Keep
+              locations: {}
+              name: \Sky Keep\Main\Skyview Room
+              sub_areas:
+                Beginning: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Skyview Room\End: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.AndCombination
+                        arguments:
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Whip
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Sky Keep\Main\Skyview Room\Beginning\Free Rope
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Clawshots
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Sky Keep\Main\Skyview Room\Beginning\Kill Pyrups
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Gust Bellows
+                        opaque: false
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sky Keep\Main\Skyview Room\End\Lever
+                      opaque: false
+                  hint_region: Sky Keep
+                  locations:
+                    Free Rope: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      opaque: false
+                    Kill Pyrups: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Hook Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      opaque: false
+                    Left Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Sky Keep\Main\Skyview Room\Beginning
+                  sub_areas: {}
+                  toplevel_alias: null
+                End: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Skyview Room\Beginning: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Sky Keep\Main\Skyview Room\End\Lever
+                  hint_region: Sky Keep
+                  locations:
+                    Lever: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Top Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Sky Keep\Main\Skyview Room\End
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Skyloft: !!python/object:logic.logic_input.Area
+      abstract: false
+      allowed_time_of_day: *id002
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: null
+      locations: {}
+      name: \Skyloft
+      sub_areas:
+        Beedle's Shop: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id002
+          can_save: false
+          can_sleep: true
+          entrances: !!set
+            Day Entrance: null
+            Night Entrance: null
+          exits:
+            Day Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Day
+            Night Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Night
+            \Skyloft\Beedle's Shop\Stall: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Day
+          hint_region: Beedle's Shop
+          locations: {}
+          name: \Skyloft\Beedle's Shop
+          sub_areas:
+            Stall: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyloft\Beedle's Shop: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Beedle's Shop
+              locations:
+                1000 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Afford 1000 Rupees
+                1200 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Afford 1200 Rupees
+                1600 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Afford 1600 Rupees
+                300 Rupee Item: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Afford 300 Rupees
+                  - !!python/object:logic.logic_expression.OrCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Pouch
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Randomized Beedle option
+                    opaque: false
+                  opaque: false
+                50 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Afford 50 Rupees
+                600 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Afford 600 Rupees
+                800 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Afford 800 Rupees
+                First 100 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Afford 100 Rupees
+                Second 100 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Can Afford 100 Rupees
+                Third 100 Rupee Item: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Afford 100 Rupees
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Medium Rupee Farm
+                  opaque: false
+              name: \Skyloft\Beedle's Shop\Stall
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Beedle
+        Central Skyloft: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id002
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Bazaar North Entrance: null
+            Bazaar South Entrance: null
+            Bazaar West Entrance: null
+            Entrance from Beedle's Shop: null
+            Entrance from Sky: null
+            Orielle and Parrow's House Entrance: null
+            Peatrice's House Entrance: null
+            Piper's House Entrance: null
+            Trial Gate Entrance: null
+            Waterfall Cave Upper Entrance: null
+            Wryna's House Entrance: null
+          exits:
+            Bazaar North Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Day
+            Bazaar South Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Day
+            Bazaar West Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Day
+            Exit to Beedle's Shop: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Day
+              - !!python/object:logic.logic_expression.OrCombination
+                arguments:
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Distance Activator
+                - !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Beedle's Shop With Bombs Trick
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  opaque: false
+                opaque: false
+              opaque: false
+            Exit to Sky: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Day
+            Orielle and Parrow's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Peatrice's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Piper's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Trial Gate Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Skyloft\Central Skyloft\Open Trial Gate
+            Waterfall Cave Upper Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Skyloft\Central Skyloft\Open Cave Entrance
+            Wryna's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Skyloft\Central Skyloft\Near Temple Entrance: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Day
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Clawshots
+              opaque: false
+            \Skyloft\Central Skyloft\Waterfall Island: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Clawshots
+            \Skyloft\Skyloft Village: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Skyloft\Upper Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Central Skyloft
+          locations:
+            Crystal between Wooden Planks: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Night
+            Crystal on Light Tower: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Night
+            Crystal on Waterfall Island: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Night
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Skyloft\Central Skyloft\Crystal on Waterfall Island from the
+                  ground
+              opaque: false
+            Crystal on Waterfall Island from the ground: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Quick Beetle
+            Crystal on West Cliff: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Night
+            Open Cave Entrance: !!python/object:logic.logic_expression.OrCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Sword
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Bomb Bag
+              opaque: false
+            Open Trial Gate: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Goddess's Harp
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Song of the Hero
+              opaque: false
+            Parrow's Crystals: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Sky\South West\Orielle's Island\Save Orielle
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Day
+              opaque: false
+            Parrow's Gift: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Sky\South West\Orielle's Island\Talk to Orielle
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Day
+              opaque: false
+            Shed Chest: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Water Dragon's Scale
+            Shed Goddess Chest: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Water Dragon's Scale
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Eldin\Volcano\Sand Slide\Goddess Cube on Sand Slide
+              opaque: false
+            Waterfall Cave Crystals from above: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Beetle
+            West Cliff Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Faron\Faron Woods\West Branch\Goddess Cube on West Great Tree
+                near Exit
+            \Can Collect Water: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Baby Rattle from Beedle's Shop Trick
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Day
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Distance Activator
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Gust Bellows
+              - !!python/object:logic.logic_expression.OrCombination
+                arguments:
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                - !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Whip
+                opaque: false
+              opaque: false
+            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Night
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Skyloft\Central Skyloft\Waterfall Cave Crystals from above
+              opaque: false
+            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Night
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Skyloft\Central Skyloft\Waterfall Cave Crystals from above
+              opaque: false
+          name: \Skyloft\Central Skyloft
+          sub_areas:
+            Bazaar: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                North Entrance: null
+                South Entrance: null
+                West Entrance: null
+              exits:
+                North Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                South Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                West Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Gondo Upgrades On option
+              hint_region: Central Skyloft
+              locations:
+                Bazaar Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Goddess Cube in
+                    Ancient Harbour
+                Endurance Potion: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Bottle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Lanayru\Raise Lanayru Mining Facility
+                  opaque: false
+                Item Check Access: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Potion Lady's Gift: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Repair Gondo's Junk: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Ancient Flower Farming
+                Talk to Peatrice: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Skyloft\Central Skyloft\Bazaar
+              sub_areas:
+                Gondo's Upgrades: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyloft\Central Skyloft\Bazaar: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Central Skyloft
+                  locations:
+                    Upgrade to Quick Beetle: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Hook Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Faron\Faron Woods\Deep Woods\Entry\Hornet Larvae Farming
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Flower Farming
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sky\North East\Bamboo Island\Inside\Clean Cut Minigame
+                      opaque: true
+                    Upgrade to Tough Beetle: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Quick Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Faron\Faron Woods\Amber Relic Farming
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Ancient Flower Farming
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sky\North East\Bamboo Island\Inside\Clean Cut Minigame
+                      opaque: true
+                  name: \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Bird Nest: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyloft\Central Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Item in Bird Nest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Gust Bellows
+              name: \Skyloft\Central Skyloft\Bird Nest
+              sub_areas: {}
+              toplevel_alias: null
+            Near Temple Entrance: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Sky Keep: null
+              exits:
+                Exit to Sky Keep: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Stone of Trials
+                \Skyloft\Central Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Clawshots
+              hint_region: Central Skyloft
+              locations: {}
+              name: \Skyloft\Central Skyloft\Near Temple Entrance
+              sub_areas: {}
+              toplevel_alias: null
+            Orielle and Parrow's House: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Crystal in Orielle and Parrow's House: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Parrow's Crystals: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sky\South West\Orielle's Island\Save Orielle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Night
+                  opaque: false
+                Parrow's Gift: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Sky\South West\Orielle's Island\Talk to Orielle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Night
+                  opaque: false
+              name: \Skyloft\Central Skyloft\Orielle and Parrow's House
+              sub_areas: {}
+              toplevel_alias: null
+            Past Waterfall Cave: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Waterfall Cave Lower Entrance: null
+              exits:
+                Waterfall Cave Lower Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Skyloft\Central Skyloft\Exit to Sky: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+              hint_region: Central Skyloft
+              locations:
+                Crystal after Waterfall Cave: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Night
+                Crystal in Loftwing Prison: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Night
+              name: \Skyloft\Central Skyloft\Past Waterfall Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Peatrice's House: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Peater/Peatrice's Crystals: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyloft\Central Skyloft\Bazaar\Talk to Peatrice
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Night
+                  opaque: false
+              name: \Skyloft\Central Skyloft\Peatrice's House
+              sub_areas: {}
+              toplevel_alias: null
+            Piper's House: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Central Skyloft
+              locations: {}
+              name: \Skyloft\Central Skyloft\Piper's House
+              sub_areas: {}
+              toplevel_alias: null
+            Waterfall Cave: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Lower Entrance: null
+                Upper Entrance: null
+              exits:
+                Lower Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Upper Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Rupee Waterfall Cave Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Waterfall Cave First Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Waterfall Cave Second Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Skyloft\Central Skyloft\Waterfall Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Waterfall Island: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyloft\Central Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Skyloft\Central Skyloft\Bird Nest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Skyloft\Skyloft Village: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Crystal on Waterfall Island: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Night
+                Floating Island Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Lake Floria\Below Rock\Emerged Area\Goddess Cube in
+                    Lake Floria
+                Gossip Stone on Waterfall Island: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Waterfall Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark
+                    Head\Goddess Cube in Pirate Stronghold
+              name: \Skyloft\Central Skyloft\Waterfall Island
+              sub_areas: {}
+              toplevel_alias: null
+            Wryna's House: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Wryna's Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Skyloft\Central Skyloft\Wryna's House
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Skyloft Silent Realm: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id002
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Skyloft Silent Realm
+          locations:
+            Relic 1: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 10: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 2: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 3: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 4: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 5: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 6: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 7: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 8: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Relic 9: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Trial Reward: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          name: \Skyloft\Skyloft Silent Realm
+          sub_areas: {}
+          toplevel_alias: null
+        Skyloft Village: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id002
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Batreaux's House Entrance: null
+            Bertie's House Entrance: null
+            Gondo's House Entrance: null
+            Mallara's House Entrance: null
+            Rupin's House Entrance: null
+            Sparrot's House Entrance: null
+          exits:
+            Batreaux's House Exit: !!python/object:logic.logic_expression.OrCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Skyloft\Skyloft Village\Opened Shed
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Gravestone Jump Trick
+              opaque: false
+            Bertie's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Gondo's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Mallara's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Rupin's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Sparrot's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Skyloft\Central Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Skyloft\Central Skyloft\Exit to Sky: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Day
+            \Skyloft\Central Skyloft\Past Waterfall Cave: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Waterfall Cave Jump Trick
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Day
+              opaque: false
+          hint_region: Skyloft Village
+          locations:
+            Crystal near Pumpkin Patch: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Night
+            Opened Shed: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Night
+          name: \Skyloft\Skyloft Village
+          sub_areas:
+            Batreaux's House: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Batreaux's House
+              locations:
+                10 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \10 Gratitude Crystals
+                30 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \30 Gratitude Crystals
+                30 Crystals Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \30 Gratitude Crystals
+                40 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \40 Gratitude Crystals
+                5 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \5 Gratitude Crystals
+                50 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \50 Gratitude Crystals
+                70 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \70 Gratitude Crystals
+                70 Crystals Second Reward: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \70 Gratitude Crystals
+                80 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \80 Gratitude Crystals
+              name: \Skyloft\Skyloft Village\Batreaux's House
+              sub_areas: {}
+              toplevel_alias: null
+            Bertie's House: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Skyloft Village
+              locations:
+                Bertie's Crystals: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Baby Rattle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Night
+                  opaque: false
+              name: \Skyloft\Skyloft Village\Bertie's House
+              sub_areas: {}
+              toplevel_alias: null
+            Gondo's House: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Skyloft Village
+              locations: {}
+              name: \Skyloft\Skyloft Village\Gondo's House
+              sub_areas: {}
+              toplevel_alias: null
+            Mallara's House: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Skyloft Village
+              locations:
+                Mallara's Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Gust Bellows
+              name: \Skyloft\Skyloft Village\Mallara's House
+              sub_areas: {}
+              toplevel_alias: null
+            Rupin's House: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Skyloft Village
+              locations: {}
+              name: \Skyloft\Skyloft Village\Rupin's House
+              sub_areas: {}
+              toplevel_alias: null
+            Sparrot's House: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Skyloft Village
+              locations:
+                Sparrot's Crystals: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Eldin\Volcano\Near Temple Entrance\Retrieve Crystal Ball
+                Start Sparrot's Quest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Skyloft\Skyloft Village\Sparrot's House
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Upper Skyloft: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id002
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Goddess Statue Entrance: null
+            Knight Academy Lower Left Door Entrance: null
+            Knight Academy Lower Right Door Entrance: null
+            Knight Academy Upper Left Door Entrance: null
+            Knight Academy Upper Right Door Entrance: null
+            Sparring Hall Left Door Entrance: null
+            Sparring Hall Right Door Entrance: null
+          exits:
+            Goddess Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Knight Academy Chimney Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Clawshots
+            Knight Academy Lower Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Day
+            Knight Academy Lower Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Day
+            Knight Academy Upper Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Knight Academy Upper Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Sparring Hall Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Sparring Hall Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            \Skyloft\Central Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Upper Skyloft
+          locations:
+            Chest near Goddess Statue: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+            Owlan's Gift: !!python/object:logic.logic_expression.BasicTextAtom
+              text: Day
+            Pumpkin Archery -- 600 Points: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Bow
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: Day
+              opaque: false
+          name: \Skyloft\Upper Skyloft
+          sub_areas:
+            Goddess Statue: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Upper Skyloft
+              locations:
+                First Goddess Sword Item in Goddess Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Second Goddess Sword Item in Goddess Statue: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Skyloft\Upper Skyloft\Goddess Statue
+              sub_areas: {}
+              toplevel_alias: null
+            Knight Academy: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Lower Left Door Entrance: null
+                Lower Right Door Entrance: null
+                Upper Left Door Entrance: null
+                Upper Right Door Entrance: null
+              exits:
+                Lower Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+                Lower Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Day
+                Upper Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Upper Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Skyloft\Upper Skyloft\Knight Academy\Link's Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Unlocked
+                    Zelda's Room
+              hint_region: Upper Skyloft
+              locations:
+                Crystal in Knight Academy Plant: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Night
+                Fledge's Crystals: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Night
+                  opaque: false
+                Fledge's Gift: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Ghost/Pipit's Crystals: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Cawlin's Letter
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Day
+                  opaque: false
+                Item from Cawlin: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyloft\Upper Skyloft\Knight Academy\Knock on Toilet Door
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Day
+                  opaque: false
+                Knock on Toilet Door: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Goddess's Harp
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Night
+                  opaque: false
+                Owlan's Crystals: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Faron\Faron Woods\Behind the Crawlspace and Rope\Retrieve
+                      Oolo
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Day
+                  opaque: false
+                Start Owlan's Quest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Faron\Faron Woods\All Kikwis Saved
+              name: \Skyloft\Upper Skyloft\Knight Academy
+              sub_areas:
+                Link's Room: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id002
+                  can_save: false
+                  can_sleep: true
+                  entrances: !!set
+                    Start Entrance: null
+                  exits:
+                    \Skyloft\Upper Skyloft\Knight Academy: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Upper Skyloft
+                  locations:
+                    Crystal in Link's Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Night
+                  name: \Skyloft\Upper Skyloft\Knight Academy\Link's Room
+                  sub_areas: {}
+                  toplevel_alias: null
+                Zelda's Room: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id002
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Chimney: null
+                  exits:
+                    \Skyloft\Upper Skyloft\Knight Academy: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Upper Skyloft
+                  locations:
+                    Crystal in Zelda's Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Night
+                    In Zelda's Closet: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Unlocked Zelda's Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Sparring Hall: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id002
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Left Door Entrance: null
+                Right Door Entrance: null
+              exits:
+                Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              hint_region: Upper Skyloft
+              locations:
+                Crystal in Sparring Hall: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Beetle
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Night
+                  opaque: false
+                Delivered Hot Soup: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Start
+                    Hot Soup Delivery
+                Sparring Hall Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Skyloft\Upper Skyloft\Sparring Hall
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Skyview: !!python/object:logic.logic_input.Area
+      abstract: true
+      allowed_time_of_day: *id001
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Skyview
+      locations:
+        Can Cut Tree: !!python/object:logic.logic_expression.OrCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Sword
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: Bomb Bag
+          opaque: false
+        Can Hit High Skyview Switches: !!python/object:logic.logic_expression.OrCombination
+          arguments:
+          - !!python/object:logic.logic_expression.BasicTextAtom
+            text: \Distance Activator
+          - !!python/object:logic.logic_expression.AndCombination
+            arguments:
+            - !!python/object:logic.logic_expression.BasicTextAtom
+              text: Bomb Bag
+            - !!python/object:logic.logic_expression.BasicTextAtom
+              text: Bomb Throws Trick
+            opaque: false
+          opaque: false
+        Skyview 2: !!python/object:logic.logic_expression.BasicTextAtom
+          text: Water Dragon's Scale
+      name: \Skyview
+      sub_areas:
+        Boss Room: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Dungeon: null
+            Entrance from Spring: null
+          exits:
+            Exit to Dungeon: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Skyview\Boss Room\Beat Ghirahim
+            Exit to Spring: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Skyview\Boss Room\Beat Ghirahim
+          hint_region: Skyview
+          locations:
+            Beat Ghirahim: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Sword
+            Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Skyview\Boss Room\Beat Ghirahim
+          name: \Skyview\Boss Room
+          sub_areas: {}
+          toplevel_alias: null
+        Main: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Skyview
+          locations: {}
+          name: \Skyview\Main
+          sub_areas:
+            Entry: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+                \Skyview\Main\First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\Entry\Cut Tree
+              hint_region: Skyview
+              locations:
+                Cut Tree: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Can Cut Tree
+              name: \Skyview\Main\Entry
+              sub_areas: {}
+              toplevel_alias: null
+            First Hub: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyview\Main\First Hub\Left Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\First Hub\Switch to Left Room
+                \Skyview\Main\First Hub\Right Room\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\First Hub\Switch to Right Room
+                \Skyview\Main\First Hub\Right Room\Upper Area: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\First Hub\Left Room\Raise Water
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\First Hub\Right Room\After Crawlspace\Raise
+                        Water
+                    opaque: false
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Clawshots
+                  opaque: false
+                \Skyview\Main\First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\First Room\Destroy Barricade
+                \Skyview\Main\One Eye Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\One Eye Room\Unlock Door to First Hub
+                \Skyview\Main\Second Hub: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyview\Main\First Hub\One Water Raise
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Skyview Small Key
+                  opaque: false
+              hint_region: Skyview
+              locations:
+                One Water Raise: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyview\Main\First Hub\Left Room\Raise Water
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyview\Main\First Hub\Right Room\After Crawlspace\Raise
+                      Water
+                  opaque: false
+                Switch to Left Room: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Can Hit Switch
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\First Hub\One Water Raise
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Water Dragon's Scale
+                    opaque: false
+                  opaque: false
+                Switch to Right Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Can Hit High Skyview Switches
+                \Skyview\Main\First Room\Destroy Barricade: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: 'True'
+              name: \Skyview\Main\First Hub
+              sub_areas:
+                Left Room: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Skyview
+                  locations:
+                    Chest on Tree Branch: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Skyview\Main\First Hub\Left Room\Hit Vines
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Skyview\Main\First Hub\Left Room\Spider Roll
+                      opaque: false
+                    Hit Vines: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Skyview\Can Hit High Skyview Switches
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Goddess Sword
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Whip
+                      opaque: false
+                    Raise Water: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.AndCombination
+                        arguments:
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Skyview\Main\First Hub\Left Room\Hit Vines
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Can Hit Switch
+                        opaque: false
+                      - !!python/object:logic.logic_expression.AndCombination
+                        arguments:
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Skyview\Main\First Hub\Left Room\Spider Roll
+                        - !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Skyview\Can Hit High Skyview Switches
+                        opaque: false
+                      opaque: false
+                    Spider Roll: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Skyview - Spider Roll Trick
+                  name: \Skyview\Main\First Hub\Left Room
+                  sub_areas: {}
+                  toplevel_alias: null
+                Right Room: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits: {}
+                  hint_region: Skyview
+                  locations: {}
+                  name: \Skyview\Main\First Hub\Right Room
+                  sub_areas:
+                    After Crawlspace: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Skyview\Main\First Hub\Right Room\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Skyview
+                      locations:
+                        Digging Spot in Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'False'
+                        Raise Water: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Skyview\Can Hit High Skyview Switches
+                      name: \Skyview\Main\First Hub\Right Room\After Crawlspace
+                      sub_areas:
+                        With Water: !!python/object:logic.logic_input.Area
+                          abstract: false
+                          allowed_time_of_day: *id001
+                          can_save: false
+                          can_sleep: false
+                          entrances: !!set {}
+                          exits:
+                            \Skyview\Main\First Hub\Right Room\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
+                              text: 'True'
+                          hint_region: Skyview
+                          locations:
+                            \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
+                              text: \Digging Mitts
+                          name: \Skyview\Main\First Hub\Right Room\After Crawlspace\With
+                            Water
+                          sub_areas: {}
+                          toplevel_alias: null
+                      toplevel_alias: null
+                    Lower Area: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        \Skyview\Main\First Hub\Right Room\After Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        \Skyview\Main\First Hub\Right Room\After Crawlspace\With Water: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: Water Dragon's Scale
+                      hint_region: Skyview
+                      locations: {}
+                      name: \Skyview\Main\First Hub\Right Room\Lower Area
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Upper Area: !!python/object:logic.logic_input.Area
+                      abstract: false
+                      allowed_time_of_day: *id001
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                        \Skyview\Main\First Hub\Right Room\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: 'True'
+                      hint_region: Skyview
+                      locations:
+                        Chest behind Two Eyes: !!python/object:logic.logic_expression.BasicTextAtom
+                          text: \Sword
+                      name: \Skyview\Main\First Hub\Right Room\Upper Area
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+              toplevel_alias: null
+            First Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyview\Main\Entry: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\Entry\Cut Tree
+                \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\First Room\Destroy Barricade
+                \Skyview\Main\One Eye Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\First Room\Switch to One Eye Room
+              hint_region: Skyview
+              locations:
+                Destroy Barricade: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyview\Skyview 2
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Bomb Bag
+                  opaque: false
+                Goddess Wall Trigger: !!python/object:logic.logic_expression.AndCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Ballad of the Goddess
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Goddess's Harp
+                  opaque: false
+                Switch to One Eye Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Can Hit High Skyview Switches
+                \Skyview\Main\Entry\Cut Tree: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Can Cut Tree
+              name: \Skyview\Main\First Room
+              sub_areas: {}
+              toplevel_alias: null
+            Last Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Skyview
+              locations: {}
+              name: \Skyview\Main\Last Room
+              sub_areas:
+                After Rope: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Boss Door Entrance: null
+                  exits:
+                    Boss Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Skyview Boss Key
+                    \Skyview\Main\Last Room\Before Rope: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\Last Room\Before Rope\Deal with Archers
+                    \Skyview\Main\Last Room\Near Boss Key Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\Last Room\After Rope\Hit Vines
+                  hint_region: Skyview
+                  locations:
+                    Chest near Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                    Hit Vines: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Long Range Skyward Strike
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Distance Activator
+                      opaque: false
+                    \Skyview\Main\Last Room\Before Rope\Deal with Archers: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Can Defeat Bokoblins
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Hook Beetle
+                      opaque: false
+                  name: \Skyview\Main\Last Room\After Rope
+                  sub_areas: {}
+                  toplevel_alias: null
+                Before Rope: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Last Room\After Rope: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\Last Room\Before Rope\Deal with Archers
+                    \Skyview\Main\Last Room\Near East Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\Last Room\Near East Entrance\Deal with Hanging
+                        Skulltula
+                    \Skyview\Main\Second Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\Last Room\Before Rope\Unlock Shortcut to
+                        Second Hub
+                  hint_region: Skyview
+                  locations:
+                    Deal with Archers: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Long Range Skyward Strike
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Hook Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      opaque: false
+                    Unlock Shortcut to Second Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Can Hit High Skyview Switches
+                    \Skyview\Main\Last Room\Near East Entrance\Deal with Hanging Skulltula: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Goddess Sword
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Skyview\Skyview 2
+                      opaque: false
+                  name: \Skyview\Main\Last Room\Before Rope
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near Boss Key Chest: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Last Room\After Rope: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\Last Room\After Rope\Hit Vines
+                    \Skyview\Main\Last Room\Before Rope: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Skyview
+                  locations:
+                    Boss Key Chest: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  name: \Skyview\Main\Last Room\Near Boss Key Chest
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near East Entrance: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Last Room\Before Rope: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\Last Room\Near East Entrance\Deal with Hanging
+                        Skulltula
+                    \Skyview\Main\Second Hub\Staldra Room: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Skyview
+                  locations:
+                    Deal with Hanging Skulltula: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Goddess Sword
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Bow
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Skyview\Skyview 2
+                      opaque: false
+                  name: \Skyview\Main\Last Room\Near East Entrance
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            One Eye Room: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\One Eye Room\Unlock Door to First Hub
+                \Skyview\Main\First Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\First Room\Switch to One Eye Room
+              hint_region: Skyview
+              locations:
+                Unlock Door to First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Sword
+              name: \Skyview\Main\One Eye Room
+              sub_areas: {}
+              toplevel_alias: null
+            Second Hub: !!python/object:logic.logic_input.Area
+              abstract: false
+              allowed_time_of_day: *id001
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Skyview Small Key x 2
+                \Skyview\Main\Last Room\Before Rope: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\Last Room\Before Rope\Unlock Shortcut to Second
+                    Hub
+                \Skyview\Main\Second Hub\Left Rooms: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\Second Hub\Switch to Left Room
+                \Skyview\Main\Second Hub\Miniboss Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Skyview\Main\Second Hub\Switch to Miniboss Room
+                \Skyview\Main\Second Hub\Staldra Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: Skyview Small Key x 2
+              hint_region: Skyview
+              locations:
+                Item behind Bars: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Skyview\Main\Second Hub\Switch for Bars
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: Whip
+                  opaque: false
+                Rupee in East Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Rupee in Southeast Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Rupee in Southwest Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Switch for Bars: !!python/object:logic.logic_expression.OrCombination
+                  arguments:
+                  - !!python/object:logic.logic_expression.BasicTextAtom
+                    text: \Beetle
+                  - !!python/object:logic.logic_expression.AndCombination
+                    arguments:
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Slingshot
+                    - !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Skyview Slingshot Shot Trick
+                    opaque: false
+                  opaque: false
+                Switch to Left Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Beetle
+                Switch to Miniboss Room: !!python/object:logic.logic_expression.BasicTextAtom
+                  text: \Distance Activator
+              name: \Skyview\Main\Second Hub
+              sub_areas:
+                Left Rooms: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Second Hub: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sword
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Projectile Item
+                      opaque: false
+                  hint_region: Skyview
+                  locations:
+                    Chest behind Three Eyes: !!python/object:logic.logic_expression.AndCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Beetle
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sword
+                      opaque: false
+                  name: \Skyview\Main\Second Hub\Left Rooms
+                  sub_areas: {}
+                  toplevel_alias: null
+                Miniboss Room: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Second Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: 'True'
+                  hint_region: Skyview
+                  locations:
+                    Chest after Stalfos Fight: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sword
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Skyview\Skyview 2
+                      opaque: false
+                  name: \Skyview\Main\Second Hub\Miniboss Room
+                  sub_areas: {}
+                  toplevel_alias: null
+                Staldra Room: !!python/object:logic.logic_input.Area
+                  abstract: false
+                  allowed_time_of_day: *id001
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Last Room\Near East Entrance: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: \Skyview\Main\Second Hub\Staldra Room\Can Defeat Staldra
+                    \Skyview\Main\Second Hub: !!python/object:logic.logic_expression.BasicTextAtom
+                      text: Skyview Small Key
+                  hint_region: Skyview
+                  locations:
+                    Can Defeat Staldra: !!python/object:logic.logic_expression.OrCombination
+                      arguments:
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: \Sword
+                      - !!python/object:logic.logic_expression.BasicTextAtom
+                        text: Bomb Bag
+                      opaque: false
+                  name: \Skyview\Main\Second Hub\Staldra Room
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+        Spring: !!python/object:logic.logic_input.Area
+          abstract: false
+          allowed_time_of_day: *id001
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: !!python/object:logic.logic_expression.BasicTextAtom
+              text: 'True'
+          hint_region: Skyview
+          locations:
+            Goddess Cube in Skyview Spring: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Goddess Sword
+            Rupee on Spring Pillar: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Beetle
+            Sacred Water: !!python/object:logic.logic_expression.AndCombination
+              arguments:
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Bottle
+              - !!python/object:logic.logic_expression.BasicTextAtom
+                text: \Skyview\Skyview 2
+              opaque: false
+            Strike Crest: !!python/object:logic.logic_expression.BasicTextAtom
+              text: \Goddess Sword
+          name: \Skyview\Spring
+          sub_areas: {}
+          toplevel_alias: Skyview Spring
+      toplevel_alias: Skyview Temple
+  toplevel_alias: null
+checks:
+  \Ancient Cistern\Boss Room\Heart Container:
+    Paths:
+    - stage/B101/r0/l1/HeartCo
+    - stage/B101/r0/l3/HeartCo
+    hint_region: Ancient Cistern
+    original item: Heart Container
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 756
+    short_name: Ancient Cistern - Heart Container
+    type: null
+  \Ancient Cistern\Flame Room\Farore's Flame:
+    Paths:
+    - event/202-ForestD2/give item after beating ancient cistern
+    - oarc/B101_1/l0
+    hint_region: Ancient Cistern
+    original item: Progressive Sword
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 757
+    short_name: Ancient Cistern - Farore's Flame
+    type: null
+  \Ancient Cistern\Main\Basement Gutters\Past Skulltula\Bokoblin:
+    Paths:
+    - stage/D101/r4/l0/EBc/0xFC00
+    hint_region: Ancient Cistern
+    original item: 'Ancient Cistern Small Key #1'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 748
+    short_name: Ancient Cistern - Bokoblin
+    type: null
+  \Ancient Cistern\Main\Basement\Under the Statue\Boss Key Chest:
+    Paths:
+    - stage/D101/r4/l0/TBox/68
+    hint_region: Ancient Cistern
+    original item: Ancient Cistern Boss Key
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 752
+    short_name: Ancient Cistern - Boss Key Chest
+    type: null
+  \Ancient Cistern\Main\East Part\Chest Ledge\Chest in East Part:
+    Paths:
+    - stage/D101/r1/l0/TBox/67
+    hint: sometimes
+    hint_region: Ancient Cistern
+    original item: 'Ancient Cistern Small Key #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 746
+    short_name: Ancient Cistern - Chest in East Part
+    text: the <r<lone east chest in the Ancient Cistern>> contains
+    type: null
+  \Ancient Cistern\Main\East Part\Second Room\First Rupee in East Part in Short Tunnel:
+    Paths:
+    - stage/D101/r2/l0/Item/65
+    hint_region: Ancient Cistern
+    original item: 'Green Rupee #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 742
+    short_name: Ancient Cistern - First Rupee in East Part in Short Tunnel
+    type: Rupees (No Quick Beetle)
+  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Cubby:
+    Paths:
+    - stage/D101/r2/l0/Item/68
+    hint_region: Ancient Cistern
+    original item: 'Red Rupee #41'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 741
+    short_name: Ancient Cistern - Rupee in East Part in Cubby
+    type: Rupees (No Quick Beetle)
+  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Main Tunnel:
+    Paths:
+    - stage/D101/r2/l0/Item/34
+    hint_region: Ancient Cistern
+    original item: 'Red Rupee #40'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 745
+    short_name: Ancient Cistern - Rupee in East Part in Main Tunnel
+    type: Rupees (No Quick Beetle)
+  \Ancient Cistern\Main\East Part\Second Room\Second Rupee in East Part in Short Tunnel:
+    Paths:
+    - stage/D101/r2/l0/Item/66
+    hint_region: Ancient Cistern
+    original item: 'Green Rupee #1'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 743
+    short_name: Ancient Cistern - Second Rupee in East Part in Short Tunnel
+    type: Rupees (No Quick Beetle)
+  \Ancient Cistern\Main\East Part\Second Room\Third Rupee in East Part in Short Tunnel:
+    Paths:
+    - stage/D101/r2/l0/Item/67
+    hint_region: Ancient Cistern
+    original item: 'Green Rupee #2'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 744
+    short_name: Ancient Cistern - Third Rupee in East Part in Short Tunnel
+    type: Rupees (No Quick Beetle)
+  \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest\Chest in Key Locked Room:
+    Paths:
+    - stage/D101/r7/l0/TBox/69
+    hint_region: Ancient Cistern
+    original item: Whip
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 754
+    short_name: Ancient Cistern - Chest in Key Locked Room
+    type: null
+  \Ancient Cistern\Main\Main Room\After Gutters\Rupee under Lilypad:
+    Paths:
+    - stage/D101/r5/l0/Item/13
+    hint_region: Ancient Cistern
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 733
+    short_name: Ancient Cistern - Rupee under Lilypad
+    type: Rupees (No Quick Beetle)
+  \Ancient Cistern\Main\Main Room\After Whip Hooks\Chest after Whip Hooks:
+    Paths:
+    - stage/D101/r0/l0/TBox/65
+    hint_region: Ancient Cistern
+    original item: Ancient Cistern Map
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 723
+    short_name: Ancient Cistern - Chest after Whip Hooks
+    type: null
+  \Ancient Cistern\Main\Main Room\Behind the Waterfall\Chest behind the Waterfall:
+    Paths:
+    - stage/D101/r3/l0/TBox/84
+    hint_region: Ancient Cistern
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 726
+    short_name: Ancient Cistern - Chest behind the Waterfall
+    type: null
+  \Ancient Cistern\Main\Main Room\Rupee in East Hand:
+    Paths:
+    - stage/D101/r0/l0/Item/92
+    hint_region: Ancient Cistern
+    original item: 'Silver Rupee #19'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 721
+    short_name: Ancient Cistern - Rupee in East Hand
+    type: Rupees (No Quick Beetle)
+  \Ancient Cistern\Main\Main Room\Rupee in West Hand:
+    Paths:
+    - stage/D101/r0/l0/Item/93
+    hint_region: Ancient Cistern
+    original item: 'Silver Rupee #20'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 722
+    short_name: Ancient Cistern - Rupee in West Hand
+    type: Rupees (No Quick Beetle)
+  \Ancient Cistern\Main\Main Room\Vines Area\Chest near Vines:
+    Paths:
+    - stage/D101/r0/l0/TBox/66
+    hint_region: Ancient Cistern
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 724
+    short_name: Ancient Cistern - Chest near Vines
+    type: null
+  \Earth Temple\Boss Room\Slope\Heart Container:
+    Paths:
+    - stage/B200/r10/l1/HeartCo
+    - stage/B200/r10/l2/HeartCo
+    hint_region: Earth Temple
+    original item: Heart Container
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 785
+    short_name: Earth Temple - Heart Container
+    type: null
+  \Earth Temple\Main\East Room\Chest after Double Lizalfos Fight:
+    Paths:
+    - stage/D200/r3/l0/TBox/65
+    hint_region: Earth Temple
+    original item: Bomb Bag
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 774
+    short_name: Earth Temple - Chest after Double Lizalfos Fight
+    text: a menacing <r<pair of Lizalfos>> protect
+    type: null
+  \Earth Temple\Main\First Room\Rupee above Drawbridge:
+    Paths:
+    - stage/D200/r1/l0/Item/25
+    hint_region: Earth Temple
+    original item: 'Red Rupee #39'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 759
+    short_name: Earth Temple - Rupee above Drawbridge
+    type: Rupees (No Quick Beetle)
+  \Earth Temple\Main\First Room\Vent Chest:
+    Paths:
+    - stage/D200/r1/l0/TBox/66
+    hint_region: Earth Temple
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 758
+    short_name: Earth Temple - Vent Chest
+    type: null
+  \Earth Temple\Main\Hub Room\Chest Left of Main Room Bridge:
+    Paths:
+    - stage/D200/r1/l0/TBox/70
+    hint_region: Earth Temple
+    original item: Golden Skull
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 764
+    short_name: Earth Temple - Chest Left of Main Room Bridge
+    type: null
+  \Earth Temple\Main\Hub Room\Chest behind Bombable Rock:
+    Paths:
+    - stage/D200/r1/l0/TBox/69
+    hint_region: Earth Temple
+    original item: Golden Skull
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 763
+    short_name: Earth Temple - Chest behind Bombable Rock
+    type: null
+  \Earth Temple\Main\Hub Room\Ledd's Gift:
+    Paths:
+    - event/301-MountainD1/16
+    - oarc/D200/l0
+    hint_region: Earth Temple
+    original item: 5 Bombs
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 765
+    short_name: Earth Temple - Ledd's Gift
+    type: null
+  \Earth Temple\Main\Hub Room\Past Lava Section\Chest Guarded by Lizalfos:
+    Paths:
+    - stage/D200/r1/l0/TBox/67
+    hint_region: Earth Temple
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 772
+    short_name: Earth Temple - Chest Guarded by Lizalfos
+    type: null
+  \Earth Temple\Main\Hub Room\Rupee in Lava Tunnel:
+    Paths:
+    - stage/D200/r2/l0/Item/21
+    hint_region: Earth Temple
+    original item: 'Silver Rupee #18'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 768
+    short_name: Earth Temple - Rupee in Lava Tunnel
+    text: hidden within the <r<neck of a dragon>> rests
+    type: Rupees (No Quick Beetle)
+  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Key Chest:
+    Paths:
+    - stage/D200/r4/l0/TBox/68
+    hint_region: Earth Temple
+    original item: Earth Temple Boss Key
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 778
+    short_name: Earth Temple - Boss Key Chest
+    type: null
+  \Earth Temple\Main\West Room\Chest in West Room:
+    Paths:
+    - stage/D200/r0/l0/TBox/64
+    hint: sometimes
+    hint_region: Earth Temple
+    original item: Earth Temple Map
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 775
+    short_name: Earth Temple - Chest in West Room
+    text: the <r<western wing in the Earth Temple>> holds
+    type: null
+  \Earth Temple\Spring\Strike Crest:
+    Paths:
+    - event/301-MountainD1/22
+    - oarc/B210/l0
+    hint_region: Earth Temple
+    original item: Amber Tablet
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 786
+    short_name: Earth Temple - Strike Crest
+    type: null
+  \Eldin\Bokoblin Base\Before Drawbridge\Chest near Drawbridge:
+    Paths:
+    - stage/F202/r2/l1/TBox/67
+    hint_region: Bokoblin Base
+    original item: Whip
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 867
+    short_name: Bokoblin Base - Chest near Drawbridge
+    type: null
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\Chest in Volcano Summit Alcove:
+    Paths:
+    - stage/F201_2/r0/l0/TBox/71
+    - stage/F201_1/r0/l4/TBox/71
+    hint_region: Bokoblin Base
+    original item: Progressive Pouch
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 876
+    short_name: Bokoblin Base - Chest in Volcano Summit Alcove
+    type: null
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\First Chest in Volcano Summit:
+    Paths:
+    - stage/F201_2/r0/l0/TBox/72
+    - stage/F201_1/r0/l4/TBox/72
+    hint_region: Bokoblin Base
+    original item: Blue Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 874
+    short_name: Bokoblin Base - First Chest in Volcano Summit
+    type: null
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\Raised Chest in Volcano Summit:
+    Paths:
+    - stage/F201_2/r0/l0/TBox/73
+    - stage/F201_1/r0/l4/TBox/73
+    hint_region: Bokoblin Base
+    original item: Progressive Sword
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 875
+    short_name: Bokoblin Base - Raised Chest in Volcano Summit
+    type: null
+  \Eldin\Bokoblin Base\Fire Dragon's Lair\Fire Dragon's Reward:
+    Paths:
+    - event/305-MountainF3/Give item after Eldin SotH CS
+    - oarc/F221/l0
+    hint_region: Bokoblin Base
+    original item: Eldin Song of the Hero Part
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 879
+    short_name: Bokoblin Base - Fire Dragon's Reward
+    text: <r<hearing a song atop the great mountain>> is rewarded with
+    type: null
+  \Eldin\Bokoblin Base\Outside Earth Temple\Chest East of Earth Temple Entrance:
+    Paths:
+    - stage/F202/r4/l1/TBox/68
+    hint_region: Bokoblin Base
+    original item: Slingshot
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 869
+    short_name: Bokoblin Base - Chest East of Earth Temple Entrance
+    type: null
+  \Eldin\Bokoblin Base\Outside Earth Temple\Chest West of Earth Temple Entrance:
+    Paths:
+    - stage/F202/r4/l1/TBox/69
+    hint_region: Bokoblin Base
+    original item: Bombs
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 871
+    short_name: Bokoblin Base - Chest West of Earth Temple Entrance
+    type: null
+  \Eldin\Bokoblin Base\Prison\Plats' Gift:
+    Paths:
+    - event/305-MountainF3/Plats' Gift
+    - oarc/F202/l1
+    hint_region: Bokoblin Base
+    original item: Mogma Mitts
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 863
+    short_name: Bokoblin Base - Plats' Gift
+    text: a gift from an <r<imprisoned mogma>> has
+    type: null
+  \Eldin\Bokoblin Base\Volcano East\Chest near Bone Bridge:
+    Paths:
+    - stage/F202/r2/l1/TBox/70
+    hint_region: Bokoblin Base
+    original item: Gust Bellows
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 864
+    short_name: Bokoblin Base - Chest near Bone Bridge
+    type: null
+  \Eldin\Bokoblin Base\Volcano East\Chest on Cliff:
+    Paths:
+    - stage/F202/r2/l1/TBox/66
+    hint_region: Bokoblin Base
+    original item: Clawshots
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 865
+    short_name: Bokoblin Base - Chest on Cliff
+    type: null
+  \Eldin\Eldin Silent Realm\Relic 1:
+    Paths:
+    - stage/S200/r0/l2/Relic/102
+    hint_region: Eldin Silent Realm
+    original item: 'Dusk Relic #31'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 842
+    short_name: Eldin Silent Realm - Relic 1
+    type: eldin, silent realm
+  \Eldin\Eldin Silent Realm\Relic 10:
+    Paths:
+    - stage/S200/r0/l2/Relic/111
+    hint_region: Eldin Silent Realm
+    original item: 'Dusk Relic #40'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 851
+    short_name: Eldin Silent Realm - Relic 10
+    type: eldin, silent realm
+  \Eldin\Eldin Silent Realm\Relic 2:
+    Paths:
+    - stage/S200/r0/l2/Relic/103
+    hint_region: Eldin Silent Realm
+    original item: 'Dusk Relic #32'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 843
+    short_name: Eldin Silent Realm - Relic 2
+    type: eldin, silent realm
+  \Eldin\Eldin Silent Realm\Relic 3:
+    Paths:
+    - stage/S200/r0/l2/Relic/104
+    hint_region: Eldin Silent Realm
+    original item: 'Dusk Relic #33'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 844
+    short_name: Eldin Silent Realm - Relic 3
+    type: eldin, silent realm
+  \Eldin\Eldin Silent Realm\Relic 4:
+    Paths:
+    - stage/S200/r0/l2/Relic/105
+    hint_region: Eldin Silent Realm
+    original item: 'Dusk Relic #34'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 845
+    short_name: Eldin Silent Realm - Relic 4
+    type: eldin, silent realm
+  \Eldin\Eldin Silent Realm\Relic 5:
+    Paths:
+    - stage/S200/r0/l2/Relic/106
+    hint_region: Eldin Silent Realm
+    original item: 'Dusk Relic #35'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 846
+    short_name: Eldin Silent Realm - Relic 5
+    type: eldin, silent realm
+  \Eldin\Eldin Silent Realm\Relic 6:
+    Paths:
+    - stage/S200/r0/l2/Relic/107
+    hint_region: Eldin Silent Realm
+    original item: 'Dusk Relic #36'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 847
+    short_name: Eldin Silent Realm - Relic 6
+    type: eldin, silent realm
+  \Eldin\Eldin Silent Realm\Relic 7:
+    Paths:
+    - stage/S200/r0/l2/Relic/108
+    hint_region: Eldin Silent Realm
+    original item: 'Dusk Relic #37'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 848
+    short_name: Eldin Silent Realm - Relic 7
+    type: eldin, silent realm
+  \Eldin\Eldin Silent Realm\Relic 8:
+    Paths:
+    - stage/S200/r0/l2/Relic/109
+    hint_region: Eldin Silent Realm
+    original item: 'Dusk Relic #38'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 849
+    short_name: Eldin Silent Realm - Relic 8
+    type: eldin, silent realm
+  \Eldin\Eldin Silent Realm\Relic 9:
+    Paths:
+    - stage/S200/r0/l2/Relic/110
+    hint_region: Eldin Silent Realm
+    original item: 'Dusk Relic #39'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 850
+    short_name: Eldin Silent Realm - Relic 9
+    type: eldin, silent realm
+  \Eldin\Eldin Silent Realm\Trial Reward:
+    Paths:
+    - stage/S200/r2/l2/WarpObj
+    hint: sometimes
+    hint_region: Eldin Silent Realm
+    original item: Fireshield Earrings
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 841
+    short_name: Eldin Silent Realm - Trial Reward
+    text: a <r<trial of power>> grants
+    type: null
+  \Eldin\Mogma Turf\Past Vent\Chest behind Bombable Wall in Fire Maze:
+    Paths:
+    - stage/F210/r0/l0/TBox/70
+    hint_region: Mogma Turf
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 840
+    short_name: Mogma Turf - Chest behind Bombable Wall in Fire Maze
+    type: null
+  \Eldin\Mogma Turf\Pre Vent\Chest behind Bombable Wall at Entrance:
+    Paths:
+    - stage/F210/r0/l0/TBox/65
+    hint_region: Mogma Turf
+    original item: Golden Skull
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 835
+    short_name: Mogma Turf - Chest behind Bombable Wall at Entrance
+    type: null
+  \Eldin\Mogma Turf\Pre Vent\Defeat Bokoblins:
+    Paths:
+    - event/300-Mountain/6
+    - event/300-Mountain/135
+    - oarc/F210/l0
+    hint_region: Mogma Turf
+    original item: Progressive Mitts
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 837
+    short_name: Mogma Turf - Defeat Bokoblins
+    text: helping <r<reclaim the mogmas' territory>> rewards
+    type: Combat
+  \Eldin\Mogma Turf\Pre Vent\Free Fall Chest:
+    Paths:
+    - stage/F210/r0/l0/TBox/64
+    hint_region: Mogma Turf
+    original item: Eldin Ore
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 833
+    short_name: Mogma Turf - Free Fall Chest
+    type: null
+  \Eldin\Mogma Turf\Sand Slide Platform\Sand Slide Chest:
+    Paths:
+    - stage/F210/r0/l0/TBox/68
+    hint_region: Mogma Turf
+    original item: Eldin Ore
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 839
+    short_name: Mogma Turf - Sand Slide Chest
+    text: <r<behind>> a slide mogmas buried
+    type: null
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Item behind Digging:
+    Paths:
+    - stage/F201_3/r0/l0/Item/104
+    hint: sometimes
+    hint_region: Volcano Summit
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 860
+    short_name: Volcano Summit - Item behind Digging
+    text: <r<fairies at the summit>> dance with
+    type: null
+  \Eldin\Volcano Summit\Waterfall\Higher Area\Chest behind Bombable Wall in Waterfall Area:
+    Paths:
+    - stage/F201_4/r0/l0/TBox/95
+    hint_region: Volcano Summit
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 854
+    short_name: Volcano Summit - Chest behind Bombable Wall in Waterfall Area
+    text: atop a <r<volcanic waterfall>> hides
+    type: null
+  \Eldin\Volcano\Ascent\Chest behind Bombable Wall near Volcano Ascent:
+    Paths:
+    - stage/F200/r2/l0/TBox/71
+    hint_region: Eldin Volcano
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 808
+    short_name: Eldin Volcano - Chest behind Bombable Wall near Volcano Ascent
+    type: null
+  \Eldin\Volcano\East\Chest after Crawlspace:
+    Paths:
+    - stage/F200/r2/l0/TBox/66
+    hint_region: Eldin Volcano
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 797
+    short_name: Eldin Volcano - Chest after Crawlspace
+    type: null
+  \Eldin\Volcano\East\Chest behind Bombable Wall near Cliff:
+    Paths:
+    - stage/F200/r2/l0/TBox/73
+    hint_region: Eldin Volcano
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 798
+    short_name: Eldin Volcano - Chest behind Bombable Wall near Cliff
+    type: null
+  \Eldin\Volcano\East\Item on Cliff:
+    Paths:
+    - stage/F200/r2/l0/Item/102
+    hint_region: Eldin Volcano
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 799
+    short_name: Eldin Volcano - Item on Cliff
+    type: null
+  \Eldin\Volcano\East\North Rupee above Mogma Turf Entrance:
+    Paths:
+    - stage/F200/r2/l0/Item/123
+    hint_region: Eldin Volcano
+    original item: 'Red Rupee #31'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 802
+    short_name: Eldin Volcano - North Rupee above Mogma Turf Entrance
+    type: Rupees (No Quick Beetle)
+  \Eldin\Volcano\East\Southeast Rupee above Mogma Turf Entrance:
+    Paths:
+    - stage/F200/r2/l0/Item/125
+    hint_region: Eldin Volcano
+    original item: 'Blue Rupee #10'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 801
+    short_name: Eldin Volcano - Southeast Rupee above Mogma Turf Entrance
+    type: Rupees (No Quick Beetle)
+  \Eldin\Volcano\Entry\Rupee on Ledge before First Room:
+    Paths:
+    - stage/F200/r0/l0/Item/41
+    hint_region: Eldin Volcano
+    original item: 'Red Rupee #30'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 790
+    short_name: Eldin Volcano - Rupee on Ledge before First Room
+    type: Rupees (No Quick Beetle)
+  \Eldin\Volcano\First Room\Chest behind Bombable Wall in First Room:
+    Paths:
+    - stage/F200/r1/l0/TBox/72
+    hint_region: Eldin Volcano
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 791
+    short_name: Eldin Volcano - Chest behind Bombable Wall in First Room
+    type: null
+  \Eldin\Volcano\First Room\Rupee behind Bombable Wall in First Room:
+    Paths:
+    - stage/F200/r1/l0/Item/13
+    hint_region: Eldin Volcano
+    original item: 'Blue Rupee #8'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 792
+    short_name: Eldin Volcano - Rupee behind Bombable Wall in First Room
+    type: Rupees (No Quick Beetle)
+  \Eldin\Volcano\First Room\Rupee in Crawlspace in First Room:
+    Paths:
+    - stage/F200/r1/l0/Item/19
+    hint_region: Eldin Volcano
+    original item: 'Blue Rupee #9'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 793
+    short_name: Eldin Volcano - Rupee in Crawlspace in First Room
+    type: Rupees (No Quick Beetle)
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot behind Boulder on Sandy Slope:
+    Paths:
+    - stage/F200/r4/l1/Soil/12
+    hint: sometimes
+    hint_region: Eldin Volcano
+    original item: Key Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 826
+    short_name: Eldin Volcano - Digging Spot behind Boulder on Sandy Slope
+    text: a <r<boulder on a sandy slope>> hides
+    type: null
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot below Tower:
+    Paths:
+    - stage/F200/r4/l1/Soil/9
+    hint_region: Eldin Volcano
+    original item: Key Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 825
+    short_name: Eldin Volcano - Digging Spot below Tower
+    type: null
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot in front of Earth Temple:
+    Paths:
+    - stage/F200/r4/l1/Soil/8
+    hint_region: Eldin Volcano
+    original item: Key Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 824
+    short_name: Eldin Volcano - Digging Spot in front of Earth Temple
+    type: null
+  \Eldin\Volcano\Near Thrill Digger Cave\Left Rupee behind Bombable Wall on First Slope:
+    Paths:
+    - stage/F200/r4/l0/Item/45
+    hint_region: Eldin Volcano
+    original item: 'Red Rupee #32'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 813
+    short_name: Eldin Volcano - Left Rupee behind Bombable Wall on First Slope
+    type: Rupees (No Quick Beetle)
+  \Eldin\Volcano\Near Thrill Digger Cave\Right Rupee behind Bombable Wall on First Slope:
+    Paths:
+    - stage/F200/r4/l0/Item/11
+    hint_region: Eldin Volcano
+    original item: 'Red Rupee #33'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 814
+    short_name: Eldin Volcano - Right Rupee behind Bombable Wall on First Slope
+    type: Rupees (No Quick Beetle)
+  \Eldin\Volcano\Past Slide\Digging Spot after Draining Lava:
+    Paths:
+    - stage/F200/r2/l1/Soil/64
+    hint_region: Eldin Volcano
+    original item: Key Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 830
+    short_name: Eldin Volcano - Digging Spot after Draining Lava
+    type: null
+  \Eldin\Volcano\Sand Slide\Digging Spot after Vents:
+    Paths:
+    - stage/F200/r6/l1/Soil/10
+    hint_region: Eldin Volcano
+    original item: Key Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 829
+    short_name: Eldin Volcano - Digging Spot after Vents
+    type: null
+  \Faron\Faron Silent Realm\Relic 1:
+    Paths:
+    - stage/S100/r0/l2/Relic/102
+    hint_region: Faron Silent Realm
+    original item: 'Dusk Relic #11'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 930
+    short_name: Faron Silent Realm - Relic 1
+    type: faron, silent realm
+  \Faron\Faron Silent Realm\Relic 10:
+    Paths:
+    - stage/S100/r0/l2/Relic/111
+    hint_region: Faron Silent Realm
+    original item: 'Dusk Relic #20'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 939
+    short_name: Faron Silent Realm - Relic 10
+    type: faron, silent realm
+  \Faron\Faron Silent Realm\Relic 2:
+    Paths:
+    - stage/S100/r0/l2/Relic/103
+    hint_region: Faron Silent Realm
+    original item: 'Dusk Relic #12'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 931
+    short_name: Faron Silent Realm - Relic 2
+    type: faron, silent realm
+  \Faron\Faron Silent Realm\Relic 3:
+    Paths:
+    - stage/S100/r0/l2/Relic/104
+    hint_region: Faron Silent Realm
+    original item: 'Dusk Relic #13'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 932
+    short_name: Faron Silent Realm - Relic 3
+    type: faron, silent realm
+  \Faron\Faron Silent Realm\Relic 4:
+    Paths:
+    - stage/S100/r0/l2/Relic/105
+    hint_region: Faron Silent Realm
+    original item: 'Dusk Relic #14'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 933
+    short_name: Faron Silent Realm - Relic 4
+    type: faron, silent realm
+  \Faron\Faron Silent Realm\Relic 5:
+    Paths:
+    - stage/S100/r0/l2/Relic/106
+    hint_region: Faron Silent Realm
+    original item: 'Dusk Relic #15'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 934
+    short_name: Faron Silent Realm - Relic 5
+    type: faron, silent realm
+  \Faron\Faron Silent Realm\Relic 6:
+    Paths:
+    - stage/S100/r0/l2/Relic/107
+    hint_region: Faron Silent Realm
+    original item: 'Dusk Relic #16'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 935
+    short_name: Faron Silent Realm - Relic 6
+    type: faron, silent realm
+  \Faron\Faron Silent Realm\Relic 7:
+    Paths:
+    - stage/S100/r0/l2/Relic/108
+    hint_region: Faron Silent Realm
+    original item: 'Dusk Relic #17'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 936
+    short_name: Faron Silent Realm - Relic 7
+    type: faron, silent realm
+  \Faron\Faron Silent Realm\Relic 8:
+    Paths:
+    - stage/S100/r0/l2/Relic/109
+    hint_region: Faron Silent Realm
+    original item: 'Dusk Relic #18'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 937
+    short_name: Faron Silent Realm - Relic 8
+    type: faron, silent realm
+  \Faron\Faron Silent Realm\Relic 9:
+    Paths:
+    - stage/S100/r0/l2/Relic/110
+    hint_region: Faron Silent Realm
+    original item: 'Dusk Relic #19'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 938
+    short_name: Faron Silent Realm - Relic 9
+    type: faron, silent realm
+  \Faron\Faron Silent Realm\Trial Reward:
+    Paths:
+    - stage/S100/r0/l2/WarpObj
+    hint: sometimes
+    hint_region: Faron Silent Realm
+    original item: Water Dragon's Scale
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 929
+    short_name: Faron Silent Realm - Trial Reward
+    text: a <r<trial of courage>> grants
+    type: null
+  \Faron\Faron Woods\Chest behind Upper Bombable Rock:
+    Paths:
+    - stage/F100/r0/l0/TBox/64
+    hint_region: Faron Woods
+    original item: Semi Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 906
+    short_name: Faron Woods - Chest behind Upper Bombable Rock
+    type: null
+  \Faron\Faron Woods\Deep Woods\Deep Woods Chest:
+    Paths:
+    - stage/F101/r0/l0/TBox/74
+    hint_region: Faron Woods
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 920
+    short_name: Faron Woods - Deep Woods Chest
+    type: null
+  \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest\Chest inside Great Tree:
+    Paths:
+    - stage/F100_1/r0/l0/TBox/84
+    hint: sometimes
+    hint_region: Faron Woods
+    original item: Gold Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 914
+    short_name: Faron Woods - Chest inside Great Tree
+    text: climbing inside an <r<old hermit's home>> rewards
+    type: null
+  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree North Branch:
+    Paths:
+    - stage/F100/r0/l0/Item/43
+    hint_region: Faron Woods
+    original item: 'Blue Rupee #4'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 917
+    short_name: Faron Woods - Rupee on Great Tree North Branch
+    type: Rupees (No Quick Beetle)
+  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree West Branch:
+    Paths:
+    - stage/F100/r0/l0/Item/44
+    hint_region: Faron Woods
+    original item: 'Blue Rupee #5'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 918
+    short_name: Faron Woods - Rupee on Great Tree West Branch
+    type: Rupees (No Quick Beetle)
+  \Faron\Faron Woods\Item behind Lower Bombable Rock:
+    Paths:
+    - stage/F100/r0/l0/Item/33
+    hint_region: Faron Woods
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 905
+    short_name: Faron Woods - Item behind Lower Bombable Rock
+    type: null
+  \Faron\Faron Woods\Item on Tree:
+    Paths:
+    - stage/F100/r0/l0/Item/68
+    hint_region: Faron Woods
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 904
+    short_name: Faron Woods - Item on Tree
+    type: null
+  \Faron\Faron Woods\Kikwi Elder's Reward:
+    Paths:
+    - event/200-Forest/595
+    - oarc/F100/l0
+    hint: sometimes
+    hint_region: Faron Woods
+    original item: Progressive Slingshot
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 903
+    short_name: Faron Woods - Kikwi Elder's Reward
+    text: the <r<Kikwi relic>> is
+    type: Combat
+  \Faron\Faron Woods\Rupee on Hollow Tree Branch:
+    Paths:
+    - stage/F100/r0/l0/Item/41
+    hint_region: Faron Woods
+    original item: 'Red Rupee #27'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 900
+    short_name: Faron Woods - Rupee on Hollow Tree Branch
+    type: Rupees (No Quick Beetle)
+  \Faron\Faron Woods\Rupee on Hollow Tree Root:
+    Paths:
+    - stage/F100/r0/l0/Item/42
+    hint_region: Faron Woods
+    original item: 'Blue Rupee #6'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 899
+    short_name: Faron Woods - Rupee on Hollow Tree Root
+    type: Rupees (No Quick Beetle)
+  \Faron\Faron Woods\Rupee on Platform near Floria Door:
+    Paths:
+    - stage/F100/r0/l0/Item/40
+    hint_region: Faron Woods
+    original item: 'Red Rupee #26'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 901
+    short_name: Faron Woods - Rupee on Platform near Floria Door
+    type: Rupees (No Quick Beetle)
+  \Faron\Flooded Faron Woods\16 Dark Blue Tadtones in the South West:
+    Paths:
+    - stage/F103/r0/l2/Clef/17
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #12'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 952
+    short_name: Flooded Faron Woods - 16 Dark Blue Tadtones in the South West
+    type: Tadtones
+  \Faron\Flooded Faron Woods\2 Dark Blue Tadtones in Grass West of Great Tree:
+    Paths:
+    - stage/F103/r0/l2/Clef/3
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #9'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 949
+    short_name: Flooded Faron Woods - 2 Dark Blue Tadtones in Grass West of Great
+      Tree
+    type: Tadtones
+  \Faron\Flooded Faron Woods\2 Red Tadtones in Grass near Lower Bombable Rock:
+    Paths:
+    - stage/F103/r0/l2/Clef/15
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #11'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 951
+    short_name: Flooded Faron Woods - 2 Red Tadtones in Grass near Lower Bombable
+      Rock
+    type: Tadtones
+  \Faron\Flooded Faron Woods\4 Light Blue Moving Tadtones under Kikwi Elder:
+    Paths:
+    - stage/F103/r0/l2/Clef/8
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #6'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 946
+    short_name: Flooded Faron Woods - 4 Light Blue Moving Tadtones under Kikwi Elder
+    type: Tadtones
+  \Faron\Flooded Faron Woods\4 Purple Moving Tadtones near Floria Gate:
+    Paths:
+    - stage/F103/r0/l2/Clef/16
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #13'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 953
+    short_name: Flooded Faron Woods - 4 Purple Moving Tadtones near Floria Gate
+    type: Tadtones
+  \Faron\Flooded Faron Woods\4 Purple Tadtones under Viewing Platform:
+    Paths:
+    - stage/F103/r0/l2/Clef/2
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #2'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 942
+    short_name: Flooded Faron Woods - 4 Purple Tadtones under Viewing Platform
+    type: Tadtones
+  \Faron\Flooded Faron Woods\4 Red Moving Tadtones North West of Great Tree:
+    Paths:
+    - stage/F103/r0/l2/Clef/11
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #7'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 947
+    short_name: Flooded Faron Woods - 4 Red Moving Tadtones North West of Great Tree
+    type: Tadtones
+  \Faron\Flooded Faron Woods\4 Yellow Tadtones under Small Hollow Tree:
+    Paths:
+    - stage/F103/r0/l2/Clef/14
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #15'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 955
+    short_name: Flooded Faron Woods - 4 Yellow Tadtones under Small Hollow Tree
+    type: Tadtones
+  \Faron\Flooded Faron Woods\8 Green Tadtones in West Tunnel:
+    Paths:
+    - stage/F103/r0/l2/Clef/9
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #10'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 950
+    short_name: Flooded Faron Woods - 8 Green Tadtones in West Tunnel
+    type: Tadtones
+  \Faron\Flooded Faron Woods\8 Light Blue Tadtones near Viewing Platform:
+    Paths:
+    - stage/F103/r0/l2/Clef/4
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #1'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 941
+    short_name: Flooded Faron Woods - 8 Light Blue Tadtones near Viewing Platform
+    type: Tadtones
+  \Faron\Flooded Faron Woods\8 Purple Tadtones in Clearing after Small Hollow Tree:
+    Paths:
+    - stage/F103/r0/l2/Clef/12
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #16'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 956
+    short_name: Flooded Faron Woods - 8 Purple Tadtones in Clearing after Small Hollow
+      Tree
+    type: Tadtones
+  \Faron\Flooded Faron Woods\8 Yellow Tadtones near Kikwi Elder:
+    Paths:
+    - stage/F103/r0/l2/Clef/6
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #5'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 945
+    short_name: Flooded Faron Woods - 8 Yellow Tadtones near Kikwi Elder
+    type: Tadtones
+  \Faron\Flooded Faron Woods\Dark Blue Moving Tadtone inside Small Hollow Tree:
+    Paths:
+    - stage/F103/r0/l2/Clef/7
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #14'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 954
+    short_name: Flooded Faron Woods - Dark Blue Moving Tadtone inside Small Hollow
+      Tree
+    type: Tadtones
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Water Dragon's Reward:
+    Paths:
+    - event/204-ForestF3/Give item after Faron SotH CS
+    - oarc/F103_1/l0
+    hint: sometimes
+    hint_region: Flooded Faron Woods
+    original item: Faron Song of the Hero Part
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 958
+    short_name: Flooded Faron Woods - Water Dragon's Reward
+    text: completing a <r<watery song>> reveals
+    type: Tadtones
+  \Faron\Flooded Faron Woods\Green Tadtone behind Upper Bombable Rock:
+    Paths:
+    - stage/F103/r0/l2/Clef/5
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #8'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 948
+    short_name: Flooded Faron Woods - Green Tadtone behind Upper Bombable Rock
+    type: Tadtones
+  \Faron\Flooded Faron Woods\Light Blue Tadtone under Great Tree Root:
+    Paths:
+    - stage/F103/r0/l2/Clef/13
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #4'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 944
+    short_name: Flooded Faron Woods - Light Blue Tadtone under Great Tree Root
+    type: Tadtones
+  \Faron\Flooded Faron Woods\Red Moving Tadtone near Viewing Platform:
+    Paths:
+    - stage/F103/r0/l2/Clef/1
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #3'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 943
+    short_name: Flooded Faron Woods - Red Moving Tadtone near Viewing Platform
+    type: Tadtones
+  \Faron\Flooded Faron Woods\Yellow Tadtone under Lilypad:
+    Paths:
+    - stage/F103/r0/l2/Clef/10
+    hint_region: Flooded Faron Woods
+    original item: 'Group of Tadtones #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 940
+    short_name: Flooded Faron Woods - Yellow Tadtone under Lilypad
+    type: Tadtones
+  \Faron\Lake Floria\Above Rock\Left Rupee behind Northwest Boulder:
+    Paths:
+    - stage/F102/r2/l0/Item/62
+    hint_region: Lake Floria
+    original item: 'Red Rupee #29'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 960
+    short_name: Lake Floria - Left Rupee behind Northwest Boulder
+    type: Rupees (No Quick Beetle)
+  \Faron\Lake Floria\Above Rock\Right Rupee behind Northwest Boulder:
+    Paths:
+    - stage/F102/r2/l0/Item/61
+    hint_region: Lake Floria
+    original item: 'Red Rupee #28'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 961
+    short_name: Lake Floria - Right Rupee behind Northwest Boulder
+    type: Rupees (No Quick Beetle)
+  \Faron\Lake Floria\Above Rock\Rupee behind Southwest Boulder:
+    Paths:
+    - stage/F102/r2/l0/Item/63
+    hint_region: Lake Floria
+    original item: 'Blue Rupee #7'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 959
+    short_name: Lake Floria - Rupee behind Southwest Boulder
+    type: Rupees (No Quick Beetle)
+  \Faron\Lake Floria\Above Rock\Rupee under Central Boulder:
+    Paths:
+    - stage/F102/r2/l0/Item/60
+    hint_region: Lake Floria
+    original item: 'Silver Rupee #12'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 962
+    short_name: Lake Floria - Rupee under Central Boulder
+    type: Rupees (No Quick Beetle)
+  \Faron\Lake Floria\Below Rock\Emerged Area\Lake Floria Chest:
+    Paths:
+    - stage/F102/r3/l0/TBox/64
+    hint: sometimes
+    hint_region: Lake Floria
+    original item: Goddess Plume
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 964
+    short_name: Lake Floria - Lake Floria Chest
+    text: a <r<lonely chest in the lake>> contains
+    type: null
+  \Faron\Lake Floria\Farore's Lair\Dragon Lair East Chest:
+    Paths:
+    - stage/F102_2/r0/l0/TBox/85
+    hint_region: Lake Floria
+    original item: Semi Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 968
+    short_name: Lake Floria - Dragon Lair East Chest
+    type: null
+  \Faron\Lake Floria\Farore's Lair\Dragon Lair South Chest:
+    Paths:
+    - stage/F102_2/r0/l0/TBox/84
+    hint_region: Lake Floria
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 967
+    short_name: Lake Floria - Dragon Lair South Chest
+    type: null
+  \Faron\Lake Floria\Waterfall\Rupee on High Ledge outside Ancient Cistern Entrance:
+    Paths:
+    - stage/F102_1/r0/l0/Item/64
+    hint_region: Lake Floria
+    original item: 'Gold Rupee #10'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 973
+    short_name: Lake Floria - Rupee on High Ledge outside Ancient Cistern Entrance
+    type: Rupees (No Quick Beetle)
+  \Faron\Sealed Grounds\Behind the Temple\Gorko's Goddess Wall Reward:
+    Paths:
+    - event/503-Goron/630
+    - oarc/F400/l0
+    hint: sometimes
+    hint_region: Sealed Grounds
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 891
+    short_name: Sealed Grounds - Gorko's Goddess Wall Reward
+    text: <r<drawing upon a magical wall>> reveals
+    type: null
+  \Faron\Sealed Grounds\Hylia's Temple\Zelda's Blessing:
+    Paths:
+    - event/502-CenterFieldBack/17
+    - oarc/F404/l1
+    hint: sometimes
+    hint_region: Sealed Grounds
+    original item: Progressive Sword
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 887
+    short_name: Sealed Grounds - Zelda's Blessing
+    text: the <r<goddess blesses you>> with
+    type: null
+  \Faron\Sealed Grounds\Sealed Temple\Chest inside Sealed Temple:
+    Paths:
+    - stage/F402/r2/l0/TBox/64
+    hint_region: Sealed Grounds
+    original item: Revitalizing Potion
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 882
+    short_name: Sealed Grounds - Chest inside Sealed Temple
+    type: null
+  \Faron\Sealed Grounds\Sealed Temple\Song from Impa:
+    Paths:
+    - event/501-Inpa/267
+    - oarc/F402/l2
+    hint_region: Sealed Grounds
+    original item: Ballad of the Goddess
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 883
+    short_name: Sealed Grounds - Song from Impa
+    type: null
+  \Fire Sanctuary\Boss Room\Heart Container:
+    Paths:
+    - stage/B201/r0/l1/HeartCo
+    - stage/B201/r0/l2/HeartCo
+    hint_region: Fire Sanctuary
+    original item: Heart Container
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1015
+    short_name: Fire Sanctuary - Heart Container
+    type: null
+  \Fire Sanctuary\Flame Room\Din's Flame:
+    Paths:
+    - event/304-MountainD2/5
+    - oarc/B201_1/l0
+    hint_region: Fire Sanctuary
+    original item: Progressive Sword
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1016
+    short_name: Fire Sanctuary - Din's Flame
+    type: null
+  \Fire Sanctuary\Main\Boss Key Room\Boss Key Chest:
+    Paths:
+    - stage/D201/r4/l0/TBox/67
+    hint_region: Fire Sanctuary
+    original item: Fire Sanctuary Boss Key
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1013
+    short_name: Fire Sanctuary - Boss Key Chest
+    type: null
+  \Fire Sanctuary\Main\First Room\Past Water Plant\Chest in First Room:
+    Paths:
+    - stage/D201/r0/l0/TBox/64
+    hint_region: Fire Sanctuary
+    original item: 'Fire Sanctuary Small Key #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 976
+    short_name: Fire Sanctuary - Chest in First Room
+    type: null
+  \Fire Sanctuary\Main\First Trapped Mogma Room\Chest near First Trapped Mogma:
+    Paths:
+    - stage/D201_1/r5/l0/TBox/69
+    hint_region: Fire Sanctuary
+    original item: 'Fire Sanctuary Small Key #1'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 985
+    short_name: Fire Sanctuary - Chest near First Trapped Mogma
+    type: null
+  \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area\Rescue First Trapped Mogma:
+    Paths:
+    - stage/D201_1/r5/l0/TBox/68
+    hint_region: Fire Sanctuary
+    original item: Progressive Mitts
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 986
+    short_name: Fire Sanctuary - Rescue First Trapped Mogma
+    text: saving a <r<mogma>> from a <r<fiery fate>> rewards
+    type: null
+  \Fire Sanctuary\Main\Second Room\Balcony\Chest on Balcony:
+    Paths:
+    - stage/D201_1/r6/l0/TBox/70
+    - stage/D201/r6/l0/TBox/70
+    hint_region: Fire Sanctuary
+    original item: Bottle
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 980
+    short_name: Fire Sanctuary - Chest on Balcony
+    type: null
+  \Fire Sanctuary\Main\Second Room\Chest in Second Room:
+    Paths:
+    - stage/D201_1/r1/l0/TBox/74
+    - stage/D201/r1/l0/TBox/74
+    hint_region: Fire Sanctuary
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 977
+    short_name: Fire Sanctuary - Chest in Second Room
+    type: null
+  \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall\Chest after Bombable Wall:
+    Paths:
+    - stage/D201_1/r11/l0/TBox/71
+    hint: always
+    hint_region: Fire Sanctuary
+    original item: 'Fire Sanctuary Small Key #2'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1001
+    short_name: Fire Sanctuary - Chest after Bombable Wall
+    text: a <r<false wall in the Fire Sanctuary>> guards
+    type: null
+  \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Second Trapped Mogma:
+    Paths:
+    - stage/D201_1/r2/l0/TBox/65
+    - stage/D201/r2/l0/TBox/65
+    hint_region: Fire Sanctuary
+    original item: Fire Sanctuary Map
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 999
+    short_name: Fire Sanctuary - Rescue Second Trapped Mogma
+    type: null
+  \Fire Sanctuary\Main\Staircase Room\Chest in Staircase Room:
+    Paths:
+    - stage/D201/r9/l0/TBox/75
+    hint_region: Fire Sanctuary
+    original item: Semi Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1010
+    short_name: Fire Sanctuary - Chest in Staircase Room
+    text: exploring a <r<broken staircase>> reveals
+    type: null
+  \Fire Sanctuary\Main\Water Fruit Room\First Chest in Water Fruit Room:
+    Paths:
+    - stage/D201_1/r7/l0/TBox/73
+    hint_region: Fire Sanctuary
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 988
+    short_name: Fire Sanctuary - First Chest in Water Fruit Room
+    type: null
+  \Fire Sanctuary\Main\Water Fruit Room\Second Chest in Water Fruit Room:
+    Paths:
+    - stage/D201_1/r7/l0/TBox/72
+    hint_region: Fire Sanctuary
+    original item: Semi Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 989
+    short_name: Fire Sanctuary - Second Chest in Water Fruit Room
+    type: null
+  \Fire Sanctuary\Main\West of Boss Door\Plats' Chest:
+    Paths:
+    - stage/D201/r3/l0/TBox/66
+    hint_region: Fire Sanctuary
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1004
+    short_name: Fire Sanctuary - Plats' Chest
+    type: null
+  \Lanayru Mining Facility\Boss Room\After Sand Drain\Heart Container:
+    Paths:
+    - stage/B300/r0/l1/HeartCo
+    - stage/B300/r0/l3/HeartCo
+    hint_region: Lanayru Mining Facility
+    original item: Heart Container
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1054
+    short_name: Lanayru Mining Facility - Heart Container
+    type: null
+  \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit Hall of Ancient Robots:
+    Paths:
+    - event/400-Desert/286
+    - oarc/F300_5/l0
+    hint_region: Lanayru Mining Facility
+    original item: Goddess's Harp
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1056
+    short_name: Lanayru Mining Facility - Exit Hall of Ancient Robots
+    type: null
+  \Lanayru Mining Facility\Main\Armos Fight Room\Chest after Armos Fight:
+    Paths:
+    - stage/D300/r6/l0/TBox/69
+    hint_region: Lanayru Mining Facility
+    original item: Lanayru Mining Facility Map
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1033
+    short_name: Lanayru Mining Facility - Chest after Armos Fight
+    type: null
+  \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes\First Chest in Hub Room:
+    Paths:
+    - stage/D300_1/r5/l0/TBox/70
+    hint_region: Lanayru Mining Facility
+    original item: Lanayru Mining Facility Small Key
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1035
+    short_name: Lanayru Mining Facility - First Chest in Hub Room
+    type: null
+  \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Shortcut Chest in Main Hub:
+    Paths:
+    - stage/D300_1/r5/l0/TBox/74
+    hint_region: Lanayru Mining Facility
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1044
+    short_name: Lanayru Mining Facility - Shortcut Chest in Main Hub
+    type: null
+  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Chest behind First Crawlspace:
+    Paths:
+    - stage/D300_1/r9/l0/TBox/72
+    - stage/D300/r9/l0/TBox/72
+    hint_region: Lanayru Mining Facility
+    original item: Golden Skull
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1040
+    short_name: Lanayru Mining Facility - Chest behind First Crawlspace
+    type: null
+  \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Chest in Spike Maze:
+    Paths:
+    - stage/D300_1/r7/l0/TBox/73
+    - stage/D300/r7/l0/TBox/73
+    hint_region: Lanayru Mining Facility
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1042
+    short_name: Lanayru Mining Facility - Chest in Spike Maze
+    type: null
+  \Lanayru Mining Facility\Main\Boss Key Room\Boss Key Chest:
+    Paths:
+    - stage/D300_1/r8/l0/TBox/71
+    hint: always
+    hint_region: Lanayru Mining Facility
+    original item: Lanayru Mining Facility Boss Key
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1052
+    short_name: Lanayru Mining Facility - Boss Key Chest
+    text: deep inside <r<Lanayru Mining Facility, a pair of Armos>> guard
+    type: null
+  \Lanayru Mining Facility\Main\First Room\Chest behind Bars:
+    Paths:
+    - stage/D300/r0/l0/TBox/64
+    hint_region: Lanayru Mining Facility
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1020
+    short_name: Lanayru Mining Facility - Chest behind Bars
+    type: null
+  \Lanayru Mining Facility\Main\First West Room\Chest in First West Room:
+    Paths:
+    - stage/D300/r3/l0/TBox/66
+    hint_region: Lanayru Mining Facility
+    original item: Golden Skull
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1030
+    short_name: Lanayru Mining Facility - Chest in First West Room
+    type: null
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Lower Chest in Hop across Boxes Room:
+    Paths:
+    - stage/D300/r4/l0/TBox/76
+    hint_region: Lanayru Mining Facility
+    original item: Golden Skull
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1027
+    short_name: Lanayru Mining Facility - Lower Chest in Hop across Boxes Room
+    type: null
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Raised Chest in Hop across Boxes Room:
+    Paths:
+    - stage/D300/r4/l0/TBox/68
+    hint_region: Lanayru Mining Facility
+    original item: Gust Bellows
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1026
+    short_name: Lanayru Mining Facility - Raised Chest in Hop across Boxes Room
+    type: null
+  \Lanayru Mining Facility\Main\Key Locked Room\Chest in Key Locked Room:
+    Paths:
+    - stage/D300/r2/l0/TBox/65
+    hint_region: Lanayru Mining Facility
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1024
+    short_name: Lanayru Mining Facility - Chest in Key Locked Room
+    type: null
+  \Lanayru\Caves\Chest:
+    Paths:
+    - stage/F303/r0/l0/TBox/127
+    hint_region: Lanayru Caves
+    original item: Golden Skull
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1137
+    short_name: Lanayru Caves - Chest
+    type: null
+  \Lanayru\Caves\Golo's Gift:
+    Paths:
+    - event/404-DesertF3/127
+    - oarc/F303/l0
+    hint_region: Lanayru Caves
+    original item: Lanayru Caves Small Key
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1138
+    short_name: Lanayru Caves - Golo's Gift
+    type: null
+  \Lanayru\Desert\East\Chest on Platform near Fire Node:
+    Paths:
+    - stage/F300/r0/l0/TBox/73
+    hint_region: Lanayru Desert
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1107
+    short_name: Lanayru Desert - Chest on Platform near Fire Node
+    type: null
+  \Lanayru\Desert\East\Fire Node\Past after Grate\Left Ending Chest:
+    Paths:
+    - stage/F300_3/r0/l0/TBox/81
+    hint_region: Lanayru Desert
+    original item: Golden Skull
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1115
+    short_name: Lanayru Desert - Fire Node - Left Ending Chest
+    type: null
+  \Lanayru\Desert\East\Fire Node\Past after Grate\Right Ending Chest:
+    Paths:
+    - stage/F300_3/r0/l0/TBox/82
+    hint_region: Lanayru Desert
+    original item: Blue Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1116
+    short_name: Lanayru Desert - Fire Node - Right Ending Chest
+    type: null
+  \Lanayru\Desert\East\Fire Node\Past\First Small Chest:
+    Paths:
+    - stage/F300_3/r0/l0/TBox/78
+    hint_region: Lanayru Desert
+    original item: Blue Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1112
+    short_name: Lanayru Desert - Fire Node - First Small Chest
+    type: null
+  \Lanayru\Desert\East\Fire Node\Past\Second Small Chest:
+    Paths:
+    - stage/F300_3/r0/l0/TBox/80
+    hint_region: Lanayru Desert
+    original item: Blue Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1113
+    short_name: Lanayru Desert - Fire Node - Second Small Chest
+    type: null
+  \Lanayru\Desert\East\Fire Node\Present after Sand\Shortcut Chest:
+    Paths:
+    - stage/F300_3/r0/l0/TBox/79
+    hint: sometimes
+    hint_region: Lanayru Desert
+    original item: Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1110
+    short_name: Lanayru Desert - Fire Node - Shortcut Chest
+    text: a <r<raised chest in the Fire Node>> holds
+    type: null
+  \Lanayru\Desert\Entry\High Ledge after Vines\Chest near Party Wheel:
+    Paths:
+    - stage/F300/r0/l0/TBox/70
+    hint_region: Lanayru Desert
+    original item: Golden Skull
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1074
+    short_name: Lanayru Desert - Chest near Party Wheel
+    type: null
+  \Lanayru\Desert\Near Caged Robot\Chest near Caged Robot:
+    Paths:
+    - stage/F300/r0/l0/TBox/84
+    hint_region: Lanayru Desert
+    original item: Tumbleweed
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1075
+    short_name: Lanayru Desert - Chest near Caged Robot
+    type: null
+  \Lanayru\Desert\Near Caged Robot\Rescue Caged Robot:
+    Paths:
+    - event/400-Desert/8
+    - oarc/F300/l0
+    hint_region: Lanayru Desert
+    original item: Progressive Beetle
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1078
+    short_name: Lanayru Desert - Rescue Caged Robot
+    type: Combat
+  \Lanayru\Desert\North Part\Chest on Platform near Lightning Node:
+    Paths:
+    - stage/F300/r0/l0/TBox/72
+    hint_region: Lanayru Desert
+    original item: 'Dusk Relic #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1095
+    short_name: Lanayru Desert - Chest on Platform near Lightning Node
+    type: lanayru, miscellaneous
+  \Lanayru\Desert\North Part\Lightning Node\Past\First Chest:
+    Paths:
+    - stage/F300_2/r0/l0/TBox/75
+    hint_region: Lanayru Desert
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1101
+    short_name: Lanayru Desert - Lightning Node - First Chest
+    type: null
+  \Lanayru\Desert\North Part\Lightning Node\Past\Second Chest:
+    Paths:
+    - stage/F300_2/r0/l0/TBox/76
+    hint_region: Lanayru Desert
+    original item: Blue Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1102
+    short_name: Lanayru Desert - Lightning Node - Second Chest
+    type: null
+  \Lanayru\Desert\North Part\Lightning Node\Present from afar\Raised Chest near Generator:
+    Paths:
+    - stage/F300_2/r0/l0/TBox/77
+    hint_region: Lanayru Desert
+    original item: Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1104
+    short_name: Lanayru Desert - Lightning Node - Raised Chest near Generator
+    text: a <r<raised chest in the Lightning Node>> contains
+    type: null
+  \Lanayru\Desert\North Part\Secret Passageway\Secret Passageway Chest:
+    Paths:
+    - stage/F300/r0/l0/TBox/74
+    hint: sometimes
+    hint_region: Lanayru Desert
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1097
+    short_name: Lanayru Desert - Secret Passageway Chest
+    text: a <r<secret passage in the desert>> holds
+    type: null
+  \Lanayru\Desert\Top of LMF\Chest on top of Lanayru Mining Facility:
+    Paths:
+    - stage/F300/r0/l1/TBox/83
+    hint: sometimes
+    hint_region: Lanayru Desert
+    original item: Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1087
+    short_name: Lanayru Desert - Chest on top of Lanayru Mining Facility
+    text: the <r<midst of the desert>> holds
+    type: null
+  \Lanayru\Desert\Top of West Wall\Chest near Sand Oasis:
+    Paths:
+    - stage/F300/r0/l0/TBox/71
+    hint_region: Lanayru Desert
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1085
+    short_name: Lanayru Desert - Chest near Sand Oasis
+    type: null
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Left Rupee on Entrance Crown:
+    Paths:
+    - stage/F301/r0/l0/Item/91
+    hint_region: Lanayru Sand Sea
+    original item: 'Silver Rupee #13'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1145
+    short_name: Lanayru Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown
+    type: Rupees (Quick Beetle)
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Right Rupee on Entrance Crown:
+    Paths:
+    - stage/F301/r0/l0/Item/93
+    hint_region: Lanayru Sand Sea
+    original item: 'Silver Rupee #14'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1146
+    short_name: Lanayru Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown
+    type: Rupees (Quick Beetle)
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Rupee on First Pillar:
+    Paths:
+    - stage/F301/r0/l0/Item/92
+    hint_region: Lanayru Sand Sea
+    original item: 'Red Rupee #34'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1147
+    short_name: Lanayru Sand Sea - Ancient Harbour - Rupee on First Pillar
+    type: Rupees (No Quick Beetle)
+  \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Digging Spot:
+    Paths:
+    - stage/F302/r0/l0/Soil/30
+    hint_region: Lanayru Gorge
+    original item: Life Tree Seedling
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1178
+    short_name: Lanayru Gorge - Digging Spot
+    type: null
+  \Lanayru\Lanayru Sand Sea\Gorge\Item on Pillar:
+    Paths:
+    - stage/F302/r0/l0/Item/9
+    hint_region: Lanayru Gorge
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1171
+    short_name: Lanayru Gorge - Item on Pillar
+    type: null
+  \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward:
+    Paths:
+    - event/404-DesertF3/give item after Healing Thunderdragon
+    - oarc/F302/l0
+    hint: sometimes
+    hint_region: Lanayru Gorge
+    original item: Lanayru Song of the Hero Part
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1173
+    short_name: Lanayru Gorge - Thunder Dragon's Reward
+    text: <r<curing an ancient dragon>> is rewarded with
+    type: null
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Chest:
+    Paths:
+    - stage/F301_2/r4/l0/TBox/75
+    hint_region: Lanayru Sand Sea
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1166
+    short_name: Lanayru Sand Sea - Pirate Stronghold - First Chest
+    type: null
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Chest:
+    Paths:
+    - stage/F301_2/r5/l0/TBox/73
+    hint_region: Lanayru Sand Sea
+    original item: Semi Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1167
+    short_name: Lanayru Sand Sea - Pirate Stronghold - Second Chest
+    type: null
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Third Chest:
+    Paths:
+    - stage/F301_2/r6/l0/TBox/74
+    hint_region: Lanayru Sand Sea
+    original item: Semi Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1168
+    short_name: Lanayru Sand Sea - Pirate Stronghold - Third Chest
+    type: null
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose:
+    Paths:
+    - stage/F301_6/r0/l1/Item/13
+    - stage/F301_6/r0/l2/Item/13
+    hint_region: Lanayru Sand Sea
+    original item: 'Silver Rupee #17'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1164
+    short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar
+      or Nose
+    type: Rupees (No Quick Beetle)
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar:
+    Paths:
+    - stage/F301_6/r0/l0/Item/12
+    hint_region: Lanayru Sand Sea
+    original item: 'Silver Rupee #16'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1163
+    short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on East Sea Pillar
+    type: Rupees (Quick Beetle)
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar:
+    Paths:
+    - stage/F301_6/r0/l0/Item/11
+    hint_region: Lanayru Sand Sea
+    original item: 'Silver Rupee #15'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1162
+    short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on West Sea Pillar
+    type: Rupees (Quick Beetle)
+  \Lanayru\Lanayru Sand Sea\Shipyard\Rickety Coaster -- Heart Stopping Track in 1'05:
+    Paths:
+    - event/406-TrolleyRace/77
+    - oarc/F301_4/l0
+    hint: sometimes
+    hint_region: Lanayru Sand Sea
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1159
+    short_name: Lanayru Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05
+    text: a <r<fast minecart time>> is rewarded with
+    type: Minigames, Combat
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Chest after Moblin:
+    Paths:
+    - stage/F301_3/r0/l0/TBox/78
+    hint_region: Lanayru Sand Sea
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1150
+    short_name: Lanayru Sand Sea - Skipper's Retreat - Chest after Moblin
+    type: null
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Chest in Shack:
+    Paths:
+    - stage/F301_5/r0/l0/TBox/65
+    hint: sometimes
+    hint_region: Lanayru Sand Sea
+    original item: Sea Chart
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1155
+    short_name: Lanayru Sand Sea - Skipper's Retreat - Chest in Shack
+    text: a <r<chest atop a sandy retreat>> holds
+    type: null
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform\Skydive Chest:
+    Paths:
+    - stage/F301_3/r0/l0/TBox/77
+    hint_region: Lanayru Sand Sea
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1156
+    short_name: Lanayru Sand Sea - Skipper's Retreat - Skydive Chest
+    type: null
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Chest on top of Cacti Pillar:
+    Paths:
+    - stage/F301_3/r0/l0/TBox/76
+    hint_region: Lanayru Sand Sea
+    original item: Semi Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1154
+    short_name: Lanayru Sand Sea - Skipper's Retreat - Chest on top of Cacti Pillar
+    text: a <r<chest amongst cacti>> holds
+    type: null
+  \Lanayru\Lanayru Silent Realm\Relic 1:
+    Paths:
+    - stage/S300/r0/l2/Relic/102
+    hint_region: Lanayru Silent Realm
+    original item: 'Dusk Relic #21'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1127
+    short_name: Lanayru Silent Realm - Relic 1
+    type: lanayru, silent realm
+  \Lanayru\Lanayru Silent Realm\Relic 10:
+    Paths:
+    - stage/S300/r0/l2/Relic/111
+    hint_region: Lanayru Silent Realm
+    original item: 'Dusk Relic #30'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1136
+    short_name: Lanayru Silent Realm - Relic 10
+    type: lanayru, silent realm
+  \Lanayru\Lanayru Silent Realm\Relic 2:
+    Paths:
+    - stage/S300/r0/l2/Relic/103
+    hint_region: Lanayru Silent Realm
+    original item: 'Dusk Relic #22'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1128
+    short_name: Lanayru Silent Realm - Relic 2
+    type: lanayru, silent realm
+  \Lanayru\Lanayru Silent Realm\Relic 3:
+    Paths:
+    - stage/S300/r0/l2/Relic/104
+    hint_region: Lanayru Silent Realm
+    original item: 'Dusk Relic #23'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1129
+    short_name: Lanayru Silent Realm - Relic 3
+    type: lanayru, silent realm
+  \Lanayru\Lanayru Silent Realm\Relic 4:
+    Paths:
+    - stage/S300/r0/l2/Relic/105
+    hint_region: Lanayru Silent Realm
+    original item: 'Dusk Relic #24'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1130
+    short_name: Lanayru Silent Realm - Relic 4
+    type: lanayru, silent realm
+  \Lanayru\Lanayru Silent Realm\Relic 5:
+    Paths:
+    - stage/S300/r0/l2/Relic/106
+    hint_region: Lanayru Silent Realm
+    original item: 'Dusk Relic #25'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1131
+    short_name: Lanayru Silent Realm - Relic 5
+    type: lanayru, silent realm
+  \Lanayru\Lanayru Silent Realm\Relic 6:
+    Paths:
+    - stage/S300/r0/l2/Relic/107
+    hint_region: Lanayru Silent Realm
+    original item: 'Dusk Relic #26'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1132
+    short_name: Lanayru Silent Realm - Relic 6
+    type: lanayru, silent realm
+  \Lanayru\Lanayru Silent Realm\Relic 7:
+    Paths:
+    - stage/S300/r0/l2/Relic/108
+    hint_region: Lanayru Silent Realm
+    original item: 'Dusk Relic #27'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1133
+    short_name: Lanayru Silent Realm - Relic 7
+    type: lanayru, silent realm
+  \Lanayru\Lanayru Silent Realm\Relic 8:
+    Paths:
+    - stage/S300/r0/l2/Relic/109
+    hint_region: Lanayru Silent Realm
+    original item: 'Dusk Relic #28'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1134
+    short_name: Lanayru Silent Realm - Relic 8
+    type: lanayru, silent realm
+  \Lanayru\Lanayru Silent Realm\Relic 9:
+    Paths:
+    - stage/S300/r0/l2/Relic/110
+    hint_region: Lanayru Silent Realm
+    original item: 'Dusk Relic #29'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1135
+    short_name: Lanayru Silent Realm - Relic 9
+    type: lanayru, silent realm
+  \Lanayru\Lanayru Silent Realm\Trial Reward:
+    Paths:
+    - stage/S300/r0/l2/WarpObj
+    hint: sometimes
+    hint_region: Lanayru Silent Realm
+    original item: Clawshots
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1126
+    short_name: Lanayru Silent Realm - Trial Reward
+    text: a <r<trial of wisdom>> grants
+    type: null
+  \Lanayru\Mine\End\Chest at the End of Mine:
+    Paths:
+    - stage/F300_1/r2/l0/TBox/66
+    hint_region: Lanayru Mine
+    original item: Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1068
+    short_name: Lanayru Mine - Chest at the End of Mine
+    type: null
+  \Lanayru\Mine\Entry\Chest near First Timeshift Stone:
+    Paths:
+    - stage/F300_1/r1/l0/TBox/65
+    hint_region: Lanayru Mine
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1063
+    short_name: Lanayru Mine - Chest near First Timeshift Stone
+    type: null
+  \Lanayru\Mine\Entry\Higher Area\Chest behind First Landing:
+    Paths:
+    - stage/F300_1/r0/l0/TBox/64
+    hint_region: Lanayru Mine
+    original item: Evil Crystal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1064
+    short_name: Lanayru Mine - Chest behind First Landing
+    type: null
+  \Lanayru\Mine\Statues Area\Chest behind Statue:
+    Paths:
+    - stage/F300_1/r2/l0/TBox/67
+    hint_region: Lanayru Mine
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1066
+    short_name: Lanayru Mine - Chest behind Statue
+    type: null
+  \Sandship\Boss Room\Heart Container:
+    Paths:
+    - stage/B301/r0/l1/HeartCo
+    - stage/D301/r0/l1/HeartCo
+    hint: sometimes
+    hint_region: Sandship
+    original item: Heart Container
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1204
+    short_name: Sandship - Heart Container
+    text: the <r<heart of an ancient sea creature>> holds
+    type: null
+  \Sandship\Boss Room\Nayru's Flame:
+    Paths:
+    - event/401-DesertD2/45
+    - oarc/B301/l1
+    - oarc/D301/l1
+    hint_region: Sandship
+    original item: Progressive Sword
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1205
+    short_name: Sandship - Nayru's Flame
+    type: null
+  \Sandship\Main\Before Boss Door\Chest behind Combination Lock:
+    Paths:
+    - stage/D301/r10/l0/TBox/69
+    hint_region: Sandship
+    original item: 'Sandship Small Key #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1195
+    short_name: Sandship - Chest behind Combination Lock
+    type: null
+  \Sandship\Main\Before Ship's Bow\Chest before 4-Door Corridor:
+    Paths:
+    - stage/D301/r3/l0/TBox/71
+    hint_region: Sandship
+    original item: Sandship Map
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1188
+    short_name: Sandship - Chest before 4-Door Corridor
+    type: null
+  \Sandship\Main\Brig Prison\Robot in Brig's Reward:
+    Paths:
+    - event/401-DesertD2/14
+    - oarc/D301/l4
+    hint: sometimes
+    hint_region: Sandship
+    original item: 'Sandship Small Key #1'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1202
+    short_name: Sandship - Robot in Brig's Reward
+    text: the <r<gratitude of a freed crew>> reveals
+    type: null
+  \Sandship\Main\Deck\Captain's Cabin\Boss Key Chest:
+    Paths:
+    - stage/D301/r14/l3/TBox/73
+    hint: sometimes
+    hint_region: Sandship
+    original item: Sandship Boss Key
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1187
+    short_name: Sandship - Boss Key Chest
+    text: the <r<secret treasure of the Sandship's captain>> is
+    type: null
+  \Sandship\Main\Deck\Stern\Chest at the Stern:
+    Paths:
+    - stage/D301/r0/l0/TBox/127
+    hint_region: Sandship
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1184
+    short_name: Sandship - Chest at the Stern
+    type: null
+  \Sandship\Main\Ship's Bow\Chest after Scervo Fight:
+    Paths:
+    - stage/D301/r15/l0/TBox/72
+    hint: sometimes
+    hint_region: Sandship
+    original item: Progressive Bow
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1189
+    short_name: Sandship - Chest after Scervo Fight
+    text: a <r<robot upon the Sandship's bow>> guards
+    type: null
+  \Sandship\Main\Treasure Room\Treasure Room Fifth Chest:
+    Paths:
+    - stage/D301/r9/l0/TBox/68
+    hint_region: Sandship
+    original item: Semi Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1201
+    short_name: Sandship - Treasure Room Fifth Chest
+    type: null
+  \Sandship\Main\Treasure Room\Treasure Room First Chest:
+    Paths:
+    - stage/D301/r9/l0/TBox/64
+    hint_region: Sandship
+    original item: Semi Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1197
+    short_name: Sandship - Treasure Room First Chest
+    type: null
+  \Sandship\Main\Treasure Room\Treasure Room Fourth Chest:
+    Paths:
+    - stage/D301/r9/l0/TBox/67
+    hint_region: Sandship
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1200
+    short_name: Sandship - Treasure Room Fourth Chest
+    type: null
+  \Sandship\Main\Treasure Room\Treasure Room Second Chest:
+    Paths:
+    - stage/D301/r9/l0/TBox/65
+    hint_region: Sandship
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1198
+    short_name: Sandship - Treasure Room Second Chest
+    type: null
+  \Sandship\Main\Treasure Room\Treasure Room Third Chest:
+    Paths:
+    - stage/D301/r9/l0/TBox/66
+    hint_region: Sandship
+    original item: Semi Rare Treasure
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1199
+    short_name: Sandship - Treasure Room Third Chest
+    type: null
+  \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Sacred Power of Farore:
+    Paths:
+    - stage/D003_8/r0/l3/Item/64
+    hint_region: Sky Keep
+    original item: Triforce of Courage
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1227
+    short_name: Sky Keep - Sacred Power of Farore
+    type: null
+  \Sky Keep\Main\Fire Sanctuary Room\First Platform\Rupee in Fire Sanctuary Room in Alcove:
+    Paths:
+    - stage/D003_2/r0/l0/Item/36
+    hint_region: Sky Keep
+    original item: 'Silver Rupee #21'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1231
+    short_name: Sky Keep - Rupee in Fire Sanctuary Room in Alcove
+    type: Rupees (No Quick Beetle)
+  \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Sacred Power of Din:
+    Paths:
+    - stage/D003_8/r0/l2/Item/61
+    hint_region: Sky Keep
+    original item: Triforce of Power
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1232
+    short_name: Sky Keep - Sacred Power of Din
+    type: null
+  \Sky Keep\Main\First Room\First Chest:
+    Paths:
+    - stage/D003_7/r0/l0/TBox/64
+    hint_region: Sky Keep
+    original item: Sky Keep Map
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1206
+    short_name: Sky Keep - First Chest
+    type: null
+  \Sky Keep\Main\Mini Boss Room\Near Chest\Chest after Dreadfuse:
+    Paths:
+    - stage/D003_6/r0/l0/TBox/65
+    hint_region: Sky Keep
+    original item: Sky Keep Small Key
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1220
+    short_name: Sky Keep - Chest after Dreadfuse
+    type: null
+  \Sky Keep\Main\Sandship Room\Triforce Area\Sacred Power of Nayru:
+    Paths:
+    - stage/D003_8/r0/l1/Item/62
+    hint_region: Sky Keep
+    original item: Triforce of Wisdom
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1239
+    short_name: Sky Keep - Sacred Power of Nayru
+    type: null
+  \Sky\North East\Bamboo Island\Bamboo Island Goddess Chest:
+    Paths:
+    - stage/F020/r0/l0/TBox/82
+    cube_region: Eldin Volcano
+    hint_region: Sky
+    original item: Gold Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1244
+    short_name: Sky - Bamboo Island Goddess Chest
+    type: goddess, Eldin Volcano Goddess Chests
+  \Sky\North East\Beedle's Island\Beedle's Crystals:
+    Paths:
+    - event/105-Terry/115
+    - oarc/F020/l0
+    hint: sometimes
+    hint_region: Sky
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1248
+    short_name: Sky - Beedle's Crystals
+    text: <r<reuniting two Beedles>> is rewarded with
+    type: Gratitude Crystal Sidequests
+  \Sky\North East\Beedle's Island\Cage\Beedle's Island Cage Goddess Chest:
+    Paths:
+    - stage/F020/r0/l0/TBox/81
+    cube_region: Faron Woods
+    hint_region: Sky
+    original item: Rupee Medal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1250
+    short_name: Sky - Beedle's Island Cage Goddess Chest
+    type: goddess, Faron Woods Goddess Chests
+  \Sky\North East\Beedle's Island\Crystal on Beedle's Ship:
+    hint_region: Sky
+    original item: 'Gratitude Crystal #14'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1247
+    short_name: Sky - Crystal on Beedle's Ship
+    type: Loose Crystals
+  \Sky\North East\Beedle's Island\Top\Beedle's Island Goddess Chest:
+    Paths:
+    - stage/F020/r0/l0/TBox/89
+    cube_region: Lanayru Desert
+    hint: sometimes
+    hint_region: Sky
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1249
+    short_name: Sky - Beedle's Island Goddess Chest
+    text: a <s<goddess cube>> at the <r<monument to time>> reveals
+    type: goddess, Lanayru Desert Goddess Chests, Combat
+  \Sky\North East\Goddess Chest in Cave on Island next to Bamboo Island:
+    Paths:
+    - stage/F020/r0/l0/TBox/83
+    cube_region: Lanayru Desert
+    hint_region: Sky
+    original item: Heart Medal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1241
+    short_name: Sky - Goddess Chest in Cave on Island next to Bamboo Island
+    type: goddess, Lanayru Desert Goddess Chests
+  \Sky\North East\Goddess Chest on Island next to Bamboo Island:
+    Paths:
+    - stage/F020/r0/l0/TBox/71
+    cube_region: Eldin Volcano
+    hint_region: Sky
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1240
+    short_name: Sky - Goddess Chest on Island next to Bamboo Island
+    type: goddess, Eldin Volcano Goddess Chests
+  \Sky\North East\Northeast Island Cage Goddess Chest:
+    Paths:
+    - stage/F020/r0/l0/TBox/74
+    cube_region: Eldin Volcano
+    hint_region: Sky
+    original item: Treasure Medal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1243
+    short_name: Sky - Northeast Island Cage Goddess Chest
+    type: goddess, Eldin Volcano Goddess Chests
+  \Sky\North East\Northeast Island Goddess Chest behind Bombable Rocks:
+    Paths:
+    - stage/F020/r0/l0/TBox/72
+    cube_region: Lanayru Mine
+    hint_region: Sky
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1242
+    short_name: Sky - Northeast Island Goddess Chest behind Bombable Rocks
+    type: goddess, Lanayru Desert Goddess Chests
+  \Sky\South East\Chest in Breakable Boulder near Lumpy Pumpkin:
+    Paths:
+    - stage/F020/r0/l0/TBox/69
+    hint_region: Sky
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1251
+    short_name: Sky - Chest in Breakable Boulder near Lumpy Pumpkin
+    type: null
+  \Sky\South East\Goddess Chest on Island Closest to Faron Pillar:
+    Paths:
+    - stage/F020/r0/l0/TBox/65
+    cube_region: Faron Woods
+    hint_region: Sky
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1252
+    short_name: Sky - Goddess Chest on Island Closest to Faron Pillar
+    type: goddess, Faron Woods Goddess Chests
+  \Sky\South East\Lumpy Pumpkin\Crystal outside Lumpy Pumpkin:
+    hint_region: Sky
+    original item: 'Gratitude Crystal #12'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1253
+    short_name: Sky - Crystal outside Lumpy Pumpkin
+    type: Loose Crystals
+  \Sky\South East\Lumpy Pumpkin\Goddess Chest on the Roof:
+    Paths:
+    - stage/F020/r0/l0/TBox/87
+    cube_region: Skyview
+    hint_region: Sky
+    original item: Gold Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1255
+    short_name: Sky - Lumpy Pumpkin - Goddess Chest on the Roof
+    type: goddess, Faron Woods Goddess Chests
+  \Sky\South East\Lumpy Pumpkin\Kina's Crystals:
+    Paths:
+    - event/117-Pumpkin/386
+    - oarc/F020/l0
+    hint: sometimes
+    hint_region: Sky
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1257
+    short_name: Sky - Kina's Crystals
+    text: <r<delivering a mogma to the sky>> is rewarded with
+    type: Scrapper Deliveries, Gratitude Crystal Sidequests
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Chandelier:
+    Paths:
+    - stage/F011r/r0/l0/Chandel
+    hint_region: Sky
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1260
+    short_name: Sky - Lumpy Pumpkin - Chandelier
+    text: <r<angering a bartender>> dislodges
+    type: null
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Crystal inside Lumpy Pumpkin:
+    hint_region: Sky
+    original item: 'Gratitude Crystal #13'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1261
+    short_name: Sky - Crystal inside Lumpy Pumpkin
+    type: Loose Crystals
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Harp Minigame:
+    Paths:
+    - event/117-Pumpkin/305
+    - oarc/F011r/l0
+    hint: sometimes
+    hint_region: Sky
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1266
+    short_name: Sky - Lumpy Pumpkin - Harp Minigame
+    text: the <r<bartender>> holds
+    type: Minigames
+  \Sky\South East\Lumpy Pumpkin\Outside Goddess Chest:
+    Paths:
+    - stage/F020/r0/l0/TBox/64
+    cube_region: Faron Woods
+    hint_region: Sky
+    original item: Progressive Pouch
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1254
+    short_name: Sky - Lumpy Pumpkin - Outside Goddess Chest
+    type: goddess, Faron Woods Goddess Chests
+  \Sky\South West\Chest in Breakable Boulder near Fun Fun Island:
+    Paths:
+    - stage/F020/r0/l0/TBox/70
+    hint_region: Sky
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1268
+    short_name: Sky - Chest in Breakable Boulder near Fun Fun Island
+    type: null
+  \Sky\South West\Fun Fun Island\Dodoh's Crystals:
+    Paths:
+    - event/110-DivingGame/60
+    - oarc/F020/l0
+    hint_region: Sky
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1276
+    short_name: Sky - Dodoh's Crystals
+    text: delivering a <r<colorful wheel>> is rewarded with
+    type: Scrapper Deliveries
+  \Sky\South West\Fun Fun Island\Fun Fun Island Minigame -- 500 Rupees:
+    Paths:
+    - event/110-DivingGame/19
+    - oarc/F020/l2
+    hint: sometimes
+    hint_region: Sky
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1277
+    short_name: Sky - Fun Fun Island Minigame -- 500 Rupees
+    text: <r<diving through 5 rings>> yields
+    type: Minigames, Scrapper Deliveries
+  \Sky\South West\Fun Fun Island\Goddess Chest under Fun Fun Island:
+    Paths:
+    - stage/F020/r0/l0/TBox/86
+    cube_region: Lake Floria
+    hint_region: Sky
+    original item: Gold Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1278
+    short_name: Sky - Goddess Chest under Fun Fun Island
+    type: goddess, Lake Floria Goddess Chests
+  \Sky\South West\Orielle's Island\Orielle's Crystals:
+    Paths:
+    - event/115-Town2/225
+    - oarc/F020/l0
+    hint_region: Sky
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1274
+    short_name: Sky - Orielle's Crystals
+    text: saving a <r<sick loftwing>> is rewarded with
+    type: Gratitude Crystal Sidequests
+  \Sky\South West\Triple Island\Southwest Triple Island Cage Goddess Chest:
+    Paths:
+    - stage/F020/r0/l0/TBox/75
+    cube_region: Lanayru Sand Sea
+    hint_region: Sky
+    original item: Potion Medal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1282
+    short_name: Sky - Southwest Triple Island Cage Goddess Chest
+    type: goddess, Sand Sea Goddess Chests
+  \Sky\South West\Triple Island\Southwest Triple Island Lower Goddess Chest:
+    Paths:
+    - stage/F020/r0/l0/TBox/84
+    cube_region: Lanayru Desert
+    hint_region: Sky
+    original item: Life Medal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1281
+    short_name: Sky - Southwest Triple Island Lower Goddess Chest
+    type: goddess, Lanayru Desert Goddess Chests
+  \Sky\South West\Triple Island\Southwest Triple Island Upper Goddess Chest:
+    Paths:
+    - stage/F020/r0/l0/TBox/66
+    cube_region: Eldin Volcano
+    hint_region: Sky
+    original item: Small Seed Satchel
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1280
+    short_name: Sky - Southwest Triple Island Upper Goddess Chest
+    type: goddess, Eldin Volcano Goddess Chests
+  \Sky\South West\Volcanic Island\Goddess Chest inside Volcanic Island:
+    Paths:
+    - stage/F020/r0/l0/TBox/68
+    cube_region: Faron Woods
+    hint_region: Sky
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1270
+    short_name: Sky - Goddess Chest inside Volcanic Island
+    type: goddess, Faron Woods Goddess Chests
+  \Sky\South West\Volcanic Island\Goddess Chest outside Volcanic Island:
+    Paths:
+    - stage/F020/r0/l0/TBox/67
+    cube_region: Lanayru Desert
+    hint_region: Sky
+    original item: Heart Medal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1269
+    short_name: Sky - Goddess Chest outside Volcanic Island
+    type: goddess, Lanayru Desert Goddess Chests
+  \Sky\Thunderhead\Bug Heaven\Bug Heaven -- 10 Bugs in 3 Minutes:
+    Paths:
+    - event/116-InsectGame/69
+    - oarc/F023/l0
+    hint: sometimes
+    hint_region: Thunderhead
+    original item: Horned Colossus Beetle
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1294
+    short_name: Thunderhead - Bug Heaven -- 10 Bugs in 3 Minutes
+    text: <r<true bug catchers>> can find
+    type: Minigames
+  \Sky\Thunderhead\Bug Heaven\Bug Heaven Goddess Chest:
+    Paths:
+    - stage/F023/r0/l0/TBox/88
+    cube_region: Volcano Summit
+    hint_region: Thunderhead
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1295
+    short_name: Thunderhead - Bug Heaven Goddess Chest
+    type: goddess, Volcano Summit Goddess Chests
+  \Sky\Thunderhead\East Island\East Island Chest:
+    Paths:
+    - stage/F023/r0/l0/TBox/94
+    hint_region: Thunderhead
+    original item: Evil Crystal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1291
+    short_name: Thunderhead - East Island Chest
+    type: null
+  \Sky\Thunderhead\East Island\East Island Goddess Chest:
+    Paths:
+    - stage/F023/r0/l0/TBox/73
+    cube_region: Faron Woods
+    hint_region: Thunderhead
+    original item: Rupee Medal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1290
+    short_name: Thunderhead - East Island Goddess Chest
+    type: goddess, Faron Woods Goddess Chests
+  \Sky\Thunderhead\Isle of Songs\Goddess Chest on top of Isle of Songs:
+    Paths:
+    - stage/F023/r0/l0/TBox/85
+    cube_region: Volcano Summit
+    hint_region: Thunderhead
+    original item: Small Bomb Bag
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1285
+    short_name: Thunderhead - Goddess Chest on top of Isle of Songs
+    type: goddess, Volcano Summit Goddess Chests
+  \Sky\Thunderhead\Isle of Songs\Goddess Chest outside Isle of Songs:
+    Paths:
+    - stage/F023/r0/l0/TBox/92
+    cube_region: Mogma Turf
+    hint_region: Thunderhead
+    original item: Gold Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1284
+    short_name: Thunderhead - Goddess Chest outside Isle of Songs
+    type: goddess, Eldin Volcano Goddess Chests
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Goddess Sword:
+    Paths:
+    - stage/F010r/r0/l0/SwSB/0
+    hint_region: Thunderhead
+    original item: Farore's Courage
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1287
+    short_name: Thunderhead - Isle of Songs - Strike Crest with Goddess Sword
+    text: the <r<goddess' blade>> reveals
+    type: null
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Longsword:
+    Paths:
+    - stage/F010r/r0/l0/SwSB/1
+    hint_region: Thunderhead
+    original item: Nayru's Wisdom
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1288
+    short_name: Thunderhead - Isle of Songs - Strike Crest with Longsword
+    text: a <r<longsword>> reveals
+    type: null
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with White Sword:
+    Paths:
+    - stage/F010r/r0/l0/SwSB/2
+    hint: sometimes
+    hint_region: Thunderhead
+    original item: Din's Power
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1289
+    short_name: Thunderhead - Isle of Songs - Strike Crest with White Sword
+    text: a <r<blade of white>> reveals
+    type: null
+  \Sky\Thunderhead\Mogma Mitts Island\First Goddess Chest on Mogma Mitts Island:
+    Paths:
+    - stage/F023/r0/l0/TBox/77
+    cube_region: Volcano Summit
+    hint_region: Thunderhead
+    original item: Bottle
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1292
+    short_name: Thunderhead - First Goddess Chest on Mogma Mitts Island
+    type: goddess, Volcano Summit Goddess Chests
+  \Sky\Thunderhead\Mogma Mitts Island\Second Goddess Chest on Mogma Mitts Island:
+    Paths:
+    - stage/F023/r0/l0/TBox/76
+    cube_region: Lanayru Gorge
+    hint_region: Thunderhead
+    original item: Small Quiver
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1293
+    short_name: Thunderhead - Second Goddess Chest on Mogma Mitts Island
+    type: goddess, Sand Sea Goddess Chests
+  \Sky\Thunderhead\Song from Levias:
+    Paths:
+    - event/120-Nushi/give item after levias
+    - oarc/F023/l0
+    hint: always
+    hint_region: Thunderhead
+    original item: Song of the Hero
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1283
+    short_name: Thunderhead - Song from Levias
+    text: the <r<ancient whale within a raging storm>> bellows out
+    type: Scrapper Deliveries, Combat
+  \Skyloft\Beedle's Shop\Stall\1000 Rupee Item:
+    Paths:
+    - ShpSmpl/27
+    hint_region: Beedle's Shop
+    original item: Bug Medal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1388
+    short_name: Beedle's Shop - 1000 Rupee Item
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
+  \Skyloft\Beedle's Shop\Stall\1200 Rupee Item:
+    Paths:
+    - ShpSmpl/22
+    hint: always
+    hint_region: Beedle's Shop
+    original item: 'Progressive Pouch #3'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1381
+    short_name: Beedle's Shop - 1200 Rupee Item
+    text: for <g+<1200 rupees>> <r<Beedle>> sells
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
+  \Skyloft\Beedle's Shop\Stall\1600 Rupee Item:
+    Paths:
+    - ShpSmpl/23
+    hint: always
+    hint_region: Beedle's Shop
+    original item: 'Heart Piece #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1383
+    short_name: Beedle's Shop - 1600 Rupee Item
+    text: for <g+<1600 rupees>> <r<Beedle>> sells
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
+  \Skyloft\Beedle's Shop\Stall\300 Rupee Item:
+    Paths:
+    - ShpSmpl/20
+    hint_region: Beedle's Shop
+    original item: 'Progressive Pouch #1'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1379
+    short_name: Beedle's Shop - 300 Rupee Item
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
+  \Skyloft\Beedle's Shop\Stall\50 Rupee Item:
+    Paths:
+    - ShpSmpl/25
+    hint_region: Beedle's Shop
+    original item: 'Progressive Bug Net #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1387
+    short_name: Beedle's Shop - 50 Rupee Item
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
+  \Skyloft\Beedle's Shop\Stall\600 Rupee Item:
+    Paths:
+    - ShpSmpl/21
+    hint_region: Beedle's Shop
+    original item: 'Progressive Pouch #2'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1380
+    short_name: Beedle's Shop - 600 Rupee Item
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
+  \Skyloft\Beedle's Shop\Stall\800 Rupee Item:
+    Paths:
+    - ShpSmpl/26
+    hint_region: Beedle's Shop
+    original item: 'Life Medal #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1382
+    short_name: Beedle's Shop - 800 Rupee Item
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
+  \Skyloft\Beedle's Shop\Stall\First 100 Rupee Item:
+    Paths:
+    - ShpSmpl/24
+    hint_region: Beedle's Shop
+    original item: 'Extra Wallet #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1384
+    short_name: Beedle's Shop - First 100 Rupee Item
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
+  \Skyloft\Beedle's Shop\Stall\Second 100 Rupee Item:
+    Paths:
+    - ShpSmpl/17
+    hint_region: Beedle's Shop
+    original item: 'Extra Wallet #1'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1385
+    short_name: Beedle's Shop - Second 100 Rupee Item
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
+  \Skyloft\Beedle's Shop\Stall\Third 100 Rupee Item:
+    Paths:
+    - ShpSmpl/18
+    hint_region: Beedle's Shop
+    original item: 'Extra Wallet #2'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1386
+    short_name: Beedle's Shop - Third 100 Rupee Item
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
+  \Skyloft\Central Skyloft\Bazaar\Bazaar Goddess Chest:
+    Paths:
+    - stage/F004r/r0/l0/TBox/93
+    cube_region: Lanayru Sand Sea
+    hint_region: Central Skyloft
+    original item: Gold Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1333
+    short_name: Central Skyloft - Bazaar Goddess Chest
+    type: goddess, Sand Sea Goddess Chests
+  \Skyloft\Central Skyloft\Bazaar\Potion Lady's Gift:
+    Paths:
+    - event/106-DrugStore/44
+    - oarc/F004r/l0
+    hint_region: Central Skyloft
+    original item: Bottle
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1331
+    short_name: Central Skyloft - Potion Lady's Gift
+    type: null
+  \Skyloft\Central Skyloft\Bazaar\Repair Gondo's Junk:
+    Paths:
+    - event/113-RemodelStore/Give Repair Gondo Junk item
+    - oarc/F004r/l0
+    hint_region: Central Skyloft
+    original item: Scrapper
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1332
+    short_name: Central Skyloft - Repair Gondo's Junk
+    type: null
+  \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest:
+    Paths:
+    - stage/F000/r0/l0/Item/13
+    hint_region: Central Skyloft
+    original item: Baby's Rattle
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1330
+    short_name: Central Skyloft - Item in Bird Nest
+    type: null
+  \Skyloft\Central Skyloft\Crystal between Wooden Planks:
+    hint_region: Central Skyloft
+    original item: 'Gratitude Crystal #4'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1317
+    short_name: Central Skyloft - Crystal between Wooden Planks
+    type: Loose Crystals
+  \Skyloft\Central Skyloft\Crystal on Light Tower:
+    hint_region: Central Skyloft
+    original item: 'Gratitude Crystal #1'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1319
+    short_name: Central Skyloft - Crystal on Light Tower
+    type: Loose Crystals
+  \Skyloft\Central Skyloft\Crystal on Waterfall Island:
+    hint_region: Central Skyloft
+    original item: 'Gratitude Crystal #10'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1328
+    short_name: Central Skyloft - Crystal on Waterfall Island
+    type: Loose Crystals
+  \Skyloft\Central Skyloft\Crystal on West Cliff:
+    hint_region: Central Skyloft
+    original item: 'Gratitude Crystal #6'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1318
+    short_name: Central Skyloft - Crystal on West Cliff
+    type: Loose Crystals
+  \Skyloft\Central Skyloft\Orielle and Parrow's House\Crystal in Orielle and Parrow's House:
+    hint_region: Central Skyloft
+    original item: 'Gratitude Crystal #3'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1339
+    short_name: Central Skyloft - Crystal in Orielle and Parrow's House
+    type: Loose Crystals
+  \Skyloft\Central Skyloft\Parrow's Crystals:
+    Paths:
+    - event/115-Town2/814
+    - oarc/F000/l4
+    - oarc/F000/l6
+    - oarc/F005r/l0
+    hint_region: Central Skyloft
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1322
+    short_name: Central Skyloft - Parrow's Crystals
+    type: Gratitude Crystal Sidequests
+  \Skyloft\Central Skyloft\Parrow's Gift:
+    Paths:
+    - event/115-Town2/230
+    - event/115-Town2/733
+    - oarc/F000/l4
+    - oarc/F000/l6
+    - oarc/F005r/l0
+    hint_region: Central Skyloft
+    original item: Bottle
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1321
+    short_name: Central Skyloft - Parrow's Gift
+    type: null
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave:
+    hint_region: Central Skyloft
+    original item: 'Gratitude Crystal #7'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1351
+    short_name: Central Skyloft - Crystal after Waterfall Cave
+    type: Loose Crystals
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison:
+    hint_region: Central Skyloft
+    original item: 'Gratitude Crystal #8'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1352
+    short_name: Central Skyloft - Crystal in Loftwing Prison
+    type: Loose Crystals
+  \Skyloft\Central Skyloft\Peatrice's House\Peater/Peatrice's Crystals:
+    Paths:
+    - event/109-TakeGoron/79
+    - event/123-Town5/316
+    - oarc/F018r/l0
+    - oarc/F019r/l0
+    hint: always
+    hint_region: Central Skyloft
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1342
+    short_name: Central Skyloft - Peater/Peatrice's Crystals
+    text: the <r<item check girl>> hides
+    type: Gratitude Crystal Sidequests
+  \Skyloft\Central Skyloft\Shed Chest:
+    Paths:
+    - stage/F000/r0/l0/TBox/70
+    hint_region: Central Skyloft
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1323
+    short_name: Central Skyloft - Shed Chest
+    type: null
+  \Skyloft\Central Skyloft\Shed Goddess Chest:
+    Paths:
+    - stage/F000/r0/l0/TBox/79
+    cube_region: Eldin Volcano
+    hint_region: Central Skyloft
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1324
+    short_name: Central Skyloft - Shed Goddess Chest
+    type: goddess, Eldin Volcano Goddess Chests
+  \Skyloft\Central Skyloft\Waterfall Cave\Rupee Waterfall Cave Crawlspace:
+    Paths:
+    - stage/D000/r0/l0/Item/88
+    hint_region: Central Skyloft
+    original item: 'Red Rupee #25'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1350
+    short_name: Central Skyloft - Rupee Waterfall Cave Crawlspace
+    type: Rupees (No Quick Beetle)
+  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave First Chest:
+    Paths:
+    - stage/D000/r0/l0/TBox/67
+    hint_region: Central Skyloft
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1348
+    short_name: Central Skyloft - Waterfall Cave First Chest
+    type: null
+  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave Second Chest:
+    Paths:
+    - stage/D000/r0/l0/TBox/68
+    hint_region: Central Skyloft
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1349
+    short_name: Central Skyloft - Waterfall Cave Second Chest
+    type: null
+  \Skyloft\Central Skyloft\Waterfall Island\Floating Island Goddess Chest:
+    Paths:
+    - stage/F000/r0/l0/TBox/91
+    cube_region: Lake Floria
+    hint_region: Central Skyloft
+    original item: Gold Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1346
+    short_name: Central Skyloft - Floating Island Goddess Chest
+    type: goddess, Lake Floria Goddess Chests
+  \Skyloft\Central Skyloft\Waterfall Island\Waterfall Goddess Chest:
+    Paths:
+    - stage/F000/r0/l0/TBox/80
+    cube_region: Lanayru Sand Sea
+    hint: sometimes
+    hint_region: Central Skyloft
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1345
+    short_name: Central Skyloft - Waterfall Goddess Chest
+    text: a <s<goddess cube>> <r<amongst the pirates>> reveals
+    type: goddess, Sand Sea Goddess Chests
+  \Skyloft\Central Skyloft\West Cliff Goddess Chest:
+    Paths:
+    - stage/F000/r0/l0/TBox/78
+    cube_region: Faron Woods
+    hint_region: Central Skyloft
+    original item: Silver Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1320
+    short_name: Central Skyloft - West Cliff Goddess Chest
+    type: goddess, Faron Woods Goddess Chests
+  \Skyloft\Central Skyloft\Wryna's House\Wryna's Crystals:
+    Paths:
+    - event/118-Town3/144
+    - oarc/F006r/l0
+    hint_region: Central Skyloft
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1343
+    short_name: Central Skyloft - Wryna's Crystals
+    type: Gratitude Crystal Sidequests
+  \Skyloft\Skyloft Silent Realm\Relic 1:
+    Paths:
+    - stage/S000/r0/l2/Relic/102
+    hint_region: Skyloft Silent Realm
+    original item: 'Dusk Relic #1'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1354
+    short_name: Skyloft Silent Realm - Relic 1
+    type: skyloft, silent realm
+  \Skyloft\Skyloft Silent Realm\Relic 10:
+    Paths:
+    - stage/S000/r0/l2/Relic/111
+    hint_region: Skyloft Silent Realm
+    original item: 'Dusk Relic #10'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1363
+    short_name: Skyloft Silent Realm - Relic 10
+    type: skyloft, silent realm
+  \Skyloft\Skyloft Silent Realm\Relic 2:
+    Paths:
+    - stage/S000/r0/l2/Relic/103
+    hint_region: Skyloft Silent Realm
+    original item: 'Dusk Relic #2'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1355
+    short_name: Skyloft Silent Realm - Relic 2
+    type: skyloft, silent realm
+  \Skyloft\Skyloft Silent Realm\Relic 3:
+    Paths:
+    - stage/S000/r0/l2/Relic/104
+    hint_region: Skyloft Silent Realm
+    original item: 'Dusk Relic #3'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1356
+    short_name: Skyloft Silent Realm - Relic 3
+    type: skyloft, silent realm
+  \Skyloft\Skyloft Silent Realm\Relic 4:
+    Paths:
+    - stage/S000/r0/l2/Relic/105
+    hint_region: Skyloft Silent Realm
+    original item: 'Dusk Relic #4'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1357
+    short_name: Skyloft Silent Realm - Relic 4
+    type: skyloft, silent realm
+  \Skyloft\Skyloft Silent Realm\Relic 5:
+    Paths:
+    - stage/S000/r0/l2/Relic/106
+    hint_region: Skyloft Silent Realm
+    original item: 'Dusk Relic #5'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1358
+    short_name: Skyloft Silent Realm - Relic 5
+    type: skyloft, silent realm
+  \Skyloft\Skyloft Silent Realm\Relic 6:
+    Paths:
+    - stage/S000/r0/l2/Relic/107
+    hint_region: Skyloft Silent Realm
+    original item: 'Dusk Relic #6'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1359
+    short_name: Skyloft Silent Realm - Relic 6
+    type: skyloft, silent realm
+  \Skyloft\Skyloft Silent Realm\Relic 7:
+    Paths:
+    - stage/S000/r0/l2/Relic/108
+    hint_region: Skyloft Silent Realm
+    original item: 'Dusk Relic #7'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1360
+    short_name: Skyloft Silent Realm - Relic 7
+    type: skyloft, silent realm
+  \Skyloft\Skyloft Silent Realm\Relic 8:
+    Paths:
+    - stage/S000/r0/l2/Relic/109
+    hint_region: Skyloft Silent Realm
+    original item: 'Dusk Relic #8'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1361
+    short_name: Skyloft Silent Realm - Relic 8
+    type: skyloft, silent realm
+  \Skyloft\Skyloft Silent Realm\Relic 9:
+    Paths:
+    - stage/S000/r0/l2/Relic/110
+    hint_region: Skyloft Silent Realm
+    original item: 'Dusk Relic #9'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1362
+    short_name: Skyloft Silent Realm - Relic 9
+    type: skyloft, silent realm
+  \Skyloft\Skyloft Silent Realm\Trial Reward:
+    Paths:
+    - stage/S000/r0/l2/WarpObj
+    hint: sometimes
+    hint_region: Skyloft Silent Realm
+    original item: Stone of Trials
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1353
+    short_name: Skyloft Silent Realm - Trial Reward
+    text: the <r<goddess's final trial>> grants
+    type: null
+  \Skyloft\Skyloft Village\Batreaux's House\10 Crystals:
+    Paths:
+    - event/121-AkumaKun/42
+    - oarc/F012r/l0
+    hint_region: Batreaux's House
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1371
+    short_name: Batreaux's House - 10 Crystals
+    type: Batreaux's Rewards
+  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals:
+    Paths:
+    - event/121-AkumaKun/24
+    - oarc/F012r/l0
+    hint_region: Batreaux's House
+    original item: Progressive Wallet
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1372
+    short_name: Batreaux's House - 30 Crystals
+    type: Batreaux's Rewards
+  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals Chest:
+    Paths:
+    - stage/F012r/r0/l0/TBox/69
+    hint_region: Batreaux's House
+    original item: Cursed Medal
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1373
+    short_name: Batreaux's House - 30 Crystals Chest
+    type: Batreaux's Rewards
+  \Skyloft\Skyloft Village\Batreaux's House\40 Crystals:
+    Paths:
+    - event/121-AkumaKun/49
+    - oarc/F012r/l0
+    hint_region: Batreaux's House
+    original item: Gold Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1374
+    short_name: Batreaux's House - 40 Crystals
+    type: Batreaux's Rewards
+  \Skyloft\Skyloft Village\Batreaux's House\5 Crystals:
+    Paths:
+    - event/121-AkumaKun/21
+    - oarc/F012r/l0
+    hint_region: Batreaux's House
+    original item: Progressive Wallet
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1370
+    short_name: Batreaux's House - 5 Crystals
+    type: Batreaux's Rewards
+  \Skyloft\Skyloft Village\Batreaux's House\50 Crystals:
+    Paths:
+    - event/121-AkumaKun/27
+    - oarc/F012r/l0
+    hint: sometimes
+    hint_region: Batreaux's House
+    original item: Progressive Wallet
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1375
+    short_name: Batreaux's House - 50 Crystals
+    text: <ye<50>> <r<pieces of gratitude>> can be exchanged for
+    type: Batreaux's Rewards
+  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals:
+    Paths:
+    - event/121-AkumaKun/161
+    - oarc/F012r/l0
+    hint: sometimes
+    hint_region: Batreaux's House
+    original item: Gold Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1376
+    short_name: Batreaux's House - 70 Crystals
+    text: the <r<demon's penultimate reward>> is
+    type: Batreaux's Rewards
+  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals Second Reward:
+    Paths:
+    - event/121-AkumaKun/163
+    - oarc/F012r/l0
+    hint: sometimes
+    hint_region: Batreaux's House
+    original item: Gold Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1377
+    short_name: Batreaux's House - 70 Crystals Second Reward
+    text: the <r<demon's penultimate reward>> is
+    type: Batreaux's Rewards
+  \Skyloft\Skyloft Village\Batreaux's House\80 Crystals:
+    Paths:
+    - event/121-AkumaKun/37
+    - oarc/F012r/l0
+    hint: always
+    hint_region: Batreaux's House
+    original item: Progressive Wallet
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1378
+    short_name: Batreaux's House - 80 Crystals
+    text: a <r<demon in human form>> grants
+    type: Batreaux's Rewards
+  \Skyloft\Skyloft Village\Bertie's House\Bertie's Crystals:
+    Paths:
+    - event/115-Town2/125
+    - oarc/F014r/l0
+    hint_region: Skyloft Village
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1366
+    short_name: Skyloft Village - Bertie's Crystals
+    text: helping an <r<exhausted parent>> rewards
+    type: Gratitude Crystal Sidequests
+  \Skyloft\Skyloft Village\Crystal near Pumpkin Patch:
+    hint_region: Skyloft Village
+    original item: 'Gratitude Crystal #2'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1364
+    short_name: Skyloft Village - Crystal near Pumpkin Patch
+    type: Loose Crystals
+  \Skyloft\Skyloft Village\Mallara's House\Mallara's Crystals:
+    Paths:
+    - event/123-Town5/186
+    - oarc/F016r/l0
+    hint_region: Skyloft Village
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1369
+    short_name: Skyloft Village - Mallara's Crystals
+    type: Gratitude Crystal Sidequests
+  \Skyloft\Skyloft Village\Sparrot's House\Sparrot's Crystals:
+    Paths:
+    - event/118-Town3/141
+    - oarc/F013r/l0
+    hint: sometimes
+    hint_region: Skyloft Village
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1368
+    short_name: Skyloft Village - Sparrot's Crystals
+    text: delivering a <r<fortune telling device>> reveals
+    type: Scrapper Deliveries, Gratitude Crystal Sidequests
+  \Skyloft\Upper Skyloft\Chest near Goddess Statue:
+    Paths:
+    - stage/F000/r0/l0/TBox/71
+    hint_region: Upper Skyloft
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1298
+    short_name: Upper Skyloft - Chest near Goddess Statue
+    type: null
+  \Skyloft\Upper Skyloft\Goddess Statue\First Goddess Sword Item in Goddess Statue:
+    Paths:
+    - event/107-Kanban/Fi give Goddess Statue item 1
+    - oarc/F008r/l1
+    hint_region: Upper Skyloft
+    original item: Progressive Sword
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1315
+    short_name: Upper Skyloft - First Goddess Sword Item in Goddess Statue
+    type: null
+  \Skyloft\Upper Skyloft\Goddess Statue\Second Goddess Sword Item in Goddess Statue:
+    Paths:
+    - event/107-Kanban/Fi give Goddess Statue item 2
+    - oarc/F008r/l1
+    hint_region: Upper Skyloft
+    original item: Emerald Tablet
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1316
+    short_name: Upper Skyloft - Second Goddess Sword Item in Goddess Statue
+    type: null
+  \Skyloft\Upper Skyloft\Knight Academy\Crystal in Knight Academy Plant:
+    hint_region: Upper Skyloft
+    original item: 'Gratitude Crystal #5'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1301
+    short_name: Upper Skyloft - Crystal in Knight Academy Plant
+    type: Loose Crystals
+  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Crystals:
+    Paths:
+    - event/115-Town2/325
+    - oarc/F001r/l0
+    hint_region: Upper Skyloft
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1307
+    short_name: Upper Skyloft - Fledge's Crystals
+    text: <r<lending strength to a friend>> yields
+    type: Gratitude Crystal Sidequests
+  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Gift:
+    Paths:
+    - event/114-Friend/16
+    - oarc/F001r/l3
+    - oarc/F001r/l4
+    hint_region: Upper Skyloft
+    original item: Progressive Pouch
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1300
+    short_name: Upper Skyloft - Fledge's Gift
+    type: null
+  \Skyloft\Upper Skyloft\Knight Academy\Ghost/Pipit's Crystals:
+    Paths:
+    - event/115-Town2/522
+    - event/115-Town2/641
+    - oarc/F001r/l0
+    hint_region: Upper Skyloft
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1306
+    short_name: Upper Skyloft - Ghost/Pipit's Crystals
+    type: Gratitude Crystal Sidequests
+  \Skyloft\Upper Skyloft\Knight Academy\Item from Cawlin:
+    Paths:
+    - event/115-Town2/166
+    - oarc/F001r/l0
+    hint_region: Upper Skyloft
+    original item: Cawlin's Letter
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1305
+    short_name: Upper Skyloft - Item from Cawlin
+    type: null
+  \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Crystal in Link's Room:
+    hint_region: Upper Skyloft
+    original item: 'Gratitude Crystal #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1308
+    short_name: Upper Skyloft - Crystal in Link's Room
+    type: Loose Crystals
+  \Skyloft\Upper Skyloft\Knight Academy\Owlan's Crystals:
+    Paths:
+    - event/118-Town3/157
+    - oarc/F001r/l0
+    hint: sometimes
+    hint_region: Upper Skyloft
+    original item: Gratitude Crystal Pack
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1303
+    short_name: Upper Skyloft - Owlan's Crystals
+    text: delivering a <r<Kikwi>> reveals
+    type: Scrapper Deliveries, Gratitude Crystal Sidequests, Combat
+  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Crystal in Zelda's Room:
+    hint_region: Upper Skyloft
+    original item: 'Gratitude Crystal #11'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1310
+    short_name: Upper Skyloft - Crystal in Zelda's Room
+    type: Loose Crystals
+  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\In Zelda's Closet:
+    Paths:
+    - stage/F001r/r6/l0/chest/32
+    hint_region: Upper Skyloft
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1311
+    short_name: Upper Skyloft - In Zelda's Closet
+    type: null
+  \Skyloft\Upper Skyloft\Owlan's Gift:
+    Paths:
+    - event/108-ShinkanA/169
+    - oarc/F000/l4
+    - oarc/F000/l6
+    hint_region: Upper Skyloft
+    original item: Wooden Shield
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1297
+    short_name: Upper Skyloft - Owlan's Gift
+    type: null
+  \Skyloft\Upper Skyloft\Pumpkin Archery -- 600 Points:
+    Paths:
+    - event/114-Friend/99
+    - oarc/F000/l4
+    - oarc/F000/l6
+    hint: sometimes
+    hint_region: Upper Skyloft
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1299
+    short_name: Upper Skyloft - Pumpkin Archery -- 600 Points
+    text: <r<shooting pumpkings>> is rewarded with
+    type: Minigames
+  \Skyloft\Upper Skyloft\Sparring Hall\Crystal in Sparring Hall:
+    hint_region: Upper Skyloft
+    original item: 'Gratitude Crystal #9'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1312
+    short_name: Upper Skyloft - Crystal in Sparring Hall
+    type: Loose Crystals
+  \Skyloft\Upper Skyloft\Sparring Hall\Sparring Hall Chest:
+    Paths:
+    - stage/F009r/r0/l0/TBox/66
+    hint_region: Upper Skyloft
+    original item: Progressive Sword
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1313
+    short_name: Upper Skyloft - Sparring Hall Chest
+    type: null
+  \Skyview\Boss Room\Heart Container:
+    Paths:
+    - stage/B100/r0/l1/HeartCo
+    - stage/B100/r0/l2/HeartCo
+    - stage/B100/r0/l3/HeartCo
+    - stage/B100/r0/l4/HeartCo
+    hint_region: Skyview
+    original item: Heart Container
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1424
+    short_name: Skyview - Heart Container
+    type: null
+  \Skyview\Main\First Hub\Left Room\Chest on Tree Branch:
+    Paths:
+    - stage/D100/r2/l0/TBox/64
+    hint_region: Skyview
+    original item: Skyview Map
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1403
+    short_name: Skyview - Chest on Tree Branch
+    type: null
+  \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace:
+    Paths:
+    - stage/D100/r4/l0/Soil/15
+    hint_region: Skyview
+    hints: sometimes
+    original item: Skyview Small Key
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1405
+    short_name: Skyview - Digging Spot in Crawlspace
+    text: in a <r<temple in the forest>> a mogma <r<buried>>
+    type: null
+  \Skyview\Main\First Hub\Right Room\Upper Area\Chest behind Two Eyes:
+    Paths:
+    - stage/D100/r4/l0/TBox/67
+    hint_region: Skyview
+    original item: 'Skyview Small Key #0'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1406
+    short_name: Skyview - Chest behind Two Eyes
+    text: <r<two watchful eyes>> guard
+    type: null
+  \Skyview\Main\Last Room\After Rope\Chest near Boss Door:
+    Paths:
+    - stage/D100/r9/l0/TBox/70
+    hint_region: Skyview
+    original item: Red Rupee
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1420
+    short_name: Skyview - Chest near Boss Door
+    type: null
+  \Skyview\Main\Last Room\Near Boss Key Chest\Boss Key Chest:
+    Paths:
+    - stage/D100/r9/l0/TBox/66
+    hint_region: Skyview
+    original item: Skyview Boss Key
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1422
+    short_name: Skyview - Boss Key Chest
+    type: null
+  \Skyview\Main\Second Hub\Item behind Bars:
+    Paths:
+    - stage/D100/r5/l0/Item/103
+    hint_region: Skyview
+    original item: Heart Piece
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1413
+    short_name: Skyview - Item behind Bars
+    type: null
+  \Skyview\Main\Second Hub\Left Rooms\Chest behind Three Eyes:
+    Paths:
+    - stage/D100/r7/l0/TBox/68
+    hint: sometimes
+    hint_region: Skyview
+    original item: 'Skyview Small Key #1'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1415
+    short_name: Skyview - Chest behind Three Eyes
+    text: <r<three watchful eyes>> guard
+    type: null
+  \Skyview\Main\Second Hub\Miniboss Room\Chest after Stalfos Fight:
+    Paths:
+    - stage/D100/r10/l1/TBox/65
+    - stage/D100/r10/l2/TBox/65
+    hint_region: Skyview
+    original item: Progressive Beetle
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1414
+    short_name: Skyview - Chest after Stalfos Fight
+    type: null
+  \Skyview\Main\Second Hub\Rupee in East Tunnel:
+    Paths:
+    - stage/D100/r5/l0/Item/66
+    hint_region: Skyview
+    original item: 'Red Rupee #37'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1409
+    short_name: Skyview - Rupee in East Tunnel
+    type: Rupees (No Quick Beetle)
+  \Skyview\Main\Second Hub\Rupee in Southeast Tunnel:
+    Paths:
+    - stage/D100/r5/l0/Item/65
+    hint_region: Skyview
+    original item: 'Red Rupee #35'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1407
+    short_name: Skyview - Rupee in Southeast Tunnel
+    type: Rupees (No Quick Beetle)
+  \Skyview\Main\Second Hub\Rupee in Southwest Tunnel:
+    Paths:
+    - stage/D100/r5/l0/Item/67
+    hint_region: Skyview
+    original item: 'Red Rupee #36'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1408
+    short_name: Skyview - Rupee in Southwest Tunnel
+    type: Rupees (No Quick Beetle)
+  \Skyview\Spring\Rupee on Spring Pillar:
+    Paths:
+    - stage/B100_1/r0/l0/Item/109
+    hint_region: Skyview
+    original item: 'Red Rupee #38'
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1425
+    short_name: Skyview - Rupee on Spring Pillar
+    type: Rupees (No Quick Beetle)
+  \Skyview\Spring\Strike Crest:
+    Paths:
+    - event/201-ForestD1/6
+    - oarc/B100_1/l0
+    hint_region: Skyview
+    original item: Ruby Tablet
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1426
+    short_name: Skyview - Strike Crest
+    type: null
+entrances:
+  \Ancient Cistern\Boss Room\Entrance from Dungeon:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2232
+    short_name: Ancient Cistern - Boss Room - Entrance from Dungeon
+    tod: 2
+    type: entrance
+  \Ancient Cistern\Boss Room\Entrance from Flame Room:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2233
+    short_name: Ancient Cistern - Boss Room - Entrance from Flame Room
+    tod: 2
+    type: entrance
+  \Ancient Cistern\Flame Room\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2234
+    short_name: Ancient Cistern - Flame Room - Entrance
+    tod: 2
+    type: entrance
+  \Ancient Cistern\Main\Inside Statue\Boss Door Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2231
+    short_name: Ancient Cistern - Boss Door Entrance
+    tod: 2
+    type: entrance
+  \Ancient Cistern\Main\Main Room\Main Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Faron Province
+    req_index: 2230
+    room: 0
+    short_name: Ancient Cistern - Main Entrance
+    stage: D101
+    tod: 2
+    type: entrance
+  \Earth Temple\Boss Room\Entry\Entrance from Dungeon:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2261
+    short_name: Earth Temple - Boss Room - Entrance from Dungeon
+    tod: 2
+    type: entrance
+  \Earth Temple\Boss Room\Slope\Entrance from Spring:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2262
+    short_name: Earth Temple - Boss Room - Entrance from Spring
+    tod: 2
+    type: entrance
+  \Earth Temple\Main\First Room\Main Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Eldin Province
+    req_index: 2259
+    room: 1
+    short_name: Earth Temple - Main Entrance
+    stage: D200
+    tod: 2
+    type: entrance
+  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2260
+    short_name: Earth Temple - Boss Door Entrance
+    tod: 2
+    type: entrance
+  \Earth Temple\Spring\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2263
+    short_name: Earth Temple - Spring - Entrance
+    tod: 2
+    type: entrance
+  \Eldin\Bokoblin Base\Prison\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 1
+    province: Eldin Province
+    req_index: 2248
+    room: 1
+    short_name: Bokoblin Base - Entrance
+    stage: F202
+    tod: 2
+    type: entrance
+  \Eldin\Eldin Silent Realm\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2251
+    short_name: Eldin Silent Realm - Entrance
+    tod: 2
+    type: entrance
+  \Eldin\Mogma Turf\Pre Vent\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Eldin Province
+    req_index: 2249
+    room: 0
+    short_name: Mogma Turf - Entrance
+    stage: F210
+    tod: 2
+    type: entrance
+  \Eldin\Volcano Summit\Entrance from Eldin Volcano:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 4
+    layer: 0
+    province: Eldin Province
+    req_index: 2254
+    room: 0
+    short_name: Volcano Summit - Entrance from Eldin Volcano
+    stage: F201_1
+    tod: 2
+    type: entrance
+  \Eldin\Volcano Summit\Entrance from Outside Fire Sanctuary:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 1
+    layer: 0
+    province: Eldin Province
+    req_index: 2252
+    room: 0
+    short_name: Volcano Summit - Entrance from Outside Fire Sanctuary
+    stage: F201_1
+    tod: 2
+    type: entrance
+  \Eldin\Volcano Summit\Entrance from Waterfall:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 2
+    layer: 0
+    province: Eldin Province
+    req_index: 2253
+    room: 0
+    short_name: Volcano Summit - Entrance from Waterfall
+    stage: F201_1
+    tod: 2
+    type: entrance
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Entrance from Summit:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Eldin Province
+    req_index: 2257
+    room: 0
+    short_name: Outside Fire Sanctuary - Entrance from Summit
+    stage: F201_3
+    tod: 2
+    type: entrance
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Entrance from Fire Sanctuary:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 1
+    layer: 0
+    province: Eldin Province
+    req_index: 2258
+    room: 0
+    short_name: Outside Fire Sanctuary - Entrance from Fire Sanctuary
+    stage: F201_3
+    tod: 2
+    type: entrance
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 3
+    layer: 0
+    province: Eldin Province
+    req_index: 2256
+    room: 0
+    short_name: Outside Fire Sanctuary - Statue Entrance
+    stage: F201_3
+    statue-name: Inside the Volcano
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Eldin\Volcano Summit\Waterfall\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Eldin Province
+    req_index: 2255
+    room: 0
+    short_name: Volcano Summit - Waterfall - Entrance
+    stage: F201_4
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Ascent\Trial Gate Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2245
+    short_name: Eldin Volcano - Trial Gate Entrance
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Ascent\Volcano Ascent Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 7
+    layer: 0
+    province: Eldin Province
+    req_index: 2238
+    room: 2
+    short_name: Eldin Volcano - Volcano Ascent Statue Entrance
+    stage: F200
+    statue-name: Volcano Ascent
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\East\Entrance from Bokoblin Base:
+    allowed_time_of_day: *id001
+    entrance: 5
+    layer: 1
+    province: Eldin Province
+    req_index: 2247
+    room: 1
+    short_name: Eldin Volcano - Entrance from Bokoblin Base
+    stage: F200
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\East\First Vent from Mogma Turf:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Eldin Province
+    req_index: 2240
+    room: 2
+    short_name: Eldin Volcano - First Vent from Mogma Turf
+    stage: F200
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\East\Volcano East Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 6
+    layer: 0
+    province: Eldin Province
+    req_index: 2237
+    room: 2
+    short_name: Eldin Volcano - Volcano East Statue Entrance
+    stage: F200
+    statue-name: Volcano East
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Entry\First Time Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Eldin Province
+    req_index: 2235
+    room: 0
+    short_name: Eldin Volcano - First Time Entrance
+    stage: F200
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Entry\Volcano Entrance Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: Eldin Province
+    req_index: 2236
+    room: 0
+    short_name: Eldin Volcano - Volcano Entrance Statue Entrance
+    stage: F200
+    statue-name: Volcano Entry
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Hot Cave\Entrance from Summit:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 2
+    layer: 0
+    province: Eldin Province
+    req_index: 2244
+    room: 5
+    short_name: Eldin Volcano - Entrance from Summit
+    stage: F200
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Hot Cave\Vent Entrance near Hot Cave:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2246
+    short_name: Eldin Volcano - Vent Entrance near Hot Cave
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Near Temple Entrance\Entrance from Earth Temple:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Eldin Province
+    req_index: 2242
+    room: 4
+    short_name: Eldin Volcano - Entrance from Earth Temple
+    stage: F200
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 7
+    layer: 0
+    province: Eldin Province
+    req_index: 2239
+    room: 4
+    short_name: Eldin Volcano - Temple Entrance Statue Entrance
+    stage: F200
+    statue-name: Temple Entrance
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Entrance:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: Eldin Province
+    req_index: 2243
+    room: 4
+    short_name: Eldin Volcano - Thrill Digger Cave Entrance
+    stage: F200
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Past Mogma Turf\Second Vent from Mogma Turf:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: Eldin Province
+    req_index: 2241
+    room: 2
+    short_name: Eldin Volcano - Second Vent from Mogma Turf
+    stage: F200
+    tod: 2
+    type: entrance
+  \Eldin\Volcano\Thrill Digger Cave\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 1
+    province: Eldin Province
+    req_index: 2250
+    room: 0
+    short_name: Thrill Digger Cave - Entrance
+    stage: F211
+    tod: 2
+    type: entrance
+  \Faron\Faron Silent Realm\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2197
+    short_name: Faron Silent Realm - Entrance
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Deep Woods\Deep Woods Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 14
+    layer: 0
+    province: Faron Province
+    req_index: 2213
+    room: 0
+    short_name: Deep Woods - Deep Woods Statue Entrance
+    stage: F101
+    statue-name: Deep Woods
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Deep Woods\Entrance from Skyview Temple:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 1
+    layer: 0
+    province: Faron Province
+    req_index: 2215
+    room: 0
+    short_name: Deep Woods - Entrance from Skyview Temple
+    stage: F101
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Deep Woods\Entry\Entrance from Faron Woods:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Faron Province
+    req_index: 2214
+    room: 0
+    short_name: Deep Woods - Entrance from Faron Woods
+    stage: F101
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Deep Woods\Forest Temple Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 13
+    layer: 0
+    province: Faron Province
+    req_index: 2212
+    room: 0
+    short_name: Deep Woods - Forest Temple Statue Entrance
+    stage: F101
+    statue-name: Forest Temple
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Entry\Entrance from Behind the Temple:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Faron Province
+    req_index: 2193
+    room: 0
+    short_name: Faron Woods - Entrance from Behind the Temple
+    stage: F100
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Entry\Faron Woods Entry Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 50
+    layer: 0
+    province: Faron Province
+    req_index: 2189
+    room: 0
+    short_name: Faron Woods - Faron Woods Entry Statue Entrance
+    stage: F100
+    statue-name: Faron Woods Entry
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Entrance from Platforms:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Faron Province
+    req_index: 2202
+    room: 0
+    short_name: Great Tree - Lower Entrance from Platforms
+    stage: F100_1
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 4
+    layer: 0
+    province: Faron Province
+    req_index: 2205
+    room: 0
+    short_name: Great Tree - Underwater Tunnel Entrance
+    stage: F100_1
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 7
+    layer: 0
+    province: Faron Province
+    req_index: 2201
+    room: 0
+    short_name: Great Tree - Underwater Hole Entrance
+    stage: F100
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Great Tree\Platforms\Lower Entrance from Great Tree:
+    allowed_time_of_day: *id001
+    entrance: 4
+    layer: 0
+    province: Faron Province
+    req_index: 2198
+    room: 0
+    short_name: Great Tree - Platforms - Lower Entrance from Great Tree
+    stage: F100
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Great Tree\Platforms\Upper Entrance from Great Tree:
+    allowed_time_of_day: *id001
+    entrance: 5
+    layer: 0
+    province: Faron Province
+    req_index: 2199
+    room: 0
+    short_name: Great Tree - Platforms - Upper Entrance from Great Tree
+    stage: F100
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Great Tree\Top\The Great Tree Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 53
+    layer: 0
+    province: Faron Province
+    req_index: 2192
+    room: 0
+    short_name: Great Tree - The Great Tree Statue Entrance
+    stage: F100
+    statue-name: Great Tree Top
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Great Tree\Top\Top Entrance from Great Tree:
+    allowed_time_of_day: *id001
+    entrance: 6
+    layer: 0
+    province: Faron Province
+    req_index: 2200
+    room: 0
+    short_name: Great Tree - Top Entrance from Great Tree
+    stage: F100
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Flooded Great Tree:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2206
+    short_name: Great Tree - Entrance from Flooded Great Tree
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Top:
+    allowed_time_of_day: *id001
+    entrance: 3
+    layer: 0
+    province: Faron Province
+    req_index: 2204
+    room: 0
+    short_name: Great Tree - Entrance from Top
+    stage: F100_1
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Great Tree\Upper Area\Upper Entrance from Platforms:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: Faron Province
+    req_index: 2203
+    room: 0
+    short_name: Great Tree - Upper Entrance from Platforms
+    stage: F100_1
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\In the Woods Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 51
+    layer: 0
+    province: Faron Province
+    req_index: 2190
+    room: 0
+    short_name: Faron Woods - In the Woods Statue Entrance
+    stage: F100
+    statue-name: In the Woods
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Ledge To Deep Woods\Entrance from Deep Woods:
+    allowed_time_of_day: *id001
+    entrance: 45
+    layer: 0
+    province: Faron Province
+    req_index: 2195
+    room: 0
+    short_name: Faron Woods - Entrance from Deep Woods
+    stage: F100
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Entrance from Floria Waterfall:
+    allowed_time_of_day: *id001
+    entrance: 17
+    layer: 0
+    province: Faron Province
+    req_index: 2194
+    room: 0
+    short_name: Faron Woods - Shortcut Entrance from Floria Waterfall
+    stage: F100
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Trial Gate Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2196
+    short_name: Faron Woods - Trial Gate Entrance
+    tod: 2
+    type: entrance
+  \Faron\Faron Woods\Viewing Platform Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 52
+    layer: 0
+    province: Faron Province
+    req_index: 2191
+    room: 0
+    short_name: Faron Woods - Viewing Platform Statue Entrance
+    stage: F100
+    statue-name: Viewing Platform
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Faron\Flooded Faron Woods\Entrance from Lower Flooded Great Tree:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2211
+    short_name: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
+    tod: 2
+    type: entrance
+  \Faron\Flooded Faron Woods\Entrance from Upper Flooded Great Tree:
+    allowed_time_of_day: *id001
+    req_index: 2210
+    short_name: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
+    type: entrance
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance:
+    allowed_time_of_day: *id001
+    req_index: 2207
+    short_name: Flooded Great Tree - Entrance
+    type: entrance
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Lower Flooded Faron Woods:
+    allowed_time_of_day: *id001
+    req_index: 2209
+    short_name: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
+    type: entrance
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Upper Flooded Faron Woods:
+    allowed_time_of_day: *id001
+    req_index: 2208
+    short_name: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
+    type: entrance
+  \Faron\Lake Floria\Above Rock\Dive from Faron Woods:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Faron Province
+    req_index: 2217
+    room: 0
+    short_name: Lake Floria - Dive from Faron Woods
+    stage: F102
+    tod: 2
+    type: entrance
+  \Faron\Lake Floria\Below Rock\Emerged Area\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: Faron Province
+    req_index: 2216
+    room: 3
+    short_name: Lake Floria - Below Rock - Statue Entrance
+    stage: F102
+    statue-name: Lake Floria
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Faron\Lake Floria\Below Rock\Entrance from Farore's Lair:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 1
+    layer: 0
+    province: Faron Province
+    req_index: 2218
+    room: 4
+    short_name: Lake Floria - Entrance from Farore's Lair
+    stage: F102
+    tod: 2
+    type: entrance
+  \Faron\Lake Floria\Farore's Lair\Entrance from Lake Floria:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Faron Province
+    req_index: 2219
+    room: 0
+    short_name: Farore's Lair - Entrance from Lake Floria
+    stage: F102_2
+    tod: 2
+    type: entrance
+  \Faron\Lake Floria\Farore's Lair\Entrance from Waterfall:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Faron Province
+    req_index: 2220
+    room: 0
+    short_name: Farore's Lair - Entrance from Waterfall
+    stage: F102_2
+    tod: 2
+    type: entrance
+  \Faron\Lake Floria\Waterfall\Entrance from Ancient Cistern:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Faron Province
+    req_index: 2223
+    room: 0
+    short_name: Floria Waterfall - Entrance from Ancient Cistern
+    stage: F102_1
+    statue-name: Floria Waterfall
+    tod: 2
+    type: entrance
+  \Faron\Lake Floria\Waterfall\Entrance from Faron Woods:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: Faron Province
+    req_index: 2224
+    room: 0
+    short_name: Floria Waterfall - Entrance from Faron Woods
+    stage: F102_1
+    tod: 2
+    type: entrance
+  \Faron\Lake Floria\Waterfall\Entrance from Farore's Lair:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Faron Province
+    req_index: 2222
+    room: 0
+    short_name: Floria Waterfall - Entrance from Farore's Lair
+    stage: F102_1
+    tod: 2
+    type: entrance
+  \Faron\Lake Floria\Waterfall\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 5
+    layer: 0
+    province: Faron Province
+    req_index: 2221
+    room: 0
+    short_name: Floria Waterfall - Statue Entrance
+    stage: F102_1
+    statue-name: Floria Waterfall
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Behind the Temple\Door Entrance:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Faron Province
+    req_index: 2186
+    room: 0
+    short_name: Behind the Temple - Door Entrance
+    stage: F400
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Behind the Temple\Entrance from Faron Woods:
+    allowed_time_of_day: *id001
+    entrance: 3
+    layer: 0
+    province: Faron Province
+    req_index: 2188
+    room: 0
+    short_name: Behind the Temple - Entrance from Faron Woods
+    stage: F400
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Behind the Temple\Shortcut Entrance from Spiral:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 2
+    layer: 0
+    province: Faron Province
+    req_index: 2187
+    room: 0
+    short_name: Behind the Temple - Shortcut Entrance from Spiral
+    stage: F400
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Behind the Temple\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 10
+    layer: 0
+    province: Faron Province
+    req_index: 2185
+    room: 0
+    short_name: Behind the Temple - Statue Entrance
+    stage: F400
+    statue-name: Behind the Temple
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 1
+    layer: 0
+    province: Faron Province
+    req_index: 2184
+    room: 2
+    short_name: Hylia's Temple - Gate of Time Entrance
+    stage: F404
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Sealed Temple\Gate of Time Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 11
+    layer: 0
+    province: Faron Province
+    req_index: 2183
+    room: 2
+    short_name: Sealed Temple - Gate of Time Entrance
+    stage: F402
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Sealed Temple\Main Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Faron Province
+    req_index: 2181
+    room: 2
+    short_name: Sealed Temple - Main Entrance
+    stage: F402
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Sealed Temple\Side Entrance:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Faron Province
+    req_index: 2182
+    room: 2
+    short_name: Sealed Temple - Side Entrance
+    stage: F402
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Spiral\Door Entrance:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: Faron Province
+    req_index: 2180
+    room: 1
+    short_name: Sealed Grounds Spiral - Door Entrance
+    stage: F401
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Entrance from Behind the Temple:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Faron Province
+    req_index: 2179
+    room: 1
+    short_name: Sealed Grounds Spiral - Shortcut Entrance from Behind the Temple
+    stage: F401
+    tod: 2
+    type: entrance
+  \Faron\Sealed Grounds\Spiral\Upper Part\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 8
+    layer: 0
+    province: Faron Province
+    req_index: 2178
+    room: 1
+    short_name: Sealed Grounds Spiral - Statue Entrance
+    stage: F401
+    statue-name: Sealed Grounds
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Fire Sanctuary\Boss Room\Entrance from Dungeon:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2271
+    short_name: Fire Sanctuary - Boss Room - Entrance from Dungeon
+    tod: 2
+    type: entrance
+  \Fire Sanctuary\Boss Room\Entrance from Flame Room:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2272
+    short_name: Fire Sanctuary - Boss Room - Entrance from Flame Room
+    tod: 2
+    type: entrance
+  \Fire Sanctuary\Flame Room\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2273
+    short_name: Fire Sanctuary - Flame Room - Entrance
+    tod: 2
+    type: entrance
+  \Fire Sanctuary\Main\First Room\Main Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Eldin Province
+    req_index: 2265
+    room: 0
+    short_name: Fire Sanctuary - Main Entrance
+    stage: D201
+    tod: 2
+    type: entrance
+  \Fire Sanctuary\Main\First Room\Past Water Plant\Entrance from Second Room:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2266
+    short_name: Fire Sanctuary - First Room - Entrance from Second Room
+    tod: 2
+    type: entrance
+  \Fire Sanctuary\Main\Front of Boss Door\Boss Door Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2270
+    short_name: Fire Sanctuary - Boss Door Entrance
+    tod: 2
+    type: entrance
+  \Fire Sanctuary\Main\Front of Boss Door\Statue Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 2
+    layer: 0
+    province: Eldin Province
+    req_index: 2264
+    room: 10
+    short_name: Fire Sanctuary - Statue Entrance
+    stage: D201
+    statue-name: Inside the Fire Sanctuary
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Entrance from West of Boss Door:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2268
+    short_name: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss
+      Door
+    tod: 2
+    type: entrance
+  \Fire Sanctuary\Main\Second Room\Outside Section\Entrance from First Room:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2267
+    short_name: Fire Sanctuary - Second Room - Entrance from First Room
+    tod: 2
+    type: entrance
+  \Fire Sanctuary\Main\West of Boss Door\Entry\Entrance from Magmanos Fight Room:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Eldin Province
+    req_index: 2269
+    short_name: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight
+      Room
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Boss Room\After Sand Drain\Entrance from Hall of Ancient Robots:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2337
+    short_name: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient
+      Robots
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Boss Room\Entrance from Dungeon:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2336
+    short_name: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Hall of Ancient Robots\End\Entrance from Temple of Time:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2339
+    room: 0
+    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Temple
+      of Time
+    stage: F300_5
+    subtype: vanilla
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Entrance from Boss Room:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2338
+    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
+      Room
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Main\Armos Fight Room\Entrance from Big Hub:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2331
+    short_name: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Main\Big Hub\Entry\Entrance from First Hub:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2332
+    short_name: Lanayru Mining Facility - Big Hub - Entrance from First Hub
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Entrance from Hop Across Boxes Room:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2333
+    short_name: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes
+      Room
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Entrance from Armos Fight Room:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2334
+    short_name: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Main\First Hub\Entrance from Big Hub:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2329
+    short_name: Lanayru Mining Facility - First Hub - Entrance from Big Hub
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Main\First Room\Main Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2328
+    room: 0
+    short_name: Lanayru Mining Facility - Main Entrance
+    stage: D300
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Entrance from Big Hub:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2330
+    short_name: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big
+      Hub
+    tod: 2
+    type: entrance
+  \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2335
+    short_name: Lanayru Mining Facility - Boss Door Entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Caves\Entrance from Desert:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2299
+    room: 0
+    short_name: Lanayru Caves - Entrance from Desert
+    stage: F303
+    tod: 2
+    type: entrance
+  \Lanayru\Caves\Entrance from Mine:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2298
+    room: 0
+    short_name: Lanayru Caves - Entrance from Mine
+    stage: F303
+    tod: 2
+    type: entrance
+  \Lanayru\Caves\Past Crawlspace\Entrance from Gorge:
+    allowed_time_of_day: *id001
+    entrance: 3
+    layer: 0
+    province: Lanayru Province
+    req_index: 2301
+    room: 0
+    short_name: Lanayru Caves - Entrance from Gorge
+    stage: F303
+    tod: 2
+    type: entrance
+  \Lanayru\Caves\Past Door to Lanayru Sand Sea\Entrance from Lanayru Sand Sea:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 2
+    layer: 0
+    province: Lanayru Province
+    req_index: 2300
+    room: 0
+    short_name: Lanayru Caves - Entrance from Lanayru Sand Sea
+    stage: F303
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\East\Fire Node Entrance:
+    allowed_time_of_day: *id001
+    entrance: 3
+    layer: 0
+    province: Lanayru Province
+    req_index: 2285
+    room: 0
+    short_name: Lanayru Desert - Fire Node Entrance
+    stage: F300
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\East\Fire Node\Present\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2292
+    room: 0
+    short_name: Fire Node - Entrance
+    stage: F300_3
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\East\Stone Cache Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 18
+    layer: 0
+    province: Lanayru Province
+    req_index: 2281
+    room: 0
+    short_name: Lanayru Desert - Stone Cache Statue Entrance
+    stage: F300
+    statue-name: Stone Cache
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\Entry\Desert Entrance Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 15
+    layer: 0
+    province: Lanayru Province
+    req_index: 2278
+    room: 0
+    short_name: Lanayru Desert - Desert Entrance Statue Entrance
+    stage: F300
+    statue-name: Desert Entrance
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\Entry\Entrance from Mine:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: Lanayru Province
+    req_index: 2284
+    room: 0
+    short_name: Lanayru Desert - Entrance from Mine
+    stage: F300
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Entrance from Caves:
+    allowed_time_of_day: *id001
+    entrance: 6
+    layer: 0
+    province: Lanayru Province
+    req_index: 2287
+    room: 0
+    short_name: Lanayru Desert - Entrance from Caves
+    stage: F300
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\Near South Exit to Temple of Time\South Entrance from Temple of Time:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2282
+    room: 0
+    short_name: Lanayru Desert - South Entrance from Temple of Time
+    stage: F300
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\North Part\Lightning Node Entrance:
+    allowed_time_of_day: *id001
+    entrance: 7
+    layer: 0
+    province: Lanayru Province
+    req_index: 2288
+    room: 0
+    short_name: Lanayru Desert - Lightning Node Entrance
+    stage: F300
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\North Part\Lightning Node\Present\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2291
+    room: 0
+    short_name: Lightning Node - Entrance
+    stage: F300_2
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\North Part\North Desert Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 17
+    layer: 0
+    province: Lanayru Province
+    req_index: 2280
+    room: 0
+    short_name: Lanayru Desert - North Desert Statue Entrance
+    stage: F300
+    statue-name: North Desert
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\North Part\North Entrance from Temple of Time:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2283
+    room: 0
+    short_name: Lanayru Desert - North Entrance from Temple of Time
+    stage: F300
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\North Part\Trial Gate Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2289
+    short_name: Lanayru Desert - Trial Gate Entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\Top of LMF\Entrance from Lanayru Mining Facility:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 5
+    layer: 0
+    province: Lanayru Province
+    req_index: 2286
+    room: 0
+    short_name: Lanayru Desert - Entrance from Lanayru Mining Facility
+    stage: F300
+    tod: 2
+    type: entrance
+  \Lanayru\Desert\West Part\West Desert Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 16
+    layer: 0
+    province: Lanayru Province
+    req_index: 2279
+    room: 0
+    short_name: Lanayru Desert - West Desert Statue Entrance
+    stage: F300
+    statue-name: West Desert
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2304
+    room: 0
+    short_name: Lanayru Sand Sea - Ancient Harbour Dock Entrance
+    stage: F301_1
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Entrance:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2311
+    room: 0
+    short_name: Lanayru Sand Sea Docks - Dock Entrance
+    stage: F301
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Entrance from Caves:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2310
+    room: 0
+    short_name: Lanayru Sand Sea Docks - Entrance from Caves
+    stage: F301
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 10
+    layer: 0
+    province: Lanayru Province
+    req_index: 2309
+    room: 0
+    short_name: Lanayru Sand Sea Docks - Statue Entrance
+    stage: F301
+    statue-name: Ancient Harbour
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Gorge\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 2
+    province: Lanayru Province
+    req_index: 2302
+    room: 0
+    short_name: Lanayru Gorge - Entrance
+    stage: F302
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Gorge\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 12
+    layer: 0
+    province: Lanayru Province
+    req_index: 2303
+    room: 0
+    short_name: Lanayru Gorge - Statue Entrance
+    stage: F302
+    statue-name: Lanayru Gorge
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Entrance:
+    allowed_time_of_day: *id001
+    entrance: 3
+    layer: 0
+    province: Lanayru Province
+    req_index: 2307
+    room: 0
+    short_name: Lanayru Sand Sea - Pirate Stronghold Dock Entrance
+    stage: F301_1
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2323
+    room: 0
+    short_name: Pirate Stronghold - Dock Entrance
+    stage: F301_6
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 2
+    layer: 0
+    province: Lanayru Province
+    req_index: 2325
+    room: 0
+    short_name: Pirate Stronghold - Top Entrance
+    stage: F301_6
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2326
+    room: 1
+    short_name: Pirate Stronghold - Inside - First Door Entrance
+    stage: F301_2
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2327
+    room: 1
+    short_name: Pirate Stronghold - Inside - Second Door Entrance
+    stage: F301_2
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Entrance:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2324
+    room: 0
+    short_name: Pirate Stronghold - Side Entrance
+    stage: F301_6
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 10
+    layer: 0
+    province: Lanayru Province
+    req_index: 2322
+    room: 0
+    short_name: Pirate Stronghold - Statue Entrance
+    stage: F301_6
+    statue-name: Pirate Stronghold
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Sandship Dock Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 4
+    layer: 0
+    province: Lanayru Province
+    req_index: 2308
+    room: 0
+    short_name: Lanayru Sand Sea - Sandship Dock Entrance
+    stage: F301_1
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard Dock Entrance:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: Lanayru Province
+    req_index: 2306
+    room: 0
+    short_name: Lanayru Sand Sea - Shipyard Dock Entrance
+    stage: F301_1
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2318
+    room: 0
+    short_name: Shipyard - Construction Bay Lower Entrance
+    stage: F301_4
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 4
+    layer: 0
+    province: Lanayru Province
+    req_index: 2319
+    room: 0
+    short_name: Shipyard - Construction Bay Upper Entrance
+    stage: F301_4
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2321
+    room: 0
+    short_name: Shipyard - Construction Bay - Lower Entrance
+    stage: F301_7
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2320
+    room: 0
+    short_name: Shipyard - Construction Bay - Upper Entrance
+    stage: F301_7
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Dock Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2317
+    room: 0
+    short_name: Shipyard - Dock Entrance
+    stage: F301_4
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 10
+    layer: 0
+    province: Lanayru Province
+    req_index: 2316
+    room: 0
+    short_name: Shipyard - Statue Entrance
+    stage: F301_4
+    statue-name: Lanayru Shipyard
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Entrance:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2305
+    room: 0
+    short_name: Lanayru Sand Sea - Skipper's Retreat Dock Entrance
+    stage: F301_1
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2313
+    room: 0
+    short_name: Skipper's Retreat - Dock Entrance
+    stage: F301_3
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2315
+    room: 0
+    short_name: Skipper's Retreat - Shack - Entrance
+    stage: F301_5
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 10
+    layer: 0
+    province: Lanayru Province
+    req_index: 2312
+    room: 0
+    short_name: Skipper's Retreat - Statue Entrance
+    stage: F301_3
+    statue-name: Skipper's Retreat
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Entrance:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2314
+    room: 0
+    short_name: Skipper's Retreat - Shack Entrance
+    stage: F301_3
+    tod: 2
+    type: entrance
+  \Lanayru\Lanayru Silent Realm\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2290
+    short_name: Lanayru Silent Realm - Entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Mine\End\In Minecart\Entrance from Desert:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2277
+    room: 2
+    short_name: Lanayru Mine - Entrance from Desert
+    stage: F300_1
+    tod: 2
+    type: entrance
+  \Lanayru\Mine\Entry\Caves Entrance\Entrance from Caves:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2275
+    room: 0
+    short_name: Lanayru Mine - Entrance from Caves
+    stage: F300_1
+    tod: 2
+    type: entrance
+  \Lanayru\Mine\Entry\First Time Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2274
+    room: 0
+    short_name: Lanayru Mine - First Time Entrance
+    stage: F300_1
+    tod: 2
+    type: entrance
+  \Lanayru\Mine\Entry\Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: Lanayru Province
+    req_index: 2276
+    room: 0
+    short_name: Lanayru Mine - Statue Entrance
+    stage: F300_1
+    statue-name: Lanayru Mine Entry
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Temple of Time\Inside\Entrance from Lanayru Mining Facility:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 5
+    layer: 2
+    province: Lanayru Province
+    req_index: 2297
+    room: 0
+    short_name: Temple of Time - Entrance from Lanayru Mining Facility
+    stage: F300_4
+    subtype: vanilla
+    tod: 2
+    type: entrance
+  \Lanayru\Temple of Time\Inside\Temple of Time Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 17
+    layer: 0
+    province: Lanayru Province
+    req_index: 2294
+    room: 0
+    short_name: Temple of Time - Temple of Time Statue Entrance
+    stage: F300_4
+    statue-name: Temple of Time
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Temple of Time\North East\North Entrance from Desert:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: Lanayru Province
+    req_index: 2296
+    room: 0
+    short_name: Temple of Time - North Entrance from Desert
+    stage: F300_4
+    tod: 2
+    type: entrance
+  \Lanayru\Temple of Time\South East\Desert Gorge Statue Entrance:
+    allowed_time_of_day: *id001
+    entrance: 16
+    layer: 0
+    province: Lanayru Province
+    req_index: 2293
+    room: 0
+    short_name: Temple of Time - Desert Gorge Statue Entrance
+    stage: F300_4
+    statue-name: Desert Gorge
+    subtype: bird-statue-entrance
+    tod: 2
+    type: entrance
+  \Lanayru\Temple of Time\South East\South Entrance from Desert:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: Lanayru Province
+    req_index: 2295
+    room: 0
+    short_name: Temple of Time - South Entrance from Desert
+    stage: F300_4
+    tod: 2
+    type: entrance
+  \Sandship\Boss Room\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Lanayru Province
+    req_index: 2341
+    short_name: Sandship - Boss Room - Entrance
+    tod: 2
+    type: entrance
+  \Sandship\Main\Deck\Main Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 1
+    province: Lanayru Province
+    req_index: 2340
+    room: 0
+    short_name: Sandship - Main Entrance
+    stage: D301
+    tod: 2
+    type: entrance
+  \Sky Keep\Main\First Room\Bottom Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 4
+    layer: 0
+    province: The Sky
+    req_index: 2342
+    room: 0
+    short_name: Sky Keep - First Room - Bottom Entrance
+    stage: D003_7
+    tod: 2
+    type: entrance
+  \Sky\Around Skyloft\Entrance from Skyloft:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: The Sky
+    req_index: 2155
+    short_name: Sky - Entrance from Skyloft
+    tod: 2
+    type: entrance
+  \Sky\Around Skyloft\Entrance from Thunderhead:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 28
+    layer: 0
+    province: The Sky
+    req_index: 2174
+    room: 0
+    short_name: Sky - Entrance from Thunderhead
+    stage: F020
+    tod: 2
+    type: entrance
+  \Sky\North East\Bamboo Island\Entrance from Inside:
+    allowed_time_of_day: *id001
+    entrance: 11
+    layer: 0
+    province: The Sky
+    req_index: 2157
+    room: 0
+    short_name: Bamboo Island - Entrance from Inside
+    stage: F020
+    tod: 2
+    type: entrance
+  \Sky\North East\Bamboo Island\Inside\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 1
+    province: The Sky
+    req_index: 2156
+    room: 0
+    short_name: Bamboo Island - Inside - Entrance
+    stage: F019r
+    tod: 2
+    type: entrance
+  \Sky\North East\Beedle's Island\Beedle's Ship Entrance:
+    allowed-time-of-day: NightOnly
+    allowed_time_of_day: &id003 !!python/object/apply:logic.logic_input.AllowedTimeOfDay
+    - 2
+    entrance: 0
+    layer: 4
+    province: The Sky
+    req_index: 2158
+    room: 0
+    short_name: Sky - Beedle's Island - Beedle's Ship Entrance
+    stage: F020
+    tod: 1
+    type: entrance
+  \Sky\North East\Eldin Pillar\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 13
+    layer: 0
+    province: The Sky
+    req_index: 2159
+    room: 0
+    short_name: Sky - Eldin Pillar - Entrance
+    stage: F020
+    statue-name: Volcano Entry
+    tod: 2
+    type: entrance
+  \Sky\South East\Faron Pillar\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 12
+    layer: 0
+    province: The Sky
+    req_index: 2172
+    room: 0
+    short_name: Sky - Faron Pillar - Entrance
+    stage: F020
+    statue-name: Sealed Grounds
+    tod: 2
+    type: entrance
+  \Sky\South East\Lumpy Pumpkin\Back Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 24
+    layer: 0
+    province: The Sky
+    req_index: 2170
+    room: 0
+    short_name: Lumpy Pumpkin - Back Door Entrance
+    stage: F020
+    tod: 2
+    type: entrance
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 3
+    layer: 0
+    province: The Sky
+    req_index: 2164
+    room: 0
+    short_name: Lumpy Pumpkin Building - Back Door Entrance
+    stage: F011r
+    tod: 2
+    type: entrance
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 2
+    layer: 0
+    province: The Sky
+    req_index: 2162
+    room: 0
+    short_name: Lumpy Pumpkin Building - Main Left Door Entrance
+    stage: F011r
+    tod: 2
+    type: entrance
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2160
+    room: 0
+    short_name: Lumpy Pumpkin Building - Main Right Door Entrance
+    stage: F011r
+    tod: 2
+    type: entrance
+  \Sky\South East\Lumpy Pumpkin\Main Left Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 22
+    layer: 0
+    province: The Sky
+    req_index: 2166
+    room: 0
+    short_name: Lumpy Pumpkin - Main Left Door Entrance
+    stage: F020
+    tod: 2
+    type: entrance
+  \Sky\South East\Lumpy Pumpkin\Main Right Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 23
+    layer: 0
+    province: The Sky
+    req_index: 2168
+    room: 0
+    short_name: Lumpy Pumpkin - Main Right Door Entrance
+    stage: F020
+    tod: 2
+    type: entrance
+  \Sky\South West\Lanayru Pillar\Entrance:
+    allowed_time_of_day: *id001
+    entrance: 14
+    layer: 0
+    province: The Sky
+    req_index: 2173
+    room: 0
+    short_name: Sky - Lanayru Pillar - Entrance
+    stage: F020
+    tod: 2
+    type: entrance
+  \Sky\Thunderhead\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2175
+    room: 0
+    short_name: Thunderhead - Entrance
+    stage: F023
+    tod: 2
+    type: entrance
+  \Sky\Thunderhead\Isle of Songs\Entrance from Inside:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 4
+    layer: 0
+    province: The Sky
+    req_index: 2177
+    room: 0
+    short_name: Isle of Songs - Entrance from Inside
+    stage: F023
+    tod: 2
+    type: entrance
+  \Sky\Thunderhead\Isle of Songs\Inside\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: The Sky
+    req_index: 2176
+    room: 0
+    short_name: Isle of Songs - Entrance
+    stage: F010r
+    tod: 2
+    type: entrance
+  \Skyloft\Beedle's Shop\Day Entrance:
+    allowed_time_of_day: *id002
+    entrance: 0
+    layer: 0
+    province: The Sky
+    req_index: 2103
+    room: 0
+    short_name: Beedle's Shop - Day Entrance
+    stage: F002r
+    tod: 2
+    type: entrance
+  \Skyloft\Beedle's Shop\Night Entrance:
+    allowed-time-of-day: NightOnly
+    allowed_time_of_day: *id003
+    entrance: 0
+    layer: 0
+    province: The Sky
+    req_index: 2105
+    room: 0
+    short_name: Beedle's Shop - Night Entrance
+    stage: F002r
+    tod: 1
+    type: entrance
+  \Skyloft\Central Skyloft\Bazaar North Entrance:
+    allowed_time_of_day: *id002
+    entrance: 2
+    layer: 0
+    province: The Sky
+    req_index: 2097
+    room: 0
+    short_name: Bazaar North Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Bazaar South Entrance:
+    allowed_time_of_day: *id002
+    entrance: 3
+    layer: 0
+    province: The Sky
+    req_index: 2099
+    room: 0
+    short_name: Bazaar South Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Bazaar West Entrance:
+    allowed_time_of_day: *id002
+    entrance: 20
+    layer: 0
+    province: The Sky
+    req_index: 2101
+    room: 0
+    short_name: Bazaar West Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Bazaar\North Entrance:
+    allowed_time_of_day: *id001
+    entrance: 0
+    layer: 0
+    province: The Sky
+    req_index: 2094
+    room: 0
+    short_name: Bazaar - North Entrance
+    stage: F004r
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Bazaar\South Entrance:
+    allowed_time_of_day: *id001
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2095
+    room: 0
+    short_name: Bazaar - South Entrance
+    stage: F004r
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Bazaar\West Entrance:
+    allowed_time_of_day: *id001
+    entrance: 2
+    layer: 0
+    province: The Sky
+    req_index: 2096
+    room: 0
+    short_name: Bazaar - West Entrance
+    stage: F004r
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Entrance from Beedle's Shop:
+    allowed_time_of_day: *id002
+    entrance: 0
+    layer: 0
+    province: The Sky
+    req_index: 2106
+    room: 0
+    short_name: Skyloft - Entrance from Beedle's Shop
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Entrance from Sky:
+    allowed_time_of_day: *id002
+    can-start-at: false
+    province: The Sky
+    req_index: 2153
+    short_name: Skyloft - Entrance from Sky
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Near Temple Entrance\Entrance from Sky Keep:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 53
+    layer: 0
+    province: The Sky
+    req_index: 2112
+    room: 0
+    short_name: Skyloft - Entrance from Sky Keep
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Orielle and Parrow's House Entrance:
+    allowed_time_of_day: *id002
+    entrance: 30
+    layer: 0
+    province: The Sky
+    req_index: 2115
+    room: 0
+    short_name: Orielle and Parrow's House Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Orielle and Parrow's House\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2113
+    room: 0
+    short_name: Orielle and Parrow's House - Entrance
+    stage: F005r
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Entrance:
+    allowed_time_of_day: *id002
+    entrance: 8
+    layer: 0
+    province: The Sky
+    req_index: 2092
+    room: 0
+    short_name: Waterfall Cave Lower Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Peatrice's House Entrance:
+    allowed_time_of_day: *id002
+    entrance: 38
+    layer: 0
+    province: The Sky
+    req_index: 2119
+    room: 0
+    short_name: Peatrice's House Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Peatrice's House\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2117
+    room: 0
+    short_name: Peatrice's House - Entrance
+    stage: F018r
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Piper's House Entrance:
+    allowed_time_of_day: *id002
+    entrance: 32
+    layer: 0
+    province: The Sky
+    req_index: 2151
+    room: 0
+    short_name: Piper's House Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Piper's House\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2149
+    room: 0
+    short_name: Piper's House - Entrance
+    stage: F007r
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Trial Gate Entrance:
+    allowed_time_of_day: *id002
+    can-start-at: false
+    province: The Sky
+    req_index: 2110
+    short_name: Skyloft - Trial Gate Entrance
+    tod: 0
+    type: entrance
+  \Skyloft\Central Skyloft\Waterfall Cave Upper Entrance:
+    allowed_time_of_day: *id002
+    entrance: 7
+    layer: 0
+    province: The Sky
+    req_index: 2090
+    room: 0
+    short_name: Waterfall Cave Upper Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Waterfall Cave\Lower Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2088
+    room: 0
+    short_name: Waterfall Cave - Lower Entrance
+    stage: D000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Waterfall Cave\Upper Entrance:
+    allowed_time_of_day: *id002
+    entrance: 0
+    layer: 0
+    province: The Sky
+    req_index: 2086
+    room: 0
+    short_name: Waterfall Cave - Upper Entrance
+    stage: D000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Wryna's House Entrance:
+    allowed_time_of_day: *id002
+    entrance: 31
+    layer: 0
+    province: The Sky
+    req_index: 2123
+    room: 0
+    short_name: Wryna's House Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Central Skyloft\Wryna's House\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2121
+    room: 0
+    short_name: Wryna's House - Entrance
+    stage: F006r
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Silent Realm\Entrance:
+    allowed_time_of_day: *id002
+    can-start-at: false
+    province: The Sky
+    req_index: 2108
+    short_name: Skyloft Silent Realm - Entrance
+    tod: 0
+    type: entrance
+  \Skyloft\Skyloft Village\Batreaux's House Entrance:
+    allowed_time_of_day: *id002
+    entrance: 29
+    layer: 0
+    province: The Sky
+    req_index: 2139
+    room: 0
+    short_name: Batreaux's House Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Batreaux's House\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 0
+    layer: 0
+    province: The Sky
+    req_index: 2137
+    room: 0
+    short_name: Batreaux's House - Entrance
+    stage: F012r
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Bertie's House Entrance:
+    allowed_time_of_day: *id002
+    entrance: 34
+    layer: 0
+    province: The Sky
+    req_index: 2127
+    room: 0
+    short_name: Bertie's House Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Bertie's House\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2125
+    room: 0
+    short_name: Bertie's House - Entrance
+    stage: F014r
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Gondo's House Entrance:
+    allowed_time_of_day: *id002
+    entrance: 35
+    layer: 0
+    province: The Sky
+    req_index: 2143
+    room: 0
+    short_name: Gondo's House Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Gondo's House\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2141
+    room: 0
+    short_name: Gondo's House - Entrance
+    stage: F015r
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Mallara's House Entrance:
+    allowed_time_of_day: *id002
+    entrance: 36
+    layer: 0
+    province: The Sky
+    req_index: 2133
+    room: 0
+    short_name: Skyloft - Mallara's House Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Mallara's House\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2135
+    room: 0
+    short_name: Mallara's House - Entrance
+    stage: F016r
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Rupin's House Entrance:
+    allowed_time_of_day: *id002
+    entrance: 37
+    layer: 0
+    province: The Sky
+    req_index: 2147
+    room: 0
+    short_name: Rupin's House Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Rupin's House\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2145
+    room: 0
+    short_name: Rupin's House - Entrance
+    stage: F017r
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Sparrot's House Entrance:
+    allowed_time_of_day: *id002
+    entrance: 33
+    layer: 0
+    province: The Sky
+    req_index: 2131
+    room: 0
+    short_name: Sparrot's House Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Skyloft Village\Sparrot's House\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2129
+    room: 0
+    short_name: Sparrot's House - Entrance
+    stage: F013r
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Goddess Statue Entrance:
+    allowed_time_of_day: *id002
+    entrance: 6
+    layer: 0
+    province: The Sky
+    req_index: 2084
+    room: 0
+    short_name: Goddess Statue Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Goddess Statue\Entrance:
+    allowed_time_of_day: *id002
+    entrance: 0
+    layer: 0
+    province: The Sky
+    req_index: 2082
+    room: 0
+    short_name: Goddess Statue - Entrance
+    stage: F008r
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 5
+    layer: 0
+    province: The Sky
+    req_index: 2068
+    room: 0
+    short_name: Skyloft - Knight Academy Lower Left Door Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 4
+    layer: 0
+    province: The Sky
+    req_index: 2066
+    room: 0
+    short_name: Skyloft - Knight Academy Lower Right Door Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 23
+    layer: 0
+    province: The Sky
+    req_index: 2070
+    room: 0
+    short_name: Skyloft - Knight Academy Upper Left Door Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 24
+    layer: 0
+    province: The Sky
+    req_index: 2072
+    room: 0
+    short_name: Skyloft - Knight Academy Upper Right Door Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Start Entrance:
+    allowed-time-of-day: DayOnly
+    allowed_time_of_day: *id001
+    entrance: 5
+    layer: 0
+    province: The Sky
+    req_index: 2055
+    room: 1
+    short_name: Skyloft - Knight Academy - Start Entrance
+    stage: F001r
+    statue-name: Link's Room
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 2
+    layer: 0
+    province: The Sky
+    req_index: 2060
+    room: 0
+    short_name: Skyloft - Knight Academy - Lower Left Door Entrance
+    stage: F001r
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2058
+    room: 0
+    short_name: Skyloft - Knight Academy - Lower Right Door Entrance
+    stage: F001r
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 4
+    layer: 0
+    province: The Sky
+    req_index: 2064
+    room: 0
+    short_name: Skyloft - Knight Academy - Upper Left Door Entrance
+    stage: F001r
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 3
+    layer: 0
+    province: The Sky
+    req_index: 2062
+    room: 0
+    short_name: Skyloft - Knight Academy - Upper Right Door Entrance
+    stage: F001r
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Chimney:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2056
+    room: 6
+    short_name: Skyloft - Knight Academy - Chimney
+    stage: F001r
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Sparring Hall Left Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 21
+    layer: 0
+    province: The Sky
+    req_index: 2078
+    room: 0
+    short_name: Skyloft - Sparring Hall Left Door Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Sparring Hall Right Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 26
+    layer: 0
+    province: The Sky
+    req_index: 2080
+    room: 0
+    short_name: Skyloft - Sparring Hall Right Door Entrance
+    stage: F000
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Sparring Hall\Left Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 2
+    layer: 0
+    province: The Sky
+    req_index: 2076
+    room: 0
+    short_name: Sparring Hall - Left Door Entrance
+    stage: F009r
+    tod: 2
+    type: entrance
+  \Skyloft\Upper Skyloft\Sparring Hall\Right Door Entrance:
+    allowed_time_of_day: *id002
+    entrance: 1
+    layer: 0
+    province: The Sky
+    req_index: 2074
+    room: 0
+    short_name: Sparring Hall - Right Door Entrance
+    stage: F009r
+    tod: 2
+    type: entrance
+  \Skyview\Boss Room\Entrance from Dungeon:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2227
+    short_name: Skyview Temple - Boss Room - Entrance from Dungeon
+    tod: 2
+    type: entrance
+  \Skyview\Boss Room\Entrance from Spring:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2228
+    short_name: Skyview Temple - Boss Room - Entrance from Spring
+    tod: 2
+    type: entrance
+  \Skyview\Main\Entry\Main Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    entrance: 0
+    layer: 0
+    province: Faron Province
+    req_index: 2225
+    room: 0
+    short_name: Skyview Temple - Main Entrance
+    stage: D100
+    tod: 2
+    type: entrance
+  \Skyview\Main\Last Room\After Rope\Boss Door Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2226
+    short_name: Skyview Temple - Boss Door Entrance
+    tod: 2
+    type: entrance
+  \Skyview\Spring\Entrance:
+    allowed_time_of_day: *id001
+    can-start-at: false
+    province: Faron Province
+    req_index: 2229
+    short_name: Skyview Temple - Spring - Entrance
+    tod: 2
+    type: entrance
+exits:
+  \Ancient Cistern\Boss Room\Exit to Dungeon:
+    req_index: 1950
+    short_name: Ancient Cistern - Boss Room - Exit to Dungeon
+    type: exit
+    vanilla: Ancient Cistern - Boss Door Entrance
+  \Ancient Cistern\Boss Room\Exit to Flame Room:
+    req_index: 1951
+    short_name: Ancient Cistern - Boss Room - Exit to Flame Room
+    type: exit
+    vanilla: Ancient Cistern - Flame Room - Entrance
+  \Ancient Cistern\Flame Room\Exit:
+    req_index: 1952
+    short_name: Ancient Cistern - Flame Room - Exit
+    type: exit
+    vanilla: Ancient Cistern - Boss Room - Entrance from Flame Room
+  \Ancient Cistern\Main\Inside Statue\Boss Door Exit:
+    req_index: 1949
+    short_name: Ancient Cistern - Boss Door Exit
+    type: exit
+    vanilla: Ancient Cistern - Boss Room - Entrance from Dungeon
+  \Ancient Cistern\Main\Main Room\Main Exit:
+    req_index: 1948
+    short_name: Ancient Cistern - Main Exit
+    type: exit
+    vanilla: Floria Waterfall - Entrance from Ancient Cistern
+  \Earth Temple\Boss Room\Entry\Exit to Dungeon:
+    req_index: 1977
+    short_name: Earth Temple - Boss Room - Exit to Dungeon
+    type: exit
+    vanilla: Earth Temple - Boss Door Entrance
+  \Earth Temple\Boss Room\Slope\Exit to Spring:
+    req_index: 1978
+    short_name: Earth Temple - Boss Room - Exit to Spring
+    type: exit
+    vanilla: Earth Temple - Spring - Entrance
+  \Earth Temple\Main\First Room\Main Exit:
+    req_index: 1975
+    short_name: Earth Temple - Main Exit
+    type: exit
+    vanilla: Eldin Volcano - Entrance from Earth Temple
+  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Exit:
+    req_index: 1976
+    short_name: Earth Temple - Boss Door Exit
+    type: exit
+    vanilla: Earth Temple - Boss Room - Entrance from Dungeon
+  \Earth Temple\Spring\Exit:
+    req_index: 1979
+    short_name: Earth Temple - Spring - Exit
+    type: exit
+    vanilla: Earth Temple - Boss Room - Entrance from Spring
+  \Eldin\Bokoblin Base\Prison\Exit:
+    req_index: 1963
+    short_name: Bokoblin Base - Exit
+    type: exit
+    vanilla: Entrance from Bokoblin Base
+  \Eldin\Eldin Silent Realm\Exit:
+    req_index: 1967
+    short_name: Eldin Silent Realm - Exit
+    type: exit
+    vanilla: Eldin Volcano - Trial Gate Entrance
+  \Eldin\Mogma Turf\Past Vent\Second Vent:
+    index: 1
+    req_index: 1965
+    room: 0
+    short_name: Mogma Turf - Second Vent
+    stage: F210
+    type: exit
+    vanilla: Eldin Volcano - Second Vent from Mogma Turf
+  \Eldin\Mogma Turf\Pre Vent\First Vent:
+    index: 0
+    req_index: 1964
+    room: 0
+    short_name: Mogma Turf - First Vent
+    stage: F210
+    type: exit
+    vanilla: Eldin Volcano - First Vent from Mogma Turf
+  \Eldin\Volcano Summit\Exit to Eldin Volcano:
+    index: 0
+    req_index: 1968
+    room: 0
+    short_name: Volcano Summit - Exit to Eldin Volcano
+    stage: F201_1
+    type: exit
+    vanilla: Eldin Volcano - Entrance from Summit
+  \Eldin\Volcano Summit\Exit to Outside Fire Sanctuary:
+    index: 2
+    req_index: 1970
+    room: 0
+    short_name: Volcano Summit - Exit to Outside Fire Sanctuary
+    stage: F201_1
+    type: exit
+    vanilla: Outside Fire Sanctuary - Entrance from Summit
+  \Eldin\Volcano Summit\Exit to Waterfall:
+    index: 1
+    req_index: 1969
+    room: 0
+    short_name: Volcano Summit - Exit to Waterfall
+    stage: F201_1
+    type: exit
+    vanilla: Volcano Summit - Waterfall - Entrance
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Exit to Summit:
+    index: 0
+    req_index: 1973
+    room: 0
+    short_name: Outside Fire Sanctuary - Exit to Summit
+    stage: F201_3
+    type: exit
+    vanilla: Volcano Summit - Entrance from Outside Fire Sanctuary
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Exit to Fire Sanctuary:
+    index: 1
+    req_index: 1974
+    room: 0
+    short_name: Outside Fire Sanctuary - Exit to Fire Sanctuary
+    stage: F201_3
+    type: exit
+    vanilla: Fire Sanctuary - Main Entrance
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Exit:
+    index: 2
+    req_index: 1972
+    room: 0
+    short_name: Outside Fire Sanctuary - Statue Exit
+    stage: F201_3
+    type: exit
+    vanilla: Sky - Eldin Pillar - Entrance
+  \Eldin\Volcano Summit\Waterfall\Exit:
+    index: 0
+    req_index: 1971
+    room: 0
+    short_name: Volcano Summit - Waterfall - Exit
+    stage: F201_4
+    type: exit
+    vanilla: Volcano Summit - Entrance from Waterfall
+  \Eldin\Volcano\Ascent\Trial Gate Exit:
+    req_index: 1960
+    short_name: Eldin Volcano - Trial Gate Exit
+    type: exit
+    vanilla: Eldin Silent Realm - Entrance
+  \Eldin\Volcano\East\Dive to Mogma Turf:
+    index: 1
+    req_index: 1956
+    room: 2
+    short_name: Eldin Volcano - Dive to Mogma Turf
+    stage: F200
+    type: exit
+    vanilla: Mogma Turf - Entrance
+  \Eldin\Volcano\East\Exit to Bokoblin Base:
+    req_index: 1962
+    short_name: Eldin Volcano - Exit to Bokoblin Base
+    type: exit
+    vanilla: Bokoblin Base - Entrance
+  \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit:
+    index: 2
+    req_index: 1954
+    room: 2
+    short_name: Eldin Volcano - Volcano East / Volcano Ascent Statue Exit
+    stage: F200
+    type: exit
+    vanilla: Sky - Eldin Pillar - Entrance
+  \Eldin\Volcano\Entry\Volcano Entrance Statue Exit:
+    index: 0
+    req_index: 1953
+    room: 0
+    short_name: Eldin Volcano - Volcano Entrance Statue Exit
+    stage: F200
+    type: exit
+    vanilla: Sky - Eldin Pillar - Entrance
+  \Eldin\Volcano\Hot Cave\Exit to Summit:
+    index: 1
+    req_index: 1959
+    room: 5
+    short_name: Eldin Volcano - Exit to Summit
+    stage: F200
+    type: exit
+    vanilla: Volcano Summit - Entrance from Eldin Volcano
+  \Eldin\Volcano\Near Temple Entrance\Exit to Earth Temple:
+    index: 0
+    req_index: 1957
+    room: 4
+    short_name: Eldin Volcano - Exit to Earth Temple
+    stage: F200
+    type: exit
+    vanilla: Earth Temple - Main Entrance
+  \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Exit:
+    index: 2
+    req_index: 1955
+    room: 4
+    short_name: Eldin Volcano - Temple Entrance Statue Exit
+    stage: F200
+    type: exit
+    vanilla: Sky - Eldin Pillar - Entrance
+  \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Exit:
+    index: 1
+    req_index: 1958
+    room: 4
+    short_name: Eldin Volcano - Thrill Digger Cave Exit
+    stage: F200
+    type: exit
+    vanilla: Thrill Digger Cave - Entrance
+  \Eldin\Volcano\Past Slide\Vent Exit near Ascent:
+    req_index: 1961
+    short_name: Eldin Volcano - Vent Exit near Ascent
+    type: exit
+    vanilla: Eldin Volcano - Vent Entrance near Hot Cave
+  \Eldin\Volcano\Thrill Digger Cave\Exit:
+    index: 0
+    req_index: 1966
+    room: 0
+    short_name: Thrill Digger Cave - Exit
+    stage: F211
+    type: exit
+    vanilla: Eldin Volcano - Thrill Digger Cave Entrance
+  \Faron\Faron Silent Realm\Exit:
+    req_index: 1917
+    short_name: Faron Silent Realm - Exit
+    type: exit
+    vanilla: Faron Woods - Trial Gate Entrance
+  \Faron\Faron Woods\Deep Woods\Entry\Exit to Faron Woods:
+    index: 0
+    req_index: 1933
+    room: 0
+    short_name: Deep Woods - Exit to Faron Woods
+    stage: F101
+    type: exit
+    vanilla: Faron Woods - Entrance from Deep Woods
+  \Faron\Faron Woods\Deep Woods\Exit to Skyview Temple:
+    index: 1
+    req_index: 1934
+    room: 0
+    short_name: Deep Woods - Exit to Skyview Temple
+    stage: F101
+    type: exit
+    vanilla: Skyview Temple - Main Entrance
+  \Faron\Faron Woods\Deep Woods\Shared Statue Exit:
+    index: 2
+    req_index: 1932
+    room: 0
+    short_name: Deep Woods - Shared Statue Exit
+    stage: F101
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+  \Faron\Faron Woods\Entry\Exit to Behind the Temple:
+    index: 0
+    req_index: 1912
+    room: 0
+    short_name: Faron Woods - Exit to Behind the Temple
+    stage: F100
+    type: exit
+    vanilla: Behind the Temple - Entrance from Faron Woods
+  \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Exit to Platforms:
+    index: 1
+    req_index: 1922
+    room: 0
+    short_name: Great Tree - Lower Exit to Platforms
+    stage: F100_1
+    type: exit
+    vanilla: Great Tree - Platforms - Lower Entrance from Great Tree
+  \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Exit:
+    index: 4
+    req_index: 1925
+    room: 0
+    short_name: Great Tree - Underwater Tunnel Exit
+    stage: F100_1
+    type: exit
+    vanilla: Great Tree - Underwater Hole Entrance
+  \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Exit:
+    index: 6
+    req_index: 1921
+    room: 0
+    short_name: Great Tree - Underwater Hole Exit
+    stage: F100
+    type: exit
+    vanilla: Great Tree - Underwater Tunnel Entrance
+  \Faron\Faron Woods\Great Tree\Platforms\Lower Exit to Great Tree:
+    index: 3
+    req_index: 1918
+    room: 0
+    short_name: Great Tree - Platforms - Lower Exit to Great Tree
+    stage: F100
+    type: exit
+    vanilla: Great Tree - Lower Entrance from Platforms
+  \Faron\Faron Woods\Great Tree\Platforms\Upper Exit to Great Tree:
+    index: 4
+    req_index: 1919
+    room: 0
+    short_name: Great Tree - Platforms - Upper Exit to Great Tree
+    stage: F100
+    type: exit
+    vanilla: Great Tree - Upper Entrance from Platforms
+  \Faron\Faron Woods\Great Tree\Top\Top Exit to Great Tree:
+    index: 5
+    req_index: 1920
+    room: 0
+    short_name: Great Tree - Top Exit to Great Tree
+    stage: F100
+    type: exit
+    vanilla: Great Tree - Entrance from Top
+  \Faron\Faron Woods\Great Tree\Upper Area\Exit to Flooded Great Tree:
+    req_index: 1926
+    short_name: Great Tree - Exit to Flooded Great Tree
+    type: exit
+    vanilla: Flooded Great Tree - Entrance
+  \Faron\Faron Woods\Great Tree\Upper Area\Exit to Top:
+    index: 3
+    req_index: 1924
+    room: 0
+    short_name: Great Tree - Exit to Top
+    stage: F100_1
+    type: exit
+    vanilla: Great Tree - Top Entrance from Great Tree
+  \Faron\Faron Woods\Great Tree\Upper Area\Upper Exit to Platforms:
+    index: 2
+    req_index: 1923
+    room: 0
+    short_name: Great Tree - Upper Exit to Platforms
+    stage: F100_1
+    type: exit
+    vanilla: Great Tree - Platforms - Upper Entrance from Great Tree
+  \Faron\Faron Woods\Lake Floria Dive:
+    index: 9
+    req_index: 1914
+    room: 0
+    short_name: Faron Woods - Lake Floria Dive
+    stage: F100
+    type: exit
+    vanilla: Lake Floria - Dive from Faron Woods
+  \Faron\Faron Woods\Ledge To Deep Woods\Exit to Deep Woods:
+    index: 1
+    req_index: 1913
+    room: 0
+    short_name: Faron Woods - Exit to Deep Woods
+    stage: F100
+    type: exit
+    vanilla: Deep Woods - Entrance from Faron Woods
+  \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Exit to Floria Waterfall:
+    index: 11
+    req_index: 1915
+    room: 0
+    short_name: Faron Woods - Shortcut Exit to Floria Waterfall
+    stage: F100
+    type: exit
+    vanilla: Floria Waterfall - Entrance from Faron Woods
+  \Faron\Faron Woods\Shared Statue Exit:
+    index: 10
+    req_index: 1911
+    room: 0
+    short_name: Faron Woods - Shared Statue Exit
+    stage: F100
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+  \Faron\Faron Woods\Trial Gate Exit:
+    req_index: 1916
+    short_name: Faron Woods - Trial Gate Exit
+    type: exit
+    vanilla: Faron Silent Realm - Entrance
+  \Faron\Flooded Faron Woods\Exit to Lower Flooded Great Tree:
+    req_index: 1931
+    short_name: Flooded Faron Woods - Exit to Lower Flooded Great Tree
+    type: exit
+    vanilla: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
+  \Faron\Flooded Faron Woods\Exit to Upper Flooded Great Tree:
+    req_index: 1930
+    short_name: Flooded Faron Woods - Exit to Upper Flooded Great Tree
+    type: exit
+    vanilla: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Exit:
+    req_index: 1927
+    short_name: Flooded Great Tree - Exit
+    type: exit
+    vanilla: Entrance from Flooded Great Tree
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Lower Flooded Faron Woods:
+    req_index: 1929
+    short_name: Flooded Great Tree - Exit to Lower Flooded Faron Woods
+    type: exit
+    vanilla: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Upper Flooded Faron Woods:
+    req_index: 1928
+    short_name: Flooded Great Tree - Exit to Upper Flooded Faron Woods
+    type: exit
+    vanilla: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
+  \Faron\Lake Floria\Below Rock\Emerged Area\Statue Exit:
+    index: 0
+    req_index: 1935
+    room: 3
+    short_name: Lake Floria - Below Rock - Statue Exit
+    stage: F102
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+  \Faron\Lake Floria\Below Rock\Exit to Farore's Lair:
+    index: 0
+    req_index: 1936
+    room: 4
+    short_name: Lake Floria - Exit to Farore's Lair
+    stage: F102
+    type: exit
+    vanilla: Farore's Lair - Entrance from Lake Floria
+  \Faron\Lake Floria\Farore's Lair\Exit to Lake Floria:
+    index: 0
+    req_index: 1937
+    room: 0
+    short_name: Farore's Lair - Exit to Lake Floria
+    stage: F102_2
+    type: exit
+    vanilla: Lake Floria - Entrance from Farore's Lair
+  \Faron\Lake Floria\Farore's Lair\Exit to Waterfall:
+    index: 1
+    req_index: 1938
+    room: 0
+    short_name: Farore's Lair - Exit to Waterfall
+    stage: F102_2
+    type: exit
+    vanilla: Floria Waterfall - Entrance from Farore's Lair
+  \Faron\Lake Floria\Waterfall\Exit to Ancient Cistern:
+    index: 1
+    req_index: 1941
+    room: 0
+    short_name: Floria Waterfall - Exit to Ancient Cistern
+    stage: F102_1
+    type: exit
+    vanilla: Ancient Cistern - Main Entrance
+  \Faron\Lake Floria\Waterfall\Exit to Faron Woods:
+    index: 2
+    req_index: 1942
+    room: 0
+    short_name: Floria Waterfall - Exit to Faron Woods
+    stage: F102_1
+    type: exit
+    vanilla: Faron Woods - Shortcut Entrance from Floria Waterfall
+  \Faron\Lake Floria\Waterfall\Exit to Farore's Lair:
+    index: 0
+    req_index: 1940
+    room: 0
+    short_name: Floria Waterfall - Exit to Farore's Lair
+    stage: F102_1
+    type: exit
+    vanilla: Farore's Lair - Entrance from Waterfall
+  \Faron\Lake Floria\Waterfall\Statue Exit:
+    index: 3
+    req_index: 1939
+    room: 0
+    short_name: Floria Waterfall - Statue Exit
+    stage: F102_1
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+  \Faron\Sealed Grounds\Behind the Temple\Door Exit:
+    index: 1
+    req_index: 1909
+    room: 0
+    short_name: Behind the Temple - Door Exit
+    stage: F400
+    type: exit
+    vanilla: Sealed Temple - Side Entrance
+  \Faron\Sealed Grounds\Behind the Temple\Exit to Faron Woods:
+    index: 2
+    req_index: 1910
+    room: 0
+    short_name: Behind the Temple - Exit to Faron Woods
+    stage: F400
+    type: exit
+    vanilla: Faron Woods - Entrance from Behind the Temple
+  \Faron\Sealed Grounds\Behind the Temple\Shortcut Exit to Spiral:
+    index: 0
+    req_index: 1908
+    room: 0
+    short_name: Behind the Temple - Shortcut Exit to Spiral
+    stage: F400
+    type: exit
+    vanilla: Sealed Grounds Spiral - Shortcut Entrance from Behind the Temple
+  \Faron\Sealed Grounds\Behind the Temple\Statue Exit:
+    index: 5
+    req_index: 1907
+    room: 0
+    short_name: Behind the Temple - Statue Exit
+    stage: F400
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+  \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Exit:
+    index: 1
+    req_index: 1906
+    room: 2
+    short_name: Hylia's Temple - Gate of Time Exit
+    stage: F404
+    type: exit
+    vanilla: Sealed Temple - Gate of Time Entrance
+  \Faron\Sealed Grounds\Sealed Temple\Gate of Time Exit:
+    index: 5
+    req_index: 1905
+    room: 2
+    short_name: Sealed Temple - Gate of Time Exit
+    stage: F402
+    type: exit
+    vanilla: Hylia's Temple - Gate of Time Entrance
+  \Faron\Sealed Grounds\Sealed Temple\Main Exit:
+    index: 0
+    req_index: 1903
+    room: 2
+    short_name: Sealed Temple - Main Exit
+    stage: F402
+    type: exit
+    vanilla: Sealed Grounds Spiral - Door Entrance
+  \Faron\Sealed Grounds\Sealed Temple\Side Exit:
+    index: 1
+    req_index: 1904
+    room: 2
+    short_name: Sealed Temple - Side Exit
+    stage: F402
+    type: exit
+    vanilla: Behind the Temple - Door Entrance
+  \Faron\Sealed Grounds\Spiral\Door Exit:
+    index: 0
+    req_index: 1901
+    room: 1
+    short_name: Sealed Grounds Spiral - Door Exit
+    stage: F401
+    type: exit
+    vanilla: Sealed Temple - Main Entrance
+  \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Exit to Behind the Temple:
+    index: 1
+    req_index: 1902
+    room: 1
+    short_name: Sealed Grounds Spiral - Shortcut Exit to Behind the Temple
+    stage: F401
+    type: exit
+    vanilla: Behind the Temple - Shortcut Entrance from Spiral
+  \Faron\Sealed Grounds\Spiral\Upper Part\Statue Exit:
+    index: 19
+    req_index: 1900
+    room: 1
+    short_name: Sealed Grounds Spiral - Statue Exit
+    stage: F401
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+  \Fire Sanctuary\Boss Room\Exit to Dungeon:
+    req_index: 1987
+    short_name: Fire Sanctuary - Boss Room - Exit to Dungeon
+    type: exit
+    vanilla: Fire Sanctuary - Boss Door Entrance
+  \Fire Sanctuary\Boss Room\Exit to Flame Room:
+    req_index: 1988
+    short_name: Fire Sanctuary - Boss Room - Exit to Flame Room
+    type: exit
+    vanilla: Fire Sanctuary - Flame Room - Entrance
+  \Fire Sanctuary\Flame Room\Exit:
+    req_index: 1989
+    short_name: Fire Sanctuary - Flame Room - Exit
+    type: exit
+    vanilla: Fire Sanctuary - Boss Room - Entrance from Flame Room
+  \Fire Sanctuary\Main\First Room\Main Exit:
+    req_index: 1981
+    short_name: Fire Sanctuary - Main Exit
+    type: exit
+    vanilla: Outside Fire Sanctuary - Entrance from Fire Sanctuary
+  \Fire Sanctuary\Main\First Room\Past Water Plant\Exit to Second Room:
+    req_index: 1982
+    short_name: Fire Sanctuary - First Room - Exit to Second Room
+    type: exit
+    vanilla: Fire Sanctuary - Second Room - Entrance from First Room
+  \Fire Sanctuary\Main\Front of Boss Door\Boss Door Exit:
+    req_index: 1986
+    short_name: Fire Sanctuary - Boss Door Exit
+    type: exit
+    vanilla: Fire Sanctuary - Boss Room - Entrance from Dungeon
+  \Fire Sanctuary\Main\Front of Boss Door\Statue Exit:
+    index: 3
+    req_index: 1980
+    room: 10
+    short_name: Fire Sanctuary - Statue Exit
+    stage: D201
+    type: exit
+    vanilla: Sky - Eldin Pillar - Entrance
+  \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Exit to West of Boss Door:
+    req_index: 1984
+    short_name: Fire Sanctuary - Magmanos Fight Room - Exit to West of Boss Door
+    type: exit
+    vanilla: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight Room
+  \Fire Sanctuary\Main\Second Room\Outside Section\Exit to First Room:
+    req_index: 1983
+    short_name: Fire Sanctuary - Second Room - Exit to First Room
+    type: exit
+    vanilla: Fire Sanctuary - First Room - Entrance from Second Room
+  \Fire Sanctuary\Main\West of Boss Door\Entry\Exit to Magmanos Fight Room:
+    req_index: 1985
+    short_name: Fire Sanctuary - West of Boss Door - Exit to Magmanos Fight Room
+    type: exit
+    vanilla: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss Door
+  \Lanayru Mining Facility\Boss Room\After Sand Drain\Exit to Hall of Ancient Robots:
+    req_index: 2049
+    short_name: Lanayru Mining Facility - Boss Room - Exit to Hall of Ancient Robots
+    type: exit
+    vanilla: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
+      Room
+  \Lanayru Mining Facility\Boss Room\Exit to Dungeon:
+    req_index: 2048
+    short_name: Lanayru Mining Facility - Boss Room - Exit to Dungeon
+    type: exit
+    vanilla: Lanayru Mining Facility - Boss Door Entrance
+  \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit to Temple of Time:
+    index: 1
+    req_index: 2051
+    room: 0
+    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Temple
+      of Time
+    stage: F300_5
+    subtype: vanilla
+    type: exit
+    vanilla: Temple of Time - Entrance from Lanayru Mining Facility
+  \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Exit to Boss Room:
+    req_index: 2050
+    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Boss Room
+    type: exit
+    vanilla: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient Robots
+  \Lanayru Mining Facility\Main\Armos Fight Room\Exit to Big Hub:
+    req_index: 2043
+    short_name: Lanayru Mining Facility - Armos Fight Room - Exit to Big Hub
+    type: exit
+    vanilla: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
+  \Lanayru Mining Facility\Main\Big Hub\Entry\Exit to First Hub:
+    req_index: 2044
+    short_name: Lanayru Mining Facility - Big Hub - Exit to First Hub
+    type: exit
+    vanilla: Lanayru Mining Facility - First Hub - Entrance from Big Hub
+  \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Exit to Hop Across Boxes Room:
+    req_index: 2045
+    short_name: Lanayru Mining Facility - Big Hub - Exit to Hop Across Boxes Room
+    type: exit
+    vanilla: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big Hub
+  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Exit to Armos Fight Room:
+    req_index: 2046
+    short_name: Lanayru Mining Facility - Big Hub - Exit to Armos Fight Room
+    type: exit
+    vanilla: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
+  \Lanayru Mining Facility\Main\First Hub\Exit to Big Hub:
+    req_index: 2041
+    short_name: Lanayru Mining Facility - First Hub - Exit to Big Hub
+    type: exit
+    vanilla: Lanayru Mining Facility - Big Hub - Entrance from First Hub
+  \Lanayru Mining Facility\Main\First Room\Main Exit:
+    req_index: 2040
+    short_name: Lanayru Mining Facility - Main Exit
+    type: exit
+    vanilla: Lanayru Desert - Entrance from Lanayru Mining Facility
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Exit to Big Hub:
+    req_index: 2042
+    short_name: Lanayru Mining Facility - Hop Across Boxes Room - Exit to Big Hub
+    type: exit
+    vanilla: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes Room
+  \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Exit:
+    req_index: 2047
+    short_name: Lanayru Mining Facility - Boss Door Exit
+    type: exit
+    vanilla: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
+  \Lanayru\Caves\Exit to Desert:
+    index: 1
+    req_index: 2010
+    room: 0
+    short_name: Lanayru Caves - Exit to Desert
+    stage: F303
+    type: exit
+    vanilla: Lanayru Desert - Entrance from Caves
+  \Lanayru\Caves\Exit to Mine:
+    index: 0
+    req_index: 2009
+    room: 0
+    short_name: Lanayru Caves - Exit to Mine
+    stage: F303
+    type: exit
+    vanilla: Lanayru Mine - Entrance from Caves
+  \Lanayru\Caves\Past Crawlspace\Exit to Gorge:
+    req_index: 2012
+    short_name: Lanayru Caves - Exit to Gorge
+    type: exit
+    vanilla: Lanayru Gorge - Entrance
+  \Lanayru\Caves\Past Door to Lanayru Sand Sea\Exit to Lanayru Sand Sea:
+    index: 2
+    req_index: 2011
+    room: 0
+    short_name: Lanayru Caves - Exit to Lanayru Sand Sea
+    stage: F303
+    type: exit
+    vanilla: Lanayru Sand Sea Docks - Entrance from Caves
+  \Lanayru\Desert\East\Fire Node Exit:
+    index: 2
+    req_index: 1996
+    room: 0
+    short_name: Lanayru Desert - Fire Node Exit
+    stage: F300
+    type: exit
+    vanilla: Fire Node - Entrance
+  \Lanayru\Desert\East\Fire Node\Present\Exit:
+    index: 0
+    req_index: 2004
+    room: 0
+    short_name: Fire Node - Exit
+    stage: F300_3
+    type: exit
+    vanilla: Lanayru Desert - Fire Node Entrance
+  \Lanayru\Desert\Entry\Exit to Mine:
+    index: 1
+    req_index: 1995
+    room: 0
+    short_name: Lanayru Desert - Exit to Mine
+    stage: F300
+    type: exit
+    vanilla: Lanayru Mine - Entrance from Desert
+  \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Exit to Caves:
+    index: 8
+    req_index: 2000
+    room: 0
+    short_name: Lanayru Desert - Exit to Caves
+    stage: F300
+    type: exit
+    vanilla: Lanayru Caves - Entrance from Desert
+  \Lanayru\Desert\Near South Exit to Temple of Time\South Exit to Temple of Time:
+    index: 3
+    req_index: 1997
+    room: 0
+    short_name: Lanayru Desert - South Exit to Temple of Time
+    stage: F300
+    type: exit
+    vanilla: Temple of Time - South Entrance from Desert
+  \Lanayru\Desert\North Part\Lightning Node Exit:
+    index: 0
+    req_index: 1994
+    room: 0
+    short_name: Lanayru Desert - Lightning Node Exit
+    stage: F300
+    type: exit
+    vanilla: Lightning Node - Entrance
+  \Lanayru\Desert\North Part\Lightning Node\Present\Exit:
+    index: 0
+    req_index: 2003
+    room: 0
+    short_name: Lightning Node - Exit
+    stage: F300_2
+    type: exit
+    vanilla: Lanayru Desert - Lightning Node Entrance
+  \Lanayru\Desert\North Part\North Exit to Temple of Time:
+    index: 4
+    req_index: 1998
+    room: 0
+    short_name: Lanayru Desert - North Exit to Temple of Time
+    stage: F300
+    type: exit
+    vanilla: Temple of Time - North Entrance from Desert
+  \Lanayru\Desert\North Part\Trial Gate Exit:
+    req_index: 2001
+    short_name: Lanayru Desert - Trial Gate Exit
+    type: exit
+    vanilla: Lanayru Silent Realm - Entrance
+  \Lanayru\Desert\Shared Statue Exit:
+    index: 6
+    req_index: 1993
+    room: 0
+    short_name: Lanayru Desert - Shared Statue Exit
+    stage: F300
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+  \Lanayru\Desert\Top of LMF\Exit to Lanayru Mining Facility:
+    index: 5
+    req_index: 1999
+    room: 0
+    short_name: Lanayru Desert - Exit to Lanayru Mining Facility
+    stage: F300
+    type: exit
+    vanilla: Lanayru Mining Facility - Main Entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Exit:
+    index: 0
+    req_index: 2015
+    room: 0
+    short_name: Lanayru Sand Sea - Ancient Harbour Dock Exit
+    stage: F301_1
+    type: exit
+    vanilla: Lanayru Sand Sea Docks - Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Exit:
+    index: 2
+    req_index: 2023
+    room: 0
+    short_name: Lanayru Sand Sea Docks - Dock Exit
+    stage: F301
+    type: exit
+    vanilla: Lanayru Sand Sea - Ancient Harbour Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Exit to Sandship:
+    index: 0
+    req_index: 2021
+    room: 0
+    short_name: Lanayru Sand Sea Docks - Exit to Sandship
+    stage: F301
+    type: exit
+    vanilla: Sandship - Main Entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Exit to Caves:
+    index: 1
+    req_index: 2022
+    room: 0
+    short_name: Lanayru Sand Sea Docks - Exit to Caves
+    stage: F301
+    type: exit
+    vanilla: Lanayru Caves - Entrance from Lanayru Sand Sea
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Exit:
+    index: 3
+    req_index: 2020
+    room: 0
+    short_name: Lanayru Sand Sea Docks - Statue Exit
+    stage: F301
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+  \Lanayru\Lanayru Sand Sea\Gorge\Exit:
+    req_index: 2013
+    short_name: Lanayru Gorge - Exit
+    type: exit
+    vanilla: Lanayru Caves - Entrance from Gorge
+  \Lanayru\Lanayru Sand Sea\Gorge\Statue Exit:
+    req_index: 2014
+    short_name: Lanayru Gorge - Statue Exit
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Exit:
+    index: 4
+    req_index: 2019
+    room: 0
+    short_name: Lanayru Sand Sea - Pirate Stronghold Dock Exit
+    stage: F301_1
+    type: exit
+    vanilla: Pirate Stronghold - Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Exit:
+    index: 0
+    req_index: 2035
+    room: 0
+    short_name: Pirate Stronghold - Dock Exit
+    stage: F301_6
+    type: exit
+    vanilla: Lanayru Sand Sea - Pirate Stronghold Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Exit:
+    index: 2
+    req_index: 2037
+    room: 0
+    short_name: Pirate Stronghold - Top Exit
+    stage: F301_6
+    type: exit
+    vanilla: Pirate Stronghold - Inside - Second Door Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Exit:
+    index: 0
+    req_index: 2038
+    room: 1
+    short_name: Pirate Stronghold - Inside - First Door Exit
+    stage: F301_2
+    type: exit
+    vanilla: Pirate Stronghold - Side Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Exit:
+    index: 2
+    req_index: 2039
+    room: 1
+    short_name: Pirate Stronghold - Inside - Second Door Exit
+    stage: F301_2
+    type: exit
+    vanilla: Pirate Stronghold - Top Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Exit:
+    index: 1
+    req_index: 2036
+    room: 0
+    short_name: Pirate Stronghold - Side Exit
+    stage: F301_6
+    type: exit
+    vanilla: Pirate Stronghold - Inside - First Door Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Exit:
+    index: 3
+    req_index: 2034
+    room: 0
+    short_name: Pirate Stronghold - Statue Exit
+    stage: F301_6
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+  \Lanayru\Lanayru Sand Sea\Sandship Dock Exit:
+    index: 1
+    req_index: 2016
+    room: 0
+    short_name: Lanayru Sand Sea - Sandship Dock Exit
+    stage: F301_1
+    type: exit
+    vanilla: Sandship - Main Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard Dock Exit:
+    index: 3
+    req_index: 2018
+    room: 0
+    short_name: Lanayru Sand Sea - Shipyard Dock Exit
+    stage: F301_1
+    type: exit
+    vanilla: Shipyard - Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Exit:
+    index: 4
+    req_index: 2031
+    room: 0
+    short_name: Shipyard - Construction Bay Lower Exit
+    stage: F301_4
+    type: exit
+    vanilla: Shipyard - Construction Bay - Lower Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Exit:
+    index: 3
+    req_index: 2030
+    room: 0
+    short_name: Shipyard - Construction Bay Upper Exit
+    stage: F301_4
+    type: exit
+    vanilla: Shipyard - Construction Bay - Upper Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Exit:
+    index: 0
+    req_index: 2032
+    room: 0
+    short_name: Shipyard - Construction Bay - Lower Exit
+    stage: F301_7
+    type: exit
+    vanilla: Shipyard - Construction Bay Lower Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Exit:
+    index: 1
+    req_index: 2033
+    room: 0
+    short_name: Shipyard - Construction Bay - Upper Exit
+    stage: F301_7
+    type: exit
+    vanilla: Shipyard - Construction Bay Upper Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Dock Exit:
+    index: 2
+    req_index: 2029
+    room: 0
+    short_name: Shipyard - Dock Exit
+    stage: F301_4
+    type: exit
+    vanilla: Lanayru Sand Sea - Shipyard Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Statue Exit:
+    index: 1
+    req_index: 2028
+    room: 0
+    short_name: Shipyard - Statue Exit
+    stage: F301_4
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Exit:
+    index: 2
+    req_index: 2017
+    room: 0
+    short_name: Lanayru Sand Sea - Skipper's Retreat Dock Exit
+    stage: F301_1
+    type: exit
+    vanilla: Skipper's Retreat - Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Exit:
+    index: 2
+    req_index: 2025
+    room: 0
+    short_name: Skipper's Retreat - Dock Exit
+    stage: F301_3
+    type: exit
+    vanilla: Lanayru Sand Sea - Skipper's Retreat Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Exit:
+    index: 0
+    req_index: 2027
+    room: 0
+    short_name: Skipper's Retreat - Shack - Exit
+    stage: F301_5
+    type: exit
+    vanilla: Skipper's Retreat - Shack Entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Exit:
+    index: 1
+    req_index: 2024
+    room: 0
+    short_name: Skipper's Retreat - Statue Exit
+    stage: F301_3
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Exit:
+    index: 3
+    req_index: 2026
+    room: 0
+    short_name: Skipper's Retreat - Shack Exit
+    stage: F301_3
+    type: exit
+    vanilla: Skipper's Retreat - Shack - Entrance
+  \Lanayru\Lanayru Silent Realm\Exit:
+    req_index: 2002
+    short_name: Lanayru Silent Realm - Exit
+    type: exit
+    vanilla: Lanayru Desert - Trial Gate Entrance
+  \Lanayru\Mine\End\In Minecart\Exit to Desert:
+    index: 0
+    req_index: 1992
+    room: 2
+    short_name: Lanayru Mine - Exit to Desert
+    stage: F300_1
+    type: exit
+    vanilla: Lanayru Desert - Entrance from Mine
+  \Lanayru\Mine\Entry\Caves Entrance\Exit to Caves:
+    index: 1
+    req_index: 1991
+    room: 0
+    short_name: Lanayru Mine - Exit to Caves
+    stage: F300_1
+    type: exit
+    vanilla: Lanayru Caves - Entrance from Mine
+  \Lanayru\Mine\Entry\Statue Exit:
+    index: 0
+    req_index: 1990
+    room: 0
+    short_name: Lanayru Mine - Statue Exit
+    stage: F300_1
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+  \Lanayru\Temple of Time\Inside\Exit to Lanayru Mining Facility:
+    index: 4
+    req_index: 2008
+    room: 0
+    short_name: Temple of Time - Exit to Lanayru Mining Facility
+    stage: F300_4
+    subtype: vanilla
+    type: exit
+  \Lanayru\Temple of Time\North East\North Exit to Desert:
+    index: 1
+    req_index: 2007
+    room: 0
+    short_name: Temple of Time - North Exit to Desert
+    stage: F300_4
+    type: exit
+    vanilla: Lanayru Desert - North Entrance from Temple of Time
+  \Lanayru\Temple of Time\Shared Statue Exit:
+    index: 2
+    req_index: 2005
+    room: 0
+    short_name: Temple of Time - Shared Statue Exit
+    stage: F300_4
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+  \Lanayru\Temple of Time\South East\South Exit to Desert:
+    index: 0
+    req_index: 2006
+    room: 0
+    short_name: Temple of Time - South Exit to Desert
+    stage: F300_4
+    type: exit
+    vanilla: Lanayru Desert - South Entrance from Temple of Time
+  \Sandship\Main\Before Boss Door\Boss Door one-way Exit:
+    req_index: 2053
+    short_name: Sandship - Boss Door one-way Exit
+    type: exit
+    vanilla: Sandship - Boss Room - Entrance
+  \Sandship\Main\Deck\Main Exit:
+    req_index: 2052
+    short_name: Sandship - Main Exit
+    type: exit
+    vanilla: Lanayru Sand Sea - Sandship Dock Entrance
+  \Sky Keep\Main\First Room\Bottom Exit:
+    req_index: 2054
+    short_name: Sky Keep - First Room - Bottom Exit
+    type: exit
+    vanilla: Skyloft - Entrance from Sky Keep
+  \Sky\Around Skyloft\Exit to Skyloft:
+    req_index: 1855
+    short_name: Sky - Exit to Skyloft
+    type: exit
+    vanilla: Skyloft - Entrance from Sky
+  \Sky\Around Skyloft\Exit to Thunderhead:
+    index: 25
+    req_index: 1896
+    room: 0
+    short_name: Sky - Exit to Thunderhead
+    stage: F020
+    type: exit
+    vanilla: Thunderhead - Entrance
+  \Sky\North East\Bamboo Island\Exit to Inside:
+    index: 13
+    req_index: 1857
+    room: 0
+    short_name: Bamboo Island - Exit to Inside
+    stage: F020
+    type: exit
+    vanilla: Bamboo Island - Inside - Entrance
+  \Sky\North East\Bamboo Island\Inside\Exit:
+    index: 2
+    req_index: 1856
+    room: 0
+    short_name: Bamboo Island - Inside - Exit
+    stage: F019r
+    type: exit
+    vanilla: Bamboo Island - Entrance from Inside
+  \Sky\North East\Beedle's Island\Beedle's Ship Exit:
+    allowed-time-of-day: NightOnly
+    index: 14
+    req_index: 1858
+    room: 0
+    short_name: Sky - Beedle's Island - Beedle's Ship Exit
+    stage: F020
+    type: exit
+    vanilla: Beedle's Shop - Night Entrance
+  \Sky\North East\Eldin Pillar\Fire Sanctuary Statue Dive:
+    index: 55
+    req_index: 1865
+    room: 0
+    short_name: Sky - Eldin Pillar - Fire Sanctuary Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Fire Sanctuary - Statue Entrance
+  \Sky\North East\Eldin Pillar\First Time Dive:
+    index: 1
+    req_index: 1859
+    room: 0
+    short_name: Sky - Eldin Pillar - First Time Dive
+    stage: F020
+    type: exit
+    vanilla: Eldin Volcano - First Time Entrance
+  \Sky\North East\Eldin Pillar\Inside the Volcano Statue Dive:
+    index: 30
+    req_index: 1861
+    room: 0
+    short_name: Sky - Eldin Pillar - Inside the Volcano Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Outside Fire Sanctuary - Statue Entrance
+  \Sky\North East\Eldin Pillar\Temple Entrance Statue Dive:
+    index: 29
+    req_index: 1860
+    room: 0
+    short_name: Sky - Eldin Pillar - Temple Entrance Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Eldin Volcano - Temple Entrance Statue Entrance
+  \Sky\North East\Eldin Pillar\Volcano Ascent Statue Dive:
+    index: 52
+    req_index: 1864
+    room: 0
+    short_name: Sky - Eldin Pillar - Volcano Ascent Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Eldin Volcano - Volcano Ascent Statue Entrance
+  \Sky\North East\Eldin Pillar\Volcano East Statue Dive:
+    index: 51
+    req_index: 1863
+    room: 0
+    short_name: Sky - Eldin Pillar - Volcano East Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Eldin Volcano - Volcano East Statue Entrance
+  \Sky\North East\Eldin Pillar\Volcano Entrance Statue Dive:
+    index: 50
+    req_index: 1862
+    room: 0
+    short_name: Sky - Eldin Pillar - Volcano Entrance Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Eldin Volcano - Volcano Entrance Statue Entrance
+  \Sky\South East\Faron Pillar\Behind the Temple Statue Dive:
+    index: 40
+    req_index: 1875
+    room: 0
+    short_name: Sky - Faron Pillar - Behind the Temple Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Behind the Temple - Statue Entrance
+  \Sky\South East\Faron Pillar\Deep Woods Statue Dive:
+    index: 46
+    req_index: 1880
+    room: 0
+    short_name: Sky - Faron Pillar - Deep Woods Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Deep Woods - Deep Woods Statue Entrance
+  \Sky\South East\Faron Pillar\Faron Woods Entry Statue Dive:
+    index: 41
+    req_index: 1876
+    room: 0
+    short_name: Sky - Faron Pillar - Faron Woods Entry Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Faron Woods - Faron Woods Entry Statue Entrance
+  \Sky\South East\Faron Pillar\First Time Dive:
+    index: 0
+    req_index: 1872
+    room: 0
+    short_name: Sky - Faron Pillar - First Time Dive
+    stage: F020
+    type: exit
+    vanilla: Sealed Grounds Spiral - Statue Entrance
+  \Sky\South East\Faron Pillar\Floria Waterfall Statue Dive:
+    index: 48
+    req_index: 1882
+    room: 0
+    short_name: Sky - Faron Pillar - Floria Waterfall Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Floria Waterfall - Statue Entrance
+  \Sky\South East\Faron Pillar\Forest Temple Statue Dive:
+    index: 27
+    req_index: 1874
+    room: 0
+    short_name: Sky - Faron Pillar - Forest Temple Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Deep Woods - Forest Temple Statue Entrance
+  \Sky\South East\Faron Pillar\In the Woods Statue Dive:
+    index: 42
+    req_index: 1877
+    room: 0
+    short_name: Sky - Faron Pillar - In the Woods Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Faron Woods - In the Woods Statue Entrance
+  \Sky\South East\Faron Pillar\Lake Floria Statue Dive:
+    index: 47
+    req_index: 1881
+    room: 0
+    short_name: Sky - Faron Pillar - Lake Floria Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Lake Floria - Below Rock - Statue Entrance
+  \Sky\South East\Faron Pillar\Sealed Grounds Statue Dive:
+    index: 68
+    req_index: 1873
+    room: 0
+    short_name: Sky - Faron Pillar - Sealed Grounds Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Sealed Grounds Spiral - Statue Entrance
+  \Sky\South East\Faron Pillar\The Great Tree Statue Dive:
+    index: 44
+    req_index: 1879
+    room: 0
+    short_name: Sky - Faron Pillar - The Great Tree Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Great Tree - The Great Tree Statue Entrance
+  \Sky\South East\Faron Pillar\Viewing Platform Statue Dive:
+    index: 43
+    req_index: 1878
+    room: 0
+    short_name: Sky - Faron Pillar - Viewing Platform Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Faron Woods - Viewing Platform Statue Entrance
+  \Sky\South East\Lumpy Pumpkin\Back Door Exit:
+    index: 20
+    req_index: 1871
+    room: 0
+    short_name: Lumpy Pumpkin - Back Door Exit
+    stage: F020
+    type: exit
+    vanilla: Lumpy Pumpkin Building - Back Door Entrance
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Exit:
+    index: 2
+    req_index: 1868
+    room: 0
+    short_name: Lumpy Pumpkin Building - Back Door Exit
+    stage: F011r
+    type: exit
+    vanilla: Lumpy Pumpkin - Back Door Entrance
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Exit:
+    index: 1
+    req_index: 1867
+    room: 0
+    short_name: Lumpy Pumpkin Building - Main Left Door Exit
+    stage: F011r
+    type: exit
+    vanilla: Lumpy Pumpkin - Main Right Door Entrance
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Exit:
+    index: 0
+    req_index: 1866
+    room: 0
+    short_name: Lumpy Pumpkin Building - Main Right Door Exit
+    stage: F011r
+    type: exit
+    vanilla: Lumpy Pumpkin - Main Left Door Entrance
+  \Sky\South East\Lumpy Pumpkin\Main Left Door Exit:
+    index: 19
+    req_index: 1870
+    room: 0
+    short_name: Lumpy Pumpkin - Main Left Door Exit
+    stage: F020
+    type: exit
+    vanilla: Lumpy Pumpkin Building - Main Right Door Entrance
+  \Sky\South East\Lumpy Pumpkin\Main Right Door Exit:
+    index: 18
+    req_index: 1869
+    room: 0
+    short_name: Lumpy Pumpkin - Main Right Door Exit
+    stage: F020
+    type: exit
+    vanilla: Lumpy Pumpkin Building - Main Left Door Entrance
+  \Sky\South West\Lanayru Pillar\Ancient Harbour Statue Dive:
+    index: 63
+    req_index: 1891
+    room: 0
+    short_name: Sky - Lanayru Pillar - Ancient Harbour Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Lanayru Sand Sea Docks - Statue Entrance
+  \Sky\South West\Lanayru Pillar\Desert Entrance Statue Dive:
+    index: 57
+    req_index: 1885
+    room: 0
+    short_name: Sky - Lanayru Pillar - Desert Entrance Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Lanayru Desert - Desert Entrance Statue Entrance
+  \Sky\South West\Lanayru Pillar\Desert Gorge Statue Dive:
+    index: 61
+    req_index: 1889
+    room: 0
+    short_name: Sky - Lanayru Pillar - Desert Gorge Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Temple of Time - Desert Gorge Statue Entrance
+  \Sky\South West\Lanayru Pillar\First Time Dive:
+    index: 2
+    req_index: 1883
+    room: 0
+    short_name: Sky - Lanayru Pillar - First Time Dive
+    stage: F020
+    type: exit
+    vanilla: Lanayru Mine - First Time Entrance
+  \Sky\South West\Lanayru Pillar\Lanayru Gorge Statue Dive:
+    req_index: 1895
+    short_name: Sky - Lanayru Pillar - Lanayru Gorge Statue Dive
+    type: exit
+    vanilla: Lanayru Gorge - Statue Entrance
+  \Sky\South West\Lanayru Pillar\Lanayru Mine Entry Statue Dive:
+    index: 56
+    req_index: 1884
+    room: 0
+    short_name: Sky - Lanayru Pillar - Lanayru Mine Entry Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Lanayru Mine - Statue Entrance
+  \Sky\South West\Lanayru Pillar\North Desert Statue Dive:
+    index: 59
+    req_index: 1887
+    room: 0
+    short_name: Sky - Lanayru Pillar - North Desert Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Lanayru Desert - North Desert Statue Entrance
+  \Sky\South West\Lanayru Pillar\Pirate Stronghold Statue Dive:
+    index: 66
+    req_index: 1894
+    room: 0
+    short_name: Sky - Lanayru Pillar - Pirate Stronghold Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Pirate Stronghold - Statue Entrance
+  \Sky\South West\Lanayru Pillar\Shipyard Statue Dive:
+    index: 65
+    req_index: 1893
+    room: 0
+    short_name: Sky - Lanayru Pillar - Shipyard Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Shipyard - Statue Entrance
+  \Sky\South West\Lanayru Pillar\Skipper's Retreat Statue Dive:
+    index: 64
+    req_index: 1892
+    room: 0
+    short_name: Sky - Lanayru Pillar - Skipper's Retreat Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Skipper's Retreat - Statue Entrance
+  \Sky\South West\Lanayru Pillar\Stone Cache Statue Dive:
+    index: 60
+    req_index: 1888
+    room: 0
+    short_name: Sky - Lanayru Pillar - Stone Cache Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Lanayru Desert - Stone Cache Statue Entrance
+  \Sky\South West\Lanayru Pillar\Temple of Time Statue Dive:
+    index: 62
+    req_index: 1890
+    room: 0
+    short_name: Sky - Lanayru Pillar - Temple of Time Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Temple of Time - Temple of Time Statue Entrance
+  \Sky\South West\Lanayru Pillar\West Desert Statue Dive:
+    index: 58
+    req_index: 1886
+    room: 0
+    short_name: Sky - Lanayru Pillar - West Desert Statue Dive
+    stage: F020
+    type: exit
+    vanilla: Lanayru Desert - West Desert Statue Entrance
+  \Sky\Thunderhead\Exit:
+    index: 1
+    req_index: 1897
+    room: 0
+    short_name: Thunderhead - Exit
+    stage: F023
+    type: exit
+    vanilla: Sky - Entrance from Thunderhead
+  \Sky\Thunderhead\Isle of Songs\Exit to Inside:
+    index: 2
+    req_index: 1899
+    room: 0
+    short_name: Isle of Songs - Exit to Inside
+    stage: F023
+    type: exit
+    vanilla: Isle of Songs - Entrance
+  \Sky\Thunderhead\Isle of Songs\Inside\Exit:
+    index: 0
+    req_index: 1898
+    room: 0
+    short_name: Isle of Songs - Exit
+    stage: F010r
+    type: exit
+    vanilla: Isle of Songs - Entrance from Inside
+  \Skyloft\Beedle's Shop\Day Exit:
+    index: 0
+    req_index: 1828
+    room: 0
+    short_name: Beedle's Shop - Day Exit
+    stage: F002r
+    type: exit
+    vanilla: Skyloft - Entrance from Beedle's Shop
+  \Skyloft\Beedle's Shop\Night Exit:
+    allowed-time-of-day: NightOnly
+    index: 2
+    req_index: 1829
+    room: 0
+    short_name: Beedle's Shop - Night Exit
+    stage: F002r
+    type: exit
+    vanilla: Sky - Beedle's Island - Beedle's Ship Entrance
+  \Skyloft\Central Skyloft\Bazaar North Exit:
+    index: 1
+    req_index: 1825
+    room: 0
+    short_name: Bazaar North Exit
+    stage: F000
+    type: exit
+    vanilla: Bazaar - North Entrance
+  \Skyloft\Central Skyloft\Bazaar South Exit:
+    index: 2
+    req_index: 1826
+    room: 0
+    short_name: Bazaar South Exit
+    stage: F000
+    type: exit
+    vanilla: Bazaar - South Entrance
+  \Skyloft\Central Skyloft\Bazaar West Exit:
+    index: 19
+    req_index: 1827
+    room: 0
+    short_name: Bazaar West Exit
+    stage: F000
+    type: exit
+    vanilla: Bazaar - West Entrance
+  \Skyloft\Central Skyloft\Bazaar\North Exit:
+    index: 0
+    req_index: 1822
+    room: 0
+    short_name: Bazaar - North Exit
+    stage: F004r
+    type: exit
+    vanilla: Bazaar North Entrance
+  \Skyloft\Central Skyloft\Bazaar\South Exit:
+    index: 1
+    req_index: 1823
+    room: 0
+    short_name: Bazaar - South Exit
+    stage: F004r
+    type: exit
+    vanilla: Bazaar South Entrance
+  \Skyloft\Central Skyloft\Bazaar\West Exit:
+    index: 2
+    req_index: 1824
+    room: 0
+    short_name: Bazaar - West Exit
+    stage: F004r
+    type: exit
+    vanilla: Bazaar West Entrance
+  \Skyloft\Central Skyloft\Exit to Beedle's Shop:
+    index: 26
+    req_index: 1830
+    room: 0
+    short_name: Skyloft - Exit to Beedle's Shop
+    stage: F000
+    type: exit
+    vanilla: Beedle's Shop - Day Entrance
+  \Skyloft\Central Skyloft\Exit to Sky:
+    req_index: 1854
+    short_name: Skyloft - Exit to Sky
+    type: exit
+    vanilla: Sky - Entrance from Skyloft
+  \Skyloft\Central Skyloft\Near Temple Entrance\Exit to Sky Keep:
+    index: 48
+    req_index: 1833
+    room: 0
+    short_name: Skyloft - Exit to Sky Keep
+    stage: F000
+    type: exit
+    vanilla: Sky Keep - First Room - Bottom Entrance
+  \Skyloft\Central Skyloft\Orielle and Parrow's House Exit:
+    index: 31
+    req_index: 1835
+    room: 0
+    short_name: Orielle and Parrow's House Exit
+    stage: F000
+    type: exit
+    vanilla: Orielle and Parrow's House - Entrance
+  \Skyloft\Central Skyloft\Orielle and Parrow's House\Exit:
+    index: 0
+    req_index: 1834
+    room: 0
+    short_name: Orielle and Parrow's House - Exit
+    stage: F005r
+    type: exit
+    vanilla: Orielle and Parrow's House Entrance
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Exit:
+    index: 7
+    req_index: 1821
+    room: 0
+    short_name: Waterfall Cave Lower Exit
+    stage: F000
+    type: exit
+    vanilla: Waterfall Cave - Lower Entrance
+  \Skyloft\Central Skyloft\Peatrice's House Exit:
+    index: 38
+    req_index: 1837
+    room: 0
+    short_name: Peatrice's House Exit
+    stage: F000
+    type: exit
+    vanilla: Peatrice's House - Entrance
+  \Skyloft\Central Skyloft\Peatrice's House\Exit:
+    index: 0
+    req_index: 1836
+    room: 0
+    short_name: Peatrice's House - Exit
+    stage: F018r
+    type: exit
+    vanilla: Peatrice's House Entrance
+  \Skyloft\Central Skyloft\Piper's House Exit:
+    index: 32
+    req_index: 1853
+    room: 0
+    short_name: Piper's House Exit
+    stage: F000
+    type: exit
+    vanilla: Piper's House - Entrance
+  \Skyloft\Central Skyloft\Piper's House\Exit:
+    index: 0
+    req_index: 1852
+    room: 0
+    short_name: Piper's House - Exit
+    stage: F007r
+    type: exit
+    vanilla: Piper's House Entrance
+  \Skyloft\Central Skyloft\Trial Gate Exit:
+    req_index: 1832
+    short_name: Skyloft - Trial Gate Exit
+    type: exit
+    vanilla: Skyloft Silent Realm - Entrance
+  \Skyloft\Central Skyloft\Waterfall Cave Upper Exit:
+    index: 6
+    req_index: 1820
+    room: 0
+    short_name: Waterfall Cave Upper Exit
+    stage: F000
+    type: exit
+    vanilla: Waterfall Cave - Upper Entrance
+  \Skyloft\Central Skyloft\Waterfall Cave\Lower Exit:
+    index: 1
+    req_index: 1819
+    room: 0
+    short_name: Waterfall Cave - Lower Exit
+    stage: D000
+    type: exit
+    vanilla: Waterfall Cave Lower Entrance
+  \Skyloft\Central Skyloft\Waterfall Cave\Upper Exit:
+    index: 0
+    req_index: 1818
+    room: 0
+    short_name: Waterfall Cave - Upper Exit
+    stage: D000
+    type: exit
+    vanilla: Waterfall Cave Upper Entrance
+  \Skyloft\Central Skyloft\Wryna's House Exit:
+    index: 10
+    req_index: 1839
+    room: 0
+    short_name: Wryna's House Exit
+    stage: F000
+    type: exit
+    vanilla: Wryna's House - Entrance
+  \Skyloft\Central Skyloft\Wryna's House\Exit:
+    index: 0
+    req_index: 1838
+    room: 0
+    short_name: Wryna's House - Exit
+    stage: F006r
+    type: exit
+    vanilla: Wryna's House Entrance
+  \Skyloft\Skyloft Silent Realm\Exit:
+    req_index: 1831
+    short_name: Skyloft Silent Realm - Exit
+    type: exit
+    vanilla: Skyloft - Trial Gate Entrance
+  \Skyloft\Skyloft Village\Batreaux's House Exit:
+    index: 30
+    req_index: 1847
+    room: 0
+    short_name: Batreaux's House Exit
+    stage: F000
+    type: exit
+    vanilla: Batreaux's House - Entrance
+  \Skyloft\Skyloft Village\Batreaux's House\Exit:
+    index: 0
+    req_index: 1846
+    room: 0
+    short_name: Batreaux's House - Exit
+    stage: F012r
+    type: exit
+    vanilla: Batreaux's House Entrance
+  \Skyloft\Skyloft Village\Bertie's House Exit:
+    index: 34
+    req_index: 1841
+    room: 0
+    short_name: Bertie's House Exit
+    stage: F000
+    type: exit
+    vanilla: Bertie's House - Entrance
+  \Skyloft\Skyloft Village\Bertie's House\Exit:
+    index: 0
+    req_index: 1840
+    room: 0
+    short_name: Bertie's House - Exit
+    stage: F014r
+    type: exit
+    vanilla: Bertie's House Entrance
+  \Skyloft\Skyloft Village\Gondo's House Exit:
+    index: 35
+    req_index: 1849
+    room: 0
+    short_name: Gondo's House Exit
+    stage: F000
+    type: exit
+    vanilla: Gondo's House - Entrance
+  \Skyloft\Skyloft Village\Gondo's House\Exit:
+    index: 0
+    req_index: 1848
+    room: 0
+    short_name: Gondo's House - Exit
+    stage: F015r
+    type: exit
+    vanilla: Gondo's House Entrance
+  \Skyloft\Skyloft Village\Mallara's House Exit:
+    index: 36
+    req_index: 1844
+    room: 0
+    short_name: Skyloft - Mallara's House Exit
+    stage: F000
+    type: exit
+    vanilla: Mallara's House - Entrance
+  \Skyloft\Skyloft Village\Mallara's House\Exit:
+    index: 0
+    req_index: 1845
+    room: 0
+    short_name: Mallara's House - Exit
+    stage: F016r
+    type: exit
+    vanilla: Mallara's House Entrance
+  \Skyloft\Skyloft Village\Rupin's House Exit:
+    index: 37
+    req_index: 1851
+    room: 0
+    short_name: Rupin's House Exit
+    stage: F000
+    type: exit
+    vanilla: Rupin's House - Entrance
+  \Skyloft\Skyloft Village\Rupin's House\Exit:
+    index: 1
+    req_index: 1850
+    room: 0
+    short_name: Rupin's House - Exit
+    stage: F017r
+    type: exit
+    vanilla: Rupin's House Entrance
+  \Skyloft\Skyloft Village\Sparrot's House Exit:
+    index: 33
+    req_index: 1843
+    room: 0
+    short_name: Sparrot's House Exit
+    stage: F000
+    type: exit
+    vanilla: Sparrot's House - Entrance
+  \Skyloft\Skyloft Village\Sparrot's House\Exit:
+    index: 0
+    req_index: 1842
+    room: 0
+    short_name: Sparrot's House - Exit
+    stage: F013r
+    type: exit
+    vanilla: Sparrot's House Entrance
+  \Skyloft\Upper Skyloft\Goddess Statue Exit:
+    index: 5
+    req_index: 1817
+    room: 0
+    short_name: Goddess Statue Exit
+    stage: F000
+    type: exit
+    vanilla: Goddess Statue - Entrance
+  \Skyloft\Upper Skyloft\Goddess Statue\Exit:
+    index: 0
+    req_index: 1816
+    room: 0
+    short_name: Goddess Statue - Exit
+    stage: F008r
+    type: exit
+    vanilla: Goddess Statue Entrance
+  \Skyloft\Upper Skyloft\Knight Academy Chimney Entrance:
+    index: 57
+    req_index: 1811
+    room: 0
+    short_name: Skyloft - Knight Academy Chimney Entrance
+    stage: F000
+    type: exit
+    vanilla: Skyloft - Knight Academy - Chimney
+  \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Exit:
+    index: 4
+    req_index: 1808
+    room: 0
+    short_name: Skyloft - Knight Academy Lower Left Door Exit
+    stage: F000
+    type: exit
+    vanilla: Skyloft - Knight Academy - Lower Right Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Exit:
+    index: 3
+    req_index: 1807
+    room: 0
+    short_name: Skyloft - Knight Academy Lower Right Door Exit
+    stage: F000
+    type: exit
+    vanilla: Skyloft - Knight Academy - Lower Left Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Exit:
+    index: 23
+    req_index: 1809
+    room: 0
+    short_name: Skyloft - Knight Academy Upper Left Door Exit
+    stage: F000
+    type: exit
+    vanilla: Skyloft - Knight Academy - Upper Right Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Exit:
+    index: 24
+    req_index: 1810
+    room: 0
+    short_name: Skyloft - Knight Academy Upper Right Door Exit
+    stage: F000
+    type: exit
+    vanilla: Skyloft - Knight Academy - Upper Left Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Exit:
+    index: 0
+    req_index: 1803
+    room: 0
+    short_name: Skyloft - Knight Academy - Lower Left Door Exit
+    stage: F001r
+    type: exit
+    vanilla: Skyloft - Knight Academy Lower Right Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Exit:
+    index: 1
+    req_index: 1804
+    room: 0
+    short_name: Skyloft - Knight Academy - Lower Right Door Exit
+    stage: F001r
+    type: exit
+    vanilla: Skyloft - Knight Academy Lower Left Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Exit:
+    index: 3
+    req_index: 1806
+    room: 0
+    short_name: Skyloft - Knight Academy - Upper Left Door Exit
+    stage: F001r
+    type: exit
+    vanilla: Skyloft - Knight Academy Upper Right Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Exit:
+    index: 2
+    req_index: 1805
+    room: 0
+    short_name: Skyloft - Knight Academy - Upper Right Door Exit
+    stage: F001r
+    type: exit
+    vanilla: Skyloft - Knight Academy Upper Left Door Entrance
+  \Skyloft\Upper Skyloft\Sparring Hall Left Door Exit:
+    index: 20
+    req_index: 1814
+    room: 0
+    short_name: Skyloft - Sparring Hall Left Door Exit
+    stage: F000
+    type: exit
+    vanilla: Sparring Hall - Right Door Entrance
+  \Skyloft\Upper Skyloft\Sparring Hall Right Door Exit:
+    index: 27
+    req_index: 1815
+    room: 0
+    short_name: Skyloft - Sparring Hall Right Door Exit
+    stage: F000
+    type: exit
+    vanilla: Sparring Hall - Left Door Entrance
+  \Skyloft\Upper Skyloft\Sparring Hall\Left Door Exit:
+    index: 1
+    req_index: 1813
+    room: 0
+    short_name: Sparring Hall - Left Door Exit
+    stage: F009r
+    type: exit
+    vanilla: Skyloft - Sparring Hall Right Door Entrance
+  \Skyloft\Upper Skyloft\Sparring Hall\Right Door Exit:
+    index: 0
+    req_index: 1812
+    room: 0
+    short_name: Sparring Hall - Right Door Exit
+    stage: F009r
+    type: exit
+    vanilla: Skyloft - Sparring Hall Left Door Entrance
+  \Skyview\Boss Room\Exit to Dungeon:
+    req_index: 1945
+    short_name: Skyview Temple - Boss Room - Exit to Dungeon
+    type: exit
+    vanilla: Skyview Temple - Boss Door Entrance
+  \Skyview\Boss Room\Exit to Spring:
+    req_index: 1946
+    short_name: Skyview Temple - Boss Room - Exit to Spring
+    type: exit
+    vanilla: Skyview Temple - Spring - Entrance
+  \Skyview\Main\Entry\Main Exit:
+    req_index: 1943
+    short_name: Skyview Temple - Main Exit
+    type: exit
+    vanilla: Deep Woods - Entrance from Skyview Temple
+  \Skyview\Main\Last Room\After Rope\Boss Door Exit:
+    req_index: 1944
+    short_name: Skyview Temple - Boss Door Exit
+    type: exit
+    vanilla: Skyview Temple - Boss Room - Entrance from Dungeon
+  \Skyview\Spring\Exit:
+    req_index: 1947
+    short_name: Skyview Temple - Spring - Exit
+    type: exit
+    vanilla: Skyview Temple - Boss Room - Entrance from Spring
+  \Start:
+    index: 2
+    req_index: 1802
+    room: 1
+    short_name: Start
+    stage: F001r
+    type: exit
+    vanilla: Skyloft - Knight Academy - Start Entrance
+gossip_stones:
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Gossip Stone near Second Thirsty Frog:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 861
+    short_name: Volcano Summit - Gossip Stone near Second Thirsty Frog
+    textfile: 004-Object
+    textindex: 31
+  \Eldin\Volcano Summit\Waterfall\Higher Area\Gossip Stone in Waterfall Area:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 855
+    short_name: Volcano Summit - Gossip Stone in Waterfall Area
+    textfile: 004-Object
+    textindex: 26
+  \Eldin\Volcano\Lower Platform Cave\Gossip Stone in Lower Platform Cave:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 832
+    short_name: Eldin Volcano - Gossip Stone in Lower Platform Cave
+    textfile: 004-Object
+    textindex: 17
+  \Eldin\Volcano\Near Temple Entrance\Gossip Stone next to Earth Temple:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 822
+    short_name: Eldin Volcano - Gossip Stone next to Earth Temple
+    textfile: 004-Object
+    textindex: 14
+  \Eldin\Volcano\Thrill Digger Cave\Gossip Stone in Thrill Digger Cave:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 817
+    short_name: Eldin Volcano - Gossip Stone in Thrill Digger Cave
+    textfile: 004-Object
+    textindex: 16
+  \Eldin\Volcano\Upper Platform Cave\Gossip Stone in Upper Platform Cave:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 827
+    short_name: Eldin Volcano - Gossip Stone in Upper Platform Cave
+    textfile: 004-Object
+    textindex: 21
+  \Faron\Faron Woods\Deep Woods\Gossip Stone in Deep Woods:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 924
+    short_name: Faron Woods - Gossip Stone in Deep Woods
+    textfile: 004-Object
+    textindex: 15
+  \Faron\Lake Floria\Waterfall\Gossip Stone outside Ancient Cistern:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 971
+    short_name: Lake Floria - Gossip Stone outside Ancient Cistern
+    textfile: 004-Object
+    textindex: 28
+  \Faron\Sealed Grounds\Behind the Temple\Gossip Stone behind the Temple:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 890
+    short_name: Sealed Grounds - Gossip Stone behind the Temple
+    textfile: 004-Object
+    textindex: 13
+  \Lanayru\Caves\Gossip Stone in Center:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1139
+    short_name: Lanayru Caves - Gossip Stone in Center
+    textfile: 004-Object
+    textindex: 24
+  \Lanayru\Caves\Past Crawlspace\Gossip Stone towards Lanayru Gorge:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1140
+    short_name: Lanayru Caves - Gossip Stone towards Lanayru Gorge
+    textfile: 004-Object
+    textindex: 29
+  \Lanayru\Lanayru Sand Sea\Shipyard\Gossip Stone in Shipyard:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1158
+    short_name: Lanayru Sand Sea - Gossip Stone in Shipyard
+    textfile: 004-Object
+    textindex: 23
+  \Lanayru\Temple of Time\Front\Gossip Stone in Temple of Time Area:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1119
+    short_name: Temple of Time - Gossip Stone in Temple of Time Area
+    textfile: 004-Object
+    textindex: 25
+  \Sky\North East\Bamboo Island\Inside\Gossip Stone on Bamboo Island:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1246
+    short_name: Sky - Gossip Stone on Bamboo Island
+    textfile: 004-Object
+    textindex: 11
+  \Sky\South East\Lumpy Pumpkin\Gossip Stone on Lumpy Pumpkin:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1258
+    short_name: Sky - Gossip Stone on Lumpy Pumpkin
+    textfile: 004-Object
+    textindex: 27
+  \Sky\South West\Volcanic Island\Gossip Stone on Volcanic Island:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1271
+    short_name: Sky - Gossip Stone on Volcanic Island
+    textfile: 004-Object
+    textindex: 30
+  \Sky\Thunderhead\Bug Heaven\Gossip Stone near Bug Heaven:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1296
+    short_name: Thunderhead - Gossip Stone near Bug Heaven
+    textfile: 004-Object
+    textindex: 12
+  \Skyloft\Central Skyloft\Waterfall Island\Gossip Stone on Waterfall Island:
+    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
+    - 1347
+    short_name: Central Skyloft - Gossip Stone on Waterfall Island
+    textfile: 124-Town6
+    textindex: 18
+items:
+- Day
+- Night
+- Banned
+- Everything
+- Everything unbanned
+- Hint bypass
+- 5 Bombs
+- Amber Tablet
+- Ancient Cistern Boss Key
+- Ancient Cistern Map
+- 'Ancient Cistern Small Key #0'
+- 'Ancient Cistern Small Key #1'
+- Baby Rattle
+- Ballad of the Goddess
+- 'Blue Rupee #0'
+- 'Blue Rupee #1'
+- 'Blue Rupee #10'
+- 'Blue Rupee #2'
+- 'Blue Rupee #3'
+- 'Blue Rupee #4'
+- 'Blue Rupee #5'
+- 'Blue Rupee #6'
+- 'Blue Rupee #7'
+- 'Blue Rupee #8'
+- 'Blue Rupee #9'
+- Bomb Bag
+- Bug Medal
+- Cawlin's Letter
+- Clawshots
+- Cursed Medal
+- Din's Power
+- 'Dusk Relic #0'
+- 'Dusk Relic #1'
+- 'Dusk Relic #10'
+- 'Dusk Relic #11'
+- 'Dusk Relic #12'
+- 'Dusk Relic #13'
+- 'Dusk Relic #14'
+- 'Dusk Relic #15'
+- 'Dusk Relic #16'
+- 'Dusk Relic #17'
+- 'Dusk Relic #18'
+- 'Dusk Relic #19'
+- 'Dusk Relic #2'
+- 'Dusk Relic #20'
+- 'Dusk Relic #21'
+- 'Dusk Relic #22'
+- 'Dusk Relic #23'
+- 'Dusk Relic #24'
+- 'Dusk Relic #25'
+- 'Dusk Relic #26'
+- 'Dusk Relic #27'
+- 'Dusk Relic #28'
+- 'Dusk Relic #29'
+- 'Dusk Relic #3'
+- 'Dusk Relic #30'
+- 'Dusk Relic #31'
+- 'Dusk Relic #32'
+- 'Dusk Relic #33'
+- 'Dusk Relic #34'
+- 'Dusk Relic #35'
+- 'Dusk Relic #36'
+- 'Dusk Relic #37'
+- 'Dusk Relic #38'
+- 'Dusk Relic #39'
+- 'Dusk Relic #4'
+- 'Dusk Relic #40'
+- 'Dusk Relic #5'
+- 'Dusk Relic #6'
+- 'Dusk Relic #7'
+- 'Dusk Relic #8'
+- 'Dusk Relic #9'
+- Earth Temple Boss Key
+- Earth Temple Map
+- 'Eldin Ore #0'
+- 'Eldin Ore #1'
+- Eldin Song of the Hero Part
+- Emerald Tablet
+- 'Empty Bottle #0'
+- 'Empty Bottle #1'
+- 'Empty Bottle #2'
+- 'Empty Bottle #3'
+- 'Empty Bottle #4'
+- 'Evil Crystal #0'
+- 'Evil Crystal #1'
+- 'Extra Wallet #0'
+- 'Extra Wallet #1'
+- 'Extra Wallet #2'
+- Faron Song of the Hero Part
+- Farore's Courage
+- Fire Sanctuary Boss Key
+- Fire Sanctuary Map
+- 'Fire Sanctuary Small Key #0'
+- 'Fire Sanctuary Small Key #1'
+- 'Fire Sanctuary Small Key #2'
+- Fireshield Earrings
+- Goddess Plume
+- Goddess's Harp
+- 'Gold Rupee #0'
+- 'Gold Rupee #1'
+- 'Gold Rupee #10'
+- 'Gold Rupee #2'
+- 'Gold Rupee #3'
+- 'Gold Rupee #4'
+- 'Gold Rupee #5'
+- 'Gold Rupee #6'
+- 'Gold Rupee #7'
+- 'Gold Rupee #8'
+- 'Gold Rupee #9'
+- Golden Skull
+- 'Gratitude Crystal #0'
+- 'Gratitude Crystal #1'
+- 'Gratitude Crystal #10'
+- 'Gratitude Crystal #11'
+- 'Gratitude Crystal #12'
+- 'Gratitude Crystal #13'
+- 'Gratitude Crystal #14'
+- 'Gratitude Crystal #2'
+- 'Gratitude Crystal #3'
+- 'Gratitude Crystal #4'
+- 'Gratitude Crystal #5'
+- 'Gratitude Crystal #6'
+- 'Gratitude Crystal #7'
+- 'Gratitude Crystal #8'
+- 'Gratitude Crystal #9'
+- 'Gratitude Crystal Pack #0'
+- 'Gratitude Crystal Pack #1'
+- 'Gratitude Crystal Pack #10'
+- 'Gratitude Crystal Pack #11'
+- 'Gratitude Crystal Pack #12'
+- 'Gratitude Crystal Pack #2'
+- 'Gratitude Crystal Pack #3'
+- 'Gratitude Crystal Pack #4'
+- 'Gratitude Crystal Pack #5'
+- 'Gratitude Crystal Pack #6'
+- 'Gratitude Crystal Pack #7'
+- 'Gratitude Crystal Pack #8'
+- 'Gratitude Crystal Pack #9'
+- 'Green Rupee #0'
+- 'Green Rupee #1'
+- 'Green Rupee #2'
+- 'Group of Tadtones #0'
+- 'Group of Tadtones #1'
+- 'Group of Tadtones #10'
+- 'Group of Tadtones #11'
+- 'Group of Tadtones #12'
+- 'Group of Tadtones #13'
+- 'Group of Tadtones #14'
+- 'Group of Tadtones #15'
+- 'Group of Tadtones #16'
+- 'Group of Tadtones #2'
+- 'Group of Tadtones #3'
+- 'Group of Tadtones #4'
+- 'Group of Tadtones #5'
+- 'Group of Tadtones #6'
+- 'Group of Tadtones #7'
+- 'Group of Tadtones #8'
+- 'Group of Tadtones #9'
+- Gust Bellows
+- 'Heart Container #0'
+- 'Heart Container #1'
+- 'Heart Container #2'
+- 'Heart Container #3'
+- 'Heart Container #4'
+- 'Heart Container #5'
+- 'Heart Medal #0'
+- 'Heart Medal #1'
+- 'Heart Piece #0'
+- 'Heart Piece #1'
+- 'Heart Piece #10'
+- 'Heart Piece #11'
+- 'Heart Piece #12'
+- 'Heart Piece #13'
+- 'Heart Piece #14'
+- 'Heart Piece #15'
+- 'Heart Piece #16'
+- 'Heart Piece #17'
+- 'Heart Piece #18'
+- 'Heart Piece #19'
+- 'Heart Piece #2'
+- 'Heart Piece #20'
+- 'Heart Piece #21'
+- 'Heart Piece #22'
+- 'Heart Piece #23'
+- 'Heart Piece #3'
+- 'Heart Piece #4'
+- 'Heart Piece #5'
+- 'Heart Piece #6'
+- 'Heart Piece #7'
+- 'Heart Piece #8'
+- 'Heart Piece #9'
+- Horned Colossus Beetle
+- Hylian Shield
+- 'Key Piece #0'
+- 'Key Piece #1'
+- 'Key Piece #2'
+- 'Key Piece #3'
+- 'Key Piece #4'
+- Lanayru Caves Small Key
+- Lanayru Mining Facility Boss Key
+- Lanayru Mining Facility Map
+- Lanayru Mining Facility Small Key
+- Lanayru Song of the Hero Part
+- 'Life Medal #0'
+- 'Life Medal #1'
+- Life Tree Fruit
+- Nayru's Wisdom
+- Potion Medal
+- 'Progressive Beetle #0'
+- 'Progressive Beetle #1'
+- 'Progressive Beetle #2'
+- 'Progressive Beetle #3'
+- 'Progressive Bow #0'
+- 'Progressive Bow #1'
+- 'Progressive Bow #2'
+- 'Progressive Bug Net #0'
+- 'Progressive Bug Net #1'
+- 'Progressive Mitts #0'
+- 'Progressive Mitts #1'
+- 'Progressive Pouch #0'
+- 'Progressive Pouch #1'
+- 'Progressive Pouch #2'
+- 'Progressive Pouch #3'
+- 'Progressive Pouch #4'
+- 'Progressive Slingshot #0'
+- 'Progressive Slingshot #1'
+- 'Progressive Sword #0'
+- 'Progressive Sword #1'
+- 'Progressive Sword #2'
+- 'Progressive Sword #3'
+- 'Progressive Sword #4'
+- 'Progressive Sword #5'
+- 'Progressive Wallet #0'
+- 'Progressive Wallet #1'
+- 'Progressive Wallet #2'
+- 'Progressive Wallet #3'
+- 'Rare Treasure #0'
+- 'Rare Treasure #1'
+- 'Rare Treasure #10'
+- 'Rare Treasure #11'
+- 'Rare Treasure #2'
+- 'Rare Treasure #3'
+- 'Rare Treasure #4'
+- 'Rare Treasure #5'
+- 'Rare Treasure #6'
+- 'Rare Treasure #7'
+- 'Rare Treasure #8'
+- 'Rare Treasure #9'
+- 'Red Rupee #0'
+- 'Red Rupee #1'
+- 'Red Rupee #10'
+- 'Red Rupee #11'
+- 'Red Rupee #12'
+- 'Red Rupee #13'
+- 'Red Rupee #14'
+- 'Red Rupee #15'
+- 'Red Rupee #16'
+- 'Red Rupee #17'
+- 'Red Rupee #18'
+- 'Red Rupee #19'
+- 'Red Rupee #2'
+- 'Red Rupee #20'
+- 'Red Rupee #21'
+- 'Red Rupee #22'
+- 'Red Rupee #23'
+- 'Red Rupee #24'
+- 'Red Rupee #25'
+- 'Red Rupee #26'
+- 'Red Rupee #27'
+- 'Red Rupee #28'
+- 'Red Rupee #29'
+- 'Red Rupee #3'
+- 'Red Rupee #30'
+- 'Red Rupee #31'
+- 'Red Rupee #32'
+- 'Red Rupee #33'
+- 'Red Rupee #34'
+- 'Red Rupee #35'
+- 'Red Rupee #36'
+- 'Red Rupee #37'
+- 'Red Rupee #38'
+- 'Red Rupee #39'
+- 'Red Rupee #4'
+- 'Red Rupee #40'
+- 'Red Rupee #41'
+- 'Red Rupee #5'
+- 'Red Rupee #6'
+- 'Red Rupee #7'
+- 'Red Rupee #8'
+- 'Red Rupee #9'
+- Ruby Tablet
+- 'Rupee Medal #0'
+- 'Rupee Medal #1'
+- Sandship Boss Key
+- Sandship Map
+- 'Sandship Small Key #0'
+- 'Sandship Small Key #1'
+- Scrapper
+- Sea Chart
+- 'Semi Rare Treasure #0'
+- 'Semi Rare Treasure #1'
+- 'Semi Rare Treasure #2'
+- 'Semi Rare Treasure #3'
+- 'Semi Rare Treasure #4'
+- 'Semi Rare Treasure #5'
+- 'Semi Rare Treasure #6'
+- 'Semi Rare Treasure #7'
+- 'Semi Rare Treasure #8'
+- 'Semi Rare Treasure #9'
+- 'Silver Rupee #0'
+- 'Silver Rupee #1'
+- 'Silver Rupee #10'
+- 'Silver Rupee #11'
+- 'Silver Rupee #12'
+- 'Silver Rupee #13'
+- 'Silver Rupee #14'
+- 'Silver Rupee #15'
+- 'Silver Rupee #16'
+- 'Silver Rupee #17'
+- 'Silver Rupee #18'
+- 'Silver Rupee #19'
+- 'Silver Rupee #2'
+- 'Silver Rupee #20'
+- 'Silver Rupee #21'
+- 'Silver Rupee #3'
+- 'Silver Rupee #4'
+- 'Silver Rupee #5'
+- 'Silver Rupee #6'
+- 'Silver Rupee #7'
+- 'Silver Rupee #8'
+- 'Silver Rupee #9'
+- Sky Keep Map
+- Sky Keep Small Key
+- Skyview Boss Key
+- Skyview Map
+- 'Skyview Small Key #0'
+- 'Skyview Small Key #1'
+- Small Bomb Bag
+- Small Quiver
+- Small Seed Satchel
+- Spiral Charge
+- Stone of Trials
+- Treasure Medal
+- Triforce of Courage
+- Triforce of Power
+- Triforce of Wisdom
+- Tumbleweed
+- Water Dragon's Scale
+- Whip
+- Wooden Shield
+- Open Thunderhead option
+- Open ET option
+- Open LMF option
+- LMF Nodes On option
+- Floria Gates option
+- Talk to Yerbal option
+- Vanilla Lake Floria option
+- Open Lake Floria option
+- Randomized Beedle option
+- Gondo Upgrades On option
+- No BiT crashes
+- Nonlethal Hot Cave
+- Upgraded Skyward Strike option
+- FS Lava Flow option
+- GoT Opening Requirement
+- GoT Raising Requirement
+- Horde Door Requirement
+- Bomb Throws Trick
+- Long Range Skyward Strike Jumpslash Trick
+- Advanced Lizalfos Combat Trick
+- Waterfall Cave Jump Trick
+- Beedle's Shop With Bombs Trick
+- Baby Rattle from Beedle's Shop Trick
+- Sky Keep Entrance Jump Trick
+- Gravestone Jump Trick
+- Sky - Volcanic Island Dive Trick
+- Sky - Beedle's Island Cage Chest Dive Trick
+- Thunderhead - East Island Dive Trick
+- Gym's Rope Jump Trick
+- Early Lake Floria - Fence Hop Trick
+- Early Lake Floria - Swordless Rope Floria Trick
+- Faron - Bokoblin Luring Trick
+- Stuttersprint Trick
+- Itemless First Timeshift Stone Trick
+- Lanayru Mine - Quick Bomb Trick
+- Brakeslide Trick
+- Lanayru Desert - Ampilus Bomb Toss Trick
+- Temple of Time - Slingshot Shot Trick
+- Temple of Time Skip - Brakeslide Trick
+- Secret Passageway Hook Beetle Opening Trick
+- Lightning Node End with Bombs Trick
+- Cactus Bomb Whip Trick
+- Skipper's Retreat Fast Clawshots Trick
+- Skyview - Spider Roll Trick
+- Skyview Slingshot Shot Trick
+- Earth Temple - Keese Yeet Trick
+- Earth Temple - Slope Stuttersprint Trick
+- Earth Temple - Bomb Flower Scaldera Trick
+- LMF - Whip First Room Switch Trick
+- LMF - Keylocked Slingshot Trickshot Trick
+- LMF - Whip Armos Room Timeshift Stone Trick
+- LMF - Minecart Jump Trick
+- LMF - Moldarach without Gust Bellows Trick
+- Ancient Cistern - Cistern Clip Trick
+- Ancient Cistern - Cistern Whip Room Clip Trick
+- Ancient Cistern - Map Chest Jump Trick
+- Ancient Cistern - Lever Jump Trick
+- Ancient Cistern - Basement Highflip Trick
+- Sandship - No Combination Hint Trick
+- Sandship - Itemless Spume Skip Trick
+- Sandship - Mast Jump Trick
+- Fire Sanctuary - Pillar Jump Trick
+- Fire Sanctuary - Swordless Pillar Jump Trick
+- Fire Sanctuary - No Bombable Wall Hint Trick
+- Sky Keep - Shooting LMF Bow Switches in Present Trick
+- Sky Keep - FS Room Clawshots Vine Clip Trick
+- Bed Trick Trick
+- Owlan Crystals without Bombs Trick
+- Ancient Cistern - Lilypad Skip Trick
+- Ancient Cistern - Swordless Cistern Clip Trick
+- Fire Sanctuary - Hook Beetle Skip Trick
+- 'Hint #0'
+- 'Hint #1'
+- 'Hint #2'
+- 'Hint #3'
+- 'Hint #4'
+- 'Hint #5'
+- 'Hint #6'
+- 'Hint #7'
+- 'Hint #8'
+- 'Hint #9'
+- 'Hint #10'
+- 'Hint #11'
+- 'Hint #12'
+- 'Hint #13'
+- 'Hint #14'
+- 'Hint #15'
+- 'Hint #16'
+- 'Hint #17'
+- 'Hint #18'
+- 'Hint #19'
+- 'Hint #20'
+- 'Hint #21'
+- 'Hint #22'
+- 'Hint #23'
+- 'Hint #24'
+- 'Hint #25'
+- 'Hint #26'
+- 'Hint #27'
+- 'Hint #28'
+- 'Hint #29'
+- 'Hint #30'
+- 'Hint #31'
+- 'Hint #32'
+- 'Hint #33'
+- 'Hint #34'
+- 'Hint #35'
+- 'Hint #36'
+- 'Hint #37'
+- 'Hint #38'
+- 'Hint #39'
+- 'Hint #40'
+- 'Hint #41'
+- 'Hint #42'
+- 'Hint #43'
+- 'Hint #44'
+- 'Hint #45'
+- 'Hint #46'
+- 'Hint #47'
+- 'Hint #48'
+- 'Hint #49'
+- 'Hint #50'
+- 'Hint #51'
+- 'Hint #52'
+- 'Hint #53'
+- 'Hint #54'
+- 'Hint #55'
+- 'Hint #56'
+- 'Hint #57'
+- 'Hint #58'
+- 'Hint #59'
+- 'Hint #60'
+- 'Hint #61'
+- 'Hint #62'
+- 'Hint #63'
+- 'Hint #64'
+- 'Hint #65'
+- 'Hint #66'
+- 'Hint #67'
+- 'Hint #68'
+- 'Hint #69'
+- 'Hint #70'
+- 'Hint #71'
+- 'Hint #72'
+- 'Hint #73'
+- 'Hint #74'
+- 'Hint #75'
+- 'Hint #76'
+- 'Hint #77'
+- 'Hint #78'
+- 'Hint #79'
+- 'Hint #80'
+- 'Hint #81'
+- 'Hint #82'
+- 'Hint #83'
+- 'Hint #84'
+- 'Hint #85'
+- 'Hint #86'
+- 'Hint #87'
+- 'Hint #88'
+- 'Hint #89'
+- 'Hint #90'
+- 'Hint #91'
+- 'Hint #92'
+- 'Hint #93'
+- 'Hint #94'
+- 'Hint #95'
+- 'Hint #96'
+- 'Hint #97'
+- 'Hint #98'
+- 'Hint #99'
+- 'Hint #100'
+- 'Hint #101'
+- 'Hint #102'
+- 'Hint #103'
+- 'Hint #104'
+- 'Hint #105'
+- 'Hint #106'
+- 'Hint #107'
+- 'Hint #108'
+- 'Hint #109'
+- 'Hint #110'
+- 'Hint #111'
+- 'Hint #112'
+- 'Hint #113'
+- 'Hint #114'
+- 'Hint #115'
+- 'Hint #116'
+- 'Hint #117'
+- 'Hint #118'
+- 'Hint #119'
+- 'Hint #120'
+- 'Hint #121'
+- 'Hint #122'
+- 'Hint #123'
+- 'Hint #124'
+- 'Hint #125'
+- 'Hint #126'
+- 'Hint #127'
+- 'Hint #128'
+- 'Hint #129'
+- 'Hint #130'
+- 'Hint #131'
+- 'Hint #132'
+- 'Hint #133'
+- 'Hint #134'
+- 'Hint #135'
+- 'Hint #136'
+- 'Hint #137'
+- 'Hint #138'
+- 'Hint #139'
+- 'Hint #140'
+- 'Hint #141'
+- 'Hint #142'
+- 'Hint #143'
+- 'Hint #144'
+- 'Hint #145'
+- 'Hint #146'
+- 'Hint #147'
+- 'Hint #148'
+- 'Hint #149'
+- 'Hint #150'
+- 'Hint #151'
+- 'Hint #152'
+- 'Hint #153'
+- 'Hint #154'
+- 'Hint #155'
+- 'Hint #156'
+- 'Hint #157'
+- 'Hint #158'
+- 'Hint #159'
+- 'Hint #160'
+- 'Hint #161'
+- 'Hint #162'
+- 'Hint #163'
+- 'Hint #164'
+- 'Hint #165'
+- 'Hint #166'
+- 'Hint #167'
+- 'Hint #168'
+- 'Hint #169'
+- 'Hint #170'
+- 'Hint #171'
+- 'Hint #172'
+- 'Hint #173'
+- 'Hint #174'
+- 'Hint #175'
+- 'Hint #176'
+- 'Hint #177'
+- 'Hint #178'
+- 'Hint #179'
+- 'Hint #180'
+- 'Hint #181'
+- 'Hint #182'
+- 'Hint #183'
+- 'Hint #184'
+- 'Hint #185'
+- 'Hint #186'
+- 'Hint #187'
+- 'Hint #188'
+- 'Hint #189'
+- 'Hint #190'
+- 'Hint #191'
+- 'Hint #192'
+- 'Hint #193'
+- 'Hint #194'
+- 'Hint #195'
+- 'Hint #196'
+- 'Hint #197'
+- 'Hint #198'
+- 'Hint #199'
+- 'Hint #200'
+- 'Hint #201'
+- 'Hint #202'
+- 'Hint #203'
+- 'Hint #204'
+- 'Hint #205'
+- 'Hint #206'
+- 'Hint #207'
+- \Practice Sword
+- \Goddess Sword
+- \Goddess Longsword
+- \Goddess White Sword
+- \Master Sword
+- \True Master Sword
+- \Beetle
+- \Hook Beetle
+- \Three Beetles
+- \Quick Beetle
+- \Tough Beetle
+- \Bow
+- \Slingshot
+- \Bug Net
+- \Digging Mitts
+- \Mogma Mitts
+- \Pouch
+- \Medium Wallet
+- \Big Wallet
+- \Giant Wallet
+- \Tycoon Wallet
+- \1 Extra Wallet
+- \2 Extra Wallets
+- \3 Extra Wallets
+- \Can Afford 50 Rupees
+- \Can Afford 100 Rupees
+- \Can Afford 300 Rupees
+- \Can Afford 600 Rupees
+- \Can Afford 800 Rupees
+- \Can Afford 1000 Rupees
+- \Can Afford 1200 Rupees
+- \Can Afford 1600 Rupees
+- \Can Medium Rupee Farm
+- \Can High Rupee Farm
+- \Song of the Hero
+- \Complete Triforce
+- \Empty Bottle_
+- \Bottle
+- \Can Collect Water
+- \Water Bottle
+- \Ancient Flower Farming
+- \5 Single Gratitude Crystals
+- \10 Single Gratitude Crystals
+- \15 Single Gratitude Crystals
+- \1 Gratitude Crystal Pack
+- \2 Gratitude Crystal Packs
+- \3 Gratitude Crystal Packs
+- \4 Gratitude Crystal Packs
+- \5 Gratitude Crystal Packs
+- \6 Gratitude Crystal Packs
+- \7 Gratitude Crystal Packs
+- \8 Gratitude Crystal Packs
+- \9 Gratitude Crystal Packs
+- \10 Gratitude Crystal Packs
+- \11 Gratitude Crystal Packs
+- \12 Gratitude Crystal Packs
+- \13 Gratitude Crystal Packs
+- \5 Gratitude Crystals
+- \10 Gratitude Crystals
+- \30 Gratitude Crystals
+- \40 Gratitude Crystals
+- \50 Gratitude Crystals
+- \70 Gratitude Crystals
+- \80 Gratitude Crystals
+- \Sword
+- \Long Range Skyward Strike
+- \Damaging Item
+- \Projectile Item
+- \Distance Activator
+- \Can Cut Tree
+- \Can Unlock Combination Lock
+- \Can Hit Switch
+- \Can Hit Timeshift Stone
+- \Can Hit Timeshift Stone in Minecart
+- \Early Lake Floria Tricks
+- \Can bypass Boko Base Watch Tower
+- \Can Defeat Bokoblins
+- \Can Defeat Moblins
+- \Can Defeat Keeses
+- \Can Defeat Lizalfos
+- \Can Defeat Ampilus
+- \Can Defeat Armos
+- \Can Defeat Beamos
+- \Can Defeat Cursed Bokoblins
+- \Can Defeat Stalfos
+- \Can Defeat Stalmaster
+- \Can Defeat Scervo/Dreadfuse
+- \Ancient Cistern\Can Lower Statue
+- \Ancient Cistern\Can Freely Raise and Lower Statue
+- \Ancient Cistern\Main\Main Room\Lock Combination Knowledge
+- \Ancient Cistern\Main\Main Room\Lever to East Part
+- \Ancient Cistern\Main\Main Room\Lever to Block Waterfall
+- \Ancient Cistern\Main\Main Room\Rupee in East Hand
+- \Ancient Cistern\Main\Main Room\Rupee in West Hand
+- \Ancient Cistern\Main\Main Room\After Whip Hooks\Chest after Whip Hooks
+- \Ancient Cistern\Main\Main Room\Vines Area\Chest near Vines
+- \Ancient Cistern\Main\Main Room\Vines Area\Activate Water Geyser
+- \Ancient Cistern\Main\Main Room\Behind the Waterfall\Chest behind the Waterfall
+- \Ancient Cistern\Main\Main Room\Behind the Waterfall\First Lever
+- \Ancient Cistern\Main\Main Room\Behind the Waterfall\Second Lever
+- \Ancient Cistern\Main\Main Room\Behind the Waterfall\Toilet Flush
+- \Ancient Cistern\Main\Main Room\After Gutters\Lower Lever
+- \Ancient Cistern\Main\Main Room\After Gutters\Flip First Lilypad
+- \Ancient Cistern\Main\Main Room\After Gutters\Flip Second Lilypad 1
+- \Ancient Cistern\Main\Main Room\After Gutters\Rupee under Lilypad
+- \Ancient Cistern\Main\Main Room\After Gutters\Activate Water Geyser
+- \Ancient Cistern\Main\Main Room\After Gutters\Flip Second Lilypad 2
+- \Ancient Cistern\Main\Main Room\After Gutters\Upper Area\Upper Lever
+- \Ancient Cistern\Main\Main Room\Spider Thread Area\Extend Platform
+- \Ancient Cistern\Main\East Part\Unlock Combination Lock Door
+- \Ancient Cistern\Main\East Part\Second Room\Flip Side Lilypad
+- \Ancient Cistern\Main\East Part\Second Room\Flip Main Lilypad
+- \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Cubby
+- \Ancient Cistern\Main\East Part\Second Room\First Rupee in East Part in Short Tunnel
+- \Ancient Cistern\Main\East Part\Second Room\Second Rupee in East Part in Short Tunnel
+- \Ancient Cistern\Main\East Part\Second Room\Third Rupee in East Part in Short Tunnel
+- \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Main Tunnel
+- \Ancient Cistern\Main\East Part\Chest Ledge\Chest in East Part
+- \Ancient Cistern\Main\Basement Gutters\Can Get Past Skulltula
+- \Ancient Cistern\Main\Basement Gutters\Past Skulltula\Bokoblin
+- \Ancient Cistern\Main\Basement\Stop Cursed Waterfall
+- \Ancient Cistern\Main\Basement\Blow Rock
+- \Ancient Cistern\Main\Basement\Spider Thread\Activate Water Geyser
+- \Ancient Cistern\Main\Basement\Under the Statue\Boss Key Chest
+- \Ancient Cistern\Main\Inside Statue\Activate Water Geysers
+- \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest\Chest in Key Locked
+  Room
+- \Ancient Cistern\Boss Room\Beat Koloktos
+- \Ancient Cistern\Boss Room\Heart Container
+- \Ancient Cistern\Flame Room\Farore's Flame
+- \Earth Temple\Main\First Room\Vent Chest
+- \Earth Temple\Main\First Room\Rupee above Drawbridge
+- \Earth Temple\Main\First Room\Lower Drawbridge
+- \Earth Temple\Main\First Room\Dislodge Boulder
+- \Earth Temple\Main\Hub Room\Access to Boulder
+- \Earth Temple\Main\Hub Room\Chest behind Bombable Rock
+- \Earth Temple\Main\Hub Room\Chest Left of Main Room Bridge
+- \Earth Temple\Main\Hub Room\Ledd's Gift
+- \Earth Temple\Main\Hub Room\Rock to West Room
+- \Earth Temple\Main\Hub Room\Wall to Lava Section
+- \Earth Temple\Main\Hub Room\Rupee in Lava Tunnel
+- \Earth Temple\Main\Hub Room\Lower Lava Section Portcullis
+- \Earth Temple\Main\Hub Room\Left Peg
+- \Earth Temple\Main\Hub Room\Raise Bridge
+- \Earth Temple\Main\Hub Room\Past Lava Section\Chest Guarded by Lizalfos
+- \Earth Temple\Main\Hub Room\Past Lava Section\Right Peg
+- \Earth Temple\Main\East Room\Chest after Double Lizalfos Fight
+- \Earth Temple\Main\West Room\Chest in West Room
+- \Earth Temple\Main\West Room\Rock to Hub Room
+- \Earth Temple\Main\Room with Slopes\Rock in Second Slope Resting Area
+- \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Key Chest
+- \Earth Temple\Main\Room with Slopes\Front of Boss Door\Open Boss Door
+- \Earth Temple\Boss Room\Slope\Goddess Sword Strat
+- \Earth Temple\Boss Room\Slope\Longsword Strat
+- \Earth Temple\Boss Room\Slope\Master Sword Strat
+- \Earth Temple\Boss Room\Slope\Bomb Flower Scaldera
+- \Earth Temple\Boss Room\Slope\Beat Scaldera
+- \Earth Temple\Boss Room\Slope\Heart Container
+- \Earth Temple\Spring\Strike Crest
+- \Eldin\Can Survive Hot Cave
+- \Eldin\Volcano\Entry\Goddess Cube at Eldin Entrance
+- \Eldin\Volcano\Entry\Unlock Statue
+- \Eldin\Volcano\Entry\Rupee on Ledge before First Room
+- \Eldin\Volcano\First Room\Chest behind Bombable Wall in First Room
+- \Eldin\Volcano\First Room\Rupee behind Bombable Wall in First Room
+- \Eldin\Volcano\First Room\Rupee in Crawlspace in First Room
+- \Eldin\Volcano\First Room\Blow up Rock to East
+- \Eldin\Volcano\East\Unlock Statue
+- \Eldin\Volcano\East\Goddess Cube near Mogma Turf Entrance
+- \Eldin\Volcano\East\Chest after Crawlspace
+- \Eldin\Volcano\East\Chest behind Bombable Wall near Cliff
+- \Eldin\Volcano\East\Item on Cliff
+- \Eldin\Volcano\East\Drain Lava
+- \Eldin\Volcano\East\Southeast Rupee above Mogma Turf Entrance
+- \Eldin\Volcano\East\North Rupee above Mogma Turf Entrance
+- \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf
+- \Eldin\Volcano\Past Mogma Turf\Watch Bridge Cutscene
+- \Eldin\Volcano\Past Mogma Turf\Southeast Rupee above Mogma Turf Entrance
+- \Eldin\Volcano\Past Mogma Turf\North Rupee above Mogma Turf Entrance
+- \Eldin\Volcano\Past Mogma Turf\Goddess Cube near Mogma Turf Entrance
+- \Eldin\Volcano\Ascent\Chest behind Bombable Wall near Volcano Ascent
+- \Eldin\Volcano\Ascent\Unlock Statue
+- \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
+- \Eldin\Volcano\Ascent\Defeat Slope Bokoblins
+- \Eldin\Volcano\Ascent\Open Trial Gate
+- \Eldin\Volcano\Near Thrill Digger Cave\Left Rupee behind Bombable Wall on First
+  Slope
+- \Eldin\Volcano\Near Thrill Digger Cave\Right Rupee behind Bombable Wall on First
+  Slope
+- \Eldin\Volcano\Near Thrill Digger Cave\Blow down Watchtower
+- \Eldin\Volcano\Thrill Digger Cave\Thrill Digger Minigame
+- \Eldin\Volcano\Thrill Digger Cave\Gossip Stone in Thrill Digger Cave
+- \Eldin\Volcano\Near Temple Entrance\Unlock Statue
+- \Eldin\Volcano\Near Temple Entrance\Blow down Watchtower to Hot Cave
+- \Eldin\Volcano\Near Temple Entrance\Retrieve Crystal Ball
+- \Eldin\Volcano\Near Temple Entrance\Goddess Cube West of Earth Temple Entrance
+- \Eldin\Volcano\Near Temple Entrance\Gossip Stone next to Earth Temple
+- \Eldin\Volcano\Near Temple Entrance\Goddess Cube East of Earth Temple Entrance
+- \Eldin\Volcano\Near Temple Entrance\Digging Spot in front of Earth Temple
+- \Eldin\Volcano\Near Temple Entrance\Digging Spot below Tower
+- \Eldin\Volcano\Near Temple Entrance\Digging Spot behind Boulder on Sandy Slope
+- \Eldin\Volcano\Upper Platform Cave\Gossip Stone in Upper Platform Cave
+- \Eldin\Volcano\Sand Slide\Goddess Cube on Sand Slide
+- \Eldin\Volcano\Sand Slide\Digging Spot after Vents
+- \Eldin\Volcano\Past Slide\Digging Spot after Draining Lava
+- \Eldin\Volcano\Past Slide\Unlock Shortcut to Ascent
+- \Eldin\Volcano\Lower Platform Cave\Gossip Stone in Lower Platform Cave
+- \Eldin\Mogma Turf\Pre Vent\Free Fall Chest
+- \Eldin\Mogma Turf\Pre Vent\Goddess Cube in Mogma Turf
+- \Eldin\Mogma Turf\Pre Vent\Chest behind Bombable Wall at Entrance
+- \Eldin\Mogma Turf\Pre Vent\Pick up Guld
+- \Eldin\Mogma Turf\Pre Vent\Defeat Bokoblins
+- \Eldin\Mogma Turf\Pre Vent\Open Vent
+- \Eldin\Mogma Turf\Sand Slide Platform\Sand Slide Chest
+- \Eldin\Mogma Turf\Past Vent\Chest behind Bombable Wall in Fire Maze
+- \Eldin\Eldin Silent Realm\Trial Reward
+- \Eldin\Eldin Silent Realm\Relic 1
+- \Eldin\Eldin Silent Realm\Relic 2
+- \Eldin\Eldin Silent Realm\Relic 3
+- \Eldin\Eldin Silent Realm\Relic 4
+- \Eldin\Eldin Silent Realm\Relic 5
+- \Eldin\Eldin Silent Realm\Relic 6
+- \Eldin\Eldin Silent Realm\Relic 7
+- \Eldin\Eldin Silent Realm\Relic 8
+- \Eldin\Eldin Silent Realm\Relic 9
+- \Eldin\Eldin Silent Realm\Relic 10
+- \Eldin\Volcano Summit\Goddess Cube inside Volcano Summit
+- \Eldin\Volcano Summit\Waterfall\Goddess Cube in Summit Waterfall
+- \Eldin\Volcano Summit\Waterfall\Higher Area\Chest behind Bombable Wall in Waterfall
+  Area
+- \Eldin\Volcano Summit\Waterfall\Higher Area\Gossip Stone in Waterfall Area
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Goddess Cube near Fire Sanctuary Entrance
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Hydrate Giant Frog
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Hydrate First
+  Frog
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Item behind Digging
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Gossip Stone
+  near Second Thirsty Frog
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Hydrate Second
+  Frog
+- \Eldin\Bokoblin Base\Prison\Plats' Gift
+- \Eldin\Bokoblin Base\Volcano East\Chest near Bone Bridge
+- \Eldin\Bokoblin Base\Volcano East\Chest on Cliff
+- \Eldin\Bokoblin Base\Volcano East\Goddess Cube near Mogma Turf Entrance
+- \Eldin\Bokoblin Base\Before Drawbridge\Chest near Drawbridge
+- \Eldin\Bokoblin Base\Lower Platform Cave\Gossip Stone in Lower Platform Cave
+- \Eldin\Bokoblin Base\Outside Earth Temple\Chest East of Earth Temple Entrance
+- \Eldin\Bokoblin Base\Outside Earth Temple\Goddess Cube East of Earth Temple Entrance
+- \Eldin\Bokoblin Base\Outside Earth Temple\Chest West of Earth Temple Entrance
+- \Eldin\Bokoblin Base\Outside Earth Temple\Goddess Cube West of Earth Temple Entrance
+- \Eldin\Bokoblin Base\Upper Platform Cave\Gossip Stone in Upper Platform Cave
+- \Eldin\Bokoblin Base\Bokoblin Base Summit\First Chest in Volcano Summit
+- \Eldin\Bokoblin Base\Bokoblin Base Summit\Raised Chest in Volcano Summit
+- \Eldin\Bokoblin Base\Bokoblin Base Summit\Chest in Volcano Summit Alcove
+- \Eldin\Bokoblin Base\Bokoblin Base Summit\Goddess Cube inside Volcano Summit
+- \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
+- \Eldin\Bokoblin Base\Fire Dragon's Lair\Fire Dragon's Reward
+- \Faron\Sealed Grounds\Spiral\Defeat Imprisoned 2
+- \Faron\Sealed Grounds\Spiral\Upper Part\Unlock Statue
+- \Faron\Sealed Grounds\Sealed Temple\Chest inside Sealed Temple
+- \Faron\Sealed Grounds\Sealed Temple\Song from Impa
+- \Faron\Sealed Grounds\Sealed Temple\Raise Gate of Time
+- \Faron\Sealed Grounds\Sealed Temple\Start Imprisoned 2
+- \Faron\Sealed Grounds\Sealed Temple\Open Gate of Time
+- \Faron\Sealed Grounds\Hylia's Temple\Zelda's Blessing
+- \Faron\Sealed Grounds\Hylia's Temple\Defeat Demise
+- \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
+- \Faron\Sealed Grounds\Behind the Temple\Gossip Stone behind the Temple
+- \Faron\Sealed Grounds\Behind the Temple\Gorko's Goddess Wall Reward
+- \Faron\Faron Woods\Unlock Viewing Platform Statue
+- \Faron\Faron Woods\Unlock In the Woods Statue
+- \Faron\Faron Woods\Push Log to Sealed Grounds
+- \Faron\Faron Woods\Amber Relic Farming
+- \Faron\Faron Woods\Hit Vine to Deep Woods
+- \Faron\Faron Woods\Open Trial Gate
+- \Faron\Faron Woods\Open Door to Lake Floria
+- \Faron\Faron Woods\Rupee on Hollow Tree Root
+- \Faron\Faron Woods\Rupee on Hollow Tree Branch
+- \Faron\Faron Woods\Rupee on Platform near Floria Door
+- \Faron\Faron Woods\All Kikwis Saved
+- \Faron\Faron Woods\Kikwi Elder's Reward
+- \Faron\Faron Woods\Item on Tree
+- \Faron\Faron Woods\Item behind Lower Bombable Rock
+- \Faron\Faron Woods\Chest behind Upper Bombable Rock
+- \Faron\Faron Woods\Entry\Unlock Statue
+- \Faron\Faron Woods\Ledge to Lake Floria\Push Log
+- \Faron\Faron Woods\Behind the Crawlspace and Rope\Push Log
+- \Faron\Faron Woods\Behind the Crawlspace and Rope\Retrieve Oolo
+- \Faron\Faron Woods\West Branch\Goddess Cube on West Great Tree near Exit
+- \Faron\Faron Woods\Clawshot Target Branch\Goddess Cube on East Great Tree with Clawshots
+  Target
+- \Faron\Faron Woods\Rope Branch\Goddess Cube on East Great Tree with Rope
+- \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest\Chest inside Great Tree
+- \Faron\Faron Woods\Great Tree\Upper Area\Remove Void Plane
+- \Faron\Faron Woods\Great Tree\Top\Unlock Statue
+- \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree North Branch
+- \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree West Branch
+- \Faron\Faron Woods\Great Tree\Top\Talk to Yerbal
+- \Faron\Faron Woods\Deep Woods\Deep Woods Chest
+- \Faron\Faron Woods\Deep Woods\Unlock Deep Woods Statue
+- \Faron\Faron Woods\Deep Woods\Unlock Forest Temple Statue
+- \Faron\Faron Woods\Deep Woods\Push Shortcut Logs
+- \Faron\Faron Woods\Deep Woods\Gossip Stone in Deep Woods
+- \Faron\Faron Woods\Deep Woods\Initial Goddess Cube
+- \Faron\Faron Woods\Deep Woods\Goddess Cube in Deep Woods
+- \Faron\Faron Woods\Deep Woods\Goddess Cube on top of Skyview
+- \Faron\Faron Woods\Deep Woods\Entry\Hornet Larvae Farming
+- \Faron\Faron Silent Realm\Trial Reward
+- \Faron\Faron Silent Realm\Relic 1
+- \Faron\Faron Silent Realm\Relic 2
+- \Faron\Faron Silent Realm\Relic 3
+- \Faron\Faron Silent Realm\Relic 4
+- \Faron\Faron Silent Realm\Relic 5
+- \Faron\Faron Silent Realm\Relic 6
+- \Faron\Faron Silent Realm\Relic 7
+- \Faron\Faron Silent Realm\Relic 8
+- \Faron\Faron Silent Realm\Relic 9
+- \Faron\Faron Silent Realm\Relic 10
+- \Faron\Flooded Faron Woods\Yellow Tadtone under Lilypad
+- \Faron\Flooded Faron Woods\8 Light Blue Tadtones near Viewing Platform
+- \Faron\Flooded Faron Woods\4 Purple Tadtones under Viewing Platform
+- \Faron\Flooded Faron Woods\Red Moving Tadtone near Viewing Platform
+- \Faron\Flooded Faron Woods\Light Blue Tadtone under Great Tree Root
+- \Faron\Flooded Faron Woods\8 Yellow Tadtones near Kikwi Elder
+- \Faron\Flooded Faron Woods\4 Light Blue Moving Tadtones under Kikwi Elder
+- \Faron\Flooded Faron Woods\4 Red Moving Tadtones North West of Great Tree
+- \Faron\Flooded Faron Woods\Green Tadtone behind Upper Bombable Rock
+- \Faron\Flooded Faron Woods\2 Dark Blue Tadtones in Grass West of Great Tree
+- \Faron\Flooded Faron Woods\8 Green Tadtones in West Tunnel
+- \Faron\Flooded Faron Woods\2 Red Tadtones in Grass near Lower Bombable Rock
+- \Faron\Flooded Faron Woods\16 Dark Blue Tadtones in the South West
+- \Faron\Flooded Faron Woods\4 Purple Moving Tadtones near Floria Gate
+- \Faron\Flooded Faron Woods\Dark Blue Moving Tadtone inside Small Hollow Tree
+- \Faron\Flooded Faron Woods\4 Yellow Tadtones under Small Hollow Tree
+- \Faron\Flooded Faron Woods\8 Purple Tadtones in Clearing after Small Hollow Tree
+- \Faron\Flooded Faron Woods\Can Watch Completed Tadtones Cutscene
+- \Faron\Flooded Faron Woods\Flooded Great Tree\Water Dragon's Reward
+- \Faron\Lake Floria\Above Rock\Rupee behind Southwest Boulder
+- \Faron\Lake Floria\Above Rock\Left Rupee behind Northwest Boulder
+- \Faron\Lake Floria\Above Rock\Right Rupee behind Northwest Boulder
+- \Faron\Lake Floria\Above Rock\Rupee under Central Boulder
+- \Faron\Lake Floria\Above Rock\Blow Rock
+- \Faron\Lake Floria\Below Rock\Emerged Area\Lake Floria Chest
+- \Faron\Lake Floria\Below Rock\Emerged Area\Goddess Cube in Lake Floria
+- \Faron\Lake Floria\Below Rock\Emerged Area\Unlock Statue
+- \Faron\Lake Floria\Farore's Lair\Dragon Lair South Chest
+- \Faron\Lake Floria\Farore's Lair\Dragon Lair East Chest
+- \Faron\Lake Floria\Farore's Lair\Talk to Farore
+- \Faron\Lake Floria\Waterfall\Unlock Statue
+- \Faron\Lake Floria\Waterfall\Gossip Stone outside Ancient Cistern
+- \Faron\Lake Floria\Waterfall\Goddess Cube in Floria Waterfall
+- \Faron\Lake Floria\Waterfall\Rupee on High Ledge outside Ancient Cistern Entrance
+- \Fire Sanctuary\Main\First Room\Hit Water Plant
+- \Fire Sanctuary\Main\First Room\Past Water Plant\Defeat Last Bokoblin
+- \Fire Sanctuary\Main\First Room\Past Water Plant\Chest in First Room
+- \Fire Sanctuary\Main\Second Room\Chest in Second Room
+- \Fire Sanctuary\Main\Second Room\Open Doors to Water Fruit
+- \Fire Sanctuary\Main\Second Room\Defeat Magmanos
+- \Fire Sanctuary\Main\Second Room\Balcony\Chest on Balcony
+- \Fire Sanctuary\Main\First Bridge\Lizalfos Fight
+- \Fire Sanctuary\Main\Room with Water Plant\Blow up Rock
+- \Fire Sanctuary\Main\Room with Water Plant\Hit Water Plant
+- \Fire Sanctuary\Main\Room with Water Plant\Past Lava\Unlock Key Door
+- \Fire Sanctuary\Main\First Trapped Mogma Room\Chest near First Trapped Mogma
+- \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area\Rescue First Trapped Mogma
+- \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area\Blow up Rock in Tunnel
+- \Fire Sanctuary\Main\Water Fruit Room\First Chest in Water Fruit Room
+- \Fire Sanctuary\Main\Water Fruit Room\Second Chest in Water Fruit Room
+- \Fire Sanctuary\Main\Water Fruit Room\Hydrate Frog
+- \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos Fight
+- \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Unlock Key Door
+- \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Uncover Dig Spot
+- \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Move Sliding Door
+- \Fire Sanctuary\Main\Second Bridge\Left\Unlock Shortcut to First Bridge
+- \Fire Sanctuary\Main\Second Trapped Mogma Room\Move Sliding Doors Correctly
+- \Fire Sanctuary\Main\Second Trapped Mogma Room\Hydrate Frog
+- \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Mogma
+- \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Second Trapped Mogma
+- \Fire Sanctuary\Main\Second Trapped Mogma Room\Blow up Wall
+- \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall\Chest after Bombable
+  Wall
+- \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant
+- \Fire Sanctuary\Main\West of Boss Door\Catch Plats
+- \Fire Sanctuary\Main\West of Boss Door\Plats' Chest
+- \Fire Sanctuary\Main\West of Boss Door\Past Plats\Unlock Shortcut to Pre Plats
+- \Fire Sanctuary\Main\West of Boss Door\Past Plats\Release Lava
+- \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
+- \Fire Sanctuary\Main\Front of Boss Door\Past Bars\Unlock Way to Front
+- \Fire Sanctuary\Main\Lizalfos Fight Room\Fight
+- \Fire Sanctuary\Main\Staircase Room\Chest in Staircase Room
+- \Fire Sanctuary\Main\Boss Key Room\Solve Puzzle
+- \Fire Sanctuary\Main\Boss Key Room\Defeat Moldorm
+- \Fire Sanctuary\Main\Boss Key Room\Boss Key Chest
+- \Fire Sanctuary\Boss Room\Beat Ghirahim
+- \Fire Sanctuary\Boss Room\Heart Container
+- \Fire Sanctuary\Flame Room\Din's Flame
+- \Lanayru Mining Facility\Can Activate Minecart Timeshift Stone
+- \Lanayru Mining Facility\Main\First Room\Left Lever
+- \Lanayru Mining Facility\Main\First Room\Right Lever
+- \Lanayru Mining Facility\Main\First Room\Chest behind Bars
+- \Lanayru Mining Facility\Main\First Hub\Push Box on Switch
+- \Lanayru Mining Facility\Main\Key Locked Room\Blow Up Boxes
+- \Lanayru Mining Facility\Main\Key Locked Room\Activate Timeshift Stone
+- \Lanayru Mining Facility\Main\Key Locked Room\Chest in Key Locked Room
+- \Lanayru Mining Facility\Main\Hop Across Boxes Room\Blow Up Rocks
+- \Lanayru Mining Facility\Main\Hop Across Boxes Room\Raised Chest in Hop across Boxes
+  Room
+- \Lanayru Mining Facility\Main\Hop Across Boxes Room\Lower Chest in Hop across Boxes
+  Room
+- \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Push Shortcut Box
+- \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Remove Dust Pile at
+  Door
+- \Lanayru Mining Facility\Main\First West Room\Chest in First West Room
+- \Lanayru Mining Facility\Main\Armos Fight Room\Activate Timeshift Stone
+- \Lanayru Mining Facility\Main\Armos Fight Room\Defeat Armos
+- \Lanayru Mining Facility\Main\Armos Fight Room\Chest after Armos Fight
+- \Lanayru Mining Facility\Main\Big Hub\Entry\Blow Up Boxes
+- \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes\First Chest in Hub Room
+- \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Push Box
+- \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Blow Off Pile for First Crawlspace
+- \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Blow Off Pile for Second Crawlspace
+- \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Open Gate
+- \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Chest behind First Crawlspace
+- \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Switch under Sand
+- \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Chest in Spike Maze
+- \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Push Box
+- \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Shortcut Chest
+  in Main Hub
+- \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Get Minecart
+- \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Open First Wind Gate
+- \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Activate Minecart Stone
+  to Boss Key Room
+- \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Unlock Exit to Boss Key
+  Room
+- \Lanayru Mining Facility\Main\Near Boss Door\Get Minecart to Wind Gate
+- \Lanayru Mining Facility\Main\Near Boss Door\Open Second Wind Gate
+- \Lanayru Mining Facility\Main\Boss Key Room\Can Beat Room
+- \Lanayru Mining Facility\Main\Boss Key Room\Boss Key Chest
+- \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat Moldarach
+- \Lanayru Mining Facility\Boss Room\After Sand Drain\Heart Container
+- \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Hit Timeshift Stone
+- \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit Hall of Ancient Robots
+- \Lanayru\All Three Nodes
+- \Lanayru\Raise Lanayru Mining Facility
+- \Lanayru\Can Navigate in Oasis
+- \Lanayru\Mine\Entry\Unlock Statue
+- \Lanayru\Mine\Entry\Goddess Cube at Lanayru Mine Entrance
+- \Lanayru\Mine\Entry\Timeshift Stone
+- \Lanayru\Mine\Entry\Chest near First Timeshift Stone
+- \Lanayru\Mine\Entry\Higher Area\Chest behind First Landing
+- \Lanayru\Mine\Statues Area\Blow Statues Down
+- \Lanayru\Mine\Statues Area\Chest behind Statue
+- \Lanayru\Mine\End\Blow up Rock on Track
+- \Lanayru\Mine\End\Chest at the End of Mine
+- \Lanayru\Mine\End\In Minecart\Blow up Rock on Track
+- \Lanayru\Desert\Entry\Unlock Statue
+- \Lanayru\Desert\Entry\Blow up Rock for Timeshift Stone
+- \Lanayru\Desert\Entry\Timeshift Stone
+- \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve Party Wheel
+- \Lanayru\Desert\Entry\High Ledge after Vines\Chest near Party Wheel
+- \Lanayru\Desert\Near Caged Robot\Chest near Caged Robot
+- \Lanayru\Desert\Near Caged Robot\Goddess Cube near Caged Robot
+- \Lanayru\Desert\Near Caged Robot\Blow up Rock for Timeshift Stone
+- \Lanayru\Desert\Near Caged Robot\Rescue Caged Robot
+- \Lanayru\Desert\Near Caged Robot\Blow Statues to Sand Oasis Down
+- \Lanayru\Desert\Near Caged Robot\Get Past Spume to Sand Oasis
+- \Lanayru\Desert\Sand Oasis\Goddess Cube in Sand Oasis
+- \Lanayru\Desert\West Part\Unlock Statue
+- \Lanayru\Desert\West Part\Push Minecart
+- \Lanayru\Desert\Near South Exit to Temple of Time\Push Minecart
+- \Lanayru\Desert\Top of West Wall\Chest near Sand Oasis
+- \Lanayru\Desert\Top of West Wall\Push Minecart
+- \Lanayru\Desert\Top of LMF\Chest on top of Lanayru Mining Facility
+- \Lanayru\Desert\North Part\Water Node
+- \Lanayru\Desert\North Part\Blow up Main Node Timeshift Stone Rock
+- \Lanayru\Desert\North Part\Main Node Timeshift Stone
+- \Lanayru\Desert\North Part\Activate Main Node
+- \Lanayru\Desert\North Part\Unlock Statue
+- \Lanayru\Desert\North Part\Open Trial Gate
+- \Lanayru\Desert\North Part\Open Secret Passageway
+- \Lanayru\Desert\North Part\Chest on Platform near Lightning Node
+- \Lanayru\Desert\North Part\Open Lightning Node
+- \Lanayru\Desert\North Part\Secret Passageway\Secret Passageway Chest
+- \Lanayru\Desert\North Part\Secret Passageway\Goddess Cube in Secret Passageway
+- \Lanayru\Desert\North Part\Lightning Node\Present\Blow up Rock for Timeshift Stone
+- \Lanayru\Desert\North Part\Lightning Node\Present\Timeshift Stone
+- \Lanayru\Desert\North Part\Lightning Node\Past\First Chest
+- \Lanayru\Desert\North Part\Lightning Node\Past\Second Chest
+- \Lanayru\Desert\North Part\Lightning Node\Past\Lightning Node
+- \Lanayru\Desert\North Part\Lightning Node\Present from afar\Raised Chest near Generator
+- \Lanayru\Desert\East\Open Wall Shortcut
+- \Lanayru\Desert\East\Unlock Statue
+- \Lanayru\Desert\East\Chest on Platform near Fire Node
+- \Lanayru\Desert\East\Fire Node\Present\Blow up Rock for Timeshift Stone
+- \Lanayru\Desert\East\Fire Node\Present\Timeshift Stone
+- \Lanayru\Desert\East\Fire Node\Present after Sand\Shortcut Chest
+- \Lanayru\Desert\East\Fire Node\Present after Sand\Push Box
+- \Lanayru\Desert\East\Fire Node\Past\First Small Chest
+- \Lanayru\Desert\East\Fire Node\Past\Second Small Chest
+- \Lanayru\Desert\East\Fire Node\Past after Void\Open Grate
+- \Lanayru\Desert\East\Fire Node\Past after Grate\Left Ending Chest
+- \Lanayru\Desert\East\Fire Node\Past after Grate\Right Ending Chest
+- \Lanayru\Desert\East\Fire Node\Past after Grate\Fire Node
+- \Lanayru\Temple of Time\South East\Unlock Statue
+- \Lanayru\Temple of Time\Front\Gossip Stone in Temple of Time Area
+- \Lanayru\Temple of Time\Front\Blow up Rock for Timeshift Stone
+- \Lanayru\Temple of Time\Front\Timeshift Stone
+- \Lanayru\Temple of Time\Front\Save Robot
+- \Lanayru\Temple of Time\Inside\Unlock Statue
+- \Lanayru\Temple of Time\Near Goddess Cube\Timeshift Stone
+- \Lanayru\Temple of Time\Near Goddess Cube\Goddess Cube at Ride near Temple of Time
+- \Lanayru\Lanayru Silent Realm\Trial Reward
+- \Lanayru\Lanayru Silent Realm\Relic 1
+- \Lanayru\Lanayru Silent Realm\Relic 2
+- \Lanayru\Lanayru Silent Realm\Relic 3
+- \Lanayru\Lanayru Silent Realm\Relic 4
+- \Lanayru\Lanayru Silent Realm\Relic 5
+- \Lanayru\Lanayru Silent Realm\Relic 6
+- \Lanayru\Lanayru Silent Realm\Relic 7
+- \Lanayru\Lanayru Silent Realm\Relic 8
+- \Lanayru\Lanayru Silent Realm\Relic 9
+- \Lanayru\Lanayru Silent Realm\Relic 10
+- \Lanayru\Caves\Chest
+- \Lanayru\Caves\Golo's Gift
+- \Lanayru\Caves\Gossip Stone in Center
+- \Lanayru\Caves\Past Crawlspace\Gossip Stone towards Lanayru Gorge
+- \Lanayru\Lanayru Sand Sea\Shoot down Sandship
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Goddess Cube in Ancient Harbour
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Unlock Statue
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Ship Timeshift Stone
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Left Rupee on Entrance
+  Crown
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Right Rupee on Entrance
+  Crown
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Rupee on First Pillar
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Unlock Statue
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Blow up Rock
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Chest after Moblin
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Goddess Cube in Skipper's
+  Retreat
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Whip Peahat
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Deal with Deku Baba
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Chest on top of Cacti Pillar
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Chest in Shack
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform\Skydive Chest
+- \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
+- \Lanayru\Lanayru Sand Sea\Shipyard\Gossip Stone in Shipyard
+- \Lanayru\Lanayru Sand Sea\Shipyard\Rickety Coaster -- Heart Stopping Track in 1'05
+- \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat Moldarach
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Goddess Cube in
+  Pirate Stronghold
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Chest
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Chest
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Third Chest
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish Minidungeon
+- \Lanayru\Lanayru Sand Sea\Gorge\Unlock Statue
+- \Lanayru\Lanayru Sand Sea\Gorge\Item on Pillar
+- \Lanayru\Lanayru Sand Sea\Gorge\Activate Timeshift Stone
+- \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward
+- \Lanayru\Lanayru Sand Sea\Gorge\Boss Rush -- 4 Bosses
+- \Lanayru\Lanayru Sand Sea\Gorge\Boss Rush -- 8 Bosses
+- \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Activate Timeshift Stone
+- \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Goddess Cube in Lanayru Gorge
+- \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Digging Spot
+- \Sandship\Pass Spume
+- \Sandship\Main\Deck\Raise Timeshift Stone
+- \Sandship\Main\Deck\Start Mast Sequence
+- \Sandship\Main\Deck\Freely Usable Timeshift Stone
+- \Sandship\Main\Deck\Mast\Finish Mast Sequence
+- \Sandship\Main\Deck\Stern\Chest at the Stern
+- \Sandship\Main\Deck\Captain's Cabin\Switch
+- \Sandship\Main\Deck\Captain's Cabin\Bars
+- \Sandship\Main\Deck\Captain's Cabin\Boss Key Chest
+- \Sandship\Main\Before Ship's Bow\Chest before 4-Door Corridor
+- \Sandship\Main\Ship's Bow\Chest after Scervo Fight
+- \Sandship\Main\Starboard Rooms\Switch
+- \Sandship\Main\Starboard Rooms\Generator
+- \Sandship\Main\Port Rooms\Switch
+- \Sandship\Main\Port Rooms\Generator
+- \Sandship\Main\Before Boss Door\Combination Lock
+- \Sandship\Main\Before Boss Door\Chest behind Combination Lock
+- \Sandship\Main\Before Boss Door\Open Boss Door
+- \Sandship\Main\Treasure Room\Treasure Room First Chest
+- \Sandship\Main\Treasure Room\Treasure Room Second Chest
+- \Sandship\Main\Treasure Room\Treasure Room Third Chest
+- \Sandship\Main\Treasure Room\Treasure Room Fourth Chest
+- \Sandship\Main\Treasure Room\Treasure Room Fifth Chest
+- \Sandship\Main\Brig Prison\Robot in Brig's Reward
+- \Sandship\Boss Room\Beat Tentalus
+- \Sandship\Boss Room\Heart Container
+- \Sandship\Boss Room\Nayru's Flame
+- \Sky Keep\Main\First Room\First Chest
+- \Sky Keep\Main\First Room\Right Exit
+- \Sky Keep\Main\Skyview Room\Beginning\Free Rope
+- \Sky Keep\Main\Skyview Room\Beginning\Kill Pyrups
+- \Sky Keep\Main\Skyview Room\Beginning\Left Exit
+- \Sky Keep\Main\Skyview Room\End\Lever
+- \Sky Keep\Main\Skyview Room\End\Top Exit
+- \Sky Keep\Main\LMF Room\Finish Room
+- \Sky Keep\Main\LMF Room\Bottom Exit
+- \Sky Keep\Main\LMF Room\Top Exit
+- \Sky Keep\Main\Earth Temple Room\Right Exit
+- \Sky Keep\Main\Earth Temple Room\Top Exit
+- \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat Dreadfuse
+- \Sky Keep\Main\Mini Boss Room\From Bottom\Bottom Exit
+- \Sky Keep\Main\Mini Boss Room\Near Chest\Chest after Dreadfuse
+- \Sky Keep\Main\Mini Boss Room\Near Chest\Unlock Door
+- \Sky Keep\Main\Mini Boss Room\From Left\Left Exit
+- \Sky Keep\Main\Ancient Cistern Room\Unlock Key Door
+- \Sky Keep\Main\Ancient Cistern Room\Right Exit
+- \Sky Keep\Main\Ancient Cistern Room\Bottom Exit
+- \Sky Keep\Main\Ancient Cistern Room\After Key\Beat Trial
+- \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Sacred Power of Farore
+- \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Lever
+- \Sky Keep\Main\Fire Sanctuary Room\From Right\Right Exit
+- \Sky Keep\Main\Fire Sanctuary Room\First Platform\Lever
+- \Sky Keep\Main\Fire Sanctuary Room\First Platform\Rupee in Fire Sanctuary Room in
+  Alcove
+- \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Sacred Power of Din
+- \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Lower Lever
+- \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Upper Lever
+- \Sky Keep\Main\Fire Sanctuary Room\From Left\Left Exit
+- \Sky Keep\Main\Sandship Room\Higher Eye
+- \Sky Keep\Main\Sandship Room\Lower Eye
+- \Sky Keep\Main\Sandship Room\Left Exit
+- \Sky Keep\Main\Sandship Room\Triforce Area\Sacred Power of Nayru
+- \Sky\North East\Goddess Chest on Island next to Bamboo Island
+- \Sky\North East\Goddess Chest in Cave on Island next to Bamboo Island
+- \Sky\North East\Northeast Island Goddess Chest behind Bombable Rocks
+- \Sky\North East\Northeast Island Cage Goddess Chest
+- \Sky\North East\Bamboo Island\Bamboo Island Goddess Chest
+- \Sky\North East\Bamboo Island\Inside\Clean Cut Minigame
+- \Sky\North East\Bamboo Island\Inside\Gossip Stone on Bamboo Island
+- \Sky\North East\Beedle's Island\Crystal on Beedle's Ship
+- \Sky\North East\Beedle's Island\Beedle's Crystals
+- \Sky\North East\Beedle's Island\Top\Beedle's Island Goddess Chest
+- \Sky\North East\Beedle's Island\Cage\Beedle's Island Cage Goddess Chest
+- \Sky\South East\Chest in Breakable Boulder near Lumpy Pumpkin
+- \Sky\South East\Goddess Chest on Island Closest to Faron Pillar
+- \Sky\South East\Lumpy Pumpkin\Crystal outside Lumpy Pumpkin
+- \Sky\South East\Lumpy Pumpkin\Outside Goddess Chest
+- \Sky\South East\Lumpy Pumpkin\Goddess Chest on the Roof
+- \Sky\South East\Lumpy Pumpkin\Start Kina's Quest
+- \Sky\South East\Lumpy Pumpkin\Kina's Crystals
+- \Sky\South East\Lumpy Pumpkin\Gossip Stone on Lumpy Pumpkin
+- \Sky\South East\Lumpy Pumpkin\Pumpkin Carrying
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Chandelier
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Crystal inside Lumpy Pumpkin
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Break the Chandelier
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Start Hot Soup Delivery
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Complete Hot Soup Delivery
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Play the Harp with Kina
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Harp Minigame
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Pick up Levias' Soup
+- \Sky\South West\Chest in Breakable Boulder near Fun Fun Island
+- \Sky\South West\Volcanic Island\Goddess Chest outside Volcanic Island
+- \Sky\South West\Volcanic Island\Goddess Chest inside Volcanic Island
+- \Sky\South West\Volcanic Island\Gossip Stone on Volcanic Island
+- \Sky\South West\Orielle's Island\Talk to Orielle
+- \Sky\South West\Orielle's Island\Save Orielle
+- \Sky\South West\Orielle's Island\Orielle's Crystals
+- \Sky\South West\Fun Fun Island\Start Dodoh's Quest
+- \Sky\South West\Fun Fun Island\Dodoh's Crystals
+- \Sky\South West\Fun Fun Island\Fun Fun Island Minigame -- 500 Rupees
+- \Sky\South West\Fun Fun Island\Goddess Chest under Fun Fun Island
+- \Sky\South West\Fun Fun Island\Fun Fun Island Minigame
+- \Sky\South West\Triple Island\Southwest Triple Island Upper Goddess Chest
+- \Sky\South West\Triple Island\Southwest Triple Island Lower Goddess Chest
+- \Sky\South West\Triple Island\Southwest Triple Island Cage Goddess Chest
+- \Sky\Thunderhead\Song from Levias
+- \Sky\Thunderhead\Isle of Songs\Goddess Chest outside Isle of Songs
+- \Sky\Thunderhead\Isle of Songs\Goddess Chest on top of Isle of Songs
+- \Sky\Thunderhead\Isle of Songs\Puzzle Solved
+- \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Goddess Sword
+- \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Longsword
+- \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with White Sword
+- \Sky\Thunderhead\East Island\East Island Goddess Chest
+- \Sky\Thunderhead\East Island\East Island Chest
+- \Sky\Thunderhead\Mogma Mitts Island\First Goddess Chest on Mogma Mitts Island
+- \Sky\Thunderhead\Mogma Mitts Island\Second Goddess Chest on Mogma Mitts Island
+- \Sky\Thunderhead\Bug Heaven\Bug Heaven -- 10 Bugs in 3 Minutes
+- \Sky\Thunderhead\Bug Heaven\Bug Heaven Goddess Chest
+- \Sky\Thunderhead\Bug Heaven\Gossip Stone near Bug Heaven
+- \Skyloft\Upper Skyloft\Owlan's Gift
+- \Skyloft\Upper Skyloft\Chest near Goddess Statue
+- \Skyloft\Upper Skyloft\Pumpkin Archery -- 600 Points
+- \Skyloft\Upper Skyloft\Knight Academy\Fledge's Gift
+- \Skyloft\Upper Skyloft\Knight Academy\Crystal in Knight Academy Plant
+- \Skyloft\Upper Skyloft\Knight Academy\Start Owlan's Quest
+- \Skyloft\Upper Skyloft\Knight Academy\Owlan's Crystals
+- \Skyloft\Upper Skyloft\Knight Academy\Knock on Toilet Door
+- \Skyloft\Upper Skyloft\Knight Academy\Item from Cawlin
+- \Skyloft\Upper Skyloft\Knight Academy\Ghost/Pipit's Crystals
+- \Skyloft\Upper Skyloft\Knight Academy\Fledge's Crystals
+- \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Crystal in Link's Room
+- \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Unlocked Zelda's Room
+- \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Crystal in Zelda's Room
+- \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\In Zelda's Closet
+- \Skyloft\Upper Skyloft\Sparring Hall\Crystal in Sparring Hall
+- \Skyloft\Upper Skyloft\Sparring Hall\Sparring Hall Chest
+- \Skyloft\Upper Skyloft\Sparring Hall\Delivered Hot Soup
+- \Skyloft\Upper Skyloft\Goddess Statue\First Goddess Sword Item in Goddess Statue
+- \Skyloft\Upper Skyloft\Goddess Statue\Second Goddess Sword Item in Goddess Statue
+- \Skyloft\Central Skyloft\Crystal between Wooden Planks
+- \Skyloft\Central Skyloft\Crystal on West Cliff
+- \Skyloft\Central Skyloft\Crystal on Light Tower
+- \Skyloft\Central Skyloft\West Cliff Goddess Chest
+- \Skyloft\Central Skyloft\Parrow's Gift
+- \Skyloft\Central Skyloft\Parrow's Crystals
+- \Skyloft\Central Skyloft\Shed Chest
+- \Skyloft\Central Skyloft\Shed Goddess Chest
+- \Skyloft\Central Skyloft\Open Trial Gate
+- \Skyloft\Central Skyloft\Waterfall Cave Crystals from above
+- \Skyloft\Central Skyloft\Crystal on Waterfall Island from the ground
+- \Skyloft\Central Skyloft\Crystal on Waterfall Island
+- \Skyloft\Central Skyloft\Open Cave Entrance
+- \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest
+- \Skyloft\Central Skyloft\Bazaar\Potion Lady's Gift
+- \Skyloft\Central Skyloft\Bazaar\Repair Gondo's Junk
+- \Skyloft\Central Skyloft\Bazaar\Bazaar Goddess Chest
+- \Skyloft\Central Skyloft\Bazaar\Endurance Potion
+- \Skyloft\Central Skyloft\Bazaar\Talk to Peatrice
+- \Skyloft\Central Skyloft\Bazaar\Item Check Access
+- \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades\Upgrade to Quick Beetle
+- \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades\Upgrade to Tough Beetle
+- \Skyloft\Central Skyloft\Orielle and Parrow's House\Crystal in Orielle and Parrow's
+  House
+- \Skyloft\Central Skyloft\Orielle and Parrow's House\Parrow's Gift
+- \Skyloft\Central Skyloft\Orielle and Parrow's House\Parrow's Crystals
+- \Skyloft\Central Skyloft\Peatrice's House\Peater/Peatrice's Crystals
+- \Skyloft\Central Skyloft\Wryna's House\Wryna's Crystals
+- \Skyloft\Central Skyloft\Waterfall Island\Crystal on Waterfall Island
+- \Skyloft\Central Skyloft\Waterfall Island\Waterfall Goddess Chest
+- \Skyloft\Central Skyloft\Waterfall Island\Floating Island Goddess Chest
+- \Skyloft\Central Skyloft\Waterfall Island\Gossip Stone on Waterfall Island
+- \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave First Chest
+- \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave Second Chest
+- \Skyloft\Central Skyloft\Waterfall Cave\Rupee Waterfall Cave Crawlspace
+- \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave
+- \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison
+- \Skyloft\Skyloft Silent Realm\Trial Reward
+- \Skyloft\Skyloft Silent Realm\Relic 1
+- \Skyloft\Skyloft Silent Realm\Relic 2
+- \Skyloft\Skyloft Silent Realm\Relic 3
+- \Skyloft\Skyloft Silent Realm\Relic 4
+- \Skyloft\Skyloft Silent Realm\Relic 5
+- \Skyloft\Skyloft Silent Realm\Relic 6
+- \Skyloft\Skyloft Silent Realm\Relic 7
+- \Skyloft\Skyloft Silent Realm\Relic 8
+- \Skyloft\Skyloft Silent Realm\Relic 9
+- \Skyloft\Skyloft Silent Realm\Relic 10
+- \Skyloft\Skyloft Village\Crystal near Pumpkin Patch
+- \Skyloft\Skyloft Village\Opened Shed
+- \Skyloft\Skyloft Village\Bertie's House\Bertie's Crystals
+- \Skyloft\Skyloft Village\Sparrot's House\Start Sparrot's Quest
+- \Skyloft\Skyloft Village\Sparrot's House\Sparrot's Crystals
+- \Skyloft\Skyloft Village\Mallara's House\Mallara's Crystals
+- \Skyloft\Skyloft Village\Batreaux's House\5 Crystals
+- \Skyloft\Skyloft Village\Batreaux's House\10 Crystals
+- \Skyloft\Skyloft Village\Batreaux's House\30 Crystals
+- \Skyloft\Skyloft Village\Batreaux's House\30 Crystals Chest
+- \Skyloft\Skyloft Village\Batreaux's House\40 Crystals
+- \Skyloft\Skyloft Village\Batreaux's House\50 Crystals
+- \Skyloft\Skyloft Village\Batreaux's House\70 Crystals
+- \Skyloft\Skyloft Village\Batreaux's House\70 Crystals Second Reward
+- \Skyloft\Skyloft Village\Batreaux's House\80 Crystals
+- \Skyloft\Beedle's Shop\Stall\300 Rupee Item
+- \Skyloft\Beedle's Shop\Stall\600 Rupee Item
+- \Skyloft\Beedle's Shop\Stall\1200 Rupee Item
+- \Skyloft\Beedle's Shop\Stall\800 Rupee Item
+- \Skyloft\Beedle's Shop\Stall\1600 Rupee Item
+- \Skyloft\Beedle's Shop\Stall\First 100 Rupee Item
+- \Skyloft\Beedle's Shop\Stall\Second 100 Rupee Item
+- \Skyloft\Beedle's Shop\Stall\Third 100 Rupee Item
+- \Skyloft\Beedle's Shop\Stall\50 Rupee Item
+- \Skyloft\Beedle's Shop\Stall\1000 Rupee Item
+- \Skyview\Skyview 2
+- \Skyview\Can Hit High Skyview Switches
+- \Skyview\Can Cut Tree
+- \Skyview\Main\Entry\Cut Tree
+- \Skyview\Main\First Room\Destroy Barricade
+- \Skyview\Main\First Room\Switch to One Eye Room
+- \Skyview\Main\First Room\Goddess Wall Trigger
+- \Skyview\Main\One Eye Room\Unlock Door to First Hub
+- \Skyview\Main\First Hub\Switch to Left Room
+- \Skyview\Main\First Hub\Switch to Right Room
+- \Skyview\Main\First Hub\One Water Raise
+- \Skyview\Main\First Hub\Left Room\Hit Vines
+- \Skyview\Main\First Hub\Left Room\Spider Roll
+- \Skyview\Main\First Hub\Left Room\Raise Water
+- \Skyview\Main\First Hub\Left Room\Chest on Tree Branch
+- \Skyview\Main\First Hub\Right Room\After Crawlspace\Raise Water
+- \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace
+- \Skyview\Main\First Hub\Right Room\Upper Area\Chest behind Two Eyes
+- \Skyview\Main\Second Hub\Rupee in Southeast Tunnel
+- \Skyview\Main\Second Hub\Rupee in Southwest Tunnel
+- \Skyview\Main\Second Hub\Rupee in East Tunnel
+- \Skyview\Main\Second Hub\Switch to Miniboss Room
+- \Skyview\Main\Second Hub\Switch for Bars
+- \Skyview\Main\Second Hub\Switch to Left Room
+- \Skyview\Main\Second Hub\Item behind Bars
+- \Skyview\Main\Second Hub\Miniboss Room\Chest after Stalfos Fight
+- \Skyview\Main\Second Hub\Left Rooms\Chest behind Three Eyes
+- \Skyview\Main\Second Hub\Staldra Room\Can Defeat Staldra
+- \Skyview\Main\Last Room\Near East Entrance\Deal with Hanging Skulltula
+- \Skyview\Main\Last Room\Before Rope\Unlock Shortcut to Second Hub
+- \Skyview\Main\Last Room\Before Rope\Deal with Archers
+- \Skyview\Main\Last Room\After Rope\Chest near Boss Door
+- \Skyview\Main\Last Room\After Rope\Hit Vines
+- \Skyview\Main\Last Room\Near Boss Key Chest\Boss Key Chest
+- \Skyview\Boss Room\Beat Ghirahim
+- \Skyview\Boss Room\Heart Container
+- \Skyview\Spring\Rupee on Spring Pillar
+- \Skyview\Spring\Strike Crest
+- \Skyview\Spring\Goddess Cube in Skyview Spring
+- \Skyview\Spring\Sacred Water
+- \Ancient Cistern\Main\Main Room\After Whip Hooks
+- \Ancient Cistern\Main\Main Room\Vines Area
+- \Ancient Cistern\Main\Main Room\Behind the Waterfall
+- \Ancient Cistern\Main\Main Room\After Gutters\Upper Area
+- \Ancient Cistern\Main\Main Room\After Gutters
+- \Ancient Cistern\Main\Main Room\Spider Thread Area
+- \Ancient Cistern\Main\Main Room
+- \Ancient Cistern\Main\East Part\Second Room
+- \Ancient Cistern\Main\East Part\Chest Ledge
+- \Ancient Cistern\Main\East Part
+- \Ancient Cistern\Main\Basement Gutters\Past Skulltula
+- \Ancient Cistern\Main\Basement Gutters
+- \Ancient Cistern\Main\Basement\Rotating Vines
+- \Ancient Cistern\Main\Basement\Spider Thread
+- \Ancient Cistern\Main\Basement\Under the Statue
+- \Ancient Cistern\Main\Basement
+- \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest
+- \Ancient Cistern\Main\Inside Statue
+- \Ancient Cistern\Main
+- \Ancient Cistern\Boss Room
+- \Ancient Cistern\Flame Room
+- \Ancient Cistern
+- \Earth Temple\Main\First Room
+- \Earth Temple\Main\Hub Room\Past Lava Section
+- \Earth Temple\Main\Hub Room
+- \Earth Temple\Main\East Room
+- \Earth Temple\Main\West Room
+- \Earth Temple\Main\Room with Slopes\Front of Boss Door
+- \Earth Temple\Main\Room with Slopes
+- \Earth Temple\Main
+- \Earth Temple\Boss Room\Entry
+- \Earth Temple\Boss Room\Slope
+- \Earth Temple\Boss Room
+- \Earth Temple\Spring
+- \Earth Temple
+- \Eldin\Volcano\Entry
+- \Eldin\Volcano\First Room
+- \Eldin\Volcano\East
+- \Eldin\Volcano\Past Mogma Turf
+- \Eldin\Volcano\Ascent
+- \Eldin\Volcano\Near Thrill Digger Cave
+- \Eldin\Volcano\Thrill Digger Cave
+- \Eldin\Volcano\Near Temple Entrance
+- \Eldin\Volcano\Upper Platform Cave
+- \Eldin\Volcano\Hot Cave
+- \Eldin\Volcano\Sand Slide
+- \Eldin\Volcano\Past Slide
+- \Eldin\Volcano\Lower Platform Cave
+- \Eldin\Volcano
+- \Eldin\Mogma Turf\Pre Vent
+- \Eldin\Mogma Turf\Sand Slide Platform
+- \Eldin\Mogma Turf\Past Vent
+- \Eldin\Mogma Turf
+- \Eldin\Eldin Silent Realm
+- \Eldin\Volcano Summit\Waterfall\Higher Area
+- \Eldin\Volcano Summit\Waterfall
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs
+- \Eldin\Volcano Summit\Outside Fire Sanctuary
+- \Eldin\Volcano Summit
+- \Eldin\Bokoblin Base\Prison
+- \Eldin\Bokoblin Base\Volcano East
+- \Eldin\Bokoblin Base\Before Drawbridge
+- \Eldin\Bokoblin Base\After Drawbridge
+- \Eldin\Bokoblin Base\Lower Platform Cave
+- \Eldin\Bokoblin Base\Outside Earth Temple
+- \Eldin\Bokoblin Base\Upper Platform Cave
+- \Eldin\Bokoblin Base\Hot Cave
+- \Eldin\Bokoblin Base\Bokoblin Base Summit
+- \Eldin\Bokoblin Base\Fire Dragon's Lair
+- \Eldin\Bokoblin Base
+- \Eldin
+- \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple
+- \Faron\Sealed Grounds\Spiral\Upper Part
+- \Faron\Sealed Grounds\Spiral
+- \Faron\Sealed Grounds\Sealed Temple
+- \Faron\Sealed Grounds\Hylia's Temple
+- \Faron\Sealed Grounds\Behind the Temple
+- \Faron\Sealed Grounds
+- \Faron\Faron Woods\Entry
+- \Faron\Faron Woods\Ledge to Lake Floria
+- \Faron\Faron Woods\Ledge To Deep Woods
+- \Faron\Faron Woods\Behind the Crawlspace and Rope
+- \Faron\Faron Woods\West Branch
+- \Faron\Faron Woods\Clawshot Target Branch
+- \Faron\Faron Woods\Rope Branch
+- \Faron\Faron Woods\Great Tree\Near Underwater Hole
+- \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest
+- \Faron\Faron Woods\Great Tree\Lower Area\Near Exit
+- \Faron\Faron Woods\Great Tree\Lower Area
+- \Faron\Faron Woods\Great Tree\Platforms
+- \Faron\Faron Woods\Great Tree\Upper Area
+- \Faron\Faron Woods\Great Tree\Top
+- \Faron\Faron Woods\Great Tree
+- \Faron\Faron Woods\Deep Woods\Entry
+- \Faron\Faron Woods\Deep Woods
+- \Faron\Faron Woods
+- \Faron\Faron Silent Realm
+- \Faron\Flooded Faron Woods\Flooded Great Tree
+- \Faron\Flooded Faron Woods
+- \Faron\Lake Floria\Above Rock
+- \Faron\Lake Floria\Below Rock\Emerged Area
+- \Faron\Lake Floria\Below Rock
+- \Faron\Lake Floria\Farore's Lair
+- \Faron\Lake Floria\Waterfall
+- \Faron\Lake Floria
+- \Faron
+- \Fire Sanctuary\Main\First Room\Past Water Plant
+- \Fire Sanctuary\Main\First Room
+- \Fire Sanctuary\Main\Second Room\Outside Section
+- \Fire Sanctuary\Main\Second Room\Balcony
+- \Fire Sanctuary\Main\Second Room
+- \Fire Sanctuary\Main\First Bridge
+- \Fire Sanctuary\Main\Room with Water Plant\Past Lava
+- \Fire Sanctuary\Main\Room with Water Plant
+- \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area
+- \Fire Sanctuary\Main\First Trapped Mogma Room
+- \Fire Sanctuary\Main\Water Fruit Room\After Frog
+- \Fire Sanctuary\Main\Water Fruit Room
+- \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part
+- \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Past Sliding Door
+- \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part
+- \Fire Sanctuary\Main\Magmanos Fight Room
+- \Fire Sanctuary\Main\Second Bridge\Left
+- \Fire Sanctuary\Main\Second Bridge\Bottom Part
+- \Fire Sanctuary\Main\Second Bridge\Right
+- \Fire Sanctuary\Main\Second Bridge
+- \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall
+- \Fire Sanctuary\Main\Second Trapped Mogma Room
+- \Fire Sanctuary\Main\West of Boss Door\Entry
+- \Fire Sanctuary\Main\West of Boss Door\Past Plats
+- \Fire Sanctuary\Main\West of Boss Door
+- \Fire Sanctuary\Main\Front of Boss Door\Past Bars
+- \Fire Sanctuary\Main\Front of Boss Door
+- \Fire Sanctuary\Main\Lizalfos Fight Room
+- \Fire Sanctuary\Main\Staircase Room\Upper Part
+- \Fire Sanctuary\Main\Staircase Room
+- \Fire Sanctuary\Main\Boss Key Room
+- \Fire Sanctuary\Main
+- \Fire Sanctuary\Boss Room
+- \Fire Sanctuary\Flame Room
+- \Fire Sanctuary
+- \Lanayru Mining Facility\Main\First Room
+- \Lanayru Mining Facility\Main\First Hub
+- \Lanayru Mining Facility\Main\Key Locked Room
+- \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit
+- \Lanayru Mining Facility\Main\Hop Across Boxes Room
+- \Lanayru Mining Facility\Main\First West Room
+- \Lanayru Mining Facility\Main\Armos Fight Room
+- \Lanayru Mining Facility\Main\Big Hub\Entry
+- \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes
+- \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room
+- \Lanayru Mining Facility\Main\Big Hub\Past West Gate
+- \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze
+- \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit
+- \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit
+- \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates
+- \Lanayru Mining Facility\Main\Big Hub
+- \Lanayru Mining Facility\Main\Near Boss Door
+- \Lanayru Mining Facility\Main\Boss Key Room
+- \Lanayru Mining Facility\Main
+- \Lanayru Mining Facility\Boss Room\After Sand Drain
+- \Lanayru Mining Facility\Boss Room
+- \Lanayru Mining Facility\Hall of Ancient Robots\Entry
+- \Lanayru Mining Facility\Hall of Ancient Robots\End
+- \Lanayru Mining Facility\Hall of Ancient Robots
+- \Lanayru Mining Facility
+- \Lanayru\Mine\Entry\Higher Area
+- \Lanayru\Mine\Entry\Caves Entrance
+- \Lanayru\Mine\Entry
+- \Lanayru\Mine\Statues Area
+- \Lanayru\Mine\End\In Minecart
+- \Lanayru\Mine\End
+- \Lanayru\Mine
+- \Lanayru\Desert\Entry\High Ledge after Vines
+- \Lanayru\Desert\Entry
+- \Lanayru\Desert\Near Caged Robot
+- \Lanayru\Desert\Sand Oasis
+- \Lanayru\Desert\West Part
+- \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves
+- \Lanayru\Desert\Near South Exit to Temple of Time
+- \Lanayru\Desert\Top of West Wall
+- \Lanayru\Desert\Top of LMF
+- \Lanayru\Desert\North Part\Secret Passageway
+- \Lanayru\Desert\North Part\Lightning Node\Present
+- \Lanayru\Desert\North Part\Lightning Node\Past
+- \Lanayru\Desert\North Part\Lightning Node\Present from afar
+- \Lanayru\Desert\North Part\Lightning Node
+- \Lanayru\Desert\North Part
+- \Lanayru\Desert\East\Fire Node\Present
+- \Lanayru\Desert\East\Fire Node\Present after Sand
+- \Lanayru\Desert\East\Fire Node\Past
+- \Lanayru\Desert\East\Fire Node\Past after Void
+- \Lanayru\Desert\East\Fire Node\Past after Grate
+- \Lanayru\Desert\East\Fire Node
+- \Lanayru\Desert\East
+- \Lanayru\Desert
+- \Lanayru\Temple of Time\South East
+- \Lanayru\Temple of Time\Front
+- \Lanayru\Temple of Time\Inside
+- \Lanayru\Temple of Time\Near Goddess Cube
+- \Lanayru\Temple of Time\North East
+- \Lanayru\Temple of Time
+- \Lanayru\Lanayru Silent Realm
+- \Lanayru\Caves\Past Door to Lanayru Sand Sea
+- \Lanayru\Caves\Past Crawlspace
+- \Lanayru\Caves
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat
+- \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay
+- \Lanayru\Lanayru Sand Sea\Shipyard
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold
+- \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge
+- \Lanayru\Lanayru Sand Sea\Gorge
+- \Lanayru\Lanayru Sand Sea
+- \Lanayru
+- \Sandship\Main\Deck\Mast
+- \Sandship\Main\Deck\Stern
+- \Sandship\Main\Deck\Captain's Cabin
+- \Sandship\Main\Deck
+- \Sandship\Main\Before Ship's Bow
+- \Sandship\Main\Ship's Bow
+- \Sandship\Main\Corridor
+- \Sandship\Main\Starboard Rooms
+- \Sandship\Main\Port Rooms
+- \Sandship\Main\Before Boss Door
+- \Sandship\Main\Brig
+- \Sandship\Main\Treasure Room
+- \Sandship\Main\Brig Prison
+- \Sandship\Main
+- \Sandship\Boss Room
+- \Sandship
+- \Sky Keep\Main\First Room
+- \Sky Keep\Main\Skyview Room\Beginning
+- \Sky Keep\Main\Skyview Room\End
+- \Sky Keep\Main\Skyview Room
+- \Sky Keep\Main\LMF Room
+- \Sky Keep\Main\Earth Temple Room
+- \Sky Keep\Main\Mini Boss Room\From Bottom
+- \Sky Keep\Main\Mini Boss Room\Near Chest
+- \Sky Keep\Main\Mini Boss Room\From Left
+- \Sky Keep\Main\Mini Boss Room
+- \Sky Keep\Main\Ancient Cistern Room\After Key
+- \Sky Keep\Main\Ancient Cistern Room\Triforce Room
+- \Sky Keep\Main\Ancient Cistern Room
+- \Sky Keep\Main\Fire Sanctuary Room\From Right
+- \Sky Keep\Main\Fire Sanctuary Room\OoB
+- \Sky Keep\Main\Fire Sanctuary Room\First Platform
+- \Sky Keep\Main\Fire Sanctuary Room\Triforce Room
+- \Sky Keep\Main\Fire Sanctuary Room\From Left
+- \Sky Keep\Main\Fire Sanctuary Room
+- \Sky Keep\Main\Sandship Room\Triforce Area
+- \Sky Keep\Main\Sandship Room
+- \Sky Keep\Main\Puzzle Solving Meta Room
+- \Sky Keep\Main
+- \Sky Keep
+- \Sky\North East\Eldin Pillar
+- \Sky\North East\Bamboo Island\Inside
+- \Sky\North East\Bamboo Island
+- \Sky\North East\Beedle's Island\Top_DAY
+- \Sky\North East\Beedle's Island\Top_NIGHT
+- \Sky\North East\Beedle's Island\Cage_DAY
+- \Sky\North East\Beedle's Island\Cage_NIGHT
+- \Sky\North East\Beedle's Island_DAY
+- \Sky\North East\Beedle's Island_NIGHT
+- \Sky\North East
+- \Sky\South East\Faron Pillar
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building_DAY
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building_NIGHT
+- \Sky\South East\Lumpy Pumpkin_DAY
+- \Sky\South East\Lumpy Pumpkin_NIGHT
+- \Sky\South East
+- \Sky\South West\Lanayru Pillar
+- \Sky\South West\Volcanic Island
+- \Sky\South West\Orielle's Island
+- \Sky\South West\Fun Fun Island
+- \Sky\South West\Triple Island
+- \Sky\South West
+- \Sky\Around Skyloft
+- \Sky\Thunderhead\Isle of Songs\Inside
+- \Sky\Thunderhead\Isle of Songs
+- \Sky\Thunderhead\East Island
+- \Sky\Thunderhead\Mogma Mitts Island
+- \Sky\Thunderhead\Bug Heaven
+- \Sky\Thunderhead
+- \Sky
+- \Skyloft\Upper Skyloft\Knight Academy\Link's Room_DAY
+- \Skyloft\Upper Skyloft\Knight Academy\Link's Room_NIGHT
+- \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room_DAY
+- \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room_NIGHT
+- \Skyloft\Upper Skyloft\Knight Academy_DAY
+- \Skyloft\Upper Skyloft\Knight Academy_NIGHT
+- \Skyloft\Upper Skyloft\Sparring Hall_DAY
+- \Skyloft\Upper Skyloft\Sparring Hall_NIGHT
+- \Skyloft\Upper Skyloft\Goddess Statue_DAY
+- \Skyloft\Upper Skyloft\Goddess Statue_NIGHT
+- \Skyloft\Upper Skyloft_DAY
+- \Skyloft\Upper Skyloft_NIGHT
+- \Skyloft\Central Skyloft\Bird Nest_DAY
+- \Skyloft\Central Skyloft\Bird Nest_NIGHT
+- \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades
+- \Skyloft\Central Skyloft\Bazaar
+- \Skyloft\Central Skyloft\Orielle and Parrow's House_DAY
+- \Skyloft\Central Skyloft\Orielle and Parrow's House_NIGHT
+- \Skyloft\Central Skyloft\Peatrice's House_DAY
+- \Skyloft\Central Skyloft\Peatrice's House_NIGHT
+- \Skyloft\Central Skyloft\Wryna's House_DAY
+- \Skyloft\Central Skyloft\Wryna's House_NIGHT
+- \Skyloft\Central Skyloft\Piper's House_DAY
+- \Skyloft\Central Skyloft\Piper's House_NIGHT
+- \Skyloft\Central Skyloft\Near Temple Entrance
+- \Skyloft\Central Skyloft\Waterfall Island_DAY
+- \Skyloft\Central Skyloft\Waterfall Island_NIGHT
+- \Skyloft\Central Skyloft\Waterfall Cave_DAY
+- \Skyloft\Central Skyloft\Waterfall Cave_NIGHT
+- \Skyloft\Central Skyloft\Past Waterfall Cave_DAY
+- \Skyloft\Central Skyloft\Past Waterfall Cave_NIGHT
+- \Skyloft\Central Skyloft_DAY
+- \Skyloft\Central Skyloft_NIGHT
+- \Skyloft\Skyloft Silent Realm_DAY
+- \Skyloft\Skyloft Silent Realm_NIGHT
+- \Skyloft\Skyloft Village\Bertie's House_DAY
+- \Skyloft\Skyloft Village\Bertie's House_NIGHT
+- \Skyloft\Skyloft Village\Sparrot's House_DAY
+- \Skyloft\Skyloft Village\Sparrot's House_NIGHT
+- \Skyloft\Skyloft Village\Mallara's House_DAY
+- \Skyloft\Skyloft Village\Mallara's House_NIGHT
+- \Skyloft\Skyloft Village\Gondo's House_DAY
+- \Skyloft\Skyloft Village\Gondo's House_NIGHT
+- \Skyloft\Skyloft Village\Rupin's House_DAY
+- \Skyloft\Skyloft Village\Rupin's House_NIGHT
+- \Skyloft\Skyloft Village\Batreaux's House_DAY
+- \Skyloft\Skyloft Village\Batreaux's House_NIGHT
+- \Skyloft\Skyloft Village_DAY
+- \Skyloft\Skyloft Village_NIGHT
+- \Skyloft\Beedle's Shop\Stall_DAY
+- \Skyloft\Beedle's Shop\Stall_NIGHT
+- \Skyloft\Beedle's Shop_DAY
+- \Skyloft\Beedle's Shop_NIGHT
+- \Skyloft_DAY
+- \Skyloft_NIGHT
+- \Skyview\Main\Entry
+- \Skyview\Main\First Room
+- \Skyview\Main\One Eye Room
+- \Skyview\Main\First Hub\Left Room
+- \Skyview\Main\First Hub\Right Room\Lower Area
+- \Skyview\Main\First Hub\Right Room\After Crawlspace\With Water
+- \Skyview\Main\First Hub\Right Room\After Crawlspace
+- \Skyview\Main\First Hub\Right Room\Upper Area
+- \Skyview\Main\First Hub\Right Room
+- \Skyview\Main\First Hub
+- \Skyview\Main\Second Hub\Miniboss Room
+- \Skyview\Main\Second Hub\Left Rooms
+- \Skyview\Main\Second Hub\Staldra Room
+- \Skyview\Main\Second Hub
+- \Skyview\Main\Last Room\Near East Entrance
+- \Skyview\Main\Last Room\Before Rope
+- \Skyview\Main\Last Room\After Rope
+- \Skyview\Main\Last Room\Near Boss Key Chest
+- \Skyview\Main\Last Room
+- \Skyview\Main
+- \Skyview\Boss Room
+- \Skyview\Spring
+- \Skyview
+- _DAY
+- _NIGHT
+- \Start
+- \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Exit
+- \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Exit
+- \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Exit
+- \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Exit
+- \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Exit
+- \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Exit
+- \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Exit
+- \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Exit
+- \Skyloft\Upper Skyloft\Knight Academy Chimney Entrance
+- \Skyloft\Upper Skyloft\Sparring Hall\Right Door Exit
+- \Skyloft\Upper Skyloft\Sparring Hall\Left Door Exit
+- \Skyloft\Upper Skyloft\Sparring Hall Left Door Exit
+- \Skyloft\Upper Skyloft\Sparring Hall Right Door Exit
+- \Skyloft\Upper Skyloft\Goddess Statue\Exit
+- \Skyloft\Upper Skyloft\Goddess Statue Exit
+- \Skyloft\Central Skyloft\Waterfall Cave\Upper Exit
+- \Skyloft\Central Skyloft\Waterfall Cave\Lower Exit
+- \Skyloft\Central Skyloft\Waterfall Cave Upper Exit
+- \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Exit
+- \Skyloft\Central Skyloft\Bazaar\North Exit
+- \Skyloft\Central Skyloft\Bazaar\South Exit
+- \Skyloft\Central Skyloft\Bazaar\West Exit
+- \Skyloft\Central Skyloft\Bazaar North Exit
+- \Skyloft\Central Skyloft\Bazaar South Exit
+- \Skyloft\Central Skyloft\Bazaar West Exit
+- \Skyloft\Beedle's Shop\Day Exit
+- \Skyloft\Beedle's Shop\Night Exit
+- \Skyloft\Central Skyloft\Exit to Beedle's Shop
+- \Skyloft\Skyloft Silent Realm\Exit
+- \Skyloft\Central Skyloft\Trial Gate Exit
+- \Skyloft\Central Skyloft\Near Temple Entrance\Exit to Sky Keep
+- \Skyloft\Central Skyloft\Orielle and Parrow's House\Exit
+- \Skyloft\Central Skyloft\Orielle and Parrow's House Exit
+- \Skyloft\Central Skyloft\Peatrice's House\Exit
+- \Skyloft\Central Skyloft\Peatrice's House Exit
+- \Skyloft\Central Skyloft\Wryna's House\Exit
+- \Skyloft\Central Skyloft\Wryna's House Exit
+- \Skyloft\Skyloft Village\Bertie's House\Exit
+- \Skyloft\Skyloft Village\Bertie's House Exit
+- \Skyloft\Skyloft Village\Sparrot's House\Exit
+- \Skyloft\Skyloft Village\Sparrot's House Exit
+- \Skyloft\Skyloft Village\Mallara's House Exit
+- \Skyloft\Skyloft Village\Mallara's House\Exit
+- \Skyloft\Skyloft Village\Batreaux's House\Exit
+- \Skyloft\Skyloft Village\Batreaux's House Exit
+- \Skyloft\Skyloft Village\Gondo's House\Exit
+- \Skyloft\Skyloft Village\Gondo's House Exit
+- \Skyloft\Skyloft Village\Rupin's House\Exit
+- \Skyloft\Skyloft Village\Rupin's House Exit
+- \Skyloft\Central Skyloft\Piper's House\Exit
+- \Skyloft\Central Skyloft\Piper's House Exit
+- \Skyloft\Central Skyloft\Exit to Sky
+- \Sky\Around Skyloft\Exit to Skyloft
+- \Sky\North East\Bamboo Island\Inside\Exit
+- \Sky\North East\Bamboo Island\Exit to Inside
+- \Sky\North East\Beedle's Island\Beedle's Ship Exit
+- \Sky\North East\Eldin Pillar\First Time Dive
+- \Sky\North East\Eldin Pillar\Temple Entrance Statue Dive
+- \Sky\North East\Eldin Pillar\Inside the Volcano Statue Dive
+- \Sky\North East\Eldin Pillar\Volcano Entrance Statue Dive
+- \Sky\North East\Eldin Pillar\Volcano East Statue Dive
+- \Sky\North East\Eldin Pillar\Volcano Ascent Statue Dive
+- \Sky\North East\Eldin Pillar\Fire Sanctuary Statue Dive
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Exit
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Exit
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Exit
+- \Sky\South East\Lumpy Pumpkin\Main Right Door Exit
+- \Sky\South East\Lumpy Pumpkin\Main Left Door Exit
+- \Sky\South East\Lumpy Pumpkin\Back Door Exit
+- \Sky\South East\Faron Pillar\First Time Dive
+- \Sky\South East\Faron Pillar\Sealed Grounds Statue Dive
+- \Sky\South East\Faron Pillar\Forest Temple Statue Dive
+- \Sky\South East\Faron Pillar\Behind the Temple Statue Dive
+- \Sky\South East\Faron Pillar\Faron Woods Entry Statue Dive
+- \Sky\South East\Faron Pillar\In the Woods Statue Dive
+- \Sky\South East\Faron Pillar\Viewing Platform Statue Dive
+- \Sky\South East\Faron Pillar\The Great Tree Statue Dive
+- \Sky\South East\Faron Pillar\Deep Woods Statue Dive
+- \Sky\South East\Faron Pillar\Lake Floria Statue Dive
+- \Sky\South East\Faron Pillar\Floria Waterfall Statue Dive
+- \Sky\South West\Lanayru Pillar\First Time Dive
+- \Sky\South West\Lanayru Pillar\Lanayru Mine Entry Statue Dive
+- \Sky\South West\Lanayru Pillar\Desert Entrance Statue Dive
+- \Sky\South West\Lanayru Pillar\West Desert Statue Dive
+- \Sky\South West\Lanayru Pillar\North Desert Statue Dive
+- \Sky\South West\Lanayru Pillar\Stone Cache Statue Dive
+- \Sky\South West\Lanayru Pillar\Desert Gorge Statue Dive
+- \Sky\South West\Lanayru Pillar\Temple of Time Statue Dive
+- \Sky\South West\Lanayru Pillar\Ancient Harbour Statue Dive
+- \Sky\South West\Lanayru Pillar\Skipper's Retreat Statue Dive
+- \Sky\South West\Lanayru Pillar\Shipyard Statue Dive
+- \Sky\South West\Lanayru Pillar\Pirate Stronghold Statue Dive
+- \Sky\South West\Lanayru Pillar\Lanayru Gorge Statue Dive
+- \Sky\Around Skyloft\Exit to Thunderhead
+- \Sky\Thunderhead\Exit
+- \Sky\Thunderhead\Isle of Songs\Inside\Exit
+- \Sky\Thunderhead\Isle of Songs\Exit to Inside
+- \Faron\Sealed Grounds\Spiral\Upper Part\Statue Exit
+- \Faron\Sealed Grounds\Spiral\Door Exit
+- \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Exit to
+  Behind the Temple
+- \Faron\Sealed Grounds\Sealed Temple\Main Exit
+- \Faron\Sealed Grounds\Sealed Temple\Side Exit
+- \Faron\Sealed Grounds\Sealed Temple\Gate of Time Exit
+- \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Exit
+- \Faron\Sealed Grounds\Behind the Temple\Statue Exit
+- \Faron\Sealed Grounds\Behind the Temple\Shortcut Exit to Spiral
+- \Faron\Sealed Grounds\Behind the Temple\Door Exit
+- \Faron\Sealed Grounds\Behind the Temple\Exit to Faron Woods
+- \Faron\Faron Woods\Shared Statue Exit
+- \Faron\Faron Woods\Entry\Exit to Behind the Temple
+- \Faron\Faron Woods\Ledge To Deep Woods\Exit to Deep Woods
+- \Faron\Faron Woods\Lake Floria Dive
+- \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Exit to Floria Waterfall
+- \Faron\Faron Woods\Trial Gate Exit
+- \Faron\Faron Silent Realm\Exit
+- \Faron\Faron Woods\Great Tree\Platforms\Lower Exit to Great Tree
+- \Faron\Faron Woods\Great Tree\Platforms\Upper Exit to Great Tree
+- \Faron\Faron Woods\Great Tree\Top\Top Exit to Great Tree
+- \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Exit
+- \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Exit to Platforms
+- \Faron\Faron Woods\Great Tree\Upper Area\Upper Exit to Platforms
+- \Faron\Faron Woods\Great Tree\Upper Area\Exit to Top
+- \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Exit
+- \Faron\Faron Woods\Great Tree\Upper Area\Exit to Flooded Great Tree
+- \Faron\Flooded Faron Woods\Flooded Great Tree\Exit
+- \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Upper Flooded Faron Woods
+- \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Lower Flooded Faron Woods
+- \Faron\Flooded Faron Woods\Exit to Upper Flooded Great Tree
+- \Faron\Flooded Faron Woods\Exit to Lower Flooded Great Tree
+- \Faron\Faron Woods\Deep Woods\Shared Statue Exit
+- \Faron\Faron Woods\Deep Woods\Entry\Exit to Faron Woods
+- \Faron\Faron Woods\Deep Woods\Exit to Skyview Temple
+- \Faron\Lake Floria\Below Rock\Emerged Area\Statue Exit
+- \Faron\Lake Floria\Below Rock\Exit to Farore's Lair
+- \Faron\Lake Floria\Farore's Lair\Exit to Lake Floria
+- \Faron\Lake Floria\Farore's Lair\Exit to Waterfall
+- \Faron\Lake Floria\Waterfall\Statue Exit
+- \Faron\Lake Floria\Waterfall\Exit to Farore's Lair
+- \Faron\Lake Floria\Waterfall\Exit to Ancient Cistern
+- \Faron\Lake Floria\Waterfall\Exit to Faron Woods
+- \Skyview\Main\Entry\Main Exit
+- \Skyview\Main\Last Room\After Rope\Boss Door Exit
+- \Skyview\Boss Room\Exit to Dungeon
+- \Skyview\Boss Room\Exit to Spring
+- \Skyview\Spring\Exit
+- \Ancient Cistern\Main\Main Room\Main Exit
+- \Ancient Cistern\Main\Inside Statue\Boss Door Exit
+- \Ancient Cistern\Boss Room\Exit to Dungeon
+- \Ancient Cistern\Boss Room\Exit to Flame Room
+- \Ancient Cistern\Flame Room\Exit
+- \Eldin\Volcano\Entry\Volcano Entrance Statue Exit
+- \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit
+- \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Exit
+- \Eldin\Volcano\East\Dive to Mogma Turf
+- \Eldin\Volcano\Near Temple Entrance\Exit to Earth Temple
+- \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Exit
+- \Eldin\Volcano\Hot Cave\Exit to Summit
+- \Eldin\Volcano\Ascent\Trial Gate Exit
+- \Eldin\Volcano\Past Slide\Vent Exit near Ascent
+- \Eldin\Volcano\East\Exit to Bokoblin Base
+- \Eldin\Bokoblin Base\Prison\Exit
+- \Eldin\Mogma Turf\Pre Vent\First Vent
+- \Eldin\Mogma Turf\Past Vent\Second Vent
+- \Eldin\Volcano\Thrill Digger Cave\Exit
+- \Eldin\Eldin Silent Realm\Exit
+- \Eldin\Volcano Summit\Exit to Eldin Volcano
+- \Eldin\Volcano Summit\Exit to Waterfall
+- \Eldin\Volcano Summit\Exit to Outside Fire Sanctuary
+- \Eldin\Volcano Summit\Waterfall\Exit
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Exit
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Exit to Summit
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Exit to Fire Sanctuary
+- \Earth Temple\Main\First Room\Main Exit
+- \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Exit
+- \Earth Temple\Boss Room\Entry\Exit to Dungeon
+- \Earth Temple\Boss Room\Slope\Exit to Spring
+- \Earth Temple\Spring\Exit
+- \Fire Sanctuary\Main\Front of Boss Door\Statue Exit
+- \Fire Sanctuary\Main\First Room\Main Exit
+- \Fire Sanctuary\Main\First Room\Past Water Plant\Exit to Second Room
+- \Fire Sanctuary\Main\Second Room\Outside Section\Exit to First Room
+- \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Exit to West of Boss Door
+- \Fire Sanctuary\Main\West of Boss Door\Entry\Exit to Magmanos Fight Room
+- \Fire Sanctuary\Main\Front of Boss Door\Boss Door Exit
+- \Fire Sanctuary\Boss Room\Exit to Dungeon
+- \Fire Sanctuary\Boss Room\Exit to Flame Room
+- \Fire Sanctuary\Flame Room\Exit
+- \Lanayru\Mine\Entry\Statue Exit
+- \Lanayru\Mine\Entry\Caves Entrance\Exit to Caves
+- \Lanayru\Mine\End\In Minecart\Exit to Desert
+- \Lanayru\Desert\Shared Statue Exit
+- \Lanayru\Desert\North Part\Lightning Node Exit
+- \Lanayru\Desert\Entry\Exit to Mine
+- \Lanayru\Desert\East\Fire Node Exit
+- \Lanayru\Desert\Near South Exit to Temple of Time\South Exit to Temple of Time
+- \Lanayru\Desert\North Part\North Exit to Temple of Time
+- \Lanayru\Desert\Top of LMF\Exit to Lanayru Mining Facility
+- \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Exit to Caves
+- \Lanayru\Desert\North Part\Trial Gate Exit
+- \Lanayru\Lanayru Silent Realm\Exit
+- \Lanayru\Desert\North Part\Lightning Node\Present\Exit
+- \Lanayru\Desert\East\Fire Node\Present\Exit
+- \Lanayru\Temple of Time\Shared Statue Exit
+- \Lanayru\Temple of Time\South East\South Exit to Desert
+- \Lanayru\Temple of Time\North East\North Exit to Desert
+- \Lanayru\Temple of Time\Inside\Exit to Lanayru Mining Facility
+- \Lanayru\Caves\Exit to Mine
+- \Lanayru\Caves\Exit to Desert
+- \Lanayru\Caves\Past Door to Lanayru Sand Sea\Exit to Lanayru Sand Sea
+- \Lanayru\Caves\Past Crawlspace\Exit to Gorge
+- \Lanayru\Lanayru Sand Sea\Gorge\Exit
+- \Lanayru\Lanayru Sand Sea\Gorge\Statue Exit
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Exit
+- \Lanayru\Lanayru Sand Sea\Sandship Dock Exit
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Exit
+- \Lanayru\Lanayru Sand Sea\Shipyard Dock Exit
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Exit
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Exit
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Exit to Sandship
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Exit to Caves
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Exit
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Exit
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Exit
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Exit
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Exit
+- \Lanayru\Lanayru Sand Sea\Shipyard\Statue Exit
+- \Lanayru\Lanayru Sand Sea\Shipyard\Dock Exit
+- \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Exit
+- \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Exit
+- \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Exit
+- \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Exit
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Exit
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Exit
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Exit
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Exit
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Exit
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Exit
+- \Lanayru Mining Facility\Main\First Room\Main Exit
+- \Lanayru Mining Facility\Main\First Hub\Exit to Big Hub
+- \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Exit to Big Hub
+- \Lanayru Mining Facility\Main\Armos Fight Room\Exit to Big Hub
+- \Lanayru Mining Facility\Main\Big Hub\Entry\Exit to First Hub
+- \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Exit to
+  Hop Across Boxes Room
+- \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Exit to Armos Fight Room
+- \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Exit
+- \Lanayru Mining Facility\Boss Room\Exit to Dungeon
+- \Lanayru Mining Facility\Boss Room\After Sand Drain\Exit to Hall of Ancient Robots
+- \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Exit to Boss Room
+- \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit to Temple of Time
+- \Sandship\Main\Deck\Main Exit
+- \Sandship\Main\Before Boss Door\Boss Door one-way Exit
+- \Sky Keep\Main\First Room\Bottom Exit
+- \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Start Entrance
+- \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Chimney_DAY
+- \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Chimney_NIGHT
+- \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Sparring Hall\Right Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Sparring Hall\Right Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Sparring Hall\Left Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Sparring Hall\Left Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Sparring Hall Left Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Sparring Hall Left Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Sparring Hall Right Door Entrance_DAY
+- \Skyloft\Upper Skyloft\Sparring Hall Right Door Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Goddess Statue\Entrance_DAY
+- \Skyloft\Upper Skyloft\Goddess Statue\Entrance_NIGHT
+- \Skyloft\Upper Skyloft\Goddess Statue Entrance_DAY
+- \Skyloft\Upper Skyloft\Goddess Statue Entrance_NIGHT
+- \Skyloft\Central Skyloft\Waterfall Cave\Upper Entrance_DAY
+- \Skyloft\Central Skyloft\Waterfall Cave\Upper Entrance_NIGHT
+- \Skyloft\Central Skyloft\Waterfall Cave\Lower Entrance_DAY
+- \Skyloft\Central Skyloft\Waterfall Cave\Lower Entrance_NIGHT
+- \Skyloft\Central Skyloft\Waterfall Cave Upper Entrance_DAY
+- \Skyloft\Central Skyloft\Waterfall Cave Upper Entrance_NIGHT
+- \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Entrance_DAY
+- \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Entrance_NIGHT
+- \Skyloft\Central Skyloft\Bazaar\North Entrance
+- \Skyloft\Central Skyloft\Bazaar\South Entrance
+- \Skyloft\Central Skyloft\Bazaar\West Entrance
+- \Skyloft\Central Skyloft\Bazaar North Entrance_DAY
+- \Skyloft\Central Skyloft\Bazaar North Entrance_NIGHT
+- \Skyloft\Central Skyloft\Bazaar South Entrance_DAY
+- \Skyloft\Central Skyloft\Bazaar South Entrance_NIGHT
+- \Skyloft\Central Skyloft\Bazaar West Entrance_DAY
+- \Skyloft\Central Skyloft\Bazaar West Entrance_NIGHT
+- \Skyloft\Beedle's Shop\Day Entrance_DAY
+- \Skyloft\Beedle's Shop\Day Entrance_NIGHT
+- \Skyloft\Beedle's Shop\Night Entrance
+- \Skyloft\Central Skyloft\Entrance from Beedle's Shop_DAY
+- \Skyloft\Central Skyloft\Entrance from Beedle's Shop_NIGHT
+- \Skyloft\Skyloft Silent Realm\Entrance_DAY
+- \Skyloft\Skyloft Silent Realm\Entrance_NIGHT
+- \Skyloft\Central Skyloft\Trial Gate Entrance_DAY
+- \Skyloft\Central Skyloft\Trial Gate Entrance_NIGHT
+- \Skyloft\Central Skyloft\Near Temple Entrance\Entrance from Sky Keep
+- \Skyloft\Central Skyloft\Orielle and Parrow's House\Entrance_DAY
+- \Skyloft\Central Skyloft\Orielle and Parrow's House\Entrance_NIGHT
+- \Skyloft\Central Skyloft\Orielle and Parrow's House Entrance_DAY
+- \Skyloft\Central Skyloft\Orielle and Parrow's House Entrance_NIGHT
+- \Skyloft\Central Skyloft\Peatrice's House\Entrance_DAY
+- \Skyloft\Central Skyloft\Peatrice's House\Entrance_NIGHT
+- \Skyloft\Central Skyloft\Peatrice's House Entrance_DAY
+- \Skyloft\Central Skyloft\Peatrice's House Entrance_NIGHT
+- \Skyloft\Central Skyloft\Wryna's House\Entrance_DAY
+- \Skyloft\Central Skyloft\Wryna's House\Entrance_NIGHT
+- \Skyloft\Central Skyloft\Wryna's House Entrance_DAY
+- \Skyloft\Central Skyloft\Wryna's House Entrance_NIGHT
+- \Skyloft\Skyloft Village\Bertie's House\Entrance_DAY
+- \Skyloft\Skyloft Village\Bertie's House\Entrance_NIGHT
+- \Skyloft\Skyloft Village\Bertie's House Entrance_DAY
+- \Skyloft\Skyloft Village\Bertie's House Entrance_NIGHT
+- \Skyloft\Skyloft Village\Sparrot's House\Entrance_DAY
+- \Skyloft\Skyloft Village\Sparrot's House\Entrance_NIGHT
+- \Skyloft\Skyloft Village\Sparrot's House Entrance_DAY
+- \Skyloft\Skyloft Village\Sparrot's House Entrance_NIGHT
+- \Skyloft\Skyloft Village\Mallara's House Entrance_DAY
+- \Skyloft\Skyloft Village\Mallara's House Entrance_NIGHT
+- \Skyloft\Skyloft Village\Mallara's House\Entrance_DAY
+- \Skyloft\Skyloft Village\Mallara's House\Entrance_NIGHT
+- \Skyloft\Skyloft Village\Batreaux's House\Entrance_DAY
+- \Skyloft\Skyloft Village\Batreaux's House\Entrance_NIGHT
+- \Skyloft\Skyloft Village\Batreaux's House Entrance_DAY
+- \Skyloft\Skyloft Village\Batreaux's House Entrance_NIGHT
+- \Skyloft\Skyloft Village\Gondo's House\Entrance_DAY
+- \Skyloft\Skyloft Village\Gondo's House\Entrance_NIGHT
+- \Skyloft\Skyloft Village\Gondo's House Entrance_DAY
+- \Skyloft\Skyloft Village\Gondo's House Entrance_NIGHT
+- \Skyloft\Skyloft Village\Rupin's House\Entrance_DAY
+- \Skyloft\Skyloft Village\Rupin's House\Entrance_NIGHT
+- \Skyloft\Skyloft Village\Rupin's House Entrance_DAY
+- \Skyloft\Skyloft Village\Rupin's House Entrance_NIGHT
+- \Skyloft\Central Skyloft\Piper's House\Entrance_DAY
+- \Skyloft\Central Skyloft\Piper's House\Entrance_NIGHT
+- \Skyloft\Central Skyloft\Piper's House Entrance_DAY
+- \Skyloft\Central Skyloft\Piper's House Entrance_NIGHT
+- \Skyloft\Central Skyloft\Entrance from Sky_DAY
+- \Skyloft\Central Skyloft\Entrance from Sky_NIGHT
+- \Sky\Around Skyloft\Entrance from Skyloft
+- \Sky\North East\Bamboo Island\Inside\Entrance
+- \Sky\North East\Bamboo Island\Entrance from Inside
+- \Sky\North East\Beedle's Island\Beedle's Ship Entrance
+- \Sky\North East\Eldin Pillar\Entrance
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Entrance_DAY
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Entrance_NIGHT
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Entrance_DAY
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Entrance_NIGHT
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Entrance_DAY
+- \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Entrance_NIGHT
+- \Sky\South East\Lumpy Pumpkin\Main Left Door Entrance_DAY
+- \Sky\South East\Lumpy Pumpkin\Main Left Door Entrance_NIGHT
+- \Sky\South East\Lumpy Pumpkin\Main Right Door Entrance_DAY
+- \Sky\South East\Lumpy Pumpkin\Main Right Door Entrance_NIGHT
+- \Sky\South East\Lumpy Pumpkin\Back Door Entrance_DAY
+- \Sky\South East\Lumpy Pumpkin\Back Door Entrance_NIGHT
+- \Sky\South East\Faron Pillar\Entrance
+- \Sky\South West\Lanayru Pillar\Entrance
+- \Sky\Around Skyloft\Entrance from Thunderhead
+- \Sky\Thunderhead\Entrance
+- \Sky\Thunderhead\Isle of Songs\Inside\Entrance
+- \Sky\Thunderhead\Isle of Songs\Entrance from Inside
+- \Faron\Sealed Grounds\Spiral\Upper Part\Statue Entrance
+- \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Entrance
+  from Behind the Temple
+- \Faron\Sealed Grounds\Spiral\Door Entrance
+- \Faron\Sealed Grounds\Sealed Temple\Main Entrance
+- \Faron\Sealed Grounds\Sealed Temple\Side Entrance
+- \Faron\Sealed Grounds\Sealed Temple\Gate of Time Entrance
+- \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Entrance
+- \Faron\Sealed Grounds\Behind the Temple\Statue Entrance
+- \Faron\Sealed Grounds\Behind the Temple\Door Entrance
+- \Faron\Sealed Grounds\Behind the Temple\Shortcut Entrance from Spiral
+- \Faron\Sealed Grounds\Behind the Temple\Entrance from Faron Woods
+- \Faron\Faron Woods\Entry\Faron Woods Entry Statue Entrance
+- \Faron\Faron Woods\In the Woods Statue Entrance
+- \Faron\Faron Woods\Viewing Platform Statue Entrance
+- \Faron\Faron Woods\Great Tree\Top\The Great Tree Statue Entrance
+- \Faron\Faron Woods\Entry\Entrance from Behind the Temple
+- \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Entrance from Floria Waterfall
+- \Faron\Faron Woods\Ledge To Deep Woods\Entrance from Deep Woods
+- \Faron\Faron Woods\Trial Gate Entrance
+- \Faron\Faron Silent Realm\Entrance
+- \Faron\Faron Woods\Great Tree\Platforms\Lower Entrance from Great Tree
+- \Faron\Faron Woods\Great Tree\Platforms\Upper Entrance from Great Tree
+- \Faron\Faron Woods\Great Tree\Top\Top Entrance from Great Tree
+- \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Entrance
+- \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Entrance from Platforms
+- \Faron\Faron Woods\Great Tree\Upper Area\Upper Entrance from Platforms
+- \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Top
+- \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Entrance
+- \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Flooded Great Tree
+- \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance
+- \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Upper Flooded Faron
+  Woods
+- \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Lower Flooded Faron
+  Woods
+- \Faron\Flooded Faron Woods\Entrance from Upper Flooded Great Tree
+- \Faron\Flooded Faron Woods\Entrance from Lower Flooded Great Tree
+- \Faron\Faron Woods\Deep Woods\Forest Temple Statue Entrance
+- \Faron\Faron Woods\Deep Woods\Deep Woods Statue Entrance
+- \Faron\Faron Woods\Deep Woods\Entry\Entrance from Faron Woods
+- \Faron\Faron Woods\Deep Woods\Entrance from Skyview Temple
+- \Faron\Lake Floria\Below Rock\Emerged Area\Statue Entrance
+- \Faron\Lake Floria\Above Rock\Dive from Faron Woods
+- \Faron\Lake Floria\Below Rock\Entrance from Farore's Lair
+- \Faron\Lake Floria\Farore's Lair\Entrance from Lake Floria
+- \Faron\Lake Floria\Farore's Lair\Entrance from Waterfall
+- \Faron\Lake Floria\Waterfall\Statue Entrance
+- \Faron\Lake Floria\Waterfall\Entrance from Farore's Lair
+- \Faron\Lake Floria\Waterfall\Entrance from Ancient Cistern
+- \Faron\Lake Floria\Waterfall\Entrance from Faron Woods
+- \Skyview\Main\Entry\Main Entrance
+- \Skyview\Main\Last Room\After Rope\Boss Door Entrance
+- \Skyview\Boss Room\Entrance from Dungeon
+- \Skyview\Boss Room\Entrance from Spring
+- \Skyview\Spring\Entrance
+- \Ancient Cistern\Main\Main Room\Main Entrance
+- \Ancient Cistern\Main\Inside Statue\Boss Door Entrance
+- \Ancient Cistern\Boss Room\Entrance from Dungeon
+- \Ancient Cistern\Boss Room\Entrance from Flame Room
+- \Ancient Cistern\Flame Room\Entrance
+- \Eldin\Volcano\Entry\First Time Entrance
+- \Eldin\Volcano\Entry\Volcano Entrance Statue Entrance
+- \Eldin\Volcano\East\Volcano East Statue Entrance
+- \Eldin\Volcano\Ascent\Volcano Ascent Statue Entrance
+- \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Entrance
+- \Eldin\Volcano\East\First Vent from Mogma Turf
+- \Eldin\Volcano\Past Mogma Turf\Second Vent from Mogma Turf
+- \Eldin\Volcano\Near Temple Entrance\Entrance from Earth Temple
+- \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Entrance
+- \Eldin\Volcano\Hot Cave\Entrance from Summit
+- \Eldin\Volcano\Ascent\Trial Gate Entrance
+- \Eldin\Volcano\Hot Cave\Vent Entrance near Hot Cave
+- \Eldin\Volcano\East\Entrance from Bokoblin Base
+- \Eldin\Bokoblin Base\Prison\Entrance
+- \Eldin\Mogma Turf\Pre Vent\Entrance
+- \Eldin\Volcano\Thrill Digger Cave\Entrance
+- \Eldin\Eldin Silent Realm\Entrance
+- \Eldin\Volcano Summit\Entrance from Outside Fire Sanctuary
+- \Eldin\Volcano Summit\Entrance from Waterfall
+- \Eldin\Volcano Summit\Entrance from Eldin Volcano
+- \Eldin\Volcano Summit\Waterfall\Entrance
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Entrance
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Entrance from
+  Summit
+- \Eldin\Volcano Summit\Outside Fire Sanctuary\Entrance from Fire Sanctuary
+- \Earth Temple\Main\First Room\Main Entrance
+- \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Entrance
+- \Earth Temple\Boss Room\Entry\Entrance from Dungeon
+- \Earth Temple\Boss Room\Slope\Entrance from Spring
+- \Earth Temple\Spring\Entrance
+- \Fire Sanctuary\Main\Front of Boss Door\Statue Entrance
+- \Fire Sanctuary\Main\First Room\Main Entrance
+- \Fire Sanctuary\Main\First Room\Past Water Plant\Entrance from Second Room
+- \Fire Sanctuary\Main\Second Room\Outside Section\Entrance from First Room
+- \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Entrance from West of Boss Door
+- \Fire Sanctuary\Main\West of Boss Door\Entry\Entrance from Magmanos Fight Room
+- \Fire Sanctuary\Main\Front of Boss Door\Boss Door Entrance
+- \Fire Sanctuary\Boss Room\Entrance from Dungeon
+- \Fire Sanctuary\Boss Room\Entrance from Flame Room
+- \Fire Sanctuary\Flame Room\Entrance
+- \Lanayru\Mine\Entry\First Time Entrance
+- \Lanayru\Mine\Entry\Caves Entrance\Entrance from Caves
+- \Lanayru\Mine\Entry\Statue Entrance
+- \Lanayru\Mine\End\In Minecart\Entrance from Desert
+- \Lanayru\Desert\Entry\Desert Entrance Statue Entrance
+- \Lanayru\Desert\West Part\West Desert Statue Entrance
+- \Lanayru\Desert\North Part\North Desert Statue Entrance
+- \Lanayru\Desert\East\Stone Cache Statue Entrance
+- \Lanayru\Desert\Near South Exit to Temple of Time\South Entrance from Temple of
+  Time
+- \Lanayru\Desert\North Part\North Entrance from Temple of Time
+- \Lanayru\Desert\Entry\Entrance from Mine
+- \Lanayru\Desert\East\Fire Node Entrance
+- \Lanayru\Desert\Top of LMF\Entrance from Lanayru Mining Facility
+- \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Entrance from Caves
+- \Lanayru\Desert\North Part\Lightning Node Entrance
+- \Lanayru\Desert\North Part\Trial Gate Entrance
+- \Lanayru\Lanayru Silent Realm\Entrance
+- \Lanayru\Desert\North Part\Lightning Node\Present\Entrance
+- \Lanayru\Desert\East\Fire Node\Present\Entrance
+- \Lanayru\Temple of Time\South East\Desert Gorge Statue Entrance
+- \Lanayru\Temple of Time\Inside\Temple of Time Statue Entrance
+- \Lanayru\Temple of Time\South East\South Entrance from Desert
+- \Lanayru\Temple of Time\North East\North Entrance from Desert
+- \Lanayru\Temple of Time\Inside\Entrance from Lanayru Mining Facility
+- \Lanayru\Caves\Entrance from Mine
+- \Lanayru\Caves\Entrance from Desert
+- \Lanayru\Caves\Past Door to Lanayru Sand Sea\Entrance from Lanayru Sand Sea
+- \Lanayru\Caves\Past Crawlspace\Entrance from Gorge
+- \Lanayru\Lanayru Sand Sea\Gorge\Entrance
+- \Lanayru\Lanayru Sand Sea\Gorge\Statue Entrance
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Entrance
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Entrance
+- \Lanayru\Lanayru Sand Sea\Shipyard Dock Entrance
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Entrance
+- \Lanayru\Lanayru Sand Sea\Sandship Dock Entrance
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Entrance
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Entrance from Caves
+- \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Entrance
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Entrance
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Entrance
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Entrance
+- \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Entrance
+- \Lanayru\Lanayru Sand Sea\Shipyard\Statue Entrance
+- \Lanayru\Lanayru Sand Sea\Shipyard\Dock Entrance
+- \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Entrance
+- \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Entrance
+- \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Entrance
+- \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Entrance
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Entrance
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Entrance
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Entrance
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Entrance
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Entrance
+- \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Entrance
+- \Lanayru Mining Facility\Main\First Room\Main Entrance
+- \Lanayru Mining Facility\Main\First Hub\Entrance from Big Hub
+- \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Entrance from Big
+  Hub
+- \Lanayru Mining Facility\Main\Armos Fight Room\Entrance from Big Hub
+- \Lanayru Mining Facility\Main\Big Hub\Entry\Entrance from First Hub
+- \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Entrance
+  from Hop Across Boxes Room
+- \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Entrance from Armos Fight Room
+- \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Entrance
+- \Lanayru Mining Facility\Boss Room\Entrance from Dungeon
+- \Lanayru Mining Facility\Boss Room\After Sand Drain\Entrance from Hall of Ancient
+  Robots
+- \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Entrance from Boss Room
+- \Lanayru Mining Facility\Hall of Ancient Robots\End\Entrance from Temple of Time
+- \Sandship\Main\Deck\Main Entrance
+- \Sandship\Boss Room\Entrance
+- \Sky Keep\Main\First Room\Bottom Entrance
+

--- a/dump.yaml
+++ b/dump.yaml
@@ -1,11483 +1,3 @@
-areas:
-  abstract: true
-  allowed_time_of_day: 3
-  can_save: false
-  can_sleep: false
-  entrances: !!set {}
-  exits:
-    Start: 'True'
-  hint_region: null
-  locations:
-    1 Extra Wallet: Extra Wallet
-    1 Gratitude Crystal Pack: Gratitude Crystal Pack
-    10 Gratitude Crystal Packs: Gratitude Crystal Pack x 10
-    10 Gratitude Crystals: "\\10 Single Gratitude Crystals | \\5 Single Gratitude\
-      \ Crystals & \\1 Gratitude Crystal Pack | \\2 Gratitude Crystal Packs"
-    10 Single Gratitude Crystals: Gratitude Crystal x 10
-    11 Gratitude Crystal Packs: Gratitude Crystal Pack x 11
-    12 Gratitude Crystal Packs: Gratitude Crystal Pack x 12
-    13 Gratitude Crystal Packs: Gratitude Crystal Pack x 13
-    15 Single Gratitude Crystals: Gratitude Crystal x 15
-    2 Extra Wallets: Extra Wallet x 2
-    2 Gratitude Crystal Packs: Gratitude Crystal Pack x 2
-    3 Extra Wallets: Extra Wallet x 3
-    3 Gratitude Crystal Packs: Gratitude Crystal Pack x 3
-    30 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\3 Gratitude Crystal\
-      \ Packs | \\10 Single Gratitude Crystals & \\4 Gratitude Crystal Packs | \\\
-      5 Single Gratitude Crystals & \\5 Gratitude Crystal Packs | \\6 Gratitude Crystal\
-      \ Packs"
-    4 Gratitude Crystal Packs: Gratitude Crystal Pack x 4
-    40 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\5 Gratitude Crystal\
-      \ Packs | \\10 Single Gratitude Crystals & \\6 Gratitude Crystal Packs | \\\
-      5 Single Gratitude Crystals & \\7 Gratitude Crystal Packs | \\8 Gratitude Crystal\
-      \ Packs"
-    5 Gratitude Crystal Packs: Gratitude Crystal Pack x 5
-    5 Gratitude Crystals: "\\5 Single Gratitude Crystals | \\1 Gratitude Crystal Pack"
-    5 Single Gratitude Crystals: Gratitude Crystal x 5
-    50 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\7 Gratitude Crystal\
-      \ Packs | \\10 Single Gratitude Crystals & \\8 Gratitude Crystal Packs | \\\
-      5 Single Gratitude Crystals & \\9 Gratitude Crystal Packs | \\10 Gratitude Crystal\
-      \ Packs"
-    6 Gratitude Crystal Packs: Gratitude Crystal Pack x 6
-    7 Gratitude Crystal Packs: Gratitude Crystal Pack x 7
-    70 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\11 Gratitude Crystal\
-      \ Packs | \\10 Single Gratitude Crystals & \\12 Gratitude Crystal Packs | \\\
-      5 Single Gratitude Crystals & \\13 Gratitude Crystal Packs"
-    8 Gratitude Crystal Packs: Gratitude Crystal Pack x 8
-    80 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\13 Gratitude Crystal\
-      \ Packs"
-    9 Gratitude Crystal Packs: Gratitude Crystal Pack x 9
-    Ancient Flower Farming: 'False'
-    Beetle: Progressive Beetle
-    Big Wallet: Progressive Wallet x 2
-    Bottle: "\\Pouch & \\Skyloft\\Central Skyloft\\Bazaar\\Item Check Access & \\\
-      Empty Bottle_"
-    Bow: Progressive Bow
-    Bug Net: Progressive Bug Net
-    Can Afford 100 Rupees: 'True'
-    Can Afford 1000 Rupees: "\\Can High Rupee Farm & (\\3 Extra Wallets | \\Medium\
-      \ Wallet & \\2 Extra Wallets | \\Big Wallet)"
-    Can Afford 1200 Rupees: "\\Can High Rupee Farm & (\\3 Extra Wallets | \\Medium\
-      \ Wallet & \\3 Extra Wallets | \\Big Wallet & \\1 Extra Wallet | \\Giant Wallet)"
-    Can Afford 1600 Rupees: "\\Can High Rupee Farm & (\\Big Wallet & \\2 Extra Wallets\
-      \ | \\Giant Wallet)"
-    Can Afford 300 Rupees: \Can Medium Rupee Farm
-    Can Afford 50 Rupees: 'True'
-    Can Afford 600 Rupees: "\\Can High Rupee Farm & (\\1 Extra Wallet | \\Big Wallet)"
-    Can Afford 800 Rupees: "\\Can High Rupee Farm & (\\2 Extra Wallets | \\Medium\
-      \ Wallet & \\1 Extra Wallet | \\Big Wallet)"
-    Can Collect Water: 'False'
-    Can Cut Tree: "\\Sword | Bomb Bag"
-    Can Defeat Ampilus: \Damaging Item
-    Can Defeat Armos: "Gust Bellows & \\Sword"
-    Can Defeat Beamos: "\\Sword | \\Bow"
-    Can Defeat Bokoblins: \Damaging Item
-    Can Defeat Cursed Bokoblins: "\\Sword | Bomb Bag"
-    Can Defeat Keeses: "\\Sword | \\Slingshot | \\Beetle | Whip | Clawshots | \\Bow\
-      \ | Bomb Bag"
-    Can Defeat Lizalfos: "\\Sword | Advanced Lizalfos Combat Trick & (Bomb Bag | \\\
-      Bow)"
-    Can Defeat Moblins: \Damaging Item
-    Can Defeat Scervo/Dreadfuse: \Sword
-    Can Defeat Stalfos: \Sword
-    Can Defeat Stalmaster: \Sword
-    Can High Rupee Farm: "\\Sky\\South West\\Fun Fun Island\\Fun Fun Island Minigame\
-      \ | \\Eldin\\Volcano\\Thrill Digger Cave\\Thrill Digger Minigame"
-    Can Hit Switch: "\\Sword | Bomb Bag | Whip | \\Distance Activator"
-    Can Hit Timeshift Stone: "\\Sword | Bomb Bag | Whip | \\Distance Activator"
-    Can Hit Timeshift Stone in Minecart: "\\Sword | Bomb Bag | \\Distance Activator"
-    Can Medium Rupee Farm: "\\Sky\\North East\\Bamboo Island\\Inside\\Clean Cut Minigame\
-      \ | \\Can High Rupee Farm"
-    Can Unlock Combination Lock: "\\Sword | Whip | Clawshots | \\Slingshot | \\Bow"
-    Can bypass Boko Base Watch Tower: "\\Bow | Bomb Bag | \\Slingshot"
-    Complete Triforce: "Triforce of Courage & Triforce of Wisdom & Triforce of Power"
-    Damaging Item: "\\Sword | Bomb Bag | \\Bow"
-    Digging Mitts: Progressive Mitts
-    Distance Activator: "\\Slingshot | \\Beetle | Clawshots | \\Bow"
-    Early Lake Floria Tricks: "Early Lake Floria - Fence Hop Trick & \\Practice Sword\
-      \ | Early Lake Floria - Swordless Rope Floria Trick"
-    Empty Bottle_: Empty Bottle
-    Giant Wallet: Progressive Wallet x 3
-    Goddess Longsword: Progressive Sword x 3
-    Goddess Sword: Progressive Sword x 2
-    Goddess White Sword: Progressive Sword x 4
-    Hook Beetle: Progressive Beetle x 2
-    Long Range Skyward Strike: "\\Goddess Sword & Upgraded Skyward Strike option |\
-      \ \\True Master Sword"
-    Master Sword: Progressive Sword x 5
-    Medium Wallet: Progressive Wallet
-    Mogma Mitts: Progressive Mitts x 2
-    Pouch: Progressive Pouch
-    Practice Sword: Progressive Sword
-    Projectile Item: "\\Slingshot | \\Beetle | \\Bow"
-    Quick Beetle: "\\Three Beetles | \\Skyloft\\Central Skyloft\\Bazaar\\Gondo's Upgrades\\\
-      Upgrade to Quick Beetle"
-    Slingshot: Progressive Slingshot
-    Song of the Hero: "Faron Song of the Hero Part & Eldin Song of the Hero Part &\
-      \ Lanayru Song of the Hero Part"
-    Sword: \Practice Sword
-    Three Beetles: Progressive Beetle x 3
-    Tough Beetle: "Progressive Beetle x 4 | \\Skyloft\\Central Skyloft\\Bazaar\\Gondo's\
-      \ Upgrades\\Upgrade to Tough Beetle"
-    True Master Sword: Progressive Sword x 6
-    Tycoon Wallet: Progressive Wallet x 4
-    Water Bottle: "\\Bottle & \\Can Collect Water"
-  name: ''
-  sub_areas:
-    Ancient Cistern:
-      abstract: true
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: Ancient Cistern
-      locations:
-        Can Freely Raise and Lower Statue: 'False'
-        Can Lower Statue: \Ancient Cistern\Can Freely Raise and Lower Statue
-      name: \Ancient Cistern
-      sub_areas:
-        Boss Room:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance from Dungeon: null
-            Entrance from Flame Room: null
-          exits:
-            Exit to Dungeon: \Ancient Cistern\Boss Room\Beat Koloktos
-            Exit to Flame Room: \Ancient Cistern\Boss Room\Beat Koloktos
-          hint_region: Ancient Cistern
-          locations:
-            Beat Koloktos: "Whip & (\\Sword | Bomb Bag | \\Bow)"
-            Heart Container: \Ancient Cistern\Boss Room\Beat Koloktos
-          name: \Ancient Cistern\Boss Room
-          sub_areas: {}
-          toplevel_alias: null
-        Flame Room:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance: null
-          exits:
-            Exit: 'True'
-          hint_region: Ancient Cistern
-          locations:
-            Farore's Flame: \Goddess Sword
-          name: \Ancient Cistern\Flame Room
-          sub_areas: {}
-          toplevel_alias: null
-        Main:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Ancient Cistern
-          locations: {}
-          name: \Ancient Cistern\Main
-          sub_areas:
-            Basement:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Ancient Cistern\Main\Basement\Rotating Vines: "Whip & \\Ancient Cistern\\\
-                  Main\\Basement\\Blow Rock | Clawshots"
-                \Ancient Cistern\Main\Basement\Spider Thread: "\\Ancient Cistern\\\
-                  Main\\Basement\\Spider Thread\\Activate Water Geyser | Ancient Cistern\
-                  \ - Basement Highflip Trick"
-                \Ancient Cistern\Main\Basement\Under the Statue: Ancient Cistern -
-                  Basement Highflip Trick
-                \Ancient Cistern\Main\Inside Statue: 'True'
-              hint_region: Ancient Cistern
-              locations:
-                Blow Rock: "\\Hook Beetle | Bomb Bag & Bomb Throws Trick"
-                Stop Cursed Waterfall: \Beetle
-              name: \Ancient Cistern\Main\Basement
-              sub_areas:
-                Rotating Vines:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Basement: 'True'
-                    \Ancient Cistern\Main\Basement\Spider Thread: Whip
-                  hint_region: Ancient Cistern
-                  locations: {}
-                  name: \Ancient Cistern\Main\Basement\Rotating Vines
-                  sub_areas: {}
-                  toplevel_alias: null
-                Spider Thread:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Basement: 'True'
-                    \Ancient Cistern\Main\Basement\Under the Statue: \Ancient Cistern\Can
-                      Freely Raise and Lower Statue
-                    \Ancient Cistern\Main\Main Room\Spider Thread Area: 'True'
-                  hint_region: Ancient Cistern
-                  locations:
-                    Activate Water Geyser: Whip
-                  name: \Ancient Cistern\Main\Basement\Spider Thread
-                  sub_areas: {}
-                  toplevel_alias: null
-                Under the Statue:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Basement: 'True'
-                  hint_region: Ancient Cistern
-                  locations:
-                    Boss Key Chest: \Ancient Cistern\Can Lower Statue
-                    \Ancient Cistern\Can Lower Statue: 'True'
-                  name: \Ancient Cistern\Main\Basement\Under the Statue
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Basement Gutters:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Ancient Cistern\Main\Basement Gutters\Past Skulltula: "\\Ancient\
-                  \ Cistern\\Main\\Basement Gutters\\Can Get Past Skulltula & Water\
-                  \ Dragon's Scale"
-              hint_region: Ancient Cistern
-              locations:
-                Can Get Past Skulltula: "\\Beetle | \\Bow"
-              name: \Ancient Cistern\Main\Basement Gutters
-              sub_areas:
-                Past Skulltula:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Basement Gutters: Water Dragon's Scale
-                    \Ancient Cistern\Main\Main Room\After Gutters: Ancient Cistern
-                      Small Key x 2
-                  hint_region: Ancient Cistern
-                  locations:
-                    Bokoblin: Whip
-                  name: \Ancient Cistern\Main\Basement Gutters\Past Skulltula
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            East Part:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Ancient Cistern\Main\East Part\Second Room: \Ancient Cistern\Main\East
-                  Part\Unlock Combination Lock Door
-                \Ancient Cistern\Main\Main Room: 'True'
-              hint_region: Ancient Cistern
-              locations:
-                Unlock Combination Lock Door: "\\Can Unlock Combination Lock & \\\
-                  Ancient Cistern\\Main\\Main Room\\Lock Combination Knowledge"
-              name: \Ancient Cistern\Main\East Part
-              sub_areas:
-                Chest Ledge:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Main Room: 'True'
-                  hint_region: Ancient Cistern
-                  locations:
-                    Chest in East Part: 'True'
-                  name: \Ancient Cistern\Main\East Part\Chest Ledge
-                  sub_areas: {}
-                  toplevel_alias: null
-                Second Room:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\East Part: 'True'
-                    \Ancient Cistern\Main\East Part\Chest Ledge: "\\Ancient Cistern\\\
-                      Main\\East Part\\Second Room\\Flip Main Lilypad & Water Dragon's\
-                      \ Scale"
-                  hint_region: Ancient Cistern
-                  locations:
-                    First Rupee in East Part in Short Tunnel: Water Dragon's Scale
-                    Flip Main Lilypad: 'True'
-                    Flip Side Lilypad: 'True'
-                    Rupee in East Part in Cubby: "\\Ancient Cistern\\Main\\East Part\\\
-                      Second Room\\Flip Side Lilypad & Water Dragon's Scale"
-                    Rupee in East Part in Main Tunnel: "\\Ancient Cistern\\Main\\\
-                      East Part\\Second Room\\Flip Main Lilypad & Water Dragon's Scale"
-                    Second Rupee in East Part in Short Tunnel: Water Dragon's Scale
-                    Third Rupee in East Part in Short Tunnel: Water Dragon's Scale
-                  name: \Ancient Cistern\Main\East Part\Second Room
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Inside Statue:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Boss Door Entrance: null
-              exits:
-                Boss Door Exit: "Ancient Cistern Boss Key & \\Ancient Cistern\\Main\\\
-                  Inside Statue\\Activate Water Geysers"
-                \Ancient Cistern\Main\Basement: \Ancient Cistern\Can Lower Statue
-                \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest: "Ancient\
-                  \ Cistern Small Key x 2 & (\\Can Defeat Stalmaster | \\Ancient Cistern\\\
-                  Can Lower Statue)"
-                \Ancient Cistern\Main\Main Room: \Ancient Cistern\Main\Inside Statue\Activate
-                  Water Geysers
-              hint_region: Ancient Cistern
-              locations:
-                Activate Water Geysers: Whip
-              name: \Ancient Cistern\Main\Inside Statue
-              sub_areas:
-                Key Locked Room with Chest:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Inside Statue: Ancient Cistern Small Key
-                      x 2
-                  hint_region: Ancient Cistern
-                  locations:
-                    Chest in Key Locked Room: 'True'
-                  name: \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Main Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Main Entrance: null
-              exits:
-                Main Exit: 'True'
-                \Ancient Cistern\Main\Basement\Under the Statue: Ancient Cistern -
-                  Cistern Clip Trick
-                \Ancient Cistern\Main\East Part: \Ancient Cistern\Main\Main Room\Lever
-                  to East Part
-                \Ancient Cistern\Main\Inside Statue: "\\Ancient Cistern\\Can Lower\
-                  \ Statue | Ancient Cistern Small Key x 2"
-                \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest: "Ancient\
-                  \ Cistern - Cistern Clip Trick & Ancient Cistern - Cistern Whip\
-                  \ Room Clip Trick & Water Dragon's Scale"
-                \Ancient Cistern\Main\Main Room\After Whip Hooks: Whip
-                \Ancient Cistern\Main\Main Room\Behind the Waterfall: "\\Ancient Cistern\\\
-                  Main\\Main Room\\Lever to Block Waterfall & Water Dragon's Scale"
-                \Ancient Cistern\Main\Main Room\Vines Area: "\\Ancient Cistern\\Main\\\
-                  Main Room\\Vines Area\\Activate Water Geyser | Whip & Clawshots"
-              hint_region: Ancient Cistern
-              locations:
-                Lever to Block Waterfall: Whip
-                Lever to East Part: 'True'
-                Lock Combination Knowledge: 'True'
-                Rupee in East Hand: Water Dragon's Scale
-                Rupee in West Hand: Water Dragon's Scale
-              name: \Ancient Cistern\Main\Main Room
-              sub_areas:
-                After Gutters:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: "\\\
-                      Ancient Cistern\\Main\\Main Room\\After Gutters\\Flip First\
-                      \ Lilypad & \\Ancient Cistern\\Main\\Main Room\\After Gutters\\\
-                      Activate Water Geyser & \\Ancient Cistern\\Main\\Main Room\\\
-                      After Gutters\\Flip Second Lilypad 2"
-                    \Ancient Cistern\Main\Main Room\After Whip Hooks: 'True'
-                  hint_region: Ancient Cistern
-                  locations:
-                    Activate Water Geyser: "\\Ancient Cistern\\Main\\Main Room\\After\
-                      \ Gutters\\Flip Second Lilypad 1 & Water Dragon's Scale"
-                    Flip First Lilypad: "Water Dragon's Scale & Whip"
-                    Flip Second Lilypad 1: \Ancient Cistern\Main\Main Room\After Gutters\Flip
-                      First Lilypad
-                    Flip Second Lilypad 2: "\\Ancient Cistern\\Main\\Main Room\\After\
-                      \ Gutters\\Flip First Lilypad & \\Ancient Cistern\\Main\\Main\
-                      \ Room\\After Gutters\\Activate Water Geyser & Whip"
-                    Lower Lever: 'True'
-                    Rupee under Lilypad: "\\Ancient Cistern\\Main\\Main Room\\After\
-                      \ Gutters\\Flip Second Lilypad 1 & Water Dragon's Scale"
-                  name: \Ancient Cistern\Main\Main Room\After Gutters
-                  sub_areas:
-                    Upper Area:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Ancient Cistern\Main\Main Room\After Gutters: 'True'
-                        \Ancient Cistern\Main\Main Room\Vines Area: \Ancient Cistern\Main\Main
-                          Room\After Gutters\Upper Area\Upper Lever
-                      hint_region: Ancient Cistern
-                      locations:
-                        Upper Lever: Whip
-                      name: \Ancient Cistern\Main\Main Room\After Gutters\Upper Area
-                      sub_areas: {}
-                      toplevel_alias: null
-                  toplevel_alias: null
-                After Whip Hooks:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Main Room: 'True'
-                    \Ancient Cistern\Main\Main Room\After Gutters: \Ancient Cistern\Main\Main
-                      Room\After Gutters\Lower Lever
-                    \Ancient Cistern\Main\Main Room\Vines Area: Clawshots
-                  hint_region: Ancient Cistern
-                  locations:
-                    Chest after Whip Hooks: 'True'
-                  name: \Ancient Cistern\Main\Main Room\After Whip Hooks
-                  sub_areas: {}
-                  toplevel_alias: null
-                Behind the Waterfall:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Basement Gutters: \Ancient Cistern\Main\Main
-                      Room\Behind the Waterfall\Toilet Flush
-                  hint_region: Ancient Cistern
-                  locations:
-                    Chest behind the Waterfall: 'True'
-                    First Lever: Whip
-                    Second Lever: "\\Ancient Cistern\\Main\\Main Room\\Behind the\
-                      \ Waterfall\\First Lever & Whip"
-                    Toilet Flush: "\\Ancient Cistern\\Main\\Main Room\\Behind the\
-                      \ Waterfall\\First Lever & \\Ancient Cistern\\Main\\Main Room\\\
-                      Behind the Waterfall\\Second Lever & Whip"
-                  name: \Ancient Cistern\Main\Main Room\Behind the Waterfall
-                  sub_areas: {}
-                  toplevel_alias: null
-                Spider Thread Area:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Basement: 'True'
-                    \Ancient Cistern\Main\Main Room: 'True'
-                    \Ancient Cistern\Main\Main Room\Vines Area: \Ancient Cistern\Main\Main
-                      Room\Spider Thread Area\Extend Platform
-                  hint_region: Ancient Cistern
-                  locations:
-                    Extend Platform: 'True'
-                    \Ancient Cistern\Can Freely Raise and Lower Statue: Whip
-                  name: \Ancient Cistern\Main\Main Room\Spider Thread Area
-                  sub_areas: {}
-                  toplevel_alias: null
-                Vines Area:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Ancient Cistern\Main\Main Room: 'True'
-                    \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: \Ancient
-                      Cistern\Main\Main Room\After Gutters\Upper Area\Upper Lever
-                    \Ancient Cistern\Main\Main Room\After Whip Hooks: "\\Sword & Ancient\
-                      \ Cistern - Map Chest Jump Trick"
-                    \Ancient Cistern\Main\Main Room\Spider Thread Area: \Ancient Cistern\Main\Main
-                      Room\Spider Thread Area\Extend Platform
-                  hint_region: Ancient Cistern
-                  locations:
-                    Activate Water Geyser: Whip
-                    Chest near Vines: 'True'
-                    \Ancient Cistern\Can Lower Statue: Whip
-                    \Ancient Cistern\Main\Main Room\Lever to Block Waterfall: Ancient
-                      Cistern - Lever Jump Trick
-                  name: \Ancient Cistern\Main\Main Room\Vines Area
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-          toplevel_alias: null
-      toplevel_alias: null
-    Earth Temple:
-      abstract: false
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: Earth Temple
-      locations: {}
-      name: \Earth Temple
-      sub_areas:
-        Boss Room:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Earth Temple
-          locations: {}
-          name: \Earth Temple\Boss Room
-          sub_areas:
-            Entry:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Dungeon: null
-              exits:
-                Exit to Dungeon: \Earth Temple\Boss Room\Slope\Beat Scaldera
-                \Earth Temple\Boss Room\Slope: 'True'
-              hint_region: Earth Temple
-              locations: {}
-              name: \Earth Temple\Boss Room\Entry
-              sub_areas: {}
-              toplevel_alias: null
-            Slope:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Spring: null
-              exits:
-                Exit to Spring: \Earth Temple\Boss Room\Slope\Beat Scaldera
-              hint_region: Earth Temple
-              locations:
-                Beat Scaldera: "Bomb Bag & \\Sword | \\Earth Temple\\Boss Room\\Slope\\\
-                  Bomb Flower Scaldera"
-                Bomb Flower Scaldera: "Earth Temple - Bomb Flower Scaldera Trick &\
-                  \ (\\Earth Temple\\Boss Room\\Slope\\Goddess Sword Strat | \\Earth\
-                  \ Temple\\Boss Room\\Slope\\Longsword Strat | \\Earth Temple\\Boss\
-                  \ Room\\Slope\\Master Sword Strat)"
-                Goddess Sword Strat: "\\Goddess Sword & Upgraded Skyward Strike option"
-                Heart Container: \Earth Temple\Boss Room\Slope\Beat Scaldera
-                Longsword Strat: "\\Goddess Longsword & Upgraded Skyward Strike option"
-                Master Sword Strat: \Master Sword
-              name: \Earth Temple\Boss Room\Slope
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-        Main:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Earth Temple
-          locations: {}
-          name: \Earth Temple\Main
-          sub_areas:
-            East Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Earth Temple\Main\Hub Room: 'True'
-              hint_region: Earth Temple
-              locations:
-                Chest after Double Lizalfos Fight: \Can Defeat Lizalfos
-              name: \Earth Temple\Main\East Room
-              sub_areas: {}
-              toplevel_alias: null
-            First Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Main Entrance: null
-              exits:
-                Main Exit: 'True'
-                \Earth Temple\Main\Hub Room: "\\Earth Temple\\Main\\First Room\\Lower\
-                  \ Drawbridge & \\Earth Temple\\Main\\First Room\\Dislodge Boulder"
-              hint_region: Earth Temple
-              locations:
-                Dislodge Boulder: "\\Slingshot | \\Beetle & (Advanced Lizalfos Combat\
-                  \ Trick | \\Can Defeat Lizalfos) | Clawshots | \\Bow | \\Long Range\
-                  \ Skyward Strike"
-                Lower Drawbridge: "\\Beetle | \\Bow | \\Long Range Skyward Strike\
-                  \ & Earth Temple - Keese Yeet Trick"
-                Rupee above Drawbridge: \Beetle
-                Vent Chest: \Digging Mitts
-              name: \Earth Temple\Main\First Room
-              sub_areas: {}
-              toplevel_alias: null
-            Hub Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Earth Temple\Main\East Room: \Earth Temple\Main\Hub Room\Access to
-                  Boulder
-                \Earth Temple\Main\Hub Room\Past Lava Section: "\\Earth Temple\\Main\\\
-                  Hub Room\\Access to Boulder & (\\Earth Temple\\Main\\Hub Room\\\
-                  Wall to Lava Section & \\Earth Temple\\Main\\Hub Room\\Lower Lava\
-                  \ Section Portcullis | \\Earth Temple\\Main\\Hub Room\\Raise Bridge)"
-                \Earth Temple\Main\Room with Slopes: \Earth Temple\Main\Hub Room\Raise
-                  Bridge
-                \Earth Temple\Main\West Room: \Earth Temple\Main\Hub Room\Rock to
-                  West Room
-              hint_region: Earth Temple
-              locations:
-                Access to Boulder: \Earth Temple\Main\First Room\Dislodge Boulder
-                Chest Left of Main Room Bridge: \Earth Temple\Main\Hub Room\Access
-                  to Boulder
-                Chest behind Bombable Rock: \Earth Temple\Main\Hub Room\Access to
-                  Boulder
-                Ledd's Gift: \Can Defeat Lizalfos
-                Left Peg: \Earth Temple\Main\Hub Room\Access to Boulder
-                Lower Lava Section Portcullis: "\\Earth Temple\\Main\\Hub Room\\Wall\
-                  \ to Lava Section & \\Beetle"
-                Raise Bridge: "\\Earth Temple\\Main\\Hub Room\\Left Peg & \\Earth\
-                  \ Temple\\Main\\Hub Room\\Past Lava Section\\Right Peg"
-                Rock to West Room: "Bomb Bag | \\Hook Beetle"
-                Rupee in Lava Tunnel: "\\Earth Temple\\Main\\Hub Room\\Wall to Lava\
-                  \ Section & \\Beetle"
-                Wall to Lava Section: "Bomb Bag | \\Hook Beetle & \\Earth Temple\\\
-                  Main\\Hub Room\\Access to Boulder"
-                \Earth Temple\Main\First Room\Rupee above Drawbridge: \Beetle
-              name: \Earth Temple\Main\Hub Room
-              sub_areas:
-                Past Lava Section:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Earth Temple\Main\Hub Room: 'True'
-                  hint_region: Earth Temple
-                  locations:
-                    Chest Guarded by Lizalfos: 'True'
-                    Right Peg: 'True'
-                  name: \Earth Temple\Main\Hub Room\Past Lava Section
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Room with Slopes:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Earth Temple\Main\Hub Room: 'True'
-                \Earth Temple\Main\Room with Slopes\Front of Boss Door: "\\Earth Temple\\\
-                  Main\\Room with Slopes\\Rock in Second Slope Resting Area | Earth\
-                  \ Temple - Slope Stuttersprint Trick"
-              hint_region: Earth Temple
-              locations:
-                Rock in Second Slope Resting Area: "\\Digging Mitts & Bomb Bag | \\\
-                  Hook Beetle"
-              name: \Earth Temple\Main\Room with Slopes
-              sub_areas:
-                Front of Boss Door:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Boss Door Entrance: null
-                  exits:
-                    Boss Door Exit: \Earth Temple\Main\Room with Slopes\Front of Boss
-                      Door\Open Boss Door
-                    \Earth Temple\Main\Room with Slopes: 'True'
-                  hint_region: Earth Temple
-                  locations:
-                    Boss Key Chest: 'True'
-                    Open Boss Door: Earth Temple Boss Key
-                  name: \Earth Temple\Main\Room with Slopes\Front of Boss Door
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            West Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Earth Temple\Main\Hub Room: \Earth Temple\Main\West Room\Rock to
-                  Hub Room
-              hint_region: Earth Temple
-              locations:
-                Chest in West Room: 'True'
-                Rock to Hub Room: "Bomb Bag | \\Hook Beetle"
-              name: \Earth Temple\Main\West Room
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-        Spring:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance: null
-          exits:
-            Exit: 'True'
-          hint_region: Earth Temple
-          locations:
-            Strike Crest: \Goddess Sword
-          name: \Earth Temple\Spring
-          sub_areas: {}
-          toplevel_alias: null
-      toplevel_alias: null
-    Eldin:
-      abstract: true
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: null
-      locations:
-        Can Survive Hot Cave: "Nonlethal Hot Cave | Fireshield Earrings"
-      name: \Eldin
-      sub_areas:
-        Bokoblin Base:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Bokoblin Base
-          locations: {}
-          name: \Eldin\Bokoblin Base
-          sub_areas:
-            After Drawbridge:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Bokoblin Base\Before Drawbridge: Clawshots
-                \Eldin\Bokoblin Base\Lower Platform Cave: 'True'
-                \Eldin\Bokoblin Base\Outside Earth Temple: 'True'
-                \Eldin\Bokoblin Base\Volcano East: 'True'
-              hint_region: Bokoblin Base
-              locations: {}
-              name: \Eldin\Bokoblin Base\After Drawbridge
-              sub_areas: {}
-              toplevel_alias: null
-            Before Drawbridge:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Bokoblin Base\After Drawbridge: "Whip & Clawshots"
-                \Eldin\Bokoblin Base\Volcano East: 'True'
-              hint_region: Bokoblin Base
-              locations:
-                Chest near Drawbridge: "Clawshots | \\Can bypass Boko Base Watch Tower"
-              name: \Eldin\Bokoblin Base\Before Drawbridge
-              sub_areas: {}
-              toplevel_alias: null
-            Bokoblin Base Summit:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Bokoblin Base\Fire Dragon's Lair: Fireshield Earrings
-                \Eldin\Bokoblin Base\Hot Cave: Fireshield Earrings
-              hint_region: Bokoblin Base
-              locations:
-                Chest in Volcano Summit Alcove: "Fireshield Earrings & \\Practice\
-                  \ Sword"
-                First Chest in Volcano Summit: Fireshield Earrings
-                Goddess Cube inside Volcano Summit: Fireshield Earrings
-                Raised Chest in Volcano Summit: Fireshield Earrings
-              name: \Eldin\Bokoblin Base\Bokoblin Base Summit
-              sub_areas: {}
-              toplevel_alias: null
-            Fire Dragon's Lair:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Bokoblin Base\Bokoblin Base Summit: 'True'
-              hint_region: Bokoblin Base
-              locations:
-                Beaten Boko Base: "\\Bow | \\Beetle"
-                Fire Dragon's Reward: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten
-                  Boko Base
-              name: \Eldin\Bokoblin Base\Fire Dragon's Lair
-              sub_areas: {}
-              toplevel_alias: null
-            Hot Cave:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Bokoblin Base\After Drawbridge: "Fireshield Earrings & Bomb\
-                  \ Bag"
-                \Eldin\Bokoblin Base\Bokoblin Base Summit: "Fireshield Earrings &\
-                  \ Bomb Bag"
-              hint_region: Bokoblin Base
-              locations: {}
-              name: \Eldin\Bokoblin Base\Hot Cave
-              sub_areas: {}
-              toplevel_alias: null
-            Lower Platform Cave:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Bokoblin Base\After Drawbridge: Clawshots
-                \Eldin\Bokoblin Base\Before Drawbridge: 'True'
-                \Eldin\Bokoblin Base\Volcano East: 'True'
-              hint_region: Bokoblin Base
-              locations:
-                Gossip Stone in Lower Platform Cave: 'True'
-              name: \Eldin\Bokoblin Base\Lower Platform Cave
-              sub_areas: {}
-              toplevel_alias: null
-            Outside Earth Temple:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Bokoblin Base\Hot Cave: 'True'
-                \Eldin\Bokoblin Base\Upper Platform Cave: 'True'
-              hint_region: Bokoblin Base
-              locations:
-                Chest East of Earth Temple Entrance: 'True'
-                Chest West of Earth Temple Entrance: "(\\Slingshot | \\Bow | Bomb\
-                  \ Bag | \\Goddess Sword) & \\Can bypass Boko Base Watch Tower &\
-                  \ \\Mogma Mitts"
-                Goddess Cube East of Earth Temple Entrance: \Goddess Sword
-                Goddess Cube West of Earth Temple Entrance: "\\Goddess Sword & \\\
-                  Can bypass Boko Base Watch Tower & \\Mogma Mitts"
-              name: \Eldin\Bokoblin Base\Outside Earth Temple
-              sub_areas: {}
-              toplevel_alias: null
-            Prison:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-                \Eldin\Bokoblin Base\Volcano East: \Mogma Mitts
-              hint_region: Bokoblin Base
-              locations:
-                Plats' Gift: 'True'
-              name: \Eldin\Bokoblin Base\Prison
-              sub_areas: {}
-              toplevel_alias: null
-            Upper Platform Cave:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Bokoblin Base\Outside Earth Temple: 'True'
-              hint_region: Bokoblin Base
-              locations:
-                Gossip Stone in Upper Platform Cave: 'True'
-              name: \Eldin\Bokoblin Base\Upper Platform Cave
-              sub_areas: {}
-              toplevel_alias: null
-            Volcano East:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Bokoblin Base\After Drawbridge: "Clawshots & Bomb Bag"
-                \Eldin\Bokoblin Base\Before Drawbridge: 'True'
-                \Eldin\Bokoblin Base\Prison: \Mogma Mitts
-              hint_region: Bokoblin Base
-              locations:
-                Chest near Bone Bridge: "\\Can bypass Boko Base Watch Tower | \\Mogma\
-                  \ Mitts | Gust Bellows"
-                Chest on Cliff: "(\\Can bypass Boko Base Watch Tower | \\Mogma Mitts)\
-                  \ & Gust Bellows"
-                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
-              name: \Eldin\Bokoblin Base\Volcano East
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: Bokoblin Base
-        Eldin Silent Realm:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance: null
-          exits:
-            Exit: 'True'
-          hint_region: Eldin Silent Realm
-          locations:
-            Relic 1: 'True'
-            Relic 10: 'True'
-            Relic 2: 'True'
-            Relic 3: 'True'
-            Relic 4: 'True'
-            Relic 5: 'True'
-            Relic 6: 'True'
-            Relic 7: 'True'
-            Relic 8: 'True'
-            Relic 9: 'True'
-            Trial Reward: 'True'
-          name: \Eldin\Eldin Silent Realm
-          sub_areas: {}
-          toplevel_alias: null
-        Mogma Turf:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Mogma Turf
-          locations: {}
-          name: \Eldin\Mogma Turf
-          sub_areas:
-            Past Vent:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                Second Vent: 'True'
-                \Eldin\Mogma Turf\Pre Vent: 'True'
-                \Eldin\Mogma Turf\Sand Slide Platform: 'True'
-              hint_region: Mogma Turf
-              locations:
-                Chest behind Bombable Wall in Fire Maze: 'True'
-              name: \Eldin\Mogma Turf\Past Vent
-              sub_areas: {}
-              toplevel_alias: null
-            Pre Vent:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-              exits:
-                First Vent: 'True'
-                \Eldin\Mogma Turf\Past Vent: \Eldin\Mogma Turf\Pre Vent\Open Vent
-              hint_region: Mogma Turf
-              locations:
-                Chest behind Bombable Wall at Entrance: 'True'
-                Defeat Bokoblins: \Can Defeat Bokoblins
-                Free Fall Chest: 'True'
-                Goddess Cube in Mogma Turf: \Goddess Sword
-                Open Vent: \Digging Mitts
-                Pick up Guld: "\\Sky\\South East\\Lumpy Pumpkin\\Start Kina's Quest\
-                  \ & Scrapper"
-              name: \Eldin\Mogma Turf\Pre Vent
-              sub_areas: {}
-              toplevel_alias: null
-            Sand Slide Platform:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Mogma Turf\Pre Vent: 'True'
-              hint_region: Mogma Turf
-              locations:
-                Sand Slide Chest: 'True'
-              name: \Eldin\Mogma Turf\Sand Slide Platform
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-        Volcano:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Eldin Volcano
-          locations: {}
-          name: \Eldin\Volcano
-          sub_areas:
-            Ascent:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Trial Gate Entrance: null
-                Volcano Ascent Statue Entrance: null
-              exits:
-                Trial Gate Exit: \Eldin\Volcano\Ascent\Open Trial Gate
-                \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\Ascent\Unlock
-                  Statue
-                \Eldin\Volcano\Entry: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
-                \Eldin\Volcano\Near Thrill Digger Cave: "\\Eldin\\Volcano\\Ascent\\\
-                  Defeat Slope Bokoblins | Stuttersprint Trick"
-                \Eldin\Volcano\Past Slide: \Eldin\Volcano\Past Slide\Unlock Shortcut
-                  to Ascent
-              hint_region: Eldin Volcano
-              locations:
-                Chest behind Bombable Wall near Volcano Ascent: 'True'
-                Defeat Slope Bokoblins: "\\Bow | \\Slingshot"
-                Open Trial Gate: "Goddess's Harp & Din's Power"
-                Unlock Shortcut to Entry: 'True'
-                Unlock Statue: 'True'
-                \Eldin\Volcano\Past Slide\Unlock Shortcut to Ascent: "Bomb Bag | \\\
-                  Hook Beetle"
-              name: \Eldin\Volcano\Ascent
-              sub_areas: {}
-              toplevel_alias: null
-            East:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Bokoblin Base: null
-                First Vent from Mogma Turf: null
-                Volcano East Statue Entrance: null
-              exits:
-                Dive to Mogma Turf: \Eldin\Volcano\East\Drain Lava
-                Exit to Bokoblin Base: 'True'
-                Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\East\Unlock
-                  Statue
-                \Eldin\Volcano\Entry: Clawshots
-                \Eldin\Volcano\First Room: \Eldin\Volcano\First Room\Blow up Rock
-                  to East
-                \Eldin\Volcano\Past Mogma Turf: \Eldin\Volcano\Past Mogma Turf\Unlock
-                  Shortcut to Pre Turf
-              hint_region: Eldin Volcano
-              locations:
-                Chest after Crawlspace: 'True'
-                Chest behind Bombable Wall near Cliff: 'True'
-                Drain Lava: 'True'
-                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
-                Item on Cliff: 'True'
-                North Rupee above Mogma Turf Entrance: \Beetle
-                Southeast Rupee above Mogma Turf Entrance: \Beetle
-                Unlock Statue: 'True'
-                \Eldin\Volcano\First Room\Blow up Rock to East: Bomb Bag
-                \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf: "Bomb\
-                  \ Bag | \\Hook Beetle"
-              name: \Eldin\Volcano\East
-              sub_areas: {}
-              toplevel_alias: null
-            Entry:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                First Time Entrance: null
-                Volcano Entrance Statue Entrance: null
-              exits:
-                Volcano Entrance Statue Exit: \Eldin\Volcano\Entry\Unlock Statue
-                \Eldin\Volcano\Ascent: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
-                \Eldin\Volcano\First Room: 'True'
-              hint_region: Eldin Volcano
-              locations:
-                Goddess Cube at Eldin Entrance: \Goddess Sword
-                Rupee on Ledge before First Room: 'True'
-                Unlock Statue: 'True'
-                \Eldin\Volcano\Ascent\Unlock Shortcut to Entry: Bomb Bag
-              name: \Eldin\Volcano\Entry
-              sub_areas: {}
-              toplevel_alias: null
-            First Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Volcano\East: \Eldin\Volcano\First Room\Blow up Rock to East
-              hint_region: Eldin Volcano
-              locations:
-                Blow up Rock to East: 'True'
-                Chest behind Bombable Wall in First Room: 'True'
-                Rupee behind Bombable Wall in First Room: 'True'
-                Rupee in Crawlspace in First Room: 'True'
-              name: \Eldin\Volcano\First Room
-              sub_areas: {}
-              toplevel_alias: null
-            Hot Cave:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Summit: null
-                Vent Entrance near Hot Cave: null
-              exits:
-                Exit to Summit: Fireshield Earrings
-                \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Temple Entrance\Blow
-                  down Watchtower to Hot Cave
-                \Eldin\Volcano\Sand Slide: \Eldin\Can Survive Hot Cave
-              hint_region: Eldin Volcano
-              locations:
-                \Eldin\Volcano\Near Temple Entrance\Blow down Watchtower to Hot Cave: 'False'
-              name: \Eldin\Volcano\Hot Cave
-              sub_areas: {}
-              toplevel_alias: null
-            Lower Platform Cave:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Volcano\East: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten
-                  Boko Base
-                \Eldin\Volcano\Past Mogma Turf: \Eldin\Bokoblin Base\Fire Dragon's
-                  Lair\Beaten Boko Base
-                \Eldin\Volcano\Past Slide: Clawshots
-              hint_region: Eldin Volcano
-              locations:
-                Gossip Stone in Lower Platform Cave: 'True'
-              name: \Eldin\Volcano\Lower Platform Cave
-              sub_areas: {}
-              toplevel_alias: null
-            Near Temple Entrance:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Earth Temple: null
-                Temple Entrance Statue Entrance: null
-              exits:
-                Exit to Earth Temple: "Open ET option | Key Piece x 5"
-                Temple Entrance Statue Exit: \Eldin\Volcano\Near Temple Entrance\Unlock
-                  Statue
-                \Eldin\Volcano\Hot Cave: \Eldin\Volcano\Near Temple Entrance\Blow
-                  down Watchtower to Hot Cave
-                \Eldin\Volcano\Near Thrill Digger Cave: \Eldin\Volcano\Near Thrill
-                  Digger Cave\Blow down Watchtower
-                \Eldin\Volcano\Upper Platform Cave: \Eldin\Bokoblin Base\Fire Dragon's
-                  Lair\Beaten Boko Base
-              hint_region: Eldin Volcano
-              locations:
-                Blow down Watchtower to Hot Cave: 'True'
-                Digging Spot behind Boulder on Sandy Slope: \Digging Mitts
-                Digging Spot below Tower: \Digging Mitts
-                Digging Spot in front of Earth Temple: \Digging Mitts
-                Goddess Cube East of Earth Temple Entrance: \Goddess Sword
-                Goddess Cube West of Earth Temple Entrance: "\\Digging Mitts & \\\
-                  Goddess Sword"
-                Gossip Stone next to Earth Temple: \Digging Mitts
-                Retrieve Crystal Ball: "Clawshots & Scrapper & \\Skyloft\\Skyloft\
-                  \ Village\\Sparrot's House\\Start Sparrot's Quest"
-                Unlock Statue: 'True'
-              name: \Eldin\Volcano\Near Temple Entrance
-              sub_areas: {}
-              toplevel_alias: null
-            Near Thrill Digger Cave:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Thrill Digger Cave Entrance: null
-              exits:
-                Thrill Digger Cave Exit: 'True'
-                \Eldin\Volcano\Ascent: 'True'
-                \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Thrill Digger
-                  Cave\Blow down Watchtower
-              hint_region: Eldin Volcano
-              locations:
-                Blow down Watchtower: 'True'
-                Left Rupee behind Bombable Wall on First Slope: 'True'
-                Right Rupee behind Bombable Wall on First Slope: 'True'
-              name: \Eldin\Volcano\Near Thrill Digger Cave
-              sub_areas: {}
-              toplevel_alias: null
-            Past Mogma Turf:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Second Vent from Mogma Turf: null
-              exits:
-                \Eldin\Volcano\Ascent: \Eldin\Volcano\Past Mogma Turf\Watch Bridge
-                  Cutscene
-                \Eldin\Volcano\East: \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut
-                  to Pre Turf
-              hint_region: Eldin Volcano
-              locations:
-                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
-                North Rupee above Mogma Turf Entrance: \Beetle
-                Southeast Rupee above Mogma Turf Entrance: \Beetle
-                Unlock Shortcut to Pre Turf: 'True'
-                Watch Bridge Cutscene: 'True'
-              name: \Eldin\Volcano\Past Mogma Turf
-              sub_areas: {}
-              toplevel_alias: null
-            Past Slide:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                Vent Exit near Ascent: 'True'
-                \Eldin\Volcano\Ascent: \Eldin\Volcano\Past Slide\Unlock Shortcut to
-                  Ascent
-                \Eldin\Volcano\Lower Platform Cave: \Eldin\Bokoblin Base\Fire Dragon's
-                  Lair\Beaten Boko Base
-              hint_region: Eldin Volcano
-              locations:
-                Digging Spot after Draining Lava: \Digging Mitts
-                Unlock Shortcut to Ascent: 'True'
-              name: \Eldin\Volcano\Past Slide
-              sub_areas: {}
-              toplevel_alias: null
-            Sand Slide:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Volcano\Past Slide: 'True'
-              hint_region: Eldin Volcano
-              locations:
-                Digging Spot after Vents: \Digging Mitts
-                Goddess Cube on Sand Slide: \Goddess Sword
-              name: \Eldin\Volcano\Sand Slide
-              sub_areas: {}
-              toplevel_alias: null
-            Thrill Digger Cave:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Eldin Volcano
-              locations:
-                Gossip Stone in Thrill Digger Cave: 'True'
-                Thrill Digger Minigame: \Digging Mitts
-              name: \Eldin\Volcano\Thrill Digger Cave
-              sub_areas: {}
-              toplevel_alias: null
-            Upper Platform Cave:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Eldin\Volcano\Near Temple Entrance: "\\Eldin\\Bokoblin Base\\Fire\
-                  \ Dragon's Lair\\Beaten Boko Base | Clawshots"
-              hint_region: Eldin Volcano
-              locations:
-                Gossip Stone in Upper Platform Cave: 'True'
-              name: \Eldin\Volcano\Upper Platform Cave
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: Eldin Volcano
-        Volcano Summit:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance from Eldin Volcano: null
-            Entrance from Outside Fire Sanctuary: null
-            Entrance from Waterfall: null
-          exits:
-            Exit to Eldin Volcano: Fireshield Earrings
-            Exit to Outside Fire Sanctuary: Fireshield Earrings
-            Exit to Waterfall: Fireshield Earrings
-          hint_region: Volcano Summit
-          locations:
-            Goddess Cube inside Volcano Summit: "Fireshield Earrings & \\Long Range\
-              \ Skyward Strike"
-          name: \Eldin\Volcano Summit
-          sub_areas:
-            Outside Fire Sanctuary:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Fire Sanctuary: null
-                Statue Entrance: null
-              exits:
-                Exit to Fire Sanctuary: \Eldin\Volcano Summit\Outside Fire Sanctuary\Hydrate
-                  Giant Frog
-                Statue Exit: \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
-                \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: \Eldin\Volcano
-                  Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Hydrate Second
-                  Frog
-              hint_region: Volcano Summit
-              locations:
-                Goddess Cube near Fire Sanctuary Entrance: "Clawshots & \\Goddess\
-                  \ Sword"
-                Hydrate Giant Frog: 'True'
-                Unlock Statue: 'True'
-              name: \Eldin\Volcano Summit\Outside Fire Sanctuary
-              sub_areas:
-                Before Thirsty Frogs:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Summit: null
-                  exits:
-                    Exit to Summit: 'True'
-                    \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: \Eldin\Volcano
-                      Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Hydrate First
-                      Frog
-                  hint_region: Volcano Summit
-                  locations:
-                    Hydrate First Frog: \Water Bottle
-                  name: \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty
-                    Frogs
-                  sub_areas: {}
-                  toplevel_alias: null
-                Between Thirsty Frogs:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Eldin\Volcano Summit\Outside Fire Sanctuary: \Eldin\Volcano Summit\Outside
-                      Fire Sanctuary\Between Thirsty Frogs\Hydrate Second Frog
-                    \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs: \Eldin\Volcano
-                      Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Hydrate First
-                      Frog
-                  hint_region: Volcano Summit
-                  locations:
-                    Gossip Stone near Second Thirsty Frog: 'True'
-                    Hydrate Second Frog: "Clawshots & \\Water Bottle"
-                    Item behind Digging: \Mogma Mitts
-                  name: \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty
-                    Frogs
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Waterfall:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-                \Eldin\Volcano Summit\Waterfall\Higher Area: Clawshots
-              hint_region: Volcano Summit
-              locations:
-                Goddess Cube in Summit Waterfall: \Goddess Sword
-                \Can Collect Water: 'True'
-              name: \Eldin\Volcano Summit\Waterfall
-              sub_areas:
-                Higher Area:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Eldin\Volcano Summit\Waterfall: 'True'
-                  hint_region: Volcano Summit
-                  locations:
-                    Chest behind Bombable Wall in Waterfall Area: 'True'
-                    Gossip Stone in Waterfall Area: 'True'
-                  name: \Eldin\Volcano Summit\Waterfall\Higher Area
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-          toplevel_alias: null
-      toplevel_alias: null
-    Faron:
-      abstract: false
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: null
-      locations: {}
-      name: \Faron
-      sub_areas:
-        Faron Silent Realm:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance: null
-          exits:
-            Exit: 'True'
-          hint_region: Faron Silent Realm
-          locations:
-            Relic 1: 'True'
-            Relic 10: 'True'
-            Relic 2: 'True'
-            Relic 3: 'True'
-            Relic 4: 'True'
-            Relic 5: 'True'
-            Relic 6: 'True'
-            Relic 7: 'True'
-            Relic 8: 'True'
-            Relic 9: 'True'
-            Trial Reward: 'True'
-          name: \Faron\Faron Silent Realm
-          sub_areas: {}
-          toplevel_alias: null
-        Faron Woods:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            In the Woods Statue Entrance: null
-            Trial Gate Entrance: null
-            Viewing Platform Statue Entrance: null
-          exits:
-            Lake Floria Dive: "\\Faron\\Faron Woods\\Open Door to Lake Floria | \\\
-              Early Lake Floria Tricks"
-            Shared Statue Exit: "\\Faron\\Faron Woods\\Unlock In the Woods Statue\
-              \ | \\Faron\\Faron Woods\\Unlock Viewing Platform Statue"
-            Trial Gate Exit: \Faron\Faron Woods\Open Trial Gate
-            \Faron\Faron Woods\Behind the Crawlspace and Rope: "Bomb Bag | \\Faron\\\
-              Faron Woods\\Ledge to Lake Floria\\Push Log"
-            \Faron\Faron Woods\Clawshot Target Branch: Clawshots
-            \Faron\Faron Woods\Entry: 'True'
-            \Faron\Faron Woods\Great Tree\Near Underwater Hole: Water Dragon's Scale
-            \Faron\Faron Woods\Great Tree\Platforms: Clawshots
-            \Faron\Faron Woods\Ledge To Deep Woods: \Faron\Faron Woods\Hit Vine to
-              Deep Woods
-            \Faron\Faron Woods\Ledge to Lake Floria: \Faron\Faron Woods\Ledge to Lake
-              Floria\Push Log
-          hint_region: Faron Woods
-          locations:
-            All Kikwis Saved: "(\\Sword | \\Beetle) & \\Can Defeat Bokoblins"
-            Amber Relic Farming: 'True'
-            Chest behind Upper Bombable Rock: Bomb Bag
-            Hit Vine to Deep Woods: \Distance Activator
-            Item behind Lower Bombable Rock: Bomb Bag
-            Item on Tree: 'True'
-            Kikwi Elder's Reward: \Faron\Faron Woods\All Kikwis Saved
-            Open Door to Lake Floria: "Open Lake Floria option & Water Dragon's Scale\
-              \ | \\Faron\\Faron Woods\\Great Tree\\Top\\Talk to Yerbal & (\\Goddess\
-              \ Sword | Talk to Yerbal option)"
-            Open Trial Gate: "Goddess's Harp & Farore's Courage"
-            Push Log to Sealed Grounds: 'True'
-            Rupee on Hollow Tree Branch: \Beetle
-            Rupee on Hollow Tree Root: 'True'
-            Rupee on Platform near Floria Door: \Beetle
-            Unlock In the Woods Statue: 'True'
-            Unlock Viewing Platform Statue: 'True'
-          name: \Faron\Faron Woods
-          sub_areas:
-            Behind the Crawlspace and Rope:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Faron\Faron Woods: 'True'
-              hint_region: Faron Woods
-              locations:
-                Push Log: 'True'
-                Retrieve Oolo: "Scrapper & \\Skyloft\\Upper Skyloft\\Knight Academy\\\
-                  Start Owlan's Quest"
-              name: \Faron\Faron Woods\Behind the Crawlspace and Rope
-              sub_areas: {}
-              toplevel_alias: null
-            Clawshot Target Branch:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Faron\Faron Woods: 'True'
-              hint_region: Faron Woods
-              locations:
-                Goddess Cube on East Great Tree with Clawshots Target: \Goddess Sword
-              name: \Faron\Faron Woods\Clawshot Target Branch
-              sub_areas: {}
-              toplevel_alias: null
-            Deep Woods:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Deep Woods Statue Entrance: null
-                Entrance from Skyview Temple: null
-                Forest Temple Statue Entrance: null
-              exits:
-                Exit to Skyview Temple: \Distance Activator
-                Shared Statue Exit: 'True'
-                \Faron\Faron Woods\Deep Woods\Entry: 'True'
-              hint_region: Faron Woods
-              locations:
-                Deep Woods Chest: 'True'
-                Goddess Cube in Deep Woods: \Goddess Sword
-                Goddess Cube on top of Skyview: "\\Goddess Sword & Clawshots"
-                Gossip Stone in Deep Woods: 'True'
-                Initial Goddess Cube: \Goddess Sword
-                Push Shortcut Logs: 'True'
-                Unlock Deep Woods Statue: 'True'
-                Unlock Forest Temple Statue: 'True'
-              name: \Faron\Faron Woods\Deep Woods
-              sub_areas:
-                Entry:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Faron Woods: null
-                  exits:
-                    Exit to Faron Woods: 'True'
-                    \Faron\Faron Woods\Deep Woods: "\\Faron\\Faron Woods\\Deep Woods\\\
-                      Push Shortcut Logs | \\Distance Activator | \\Goddess Sword"
-                  hint_region: Faron Woods
-                  locations:
-                    Hornet Larvae Farming: 'True'
-                  name: \Faron\Faron Woods\Deep Woods\Entry
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Entry:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Behind the Temple: null
-                Faron Woods Entry Statue Entrance: null
-              exits:
-                Exit to Behind the Temple: 'True'
-                \Faron\Faron Woods: "\\Sword | Bomb Bag | Clawshots | \\Faron\\Faron\
-                  \ Woods\\Push Log to Sealed Grounds"
-                \Faron\Faron Woods\Shared Statue Exit: \Faron\Faron Woods\Entry\Unlock
-                  Statue
-              hint_region: Faron Woods
-              locations:
-                Unlock Statue: 'True'
-              name: \Faron\Faron Woods\Entry
-              sub_areas: {}
-              toplevel_alias: null
-            Great Tree:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits: {}
-              hint_region: Faron Woods
-              locations: {}
-              name: \Faron\Faron Woods\Great Tree
-              sub_areas:
-                Lower Area:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Underwater Tunnel Entrance: null
-                  exits:
-                    Underwater Tunnel Exit: Water Dragon's Scale
-                    \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: Gust Bellows
-                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: Gust Bellows
-                  hint_region: Faron Woods
-                  locations: {}
-                  name: \Faron\Faron Woods\Great Tree\Lower Area
-                  sub_areas:
-                    Near Exit:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set
-                        Lower Entrance from Platforms: null
-                      exits:
-                        Lower Exit to Platforms: 'True'
-                        \Faron\Faron Woods\Great Tree\Lower Area: 'True'
-                      hint_region: Faron Woods
-                      locations: {}
-                      name: \Faron\Faron Woods\Great Tree\Lower Area\Near Exit
-                      sub_areas: {}
-                      toplevel_alias: null
-                    Path to Chest:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Faron\Faron Woods\Great Tree\Lower Area: 'True'
-                        \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: 'True'
-                      hint_region: Faron Woods
-                      locations:
-                        Chest inside Great Tree: 'True'
-                      name: \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest
-                      sub_areas: {}
-                      toplevel_alias: null
-                  toplevel_alias: null
-                Near Underwater Hole:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Underwater Hole Entrance: null
-                  exits:
-                    Underwater Hole Exit: Water Dragon's Scale
-                    \Faron\Faron Woods: 'True'
-                  hint_region: Faron Woods
-                  locations: {}
-                  name: \Faron\Faron Woods\Great Tree\Near Underwater Hole
-                  sub_areas: {}
-                  toplevel_alias: null
-                Platforms:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Lower Entrance from Great Tree: null
-                    Upper Entrance from Great Tree: null
-                  exits:
-                    Lower Exit to Great Tree: 'True'
-                    Upper Exit to Great Tree: 'True'
-                    \Faron\Faron Woods: 'True'
-                    \Faron\Faron Woods\West Branch: 'True'
-                  hint_region: Faron Woods
-                  locations: {}
-                  name: \Faron\Faron Woods\Great Tree\Platforms
-                  sub_areas: {}
-                  toplevel_alias: null
-                Top:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    The Great Tree Statue Entrance: null
-                    Top Entrance from Great Tree: null
-                  exits:
-                    Top Exit to Great Tree: 'True'
-                    \Faron\Faron Woods\Clawshot Target Branch: 'True'
-                    \Faron\Faron Woods\Great Tree\Platforms: 'True'
-                    \Faron\Faron Woods\Rope Branch: 'True'
-                    \Faron\Faron Woods\Shared Statue Exit: \Faron\Faron Woods\Great
-                      Tree\Top\Unlock Statue
-                  hint_region: Faron Woods
-                  locations:
-                    Rupee on Great Tree North Branch: \Beetle
-                    Rupee on Great Tree West Branch: \Beetle
-                    Talk to Yerbal: "Water Dragon's Scale & (\\Slingshot | \\Beetle)"
-                    Unlock Statue: 'True'
-                  name: \Faron\Faron Woods\Great Tree\Top
-                  sub_areas: {}
-                  toplevel_alias: null
-                Upper Area:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Flooded Great Tree: null
-                    Entrance from Top: null
-                    Upper Entrance from Platforms: null
-                  exits:
-                    Exit to Flooded Great Tree: 'True'
-                    Exit to Top: 'True'
-                    Upper Exit to Platforms: 'True'
-                    \Faron\Faron Woods\Great Tree\Lower Area: \Faron\Faron Woods\Great
-                      Tree\Upper Area\Remove Void Plane
-                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: \Faron\Faron
-                      Woods\Great Tree\Upper Area\Remove Void Plane
-                  hint_region: Faron Woods
-                  locations:
-                    Remove Void Plane: \Can Defeat Moblins
-                  name: \Faron\Faron Woods\Great Tree\Upper Area
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Ledge To Deep Woods:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Deep Woods: null
-              exits:
-                Exit to Deep Woods: 'True'
-                \Faron\Faron Woods: 'True'
-              hint_region: Faron Woods
-              locations: {}
-              name: \Faron\Faron Woods\Ledge To Deep Woods
-              sub_areas: {}
-              toplevel_alias: null
-            Ledge to Lake Floria:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Shortcut Entrance from Floria Waterfall: null
-              exits:
-                Shortcut Exit to Floria Waterfall: "\\Faron\\Faron Woods\\Open Door\
-                  \ to Lake Floria | \\Early Lake Floria Tricks"
-                \Faron\Faron Woods: 'True'
-              hint_region: Faron Woods
-              locations:
-                Push Log: 'True'
-              name: \Faron\Faron Woods\Ledge to Lake Floria
-              sub_areas: {}
-              toplevel_alias: null
-            Rope Branch:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Faron\Faron Woods: 'True'
-              hint_region: Faron Woods
-              locations:
-                Goddess Cube on East Great Tree with Rope: \Goddess Sword
-              name: \Faron\Faron Woods\Rope Branch
-              sub_areas: {}
-              toplevel_alias: null
-            West Branch:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Faron\Faron Woods: 'True'
-              hint_region: Faron Woods
-              locations:
-                Goddess Cube on West Great Tree near Exit: \Goddess Sword
-              name: \Faron\Faron Woods\West Branch
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: Faron Woods
-        Flooded Faron Woods:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance from Lower Flooded Great Tree: null
-            Entrance from Upper Flooded Great Tree: null
-          exits:
-            Exit to Lower Flooded Great Tree: Water Dragon's Scale
-            Exit to Upper Flooded Great Tree: 'True'
-          hint_region: Flooded Faron Woods
-          locations:
-            16 Dark Blue Tadtones in the South West: Water Dragon's Scale
-            2 Dark Blue Tadtones in Grass West of Great Tree: Water Dragon's Scale
-            2 Red Tadtones in Grass near Lower Bombable Rock: Water Dragon's Scale
-            4 Light Blue Moving Tadtones under Kikwi Elder: Water Dragon's Scale
-            4 Purple Moving Tadtones near Floria Gate: Water Dragon's Scale
-            4 Purple Tadtones under Viewing Platform: Water Dragon's Scale
-            4 Red Moving Tadtones North West of Great Tree: Water Dragon's Scale
-            4 Yellow Tadtones under Small Hollow Tree: Water Dragon's Scale
-            8 Green Tadtones in West Tunnel: Water Dragon's Scale
-            8 Light Blue Tadtones near Viewing Platform: Water Dragon's Scale
-            8 Purple Tadtones in Clearing after Small Hollow Tree: Water Dragon's
-              Scale
-            8 Yellow Tadtones near Kikwi Elder: Water Dragon's Scale
-            Can Watch Completed Tadtones Cutscene: 'True'
-            Dark Blue Moving Tadtone inside Small Hollow Tree: Water Dragon's Scale
-            Green Tadtone behind Upper Bombable Rock: Water Dragon's Scale
-            Light Blue Tadtone under Great Tree Root: Water Dragon's Scale
-            Red Moving Tadtone near Viewing Platform: Water Dragon's Scale
-            Yellow Tadtone under Lilypad: Water Dragon's Scale
-            \Faron\Faron Woods\Behind the Crawlspace and Rope\Retrieve Oolo: "Scrapper\
-              \ & \\Skyloft\\Upper Skyloft\\Knight Academy\\Start Owlan's Quest"
-          name: \Faron\Flooded Faron Woods
-          sub_areas:
-            Flooded Great Tree:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-                Entrance from Lower Flooded Faron Woods: null
-                Entrance from Upper Flooded Faron Woods: null
-              exits:
-                Exit: 'True'
-                Exit to Lower Flooded Faron Woods: Water Dragon's Scale
-                Exit to Upper Flooded Faron Woods: 'True'
-              hint_region: Flooded Faron Woods
-              locations:
-                Water Dragon's Reward: "Group of Tadtones x 17 & \\Faron\\Flooded\
-                  \ Faron Woods\\Can Watch Completed Tadtones Cutscene"
-              name: \Faron\Flooded Faron Woods\Flooded Great Tree
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: Flooded Faron Woods
-        Lake Floria:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Lake Floria
-          locations: {}
-          name: \Faron\Lake Floria
-          sub_areas:
-            Above Rock:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Dive from Faron Woods: null
-              exits:
-                \Faron\Lake Floria\Below Rock: "\\Faron\\Lake Floria\\Above Rock\\\
-                  Blow Rock & Water Dragon's Scale"
-              hint_region: Lake Floria
-              locations:
-                Blow Rock: Water Dragon's Scale
-                Left Rupee behind Northwest Boulder: Water Dragon's Scale
-                Right Rupee behind Northwest Boulder: Water Dragon's Scale
-                Rupee behind Southwest Boulder: Water Dragon's Scale
-                Rupee under Central Boulder: Water Dragon's Scale
-              name: \Faron\Lake Floria\Above Rock
-              sub_areas: {}
-              toplevel_alias: null
-            Below Rock:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Farore's Lair: null
-              exits:
-                Exit to Farore's Lair: Water Dragon's Scale
-                \Faron\Lake Floria\Above Rock: Water Dragon's Scale
-                \Faron\Lake Floria\Below Rock\Emerged Area: Water Dragon's Scale
-              hint_region: Lake Floria
-              locations: {}
-              name: \Faron\Lake Floria\Below Rock
-              sub_areas:
-                Emerged Area:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Statue Entrance: null
-                  exits:
-                    Statue Exit: \Faron\Lake Floria\Below Rock\Emerged Area\Unlock
-                      Statue
-                    \Faron\Lake Floria\Below Rock: Water Dragon's Scale
-                  hint_region: Lake Floria
-                  locations:
-                    Goddess Cube in Lake Floria: \Goddess Sword
-                    Lake Floria Chest: 'True'
-                    Unlock Statue: 'True'
-                  name: \Faron\Lake Floria\Below Rock\Emerged Area
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Farore's Lair:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Lake Floria: null
-                Entrance from Waterfall: null
-              exits:
-                Exit to Lake Floria: Water Dragon's Scale
-                Exit to Waterfall: 'True'
-              hint_region: Lake Floria
-              locations:
-                Dragon Lair East Chest: 'True'
-                Dragon Lair South Chest: Water Dragon's Scale
-                Talk to Farore: 'True'
-              name: \Faron\Lake Floria\Farore's Lair
-              sub_areas: {}
-              toplevel_alias: null
-            Waterfall:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Ancient Cistern: null
-                Entrance from Faron Woods: null
-                Entrance from Farore's Lair: null
-                Statue Entrance: null
-              exits:
-                Exit to Ancient Cistern: Water Dragon's Scale
-                Exit to Faron Woods: 'True'
-                Exit to Farore's Lair: 'True'
-                Statue Exit: \Faron\Lake Floria\Waterfall\Unlock Statue
-              hint_region: Lake Floria
-              locations:
-                Goddess Cube in Floria Waterfall: "Clawshots & \\Goddess Sword"
-                Gossip Stone outside Ancient Cistern: 'True'
-                Rupee on High Ledge outside Ancient Cistern Entrance: \Beetle
-                Unlock Statue: 'True'
-              name: \Faron\Lake Floria\Waterfall
-              sub_areas: {}
-              toplevel_alias: Floria Waterfall
-          toplevel_alias: null
-        Sealed Grounds:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Sealed Grounds
-          locations: {}
-          name: \Faron\Sealed Grounds
-          sub_areas:
-            Behind the Temple:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Door Entrance: null
-                Entrance from Faron Woods: null
-                Shortcut Entrance from Spiral: null
-                Statue Entrance: null
-              exits:
-                Door Exit: 'True'
-                Exit to Faron Woods: 'True'
-                Shortcut Exit to Spiral: 'True'
-                Statue Exit: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
-              hint_region: Sealed Grounds
-              locations:
-                Gorko's Goddess Wall Reward: "Goddess's Harp & Ballad of the Goddess\
-                  \ & \\Goddess Sword"
-                Gossip Stone behind the Temple: 'True'
-                Unlock Statue: 'True'
-              name: \Faron\Sealed Grounds\Behind the Temple
-              sub_areas: {}
-              toplevel_alias: null
-            Hylia's Temple:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Gate of Time Entrance: null
-              exits:
-                Gate of Time Exit: 'True'
-              hint_region: Sealed Grounds
-              locations:
-                Defeat Demise: "Horde Door Requirement & \\Sword"
-                Zelda's Blessing: 'True'
-              name: \Faron\Sealed Grounds\Hylia's Temple
-              sub_areas: {}
-              toplevel_alias: null
-            Sealed Temple:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Gate of Time Entrance: null
-                Main Entrance: null
-                Side Entrance: null
-              exits:
-                Gate of Time Exit: \Faron\Sealed Grounds\Sealed Temple\Open Gate of
-                  Time
-                Main Exit: 'True'
-                Side Exit: 'True'
-              hint_region: Sealed Grounds
-              locations:
-                Chest inside Sealed Temple: 'True'
-                Open Gate of Time: "\\Faron\\Sealed Grounds\\Sealed Temple\\Raise\
-                  \ Gate of Time & GoT Opening Requirement & \\Faron\\Sealed Grounds\\\
-                  Spiral\\Defeat Imprisoned 2"
-                Raise Gate of Time: GoT Raising Requirement
-                Song from Impa: Goddess's Harp
-                Start Imprisoned 2: "\\Faron\\Sealed Grounds\\Sealed Temple\\Raise\
-                  \ Gate of Time & GoT Opening Requirement"
-              name: \Faron\Sealed Grounds\Sealed Temple
-              sub_areas: {}
-              toplevel_alias: null
-            Spiral:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Door Entrance: null
-              exits:
-                Door Exit: 'True'
-                \Faron\Sealed Grounds\Spiral\Upper Part: \Faron\Sealed Grounds\Spiral\Defeat
-                  Imprisoned 2
-              hint_region: Sealed Grounds
-              locations:
-                Defeat Imprisoned 2: "\\Faron\\Sealed Grounds\\Sealed Temple\\Start\
-                  \ Imprisoned 2 & \\Goddess Sword"
-              name: \Faron\Sealed Grounds\Spiral
-              sub_areas:
-                Upper Part:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Statue Entrance: null
-                  exits:
-                    Statue Exit: \Faron\Sealed Grounds\Spiral\Upper Part\Unlock Statue
-                    \Faron\Sealed Grounds\Spiral: 'True'
-                    \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple: 'True'
-                  hint_region: Sealed Grounds
-                  locations:
-                    Unlock Statue: 'True'
-                  name: \Faron\Sealed Grounds\Spiral\Upper Part
-                  sub_areas:
-                    From Behind the Temple:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set
-                        Shortcut Entrance from Behind the Temple: null
-                      exits:
-                        Shortcut Exit to Behind the Temple: 'True'
-                        \Faron\Sealed Grounds\Spiral\Upper Part: 'True'
-                      hint_region: Sealed Grounds
-                      locations: {}
-                      name: \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the
-                        Temple
-                      sub_areas: {}
-                      toplevel_alias: null
-                  toplevel_alias: null
-              toplevel_alias: Sealed Grounds Spiral
-          toplevel_alias: null
-      toplevel_alias: null
-    Fire Sanctuary:
-      abstract: false
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: Fire Sanctuary
-      locations: {}
-      name: \Fire Sanctuary
-      sub_areas:
-        Boss Room:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance from Dungeon: null
-            Entrance from Flame Room: null
-          exits:
-            Exit to Dungeon: \Fire Sanctuary\Boss Room\Beat Ghirahim
-            Exit to Flame Room: \Fire Sanctuary\Boss Room\Beat Ghirahim
-          hint_region: Fire Sanctuary
-          locations:
-            Beat Ghirahim: \Sword
-            Heart Container: \Fire Sanctuary\Boss Room\Beat Ghirahim
-          name: \Fire Sanctuary\Boss Room
-          sub_areas: {}
-          toplevel_alias: null
-        Flame Room:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance: null
-          exits:
-            Exit: 'True'
-          hint_region: Fire Sanctuary
-          locations:
-            Din's Flame: \Goddess Sword
-          name: \Fire Sanctuary\Flame Room
-          sub_areas: {}
-          toplevel_alias: null
-        Main:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Fire Sanctuary
-          locations: {}
-          name: \Fire Sanctuary\Main
-          sub_areas:
-            Boss Key Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Fire Sanctuary\Main\Front of Boss Door\Past Bars: 'True'
-                \Fire Sanctuary\Main\Staircase Room\Upper Part: 'True'
-              hint_region: Fire Sanctuary
-              locations:
-                Boss Key Chest: "\\Fire Sanctuary\\Main\\Boss Key Room\\Solve Puzzle\
-                  \ & \\Fire Sanctuary\\Main\\Boss Key Room\\Defeat Moldorm"
-                Defeat Moldorm: "\\Fire Sanctuary\\Main\\Boss Key Room\\Solve Puzzle\
-                  \ & \\Mogma Mitts"
-                Solve Puzzle: \Mogma Mitts
-              name: \Fire Sanctuary\Main\Boss Key Room
-              sub_areas: {}
-              toplevel_alias: null
-            First Bridge:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Fire Sanctuary\Main\Room with Water Plant: \Fire Sanctuary\Main\First
-                  Bridge\Lizalfos Fight
-                \Fire Sanctuary\Main\Second Bridge\Left: \Fire Sanctuary\Main\Second
-                  Bridge\Left\Unlock Shortcut to First Bridge
-                \Fire Sanctuary\Main\Second Room: \Fire Sanctuary\Main\First Bridge\Lizalfos
-                  Fight
-              hint_region: Fire Sanctuary
-              locations:
-                Lizalfos Fight: \Can Defeat Lizalfos
-              name: \Fire Sanctuary\Main\First Bridge
-              sub_areas: {}
-              toplevel_alias: null
-            First Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Main Entrance: null
-              exits:
-                Main Exit: 'True'
-                \Fire Sanctuary\Main\First Room\Past Water Plant: \Fire Sanctuary\Main\First
-                  Room\Hit Water Plant
-              hint_region: Fire Sanctuary
-              locations:
-                Hit Water Plant: "\\Distance Activator | Bomb Bag"
-              name: \Fire Sanctuary\Main\First Room
-              sub_areas:
-                Past Water Plant:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Second Room: null
-                  exits:
-                    Exit to Second Room: Fire Sanctuary Small Key
-                    \Fire Sanctuary\Main\First Room: \Fire Sanctuary\Main\First Room\Hit
-                      Water Plant
-                  hint_region: Fire Sanctuary
-                  locations:
-                    Chest in First Room: \Fire Sanctuary\Main\First Room\Past Water
-                      Plant\Defeat Last Bokoblin
-                    Defeat Last Bokoblin: \Can Defeat Bokoblins
-                    \Fire Sanctuary\Main\First Room\Hit Water Plant: "\\Distance Activator\
-                      \ | Bomb Bag"
-                  name: \Fire Sanctuary\Main\First Room\Past Water Plant
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            First Trapped Mogma Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: \Fire Sanctuary\Main\Magmanos
-                  Fight Room\Upper Part\Magmanos Fight
-                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: 'True'
-              hint_region: Fire Sanctuary
-              locations:
-                Chest near First Trapped Mogma: "Gust Bellows | Clawshots"
-              name: \Fire Sanctuary\Main\First Trapped Mogma Room
-              sub_areas:
-                Lower Area:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\First Trapped Mogma Room: \Fire Sanctuary\Main\Magmanos
-                      Fight Room\Upper Part\Magmanos Fight
-                    \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: "\\Mogma\
-                      \ Mitts & \\Fire Sanctuary\\Main\\First Trapped Mogma Room\\\
-                      Lower Area\\Blow up Rock in Tunnel"
-                    \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part: \Fire Sanctuary\Main\Magmanos
-                      Fight Room\Upper Part\Magmanos Fight
-                  hint_region: Fire Sanctuary
-                  locations:
-                    Blow up Rock in Tunnel: \Mogma Mitts
-                    Rescue First Trapped Mogma: 'True'
-                  name: \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Front of Boss Door:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Boss Door Entrance: null
-                Statue Entrance: null
-              exits:
-                Boss Door Exit: Fire Sanctuary Boss Key
-                Statue Exit: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
-                \Fire Sanctuary\Main\Front of Boss Door\Past Bars: \Fire Sanctuary\Main\Front
-                  of Boss Door\Past Bars\Unlock Way to Front
-                \Fire Sanctuary\Main\Lizalfos Fight Room: 'True'
-              hint_region: Fire Sanctuary
-              locations:
-                Unlock Statue: 'True'
-              name: \Fire Sanctuary\Main\Front of Boss Door
-              sub_areas:
-                Past Bars:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\Boss Key Room: 'True'
-                    \Fire Sanctuary\Main\Front of Boss Door: \Fire Sanctuary\Main\Front
-                      of Boss Door\Past Bars\Unlock Way to Front
-                  hint_region: Fire Sanctuary
-                  locations:
-                    Unlock Way to Front: 'True'
-                  name: \Fire Sanctuary\Main\Front of Boss Door\Past Bars
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Lizalfos Fight Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Fire Sanctuary\Main\Staircase Room: \Fire Sanctuary\Main\Lizalfos
-                  Fight Room\Fight
-              hint_region: Fire Sanctuary
-              locations:
-                Fight: \Can Defeat Lizalfos
-              name: \Fire Sanctuary\Main\Lizalfos Fight Room
-              sub_areas: {}
-              toplevel_alias: null
-            Magmanos Fight Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits: {}
-              hint_region: Fire Sanctuary
-              locations: {}
-              name: \Fire Sanctuary\Main\Magmanos Fight Room
-              sub_areas:
-                Lower Part:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from West of Boss Door: null
-                  exits:
-                    Exit to West of Boss Door: \Fire Sanctuary\Main\Magmanos Fight
-                      Room\Lower Part\Unlock Key Door
-                    \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: "\\\
-                      Mogma Mitts & \\Fire Sanctuary\\Main\\First Trapped Mogma Room\\\
-                      Lower Area\\Blow up Rock in Tunnel"
-                    \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Past Sliding Door: \Fire
-                      Sanctuary\Main\Magmanos Fight Room\Lower Part\Move Sliding Door
-                  hint_region: Fire Sanctuary
-                  locations:
-                    Move Sliding Door: "\\Fire Sanctuary\\Main\\Magmanos Fight Room\\\
-                      Lower Part\\Uncover Dig Spot & \\Mogma Mitts"
-                    Uncover Dig Spot: Gust Bellows
-                    Unlock Key Door: Fire Sanctuary Small Key x 3
-                  name: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part
-                  sub_areas:
-                    Past Sliding Door:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: \Fire
-                          Sanctuary\Main\Magmanos Fight Room\Lower Part\Move Sliding
-                          Door
-                        \Fire Sanctuary\Main\Second Bridge\Left: 'True'
-                      hint_region: Fire Sanctuary
-                      locations: {}
-                      name: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Past
-                        Sliding Door
-                      sub_areas: {}
-                      toplevel_alias: null
-                  toplevel_alias: null
-                Upper Part:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\First Trapped Mogma Room: \Fire Sanctuary\Main\Magmanos
-                      Fight Room\Upper Part\Magmanos Fight
-                    \Fire Sanctuary\Main\Water Fruit Room\After Frog: \Fire Sanctuary\Main\Magmanos
-                      Fight Room\Upper Part\Magmanos Fight
-                  hint_region: Fire Sanctuary
-                  locations:
-                    Magmanos Fight: \Sword
-                  name: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Room with Water Plant:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Fire Sanctuary\Main\First Bridge: 'True'
-                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: "\\Fire Sanctuary\\\
-                  Main\\Room with Water Plant\\Blow up Rock & \\Fire Sanctuary\\Main\\\
-                  Room with Water Plant\\Hit Water Plant"
-              hint_region: Fire Sanctuary
-              locations:
-                Blow up Rock: \Hook Beetle
-                Hit Water Plant: "\\Distance Activator | Bomb Bag"
-              name: \Fire Sanctuary\Main\Room with Water Plant
-              sub_areas:
-                Past Lava:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\First Trapped Mogma Room: 'True'
-                    \Fire Sanctuary\Main\Room with Water Plant: "Clawshots | \\Fire\
-                      \ Sanctuary\\Main\\Room with Water Plant\\Blow up Rock"
-                    \Fire Sanctuary\Main\Water Fruit Room: \Fire Sanctuary\Main\Room
-                      with Water Plant\Past Lava\Unlock Key Door
-                  hint_region: Fire Sanctuary
-                  locations:
-                    Unlock Key Door: Fire Sanctuary Small Key x 2
-                  name: \Fire Sanctuary\Main\Room with Water Plant\Past Lava
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Second Bridge:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits: {}
-              hint_region: Fire Sanctuary
-              locations: {}
-              name: \Fire Sanctuary\Main\Second Bridge
-              sub_areas:
-                Bottom Part:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\Second Bridge\Left: Clawshots
-                    \Fire Sanctuary\Main\Second Bridge\Right: Clawshots
-                  hint_region: Fire Sanctuary
-                  locations: {}
-                  name: \Fire Sanctuary\Main\Second Bridge\Bottom Part
-                  sub_areas: {}
-                  toplevel_alias: null
-                Left:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\First Bridge: \Fire Sanctuary\Main\Second
-                      Bridge\Left\Unlock Shortcut to First Bridge
-                    \Fire Sanctuary\Main\Second Bridge\Bottom Part: 'True'
-                    \Fire Sanctuary\Main\Second Bridge\Right: Clawshots
-                  hint_region: Fire Sanctuary
-                  locations:
-                    Unlock Shortcut to First Bridge: 'True'
-                  name: \Fire Sanctuary\Main\Second Bridge\Left
-                  sub_areas: {}
-                  toplevel_alias: null
-                Right:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\Second Bridge\Bottom Part: 'True'
-                    \Fire Sanctuary\Main\Second Bridge\Left: Clawshots
-                    \Fire Sanctuary\Main\Second Trapped Mogma Room: 'True'
-                  hint_region: Fire Sanctuary
-                  locations: {}
-                  name: \Fire Sanctuary\Main\Second Bridge\Right
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Second Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Fire Sanctuary\Main\First Bridge: 'True'
-                \Fire Sanctuary\Main\Second Room\Balcony: \Fire Sanctuary\Main\Second
-                  Room\Defeat Magmanos
-                \Fire Sanctuary\Main\Second Room\Outside Section: 'True'
-              hint_region: Fire Sanctuary
-              locations:
-                Chest in Second Room: 'True'
-                Defeat Magmanos: "\\Fire Sanctuary\\Main\\Second Room\\Open Doors\
-                  \ to Water Fruit & \\Sword"
-                Open Doors to Water Fruit: \Mogma Mitts
-              name: \Fire Sanctuary\Main\Second Room
-              sub_areas:
-                Balcony:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\Second Room: \Fire Sanctuary\Main\Second
-                      Room\Defeat Magmanos
-                  hint_region: Fire Sanctuary
-                  locations:
-                    Chest on Balcony: 'True'
-                  name: \Fire Sanctuary\Main\Second Room\Balcony
-                  sub_areas: {}
-                  toplevel_alias: null
-                Outside Section:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from First Room: null
-                  exits:
-                    Exit to First Room: 'True'
-                    \Fire Sanctuary\Main\Second Room: 'True'
-                  hint_region: Fire Sanctuary
-                  locations: {}
-                  name: \Fire Sanctuary\Main\Second Room\Outside Section
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Second Trapped Mogma Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Fire Sanctuary\Main\Second Bridge\Right: 'True'
-                \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall: "\\\
-                  Fire Sanctuary\\Main\\Second Trapped Mogma Room\\Hydrate Frog &\
-                  \ \\Fire Sanctuary\\Main\\Second Trapped Mogma Room\\Blow up Wall\
-                  \ & \\Mogma Mitts"
-              hint_region: Fire Sanctuary
-              locations:
-                Blow up Wall: "\\Fire Sanctuary\\Main\\Second Trapped Mogma Room\\\
-                  Hydrate Frog & Bomb Bag"
-                Hydrate Frog: "\\Fire Sanctuary\\Main\\Second Trapped Mogma Room\\\
-                  Move Sliding Doors Correctly & \\Sword"
-                Move Sliding Doors Correctly: \Mogma Mitts
-                Rescue Mogma: \Fire Sanctuary\Main\Second Trapped Mogma Room\Hydrate
-                  Frog
-                Rescue Second Trapped Mogma: \Fire Sanctuary\Main\Second Trapped Mogma
-                  Room\Rescue Mogma
-              name: \Fire Sanctuary\Main\Second Trapped Mogma Room
-              sub_areas:
-                Past Bombable Wall:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\Second Trapped Mogma Room: 'True'
-                  hint_region: Fire Sanctuary
-                  locations:
-                    Chest after Bombable Wall: 'True'
-                  name: \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable
-                    Wall
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Staircase Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Fire Sanctuary\Main\Staircase Room\Upper Part: Clawshots
-              hint_region: Fire Sanctuary
-              locations:
-                Chest in Staircase Room: Clawshots
-              name: \Fire Sanctuary\Main\Staircase Room
-              sub_areas:
-                Upper Part:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\Boss Key Room: 'True'
-                    \Fire Sanctuary\Main\Staircase Room: 'True'
-                  hint_region: Fire Sanctuary
-                  locations: {}
-                  name: \Fire Sanctuary\Main\Staircase Room\Upper Part
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Water Fruit Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: \Fire Sanctuary\Main\Room
-                  with Water Plant\Past Lava\Unlock Key Door
-                \Fire Sanctuary\Main\Water Fruit Room\After Frog: \Fire Sanctuary\Main\Water
-                  Fruit Room\Hydrate Frog
-              hint_region: Fire Sanctuary
-              locations:
-                First Chest in Water Fruit Room: 'True'
-                Hydrate Frog: \Sword
-                Second Chest in Water Fruit Room: 'True'
-                \Fire Sanctuary\Main\Room with Water Plant\Past Lava\Unlock Key Door: Fire
-                  Sanctuary Small Key x 2
-              name: \Fire Sanctuary\Main\Water Fruit Room
-              sub_areas:
-                After Frog:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part: 'True'
-                    \Fire Sanctuary\Main\Water Fruit Room: \Fire Sanctuary\Main\Water
-                      Fruit Room\Hydrate Frog
-                  hint_region: Fire Sanctuary
-                  locations: {}
-                  name: \Fire Sanctuary\Main\Water Fruit Room\After Frog
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            West of Boss Door:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Fire Sanctuary\Main\Front of Boss Door: "\\Fire Sanctuary\\Main\\\
-                  West of Boss Door\\Hit Water Plant & \\Fire Sanctuary\\Main\\West\
-                  \ of Boss Door\\Past Plats\\Release Lava"
-                \Fire Sanctuary\Main\West of Boss Door\Entry: \Fire Sanctuary\Main\West
-                  of Boss Door\Hit Water Plant
-                \Fire Sanctuary\Main\West of Boss Door\Past Plats: "\\Fire Sanctuary\\\
-                  Main\\West of Boss Door\\Catch Plats & (\\Distance Activator | Bomb\
-                  \ Bag) | \\Fire Sanctuary\\Main\\West of Boss Door\\Past Plats\\\
-                  Unlock Shortcut to Pre Plats"
-              hint_region: Fire Sanctuary
-              locations:
-                Catch Plats: \Mogma Mitts
-                Hit Water Plant: "\\Distance Activator | Bomb Bag"
-                Plats' Chest: \Fire Sanctuary\Main\West of Boss Door\Catch Plats
-              name: \Fire Sanctuary\Main\West of Boss Door
-              sub_areas:
-                Entry:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Magmanos Fight Room: null
-                  exits:
-                    Exit to Magmanos Fight Room: 'True'
-                    \Fire Sanctuary\Main\Front of Boss Door: "\\Fire Sanctuary\\Main\\\
-                      West of Boss Door\\Hit Water Plant & \\Fire Sanctuary\\Main\\\
-                      West of Boss Door\\Past Plats\\Release Lava"
-                    \Fire Sanctuary\Main\West of Boss Door: \Fire Sanctuary\Main\West
-                      of Boss Door\Hit Water Plant
-                  hint_region: Fire Sanctuary
-                  locations:
-                    \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant: "\\Distance\
-                      \ Activator | Bomb Bag"
-                  name: \Fire Sanctuary\Main\West of Boss Door\Entry
-                  sub_areas: {}
-                  toplevel_alias: null
-                Past Plats:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: true
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Fire Sanctuary\Main\West of Boss Door: \Fire Sanctuary\Main\West
-                      of Boss Door\Past Plats\Unlock Shortcut to Pre Plats
-                  hint_region: Fire Sanctuary
-                  locations:
-                    Release Lava: "\\Mogma Mitts | FS Lava Flow option"
-                    Unlock Shortcut to Pre Plats: 'True'
-                  name: \Fire Sanctuary\Main\West of Boss Door\Past Plats
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-          toplevel_alias: null
-      toplevel_alias: null
-    Lanayru:
-      abstract: true
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: null
-      locations:
-        All Three Nodes: "LMF Nodes On option | \\Lanayru\\Desert\\North Part\\Water\
-          \ Node & \\Lanayru\\Desert\\North Part\\Lightning Node\\Past\\Lightning\
-          \ Node & \\Lanayru\\Desert\\East\\Fire Node\\Past after Grate\\Fire Node"
-        Can Navigate in Oasis: "\\Can Defeat Ampilus | \\Hook Beetle | \\Skyloft\\\
-          Central Skyloft\\Bazaar\\Endurance Potion | Brakeslide Trick | Stuttersprint\
-          \ Trick"
-        Raise Lanayru Mining Facility: "Open LMF option | \\Lanayru\\Desert\\North\
-          \ Part\\Activate Main Node"
-      name: \Lanayru
-      sub_areas:
-        Caves:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance from Desert: null
-            Entrance from Mine: null
-          exits:
-            Exit to Desert: 'True'
-            Exit to Mine: 'True'
-            \Lanayru\Caves\Past Crawlspace: 'True'
-            \Lanayru\Caves\Past Door to Lanayru Sand Sea: "Clawshots & Lanayru Caves\
-              \ Small Key"
-          hint_region: Lanayru Caves
-          locations:
-            Chest: 'True'
-            Golo's Gift: 'True'
-            Gossip Stone in Center: 'True'
-          name: \Lanayru\Caves
-          sub_areas:
-            Past Crawlspace:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Gorge: null
-              exits:
-                Exit to Gorge: 'True'
-                \Lanayru\Caves: Bomb Bag
-              hint_region: Lanayru Caves
-              locations:
-                Gossip Stone towards Lanayru Gorge: 'True'
-              name: \Lanayru\Caves\Past Crawlspace
-              sub_areas: {}
-              toplevel_alias: null
-            Past Door to Lanayru Sand Sea:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Lanayru Sand Sea: null
-              exits:
-                Exit to Lanayru Sand Sea: 'True'
-                \Lanayru\Caves: Lanayru Caves Small Key
-              hint_region: Lanayru Caves
-              locations: {}
-              name: \Lanayru\Caves\Past Door to Lanayru Sand Sea
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: Lanayru Caves
-        Desert:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits:
-            Shared Statue Exit: 'False'
-          hint_region: Lanayru Desert
-          locations: {}
-          name: \Lanayru\Desert
-          sub_areas:
-            East:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Fire Node Entrance: null
-                Stone Cache Statue Entrance: null
-              exits:
-                Fire Node Exit: 'True'
-                \Lanayru\Desert\Near Caged Robot: "\\Lanayru\\Desert\\East\\Open Wall\
-                  \ Shortcut | Temple of Time Skip - Brakeslide Trick"
-                \Lanayru\Desert\North Part: 'True'
-                \Lanayru\Desert\Shared Statue Exit: 'True'
-                \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
-              hint_region: Lanayru Desert
-              locations:
-                Chest on Platform near Fire Node: Clawshots
-                Open Wall Shortcut: 'True'
-                Unlock Statue: 'True'
-              name: \Lanayru\Desert\East
-              sub_areas:
-                Fire Node:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits: {}
-                  hint_region: Lanayru Desert
-                  locations: {}
-                  name: \Lanayru\Desert\East\Fire Node
-                  sub_areas:
-                    Past:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Lanayru\Desert\East\Fire Node\Past after Void: \Lanayru\Desert\East\Fire
-                          Node\Present after Sand\Push Box
-                        \Lanayru\Desert\East\Fire Node\Present: "\\Projectile Item\
-                          \ | Bomb Bag"
-                        \Lanayru\Desert\East\Fire Node\Present\Exit: 'True'
-                      hint_region: Lanayru Desert
-                      locations:
-                        First Small Chest: 'True'
-                        Second Small Chest: 'True'
-                      name: \Lanayru\Desert\East\Fire Node\Past
-                      sub_areas: {}
-                      toplevel_alias: null
-                    Past after Grate:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Lanayru\Desert\East\Fire Node\Past after Void: 'True'
-                      hint_region: Lanayru Desert
-                      locations:
-                        Fire Node: \Sword
-                        Left Ending Chest: 'True'
-                        Right Ending Chest: 'True'
-                      name: \Lanayru\Desert\East\Fire Node\Past after Grate
-                      sub_areas: {}
-                      toplevel_alias: null
-                    Past after Void:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Lanayru\Desert\East\Fire Node\Past: 'True'
-                        \Lanayru\Desert\East\Fire Node\Past after Grate: \Lanayru\Desert\East\Fire
-                          Node\Past after Void\Open Grate
-                      hint_region: Lanayru Desert
-                      locations:
-                        Open Grate: \Hook Beetle
-                      name: \Lanayru\Desert\East\Fire Node\Past after Void
-                      sub_areas: {}
-                      toplevel_alias: null
-                    Present:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set
-                        Entrance: null
-                      exits:
-                        Exit: 'True'
-                        \Lanayru\Desert\East\Fire Node\Past: \Lanayru\Desert\East\Fire
-                          Node\Present\Timeshift Stone
-                        \Lanayru\Desert\East\Fire Node\Present after Sand: "\\Can\
-                          \ Defeat Ampilus | Brakeslide Trick | \\Lanayru\\Desert\\\
-                          East\\Fire Node\\Present after Sand\\Push Box"
-                      hint_region: Lanayru Desert
-                      locations:
-                        Blow up Rock for Timeshift Stone: Bomb Bag
-                        Timeshift Stone: "\\Lanayru\\Desert\\East\\Fire Node\\Present\\\
-                          Blow up Rock for Timeshift Stone & \\Can Hit Timeshift Stone"
-                      name: \Lanayru\Desert\East\Fire Node\Present
-                      sub_areas: {}
-                      toplevel_alias: null
-                    Present after Sand:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Lanayru\Desert\East\Fire Node\Past after Void: "\\Lanayru\\\
-                          Desert\\East\\Fire Node\\Present\\Timeshift Stone & \\Projectile\
-                          \ Item"
-                        \Lanayru\Desert\East\Fire Node\Present: 'True'
-                      hint_region: Lanayru Desert
-                      locations:
-                        Push Box: 'True'
-                        Shortcut Chest: 'True'
-                      name: \Lanayru\Desert\East\Fire Node\Present after Sand
-                      sub_areas: {}
-                      toplevel_alias: null
-                  toplevel_alias: null
-              toplevel_alias: null
-            Entry:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Desert Entrance Statue Entrance: null
-                Entrance from Mine: null
-              exits:
-                Exit to Mine: \Lanayru\Desert\Entry\Timeshift Stone
-                \Lanayru\Desert\Entry\High Ledge after Vines: \Lanayru\Desert\Entry\Timeshift
-                  Stone
-                \Lanayru\Desert\Near Caged Robot: 'True'
-                \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\Entry\Unlock Statue
-              hint_region: Lanayru Desert
-              locations:
-                Blow up Rock for Timeshift Stone: Bomb Bag
-                Timeshift Stone: "\\Lanayru\\Desert\\Entry\\Blow up Rock for Timeshift\
-                  \ Stone & \\Can Hit Timeshift Stone"
-                Unlock Statue: 'True'
-              name: \Lanayru\Desert\Entry
-              sub_areas:
-                High Ledge after Vines:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits: {}
-                  hint_region: Lanayru Desert
-                  locations:
-                    Chest near Party Wheel: 'True'
-                    Retrieve Party Wheel: "Scrapper & \\Sky\\South West\\Fun Fun Island\\\
-                      Start Dodoh's Quest"
-                    \Ancient Flower Farming: 'True'
-                  name: \Lanayru\Desert\Entry\High Ledge after Vines
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Near Caged Robot:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru\Desert\East: "Temple of Time Skip - Brakeslide Trick | \\\
-                  Lanayru\\Desert\\East\\Open Wall Shortcut | Clawshots | \\Skyloft\\\
-                  Central Skyloft\\Bazaar\\Endurance Potion"
-                \Lanayru\Desert\Entry: 'True'
-                \Lanayru\Desert\Sand Oasis: \Lanayru\Desert\Near Caged Robot\Get Past
-                  Spume to Sand Oasis
-                \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
-                \Lanayru\Desert\Top of West Wall: Clawshots
-              hint_region: Lanayru Desert
-              locations:
-                Blow Statues to Sand Oasis Down: \Hook Beetle
-                Blow up Rock for Timeshift Stone: "Bomb Bag | \\Hook Beetle | Lanayru\
-                  \ Desert - Ampilus Bomb Toss Trick"
-                Chest near Caged Robot: 'True'
-                Get Past Spume to Sand Oasis: "\\Lanayru\\Desert\\Near Caged Robot\\\
-                  Blow Statues to Sand Oasis Down | \\Skyloft\\Central Skyloft\\Bazaar\\\
-                  Endurance Potion | Brakeslide Trick & Stuttersprint Trick & (Bomb\
-                  \ Bag | \\Bow | \\Long Range Skyward Strike)"
-                Goddess Cube near Caged Robot: \Long Range Skyward Strike
-                Rescue Caged Robot: "\\Lanayru\\Desert\\Near Caged Robot\\Blow up\
-                  \ Rock for Timeshift Stone & \\Can Defeat Bokoblins"
-              name: \Lanayru\Desert\Near Caged Robot
-              sub_areas: {}
-              toplevel_alias: null
-            Near South Exit to Temple of Time:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                South Entrance from Temple of Time: null
-              exits:
-                South Exit to Temple of Time: 'True'
-                \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves: Clawshots
-                \Lanayru\Desert\West Part: 'True'
-              hint_region: Lanayru Desert
-              locations:
-                Push Minecart: 'True'
-              name: \Lanayru\Desert\Near South Exit to Temple of Time
-              sub_areas:
-                Ledge to Caves:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Caves: null
-                  exits:
-                    Exit to Caves: 'True'
-                    \Lanayru\Desert\Near South Exit to Temple of Time: 'True'
-                  hint_region: Lanayru Desert
-                  locations: {}
-                  name: \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to
-                    Caves
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            North Part:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Lightning Node Entrance: null
-                North Desert Statue Entrance: null
-                North Entrance from Temple of Time: null
-                Trial Gate Entrance: null
-              exits:
-                Lightning Node Exit: \Lanayru\Desert\North Part\Open Lightning Node
-                North Exit to Temple of Time: 'True'
-                Trial Gate Exit: \Lanayru\Desert\North Part\Open Trial Gate
-                \Lanayru\Desert\East: 'True'
-                \Lanayru\Desert\North Part\Secret Passageway: \Lanayru\Desert\North
-                  Part\Open Secret Passageway
-                \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\North Part\Unlock
-                  Statue
-                \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
-              hint_region: Lanayru Desert
-              locations:
-                Activate Main Node: "\\Lanayru\\All Three Nodes & \\Lanayru\\Desert\\\
-                  North Part\\Main Node Timeshift Stone & \\Sword"
-                Blow up Main Node Timeshift Stone Rock: "Bomb Bag | \\Hook Beetle"
-                Chest on Platform near Lightning Node: Clawshots
-                Main Node Timeshift Stone: "\\Lanayru\\Desert\\North Part\\Blow up\
-                  \ Main Node Timeshift Stone Rock & \\Can Hit Timeshift Stone"
-                Open Lightning Node: 'True'
-                Open Secret Passageway: "Bomb Bag | \\Hook Beetle & Secret Passageway\
-                  \ Hook Beetle Opening Trick | \\Tough Beetle"
-                Open Trial Gate: "Nayru's Wisdom & Goddess's Harp"
-                Unlock Statue: 'True'
-                Water Node: "(Bomb Bag | \\Hook Beetle) & \\Sword"
-                \Ancient Flower Farming: \Lanayru\Desert\North Part\Main Node Timeshift
-                  Stone
-              name: \Lanayru\Desert\North Part
-              sub_areas:
-                Lightning Node:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits: {}
-                  hint_region: Lanayru Desert
-                  locations: {}
-                  name: \Lanayru\Desert\North Part\Lightning Node
-                  sub_areas:
-                    Past:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Lanayru\Desert\North Part\Lightning Node\Present: \Projectile
-                          Item
-                        \Lanayru\Desert\North Part\Lightning Node\Present from afar: "\\\
-                          Beetle | \\Bow | Lightning Node End with Bombs Trick & Bomb\
-                          \ Bag"
-                        \Lanayru\Desert\North Part\Lightning Node\Present\Exit: 'True'
-                      hint_region: Lanayru Desert
-                      locations:
-                        First Chest: 'True'
-                        Lightning Node: \Sword
-                        Second Chest: 'True'
-                      name: \Lanayru\Desert\North Part\Lightning Node\Past
-                      sub_areas: {}
-                      toplevel_alias: null
-                    Present:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set
-                        Entrance: null
-                      exits:
-                        Exit: 'True'
-                        \Lanayru\Desert\North Part\Lightning Node\Past: \Lanayru\Desert\North
-                          Part\Lightning Node\Present\Timeshift Stone
-                      hint_region: Lanayru Desert
-                      locations:
-                        Blow up Rock for Timeshift Stone: Bomb Bag
-                        Timeshift Stone: "\\Lanayru\\Desert\\North Part\\Lightning\
-                          \ Node\\Present\\Blow up Rock for Timeshift Stone & \\Can\
-                          \ Hit Timeshift Stone"
-                      name: \Lanayru\Desert\North Part\Lightning Node\Present
-                      sub_areas: {}
-                      toplevel_alias: null
-                    Present from afar:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Lanayru\Desert\North Part\Lightning Node\Past: "\\Beetle\
-                          \ | \\Bow"
-                        \Lanayru\Desert\North Part\Lightning Node\Present: 'True'
-                      hint_region: Lanayru Desert
-                      locations:
-                        Raised Chest near Generator: 'True'
-                      name: \Lanayru\Desert\North Part\Lightning Node\Present from
-                        afar
-                      sub_areas: {}
-                      toplevel_alias: null
-                  toplevel_alias: null
-                Secret Passageway:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Lanayru\Desert\North Part: 'True'
-                  hint_region: Lanayru Desert
-                  locations:
-                    Goddess Cube in Secret Passageway: "Clawshots & \\Goddess Sword"
-                    Secret Passageway Chest: 'True'
-                  name: \Lanayru\Desert\North Part\Secret Passageway
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Sand Oasis:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru\Desert\Near Caged Robot: 'True'
-                \Lanayru\Desert\Top of West Wall: "Clawshots | \\Lanayru\\Desert\\\
-                  Top of West Wall\\Push Minecart"
-                \Lanayru\Desert\West Part: "\\Lanayru\\Can Navigate in Oasis | \\\
-                  Lanayru\\Desert\\West Part\\Push Minecart"
-              hint_region: Lanayru Desert
-              locations:
-                Goddess Cube in Sand Oasis: "\\Lanayru\\Can Navigate in Oasis & \\\
-                  Goddess Sword"
-              name: \Lanayru\Desert\Sand Oasis
-              sub_areas: {}
-              toplevel_alias: null
-            Top of LMF:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Lanayru Mining Facility: null
-              exits:
-                Exit to Lanayru Mining Facility: 'True'
-                \Lanayru\Desert\East: 'True'
-                \Lanayru\Desert\Near Caged Robot: 'True'
-                \Lanayru\Desert\North Part: 'True'
-              hint_region: Lanayru Desert
-              locations:
-                Chest on top of Lanayru Mining Facility: 'True'
-              name: \Lanayru\Desert\Top of LMF
-              sub_areas: {}
-              toplevel_alias: null
-            Top of West Wall:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru\Desert\Near Caged Robot: 'True'
-                \Lanayru\Desert\Sand Oasis: 'True'
-                \Lanayru\Desert\West Part: 'True'
-              hint_region: Lanayru Desert
-              locations:
-                Chest near Sand Oasis: 'True'
-                Push Minecart: 'True'
-                \Lanayru\Desert\Near Caged Robot\Goddess Cube near Caged Robot: \Goddess
-                  Sword
-              name: \Lanayru\Desert\Top of West Wall
-              sub_areas: {}
-              toplevel_alias: null
-            West Part:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                West Desert Statue Entrance: null
-              exits:
-                \Lanayru\Desert\Near South Exit to Temple of Time: "\\Lanayru\\Can\
-                  \ Navigate in Oasis | \\Lanayru\\Desert\\Near South Exit to Temple\
-                  \ of Time\\Push Minecart"
-                \Lanayru\Desert\Sand Oasis: 'True'
-                \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\West Part\Unlock
-                  Statue
-                \Lanayru\Desert\Top of West Wall: Clawshots
-              hint_region: Lanayru Desert
-              locations:
-                Push Minecart: 'True'
-                Unlock Statue: 'True'
-                \Lanayru\Desert\Sand Oasis\Goddess Cube in Sand Oasis: \Goddess Sword
-              name: \Lanayru\Desert\West Part
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: Lanayru Desert
-        Lanayru Sand Sea:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Ancient Harbour Dock Entrance: null
-            Pirate Stronghold Dock Entrance: null
-            Sandship Dock Entrance: null
-            Shipyard Dock Entrance: null
-            Skipper's Retreat Dock Entrance: null
-          exits:
-            Ancient Harbour Dock Exit: 'True'
-            Pirate Stronghold Dock Exit: 'True'
-            Sandship Dock Exit: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
-            Shipyard Dock Exit: 'True'
-            Skipper's Retreat Dock Exit: 'True'
-          hint_region: Lanayru Sand Sea
-          locations:
-            Shoot down Sandship: "Sea Chart & \\Sword"
-          name: \Lanayru\Lanayru Sand Sea
-          sub_areas:
-            Ancient Harbour:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Dock Entrance: null
-                Statue Entrance: null
-              exits:
-                Dock Exit: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Ship Timeshift
-                  Stone
-                Exit to Sandship: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
-                Statue Exit: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Unlock Statue
-                \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves: Clawshots
-              hint_region: Lanayru Sand Sea
-              locations:
-                Goddess Cube in Ancient Harbour: "Clawshots & \\Goddess Sword"
-                Ship Timeshift Stone: "\\Distance Activator | \\Sword | Bomb Bag"
-                Unlock Statue: 'True'
-              name: \Lanayru\Lanayru Sand Sea\Ancient Harbour
-              sub_areas:
-                Near Exit to Caves:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Caves: null
-                  exits:
-                    Exit to Caves: 'True'
-                    \Lanayru\Lanayru Sand Sea\Ancient Harbour: Clawshots
-                  hint_region: Lanayru Sand Sea
-                  locations:
-                    Left Rupee on Entrance Crown: \Quick Beetle
-                    Right Rupee on Entrance Crown: \Quick Beetle
-                    Rupee on First Pillar: \Beetle
-                  name: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: Lanayru Sand Sea Docks
-            Gorge:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-                Statue Entrance: null
-              exits:
-                Exit: 'True'
-                Statue Exit: \Lanayru\Lanayru Sand Sea\Gorge\Unlock Statue
-                \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge: \Lanayru\Lanayru Sand
-                  Sea\Gorge\Activate Timeshift Stone
-              hint_region: Lanayru Gorge
-              locations:
-                Activate Timeshift Stone: \Can Hit Timeshift Stone in Minecart
-                Boss Rush -- 4 Bosses: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Thunder\
-                  \ Dragon's Reward & False"
-                Boss Rush -- 8 Bosses: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Thunder\
-                  \ Dragon's Reward & False"
-                Item on Pillar: \Beetle
-                Thunder Dragon's Reward: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Activate\
-                  \ Timeshift Stone & Life Tree Fruit"
-                Unlock Statue: 'True'
-              name: \Lanayru\Lanayru Sand Sea\Gorge
-              sub_areas:
-                Beyond Bridge:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Lanayru\Lanayru Sand Sea\Gorge: "\\Beetle | \\Bow"
-                  hint_region: Lanayru Gorge
-                  locations:
-                    Activate Timeshift Stone: "Gust Bellows & \\Can Hit Timeshift\
-                      \ Stone"
-                    Digging Spot: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Beyond Bridge\\\
-                      Activate Timeshift Stone & \\Digging Mitts"
-                    Goddess Cube in Lanayru Gorge: \Goddess Sword
-                    \Ancient Flower Farming: \Lanayru\Lanayru Sand Sea\Gorge\Beyond
-                      Bridge\Activate Timeshift Stone
-                  name: \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: Lanayru Gorge
-            Pirate Stronghold:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Dock Entrance: null
-                Side Entrance: null
-                Statue Entrance: null
-              exits:
-                Dock Exit: 'True'
-                Side Exit: 'True'
-                Statue Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
-                \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head: \Lanayru\Lanayru
-                  Sand Sea\Pirate Stronghold\Inside\Finish Minidungeon
-              hint_region: Lanayru Sand Sea
-              locations:
-                Rupee on Bird Statue Pillar or Nose: \Beetle
-                Rupee on East Sea Pillar: \Quick Beetle
-                Rupee on West Sea Pillar: \Quick Beetle
-                Unlock Statue: 'True'
-              name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold
-              sub_areas:
-                Inside:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    First Door Entrance: null
-                    Second Door Entrance: null
-                  exits:
-                    First Door Exit: 'True'
-                    Second Door Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
-                      Minidungeon
-                  hint_region: Lanayru Sand Sea
-                  locations:
-                    Finish Minidungeon: "\\Can Defeat Beamos & \\Can Defeat Armos"
-                    First Chest: 'True'
-                    Second Chest: 'True'
-                    Third Chest: 'True'
-                    \Ancient Flower Farming: 'True'
-                  name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside
-                  sub_areas: {}
-                  toplevel_alias: null
-                Inside the Shark Head:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Top Entrance: null
-                  exits:
-                    Top Exit: 'True'
-                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold: "Clawshots | \\Lanayru\\\
-                      Lanayru Sand Sea\\Pirate Stronghold\\Inside\\Finish Minidungeon"
-                  hint_region: Lanayru Sand Sea
-                  locations:
-                    Goddess Cube in Pirate Stronghold: "Clawshots & \\Goddess Sword"
-                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose: \Beetle
-                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar: \Quick
-                      Beetle
-                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar: \Quick
-                      Beetle
-                  name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark
-                    Head
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Shipyard:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Construction Bay Lower Entrance: null
-                Construction Bay Upper Entrance: null
-                Dock Entrance: null
-                Statue Entrance: null
-              exits:
-                Construction Bay Lower Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Construction
-                  Bay\Defeat Moldarach
-                Construction Bay Upper Exit: 'True'
-                Dock Exit: 'True'
-                Statue Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
-              hint_region: Lanayru Sand Sea
-              locations:
-                Gossip Stone in Shipyard: 'True'
-                Rickety Coaster -- Heart Stopping Track in 1'05: \Lanayru\Lanayru
-                  Sand Sea\Shipyard\Construction Bay\Defeat Moldarach
-                Unlock Statue: 'True'
-              name: \Lanayru\Lanayru Sand Sea\Shipyard
-              sub_areas:
-                Construction Bay:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Lower Entrance: null
-                    Upper Entrance: null
-                  exits:
-                    Lower Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
-                      Moldarach
-                    Upper Exit: 'True'
-                  hint_region: Lanayru Sand Sea
-                  locations:
-                    Defeat Moldarach: "Gust Bellows & \\Sword"
-                  name: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Skipper's Retreat:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Dock Entrance: null
-                Statue Entrance: null
-              exits:
-                Dock Exit: 'True'
-                Statue Exit: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Unlock Statue
-                \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: "\\Lanayru\\\
-                  Lanayru Sand Sea\\Skipper's Retreat\\Blow up Rock & Clawshots"
-              hint_region: Lanayru Sand Sea
-              locations:
-                Blow up Rock: "Bomb Bag | \\Hook Beetle | Whip & Cactus Bomb Whip\
-                  \ Trick"
-                Unlock Statue: 'True'
-              name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat
-              sub_areas:
-                Past Rock:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat: 'True'
-                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part: "Clawshots\
-                      \ & \\Lanayru\\Lanayru Sand Sea\\Skipper's Retreat\\Past Rock\\\
-                      Whip Peahat & \\Lanayru\\Lanayru Sand Sea\\Skipper's Retreat\\\
-                      Past Rock\\Deal with Deku Baba"
-                  hint_region: Lanayru Sand Sea
-                  locations:
-                    Chest after Moblin: 'True'
-                    Deal with Deku Baba: "\\Projectile Item | Skipper's Retreat Fast\
-                      \ Clawshots Trick & Clawshots"
-                    Goddess Cube in Skipper's Retreat: "Clawshots & \\Goddess Sword"
-                    Whip Peahat: "Clawshots & Whip"
-                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock
-                  sub_areas: {}
-                  toplevel_alias: null
-                Shack:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance: null
-                  exits:
-                    Exit: 'True'
-                  hint_region: Lanayru Sand Sea
-                  locations:
-                    Chest in Shack: Gust Bellows
-                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack
-                  sub_areas: {}
-                  toplevel_alias: null
-                Skydive Platform:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat: Clawshots
-                  hint_region: Lanayru Sand Sea
-                  locations:
-                    Skydive Chest: 'True'
-                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform
-                  sub_areas: {}
-                  toplevel_alias: null
-                Top Part:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Shack Entrance: null
-                  exits:
-                    Shack Exit: 'True'
-                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: 'True'
-                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform: 'True'
-                  hint_region: Lanayru Sand Sea
-                  locations:
-                    Chest on top of Cacti Pillar: Clawshots
-                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-          toplevel_alias: Lanayru Sand Sea
-        Lanayru Silent Realm:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance: null
-          exits:
-            Exit: 'True'
-          hint_region: Lanayru Silent Realm
-          locations:
-            Relic 1: 'True'
-            Relic 10: 'True'
-            Relic 2: 'True'
-            Relic 3: 'True'
-            Relic 4: 'True'
-            Relic 5: 'True'
-            Relic 6: 'True'
-            Relic 7: 'True'
-            Relic 8: 'True'
-            Relic 9: 'True'
-            Trial Reward: 'True'
-          name: \Lanayru\Lanayru Silent Realm
-          sub_areas: {}
-          toplevel_alias: null
-        Mine:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Lanayru Mine
-          locations: {}
-          name: \Lanayru\Mine
-          sub_areas:
-            End:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru\Mine\End\In Minecart: \Lanayru\Mine\End\Blow up Rock on Track
-                \Lanayru\Mine\Statues Area: "\\Lanayru\\Mine\\Statues Area\\Blow Statues\
-                  \ Down | Brakeslide Trick | \\Skyloft\\Central Skyloft\\Bazaar\\\
-                  Endurance Potion"
-              hint_region: Lanayru Mine
-              locations:
-                Blow up Rock on Track: 'True'
-                Chest at the End of Mine: 'True'
-                \Ancient Flower Farming: \Can Hit Timeshift Stone
-              name: \Lanayru\Mine\End
-              sub_areas:
-                In Minecart:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Desert: null
-                  exits:
-                    Exit to Desert: 'True'
-                  hint_region: Lanayru Mine
-                  locations:
-                    Blow up Rock on Track: "Bomb Bag & Lanayru Mine - Quick Bomb Trick"
-                  name: \Lanayru\Mine\End\In Minecart
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Entry:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                First Time Entrance: null
-                Statue Entrance: null
-              exits:
-                Statue Exit: \Lanayru\Mine\Entry\Unlock Statue
-                \Lanayru\Mine\Entry\Higher Area: Clawshots
-                \Lanayru\Mine\Statues Area: \Lanayru\Mine\Entry\Timeshift Stone
-              hint_region: Lanayru Mine
-              locations:
-                Chest near First Timeshift Stone: \Lanayru\Mine\Entry\Timeshift Stone
-                Goddess Cube at Lanayru Mine Entrance: \Goddess Sword
-                Timeshift Stone: "\\Can Hit Timeshift Stone | Itemless First Timeshift\
-                  \ Stone Trick"
-                Unlock Statue: 'True'
-                \Ancient Flower Farming: \Lanayru\Mine\Entry\Timeshift Stone
-              name: \Lanayru\Mine\Entry
-              sub_areas:
-                Caves Entrance:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Caves: null
-                  exits:
-                    Exit to Caves: 'True'
-                    \Lanayru\Mine\Entry\Higher Area: Clawshots
-                  hint_region: Lanayru Mine
-                  locations: {}
-                  name: \Lanayru\Mine\Entry\Caves Entrance
-                  sub_areas: {}
-                  toplevel_alias: null
-                Higher Area:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Lanayru\Mine\Entry: 'True'
-                    \Lanayru\Mine\Entry\Caves Entrance: Clawshots
-                  hint_region: Lanayru Mine
-                  locations:
-                    Chest behind First Landing: 'True'
-                  name: \Lanayru\Mine\Entry\Higher Area
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Statues Area:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru\Mine\End: "\\Lanayru\\Mine\\Statues Area\\Blow Statues Down\
-                  \ | Brakeslide Trick | \\Skyloft\\Central Skyloft\\Bazaar\\Endurance\
-                  \ Potion"
-                \Lanayru\Mine\Entry: 'True'
-              hint_region: Lanayru Mine
-              locations:
-                Blow Statues Down: "Bomb Bag | \\Hook Beetle"
-                Chest behind Statue: \Lanayru\Mine\Statues Area\Blow Statues Down
-              name: \Lanayru\Mine\Statues Area
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: Lanayru Mine
-        Temple of Time:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits:
-            Shared Statue Exit: 'False'
-          hint_region: null
-          locations: {}
-          name: \Lanayru\Temple of Time
-          sub_areas:
-            Front:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru\Temple of Time\Inside: 'True'
-                \Lanayru\Temple of Time\Near Goddess Cube: \Lanayru\Temple of Time\Near
-                  Goddess Cube\Timeshift Stone
-              hint_region: null
-              locations:
-                Blow up Rock for Timeshift Stone: "\\Hook Beetle | Bomb Throws Trick\
-                  \ & (Bomb Bag | Cactus Bomb Whip Trick & Whip)"
-                Gossip Stone in Temple of Time Area: 'True'
-                Save Robot: "\\Lanayru\\Temple of Time\\Front\\Timeshift Stone & \\\
-                  Can Defeat Bokoblins"
-                Timeshift Stone: "\\Lanayru\\Temple of Time\\Front\\Blow up Rock for\
-                  \ Timeshift Stone & \\Distance Activator"
-                \Ancient Flower Farming: \Hook Beetle
-                \Lanayru\Temple of Time\Near Goddess Cube\Timeshift Stone: "\\Long\
-                  \ Range Skyward Strike | \\Distance Activator"
-              name: \Lanayru\Temple of Time\Front
-              sub_areas: {}
-              toplevel_alias: null
-            Inside:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Lanayru Mining Facility: null
-                Temple of Time Statue Entrance: null
-              exits:
-                Exit to Lanayru Mining Facility: 'True'
-                \Lanayru\Temple of Time\Front: 'True'
-                \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\Inside\Unlock
-                  Statue
-              hint_region: null
-              locations:
-                Unlock Statue: 'True'
-              name: \Lanayru\Temple of Time\Inside
-              sub_areas: {}
-              toplevel_alias: null
-            Near Goddess Cube:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru\Temple of Time\North East: 'True'
-              hint_region: null
-              locations:
-                Goddess Cube at Ride near Temple of Time: \Goddess Sword
-                Timeshift Stone: 'False'
-              name: \Lanayru\Temple of Time\Near Goddess Cube
-              sub_areas: {}
-              toplevel_alias: null
-            North East:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                North Entrance from Desert: null
-              exits:
-                North Exit to Desert: 'True'
-                \Ancient Flower Farming: \Distance Activator
-                \Lanayru\Temple of Time\South East: \Distance Activator
-              hint_region: null
-              locations: {}
-              name: \Lanayru\Temple of Time\North East
-              sub_areas: {}
-              toplevel_alias: null
-            South East:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Desert Gorge Statue Entrance: null
-                South Entrance from Desert: null
-              exits:
-                South Exit to Desert: 'True'
-                \Lanayru\Temple of Time\Front: "\\Hook Beetle | \\Slingshot & Temple\
-                  \ of Time - Slingshot Shot Trick"
-                \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\South
-                  East\Unlock Statue
-              hint_region: null
-              locations:
-                Unlock Statue: 'True'
-                \Ancient Flower Farming: \Distance Activator
-              name: \Lanayru\Temple of Time\South East
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-      toplevel_alias: null
-    Lanayru Mining Facility:
-      abstract: true
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: Lanayru Mining Facility
-      locations:
-        Can Activate Minecart Timeshift Stone: "\\Sword | Whip | Bomb Bag | \\Distance\
-          \ Activator"
-      name: \Lanayru Mining Facility
-      sub_areas:
-        Boss Room:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance from Dungeon: null
-          exits:
-            Exit to Dungeon: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat
-              Moldarach
-            \Lanayru Mining Facility\Boss Room\After Sand Drain: 'True'
-          hint_region: Lanayru Mining Facility
-          locations: {}
-          name: \Lanayru Mining Facility\Boss Room
-          sub_areas:
-            After Sand Drain:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Hall of Ancient Robots: null
-              exits:
-                Exit to Hall of Ancient Robots: \Lanayru Mining Facility\Boss Room\After
-                  Sand Drain\Beat Moldarach
-              hint_region: Lanayru Mining Facility
-              locations:
-                Beat Moldarach: "(Gust Bellows | LMF - Moldarach without Gust Bellows\
-                  \ Trick) & \\Sword"
-                Heart Container: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat
-                  Moldarach
-              name: \Lanayru Mining Facility\Boss Room\After Sand Drain
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-        Hall of Ancient Robots:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Lanayru Mining Facility
-          locations: {}
-          name: \Lanayru Mining Facility\Hall of Ancient Robots
-          sub_areas:
-            End:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Temple of Time: null
-              exits:
-                Exit to Temple of Time: 'True'
-              hint_region: Lanayru Mining Facility
-              locations:
-                Exit Hall of Ancient Robots: 'True'
-              name: \Lanayru Mining Facility\Hall of Ancient Robots\End
-              sub_areas: {}
-              toplevel_alias: null
-            Entry:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Boss Room: null
-              exits:
-                Exit to Boss Room: 'True'
-                \Lanayru Mining Facility\Hall of Ancient Robots\End: \Lanayru Mining
-                  Facility\Hall of Ancient Robots\Entry\Hit Timeshift Stone
-              hint_region: Lanayru Mining Facility
-              locations:
-                Hit Timeshift Stone: "\\Beetle | \\Bow"
-              name: \Lanayru Mining Facility\Hall of Ancient Robots\Entry
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-        Main:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Lanayru Mining Facility
-          locations: {}
-          name: \Lanayru Mining Facility\Main
-          sub_areas:
-            Armos Fight Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Big Hub: null
-              exits:
-                Exit to Big Hub: \Lanayru Mining Facility\Main\Armos Fight Room\Defeat
-                  Armos
-              hint_region: Lanayru Mining Facility
-              locations:
-                Activate Timeshift Stone: "Gust Bellows & (\\Slingshot | \\Bow | \\\
-                  Goddess Sword | LMF - Whip Armos Room Timeshift Stone Trick & Whip)"
-                Chest after Armos Fight: \Lanayru Mining Facility\Main\Armos Fight
-                  Room\Defeat Armos
-                Defeat Armos: "\\Lanayru Mining Facility\\Main\\Armos Fight Room\\\
-                  Activate Timeshift Stone & \\Can Defeat Armos"
-              name: \Lanayru Mining Facility\Main\Armos Fight Room
-              sub_areas: {}
-              toplevel_alias: null
-            Big Hub:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits: {}
-              hint_region: Lanayru Mining Facility
-              locations: {}
-              name: \Lanayru Mining Facility\Main\Big Hub
-              sub_areas:
-                After Wooden Boxes:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Lanayru Mining Facility\Main\Big Hub\Entry: 'True'
-                    \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room: \Lanayru
-                      Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Push
-                      Box
-                  hint_region: Lanayru Mining Facility
-                  locations:
-                    First Chest in Hub Room: 'True'
-                  name: \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes
-                  sub_areas: {}
-                  toplevel_alias: null
-                Between Wind Gates:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Lanayru Mining Facility\Main\Big Hub\Entry: \Lanayru Mining Facility\Main\Big
-                      Hub\Between Wind Gates\Open First Wind Gate
-                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: \Lanayru
-                      Mining Facility\Main\Big Hub\Between Wind Gates\Activate Minecart
-                      Stone to Boss Key Room
-                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: \Lanayru
-                      Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Push
-                      Box
-                  hint_region: Lanayru Mining Facility
-                  locations:
-                    Activate Minecart Stone to Boss Key Room: "Gust Bellows & \\Lanayru\
-                      \ Mining Facility\\Can Activate Minecart Timeshift Stone"
-                    Get Minecart: \Lanayru Mining Facility\Main\Near Boss Door\Open
-                      Second Wind Gate
-                    Open First Wind Gate: "\\Lanayru Mining Facility\\Main\\Big Hub\\\
-                      Between Wind Gates\\Get Minecart & \\Lanayru Mining Facility\\\
-                      Can Activate Minecart Timeshift Stone & Gust Bellows"
-                    Unlock Exit to Boss Key Room: "\\Lanayru Mining Facility\\Main\\\
-                      Big Hub\\Between Wind Gates\\Activate Minecart Stone to Boss\
-                      \ Key Room & Gust Bellows"
-                  name: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates
-                  sub_areas: {}
-                  toplevel_alias: null
-                Entry:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from First Hub: null
-                  exits:
-                    Exit to First Hub: 'True'
-                    \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: \Lanayru
-                      Mining Facility\Main\Big Hub\Entry\Blow Up Boxes
-                    \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: \Lanayru
-                      Mining Facility\Main\Big Hub\Between Wind Gates\Open First Wind
-                      Gate
-                    \Lanayru Mining Facility\Main\Big Hub\Past West Gate: \Lanayru
-                      Mining Facility\Main\Big Hub\Past West Gate\Open Gate
-                  hint_region: Lanayru Mining Facility
-                  locations:
-                    Blow Up Boxes: "Bomb Bag | \\Hook Beetle"
-                  name: \Lanayru Mining Facility\Main\Big Hub\Entry
-                  sub_areas: {}
-                  toplevel_alias: null
-                Near Boss Key Room First Exit:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Lanayru Mining Facility\Main\Boss Key Room: \Lanayru Mining Facility\Main\Big
-                      Hub\Between Wind Gates\Unlock Exit to Boss Key Room
-                  hint_region: Lanayru Mining Facility
-                  locations: {}
-                  name: \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First
-                    Exit
-                  sub_areas: {}
-                  toplevel_alias: null
-                Near Boss Key Room Second Exit:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: 'True'
-                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: 'True'
-                    \Lanayru Mining Facility\Main\Near Boss Door: "Gust Bellows |\
-                      \ LMF - Minecart Jump Trick & \\Sword & (Bomb Bag | \\Beetle)"
-                  hint_region: Lanayru Mining Facility
-                  locations:
-                    Push Box: 'True'
-                    Shortcut Chest in Main Hub: 'True'
-                  name: \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second
-                    Exit
-                  sub_areas: {}
-                  toplevel_alias: null
-                Near Exit to Hop Across Boxes Room:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Hop Across Boxes Room: null
-                  exits:
-                    Exit to Hop Across Boxes Room: 'True'
-                    \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: 'True'
-                  hint_region: Lanayru Mining Facility
-                  locations:
-                    Push Box: 'True'
-                  name: \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across
-                    Boxes Room
-                  sub_areas: {}
-                  toplevel_alias: null
-                Past West Gate:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Armos Fight Room: null
-                  exits:
-                    Exit to Armos Fight Room: 'True'
-                    \Lanayru Mining Facility\Main\Big Hub\Entry: \Lanayru Mining Facility\Main\Big
-                      Hub\Past West Gate\Open Gate
-                    \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze: \Lanayru
-                      Mining Facility\Main\Big Hub\Past West Gate\Blow Off Pile for
-                      Second Crawlspace
-                  hint_region: Lanayru Mining Facility
-                  locations:
-                    Blow Off Pile for First Crawlspace: Gust Bellows
-                    Blow Off Pile for Second Crawlspace: Gust Bellows
-                    Chest behind First Crawlspace: \Lanayru Mining Facility\Main\Big
-                      Hub\Past West Gate\Blow Off Pile for First Crawlspace
-                    Open Gate: 'True'
-                  name: \Lanayru Mining Facility\Main\Big Hub\Past West Gate
-                  sub_areas: {}
-                  toplevel_alias: null
-                Sand Spike Maze:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Lanayru Mining Facility\Main\Near Boss Door: "\\Lanayru Mining\
-                      \ Facility\\Main\\Big Hub\\Sand Spike Maze\\Switch under Sand\
-                      \ & \\Lanayru Mining Facility\\Can Activate Minecart Timeshift\
-                      \ Stone"
-                  hint_region: Lanayru Mining Facility
-                  locations:
-                    Chest in Spike Maze: Gust Bellows
-                    Switch under Sand: Gust Bellows
-                  name: \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Boss Key Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: \Lanayru
-                  Mining Facility\Main\Boss Key Room\Can Beat Room
-              hint_region: Lanayru Mining Facility
-              locations:
-                Boss Key Chest: \Lanayru Mining Facility\Main\Boss Key Room\Can Beat
-                  Room
-                Can Beat Room: "Bomb Bag & Gust Bellows & \\Sword"
-              name: \Lanayru Mining Facility\Main\Boss Key Room
-              sub_areas: {}
-              toplevel_alias: null
-            First Hub:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Big Hub: null
-              exits:
-                Exit to Big Hub: 'True'
-                \Lanayru Mining Facility\Main\First Room: 'True'
-                \Lanayru Mining Facility\Main\First West Room: \Lanayru Mining Facility\Main\First
-                  Hub\Push Box on Switch
-                \Lanayru Mining Facility\Main\Key Locked Room: Lanayru Mining Facility
-                  Small Key
-              hint_region: Lanayru Mining Facility
-              locations:
-                Push Box on Switch: Gust Bellows
-              name: \Lanayru Mining Facility\Main\First Hub
-              sub_areas: {}
-              toplevel_alias: null
-            First Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Main Entrance: null
-              exits:
-                Main Exit: 'True'
-                \Lanayru Mining Facility\Main\First Hub: \Lanayru Mining Facility\Main\First
-                  Room\Left Lever
-              hint_region: Lanayru Mining Facility
-              locations:
-                Chest behind Bars: \Lanayru Mining Facility\Main\First Room\Right
-                  Lever
-                Left Lever: "\\Hook Beetle | Whip & LMF - Whip First Room Switch Trick"
-                Right Lever: 'True'
-              name: \Lanayru Mining Facility\Main\First Room
-              sub_areas: {}
-              toplevel_alias: null
-            First West Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru Mining Facility\Main\Armos Fight Room: "Gust Bellows & \\\
-                  Can Defeat Beamos"
-                \Lanayru Mining Facility\Main\First Hub: 'True'
-              hint_region: Lanayru Mining Facility
-              locations:
-                Chest in First West Room: Gust Bellows
-              name: \Lanayru Mining Facility\Main\First West Room
-              sub_areas: {}
-              toplevel_alias: null
-            Hop Across Boxes Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit: "\\\
-                  Lanayru Mining Facility\\Main\\Hop Across Boxes Room\\Blow Up Rocks\
-                  \ | \\Lanayru Mining Facility\\Main\\Hop Across Boxes Room\\Near\
-                  \ Exit\\Push Shortcut Box"
-              hint_region: Lanayru Mining Facility
-              locations:
-                Blow Up Rocks: "\\Sword | \\Slingshot | \\Beetle | Bomb Bag | Gust\
-                  \ Bellows | Whip | Clawshots | \\Bow"
-                Lower Chest in Hop across Boxes Room: \Lanayru Mining Facility\Main\Hop
-                  Across Boxes Room\Blow Up Rocks
-                Raised Chest in Hop across Boxes Room: \Lanayru Mining Facility\Main\Hop
-                  Across Boxes Room\Blow Up Rocks
-              name: \Lanayru Mining Facility\Main\Hop Across Boxes Room
-              sub_areas:
-                Near Exit:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance from Big Hub: null
-                  exits:
-                    Exit to Big Hub: \Lanayru Mining Facility\Main\Hop Across Boxes
-                      Room\Near Exit\Remove Dust Pile at Door
-                  hint_region: Lanayru Mining Facility
-                  locations:
-                    Push Shortcut Box: 'True'
-                    Remove Dust Pile at Door: 'True'
-                  name: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Key Locked Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Lanayru Mining Facility\Main\First Hub: 'True'
-                \Lanayru Mining Facility\Main\Hop Across Boxes Room: \Lanayru Mining
-                  Facility\Main\Key Locked Room\Activate Timeshift Stone
-              hint_region: Lanayru Mining Facility
-              locations:
-                Activate Timeshift Stone: "\\Lanayru Mining Facility\\Main\\Key Locked\
-                  \ Room\\Blow Up Boxes & (\\Bow | \\Beetle | \\Slingshot & LMF -\
-                  \ Keylocked Slingshot Trickshot Trick)"
-                Blow Up Boxes: "\\Hook Beetle | Bomb Bag & Bomb Throws Trick"
-                Chest in Key Locked Room: \Lanayru Mining Facility\Main\Key Locked
-                  Room\Activate Timeshift Stone
-              name: \Lanayru Mining Facility\Main\Key Locked Room
-              sub_areas: {}
-              toplevel_alias: null
-            Near Boss Door:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Boss Door Entrance: null
-              exits:
-                Boss Door Exit: "Lanayru Mining Facility Boss Key & \\Lanayru Mining\
-                  \ Facility\\Can Activate Minecart Timeshift Stone"
-                \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: "\\Lanayru\
-                  \ Mining Facility\\Main\\Near Boss Door\\Open Second Wind Gate &\
-                  \ \\Can Defeat Beamos"
-                \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: "LMF\
-                  \ - Minecart Jump Trick & \\Sword & (Bomb Bag | \\Beetle)"
-              hint_region: Lanayru Mining Facility
-              locations:
-                Get Minecart to Wind Gate: "Gust Bellows & \\Lanayru Mining Facility\\\
-                  Can Activate Minecart Timeshift Stone"
-                Open Second Wind Gate: "\\Lanayru Mining Facility\\Main\\Near Boss\
-                  \ Door\\Get Minecart to Wind Gate & Gust Bellows"
-              name: \Lanayru Mining Facility\Main\Near Boss Door
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-      toplevel_alias: null
-    Sandship:
-      abstract: true
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: Sandship
-      locations:
-        Pass Spume: "\\Goddess Sword | \\Bow | Bomb Bag | \\Slingshot | Sandship -\
-          \ Itemless Spume Skip Trick"
-      name: \Sandship
-      sub_areas:
-        Boss Room:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance: null
-          exits: {}
-          hint_region: Sandship
-          locations:
-            Beat Tentalus: \Bow
-            Heart Container: \Sandship\Boss Room\Beat Tentalus
-            Nayru's Flame: "\\Sandship\\Boss Room\\Beat Tentalus & \\Goddess Sword"
-          name: \Sandship\Boss Room
-          sub_areas: {}
-          toplevel_alias: null
-        Main:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Sandship
-          locations: {}
-          name: \Sandship\Main
-          sub_areas:
-            Before Boss Door:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                Boss Door one-way Exit: \Sandship\Main\Before Boss Door\Open Boss
-                  Door
-                \Sandship\Main\Corridor: 'True'
-              hint_region: Sandship
-              locations:
-                Chest behind Combination Lock: \Sandship\Main\Before Boss Door\Combination
-                  Lock
-                Combination Lock: "(Gust Bellows | \\Sandship\\Main\\Deck\\Freely\
-                  \ Usable Timeshift Stone | Sandship - No Combination Hint Trick)\
-                  \ & \\Can Unlock Combination Lock"
-                Open Boss Door: "\\Sandship\\Main\\Deck\\Freely Usable Timeshift Stone\
-                  \ & Sandship Boss Key"
-              name: \Sandship\Main\Before Boss Door
-              sub_areas: {}
-              toplevel_alias: null
-            Before Ship's Bow:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sandship\Main\Corridor: "\\Sandship\\Pass Spume | \\Sandship\\Main\\\
-                  Deck\\Freely Usable Timeshift Stone"
-                \Sandship\Main\Ship's Bow: Sandship Small Key x 2
-              hint_region: Sandship
-              locations:
-                Chest before 4-Door Corridor: \Sandship\Main\Deck\Freely Usable Timeshift
-                  Stone
-              name: \Sandship\Main\Before Ship's Bow
-              sub_areas: {}
-              toplevel_alias: null
-            Brig:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sandship\Main\Brig Prison: "\\Sandship\\Main\\Starboard Rooms\\Generator\
-                  \ & Whip & \\Sandship\\Main\\Port Rooms\\Generator"
-                \Sandship\Main\Starboard Rooms: \Sandship\Main\Starboard Rooms\Switch
-                \Sandship\Main\Treasure Room: "\\Sandship\\Main\\Starboard Rooms\\\
-                  Generator & Whip"
-              hint_region: Sandship
-              locations: {}
-              name: \Sandship\Main\Brig
-              sub_areas: {}
-              toplevel_alias: null
-            Brig Prison:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sandship\Main\Brig: 'True'
-              hint_region: Sandship
-              locations:
-                Robot in Brig's Reward: 'True'
-              name: \Sandship\Main\Brig Prison
-              sub_areas: {}
-              toplevel_alias: null
-            Corridor:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sandship\Main\Before Boss Door: 'True'
-                \Sandship\Main\Before Ship's Bow: "\\Sandship\\Pass Spume | \\Sandship\\\
-                  Main\\Deck\\Freely Usable Timeshift Stone"
-                \Sandship\Main\Port Rooms: \Sandship\Main\Port Rooms\Switch
-                \Sandship\Main\Starboard Rooms: \Sandship\Main\Deck\Freely Usable
-                  Timeshift Stone
-              hint_region: Sandship
-              locations:
-                \Sandship\Main\Port Rooms\Switch: \Bow
-              name: \Sandship\Main\Corridor
-              sub_areas: {}
-              toplevel_alias: null
-            Deck:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Main Entrance: null
-              exits:
-                Main Exit: 'True'
-                \Sandship\Main\Before Ship's Bow: 'True'
-                \Sandship\Main\Deck\Captain's Cabin: "Sandship Small Key x 2 & (\\\
-                  Sandship\\Main\\Deck\\Start Mast Sequence | \\Sandship\\Main\\Deck\\\
-                  Freely Usable Timeshift Stone)"
-                \Sandship\Main\Deck\Mast: "\\Sandship\\Main\\Deck\\Start Mast Sequence\
-                  \ | \\Sandship\\Main\\Deck\\Freely Usable Timeshift Stone"
-                \Sandship\Main\Starboard Rooms: "\\Sandship\\Main\\Starboard Rooms\\\
-                  Switch & \\Bow"
-              hint_region: Sandship
-              locations:
-                Freely Usable Timeshift Stone: "\\Sandship\\Main\\Deck\\Mast\\Finish\
-                  \ Mast Sequence & \\Bow"
-                Raise Timeshift Stone: \Bow
-                Start Mast Sequence: "\\Sandship\\Main\\Deck\\Raise Timeshift Stone\
-                  \ & \\Bow"
-              name: \Sandship\Main\Deck
-              sub_areas:
-                Captain's Cabin:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sandship\Main\Deck: Sandship Small Key x 2
-                  hint_region: Sandship
-                  locations:
-                    Bars: \Can Defeat Beamos
-                    Boss Key Chest: "\\Sandship\\Main\\Deck\\Captain's Cabin\\Switch\
-                      \ & \\Sandship\\Main\\Deck\\Captain's Cabin\\Bars"
-                    Switch: "\\Bow & \\Sandship\\Main\\Deck\\Freely Usable Timeshift\
-                      \ Stone"
-                  name: \Sandship\Main\Deck\Captain's Cabin
-                  sub_areas: {}
-                  toplevel_alias: null
-                Mast:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sandship\Main\Deck: 'True'
-                    \Sandship\Main\Deck\Stern: "\\Bow & (Clawshots | Sandship - Mast\
-                      \ Jump Trick)"
-                  hint_region: Sandship
-                  locations:
-                    Finish Mast Sequence: "\\Bow & \\Sword"
-                  name: \Sandship\Main\Deck\Mast
-                  sub_areas: {}
-                  toplevel_alias: null
-                Stern:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sandship\Main\Deck: Clawshots
-                  hint_region: Sandship
-                  locations:
-                    Chest at the Stern: 'True'
-                  name: \Sandship\Main\Deck\Stern
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Port Rooms:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sandship\Main\Corridor: \Sandship\Main\Port Rooms\Switch
-              hint_region: Sandship
-              locations:
-                Generator: "\\Bow & \\Sandship\\Main\\Deck\\Freely Usable Timeshift\
-                  \ Stone"
-                Switch: \Bow
-              name: \Sandship\Main\Port Rooms
-              sub_areas: {}
-              toplevel_alias: null
-            Ship's Bow:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sandship\Main\Before Ship's Bow: \Lanayru\Caves\Chest
-              hint_region: Sandship
-              locations:
-                Chest after Scervo Fight: \Can Defeat Scervo/Dreadfuse
-              name: \Sandship\Main\Ship's Bow
-              sub_areas: {}
-              toplevel_alias: null
-            Starboard Rooms:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sandship\Main\Brig: \Sandship\Main\Starboard Rooms\Switch
-                \Sandship\Main\Corridor: \Sandship\Main\Deck\Freely Usable Timeshift
-                  Stone
-                \Sandship\Main\Deck: "\\Sandship\\Main\\Starboard Rooms\\Switch &\
-                  \ \\Bow"
-              hint_region: Sandship
-              locations:
-                Generator: "\\Bow & \\Sandship\\Main\\Deck\\Freely Usable Timeshift\
-                  \ Stone"
-                Switch: 'True'
-              name: \Sandship\Main\Starboard Rooms
-              sub_areas: {}
-              toplevel_alias: null
-            Treasure Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sandship\Main\Brig: 'True'
-              hint_region: Sandship
-              locations:
-                Treasure Room Fifth Chest: 'True'
-                Treasure Room First Chest: 'True'
-                Treasure Room Fourth Chest: 'True'
-                Treasure Room Second Chest: 'True'
-                Treasure Room Third Chest: 'True'
-              name: \Sandship\Main\Treasure Room
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-      toplevel_alias: null
-    Sky:
-      abstract: false
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: Sky
-      locations: {}
-      name: \Sky
-      sub_areas:
-        Around Skyloft:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance from Skyloft: null
-            Entrance from Thunderhead: null
-          exits:
-            Exit to Skyloft: 'True'
-            Exit to Thunderhead: "Open Thunderhead option | Ballad of the Goddess"
-            \Sky\North East: 'True'
-            \Sky\South East: 'True'
-            \Sky\South West: 'True'
-          hint_region: Sky
-          locations: {}
-          name: \Sky\Around Skyloft
-          sub_areas: {}
-          toplevel_alias: null
-        North East:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits:
-            \Sky\Around Skyloft: 'True'
-            \Sky\North East\Bamboo Island: 'True'
-            \Sky\North East\Beedle's Island: 'True'
-            \Sky\North East\Beedle's Island\Cage: Sky - Beedle's Island Cage Chest
-              Dive Trick
-            \Sky\North East\Beedle's Island\Top: 'True'
-            \Sky\North East\Eldin Pillar: 'True'
-            \Sky\South East: 'True'
-          hint_region: Sky
-          locations:
-            Goddess Chest in Cave on Island next to Bamboo Island: "\\Lanayru\\Desert\\\
-              North Part\\Secret Passageway\\Goddess Cube in Secret Passageway & Water\
-              \ Dragon's Scale"
-            Goddess Chest on Island next to Bamboo Island: \Eldin\Volcano\East\Goddess
-              Cube near Mogma Turf Entrance
-            Northeast Island Cage Goddess Chest: \Eldin\Volcano\Near Temple Entrance\Goddess
-              Cube East of Earth Temple Entrance
-            Northeast Island Goddess Chest behind Bombable Rocks: "\\Lanayru\\Mine\\\
-              Entry\\Goddess Cube at Lanayru Mine Entrance & Bomb Bag"
-          name: \Sky\North East
-          sub_areas:
-            Bamboo Island:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Inside: null
-              exits:
-                Exit to Inside: 'True'
-                \Sky\North East: Day
-              hint_region: Sky
-              locations:
-                Bamboo Island Goddess Chest: \Eldin\Volcano\Near Temple Entrance\Goddess
-                  Cube West of Earth Temple Entrance
-              name: \Sky\North East\Bamboo Island
-              sub_areas:
-                Inside:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance: null
-                  exits:
-                    Exit: 'True'
-                  hint_region: Sky
-                  locations:
-                    Clean Cut Minigame: \Sword
-                    Gossip Stone on Bamboo Island: 'True'
-                  name: \Sky\North East\Bamboo Island\Inside
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Beedle's Island:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Beedle's Ship Entrance: null
-              exits:
-                Beedle's Ship Exit: Night
-                \Sky\North East: Day
-                \Sky\North East\Beedle's Island\Cage: Night
-              hint_region: Sky
-              locations:
-                Beedle's Crystals: "Horned Colossus Beetle & Night"
-                Crystal on Beedle's Ship: "Night & \\Beetle"
-              name: \Sky\North East\Beedle's Island
-              sub_areas:
-                Cage:
-                  abstract: false
-                  allowed_time_of_day: 3
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky\North East\Beedle's Island: 'True'
-                  hint_region: Sky
-                  locations:
-                    Beedle's Island Cage Goddess Chest: \Faron\Faron Woods\Deep Woods\Goddess
-                      Cube on top of Skyview
-                  name: \Sky\North East\Beedle's Island\Cage
-                  sub_areas: {}
-                  toplevel_alias: null
-                Top:
-                  abstract: false
-                  allowed_time_of_day: 3
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky\North East\Beedle's Island: 'True'
-                  hint_region: Sky
-                  locations:
-                    Beedle's Island Goddess Chest: \Lanayru\Temple of Time\Near Goddess
-                      Cube\Goddess Cube at Ride near Temple of Time
-                  name: \Sky\North East\Beedle's Island\Top
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Eldin Pillar:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-              exits:
-                Fire Sanctuary Statue Dive: "Ruby Tablet & \\Fire Sanctuary\\Main\\\
-                  Front of Boss Door\\Unlock Statue"
-                First Time Dive: Ruby Tablet
-                Inside the Volcano Statue Dive: "Ruby Tablet & \\Eldin\\Volcano Summit\\\
-                  Outside Fire Sanctuary\\Unlock Statue"
-                Temple Entrance Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\Near\
-                  \ Temple Entrance\\Unlock Statue"
-                Volcano Ascent Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\Ascent\\\
-                  Unlock Statue"
-                Volcano East Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\East\\\
-                  Unlock Statue"
-                Volcano Entrance Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\Entry\\\
-                  Unlock Statue"
-                \Sky\North East: 'True'
-              hint_region: Sky
-              locations: {}
-              name: \Sky\North East\Eldin Pillar
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-        South East:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits:
-            \Sky\Around Skyloft: 'True'
-            \Sky\North East: 'True'
-            \Sky\South East\Faron Pillar: 'True'
-            \Sky\South East\Lumpy Pumpkin: 'True'
-            \Sky\South West: 'True'
-          hint_region: Sky
-          locations:
-            Chest in Breakable Boulder near Lumpy Pumpkin: Spiral Charge
-            Goddess Chest on Island Closest to Faron Pillar: \Faron\Faron Woods\Deep
-              Woods\Goddess Cube in Deep Woods
-          name: \Sky\South East
-          sub_areas:
-            Faron Pillar:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-              exits:
-                Behind the Temple Statue Dive: "Emerald Tablet & \\Faron\\Sealed Grounds\\\
-                  Behind the Temple\\Unlock Statue"
-                Deep Woods Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\Deep\
-                  \ Woods\\Unlock Deep Woods Statue"
-                Faron Woods Entry Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
-                  Entry\\Unlock Statue"
-                First Time Dive: Emerald Tablet
-                Floria Waterfall Statue Dive: "Emerald Tablet & \\Faron\\Lake Floria\\\
-                  Waterfall\\Unlock Statue"
-                Forest Temple Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
-                  Deep Woods\\Unlock Forest Temple Statue"
-                In the Woods Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
-                  Unlock In the Woods Statue"
-                Lake Floria Statue Dive: "Emerald Tablet & \\Faron\\Lake Floria\\\
-                  Below Rock\\Emerged Area\\Unlock Statue"
-                Sealed Grounds Statue Dive: "Emerald Tablet & \\Faron\\Sealed Grounds\\\
-                  Spiral\\Upper Part\\Unlock Statue"
-                The Great Tree Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
-                  Great Tree\\Top\\Unlock Statue"
-                Viewing Platform Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
-                  Unlock Viewing Platform Statue"
-                \Sky\South East: 'True'
-              hint_region: Sky
-              locations: {}
-              name: \Sky\South East\Faron Pillar
-              sub_areas: {}
-              toplevel_alias: null
-            Lumpy Pumpkin:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Back Door Entrance: null
-                Main Left Door Entrance: null
-                Main Right Door Entrance: null
-              exits:
-                Back Door Exit: 'True'
-                Main Left Door Exit: 'True'
-                Main Right Door Exit: 'True'
-                \Sky\South East: Day
-              hint_region: Sky
-              locations:
-                Crystal outside Lumpy Pumpkin: Night
-                Goddess Chest on the Roof: "\\Skyview\\Spring\\Goddess Cube in Skyview\
-                  \ Spring & Day"
-                Gossip Stone on Lumpy Pumpkin: 'True'
-                Kina's Crystals: "\\Eldin\\Mogma Turf\\Pre Vent\\Pick up Guld & Day"
-                Outside Goddess Chest: \Faron\Faron Woods\Deep Woods\Initial Goddess
-                  Cube
-                Pumpkin Carrying: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy Pumpkin\
-                  \ Building\\Complete Hot Soup Delivery & Day"
-                Start Kina's Quest: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy Pumpkin\
-                  \ Building\\Complete Hot Soup Delivery & Day"
-              name: \Sky\South East\Lumpy Pumpkin
-              sub_areas:
-                Lumpy Pumpkin Building:
-                  abstract: false
-                  allowed_time_of_day: 3
-                  can_save: false
-                  can_sleep: true
-                  entrances: !!set
-                    Back Door Entrance: null
-                    Main Left Door Entrance: null
-                    Main Right Door Entrance: null
-                  exits:
-                    Back Door Exit: 'True'
-                    Main Left Door Exit: 'True'
-                    Main Right Door Exit: 'True'
-                  hint_region: Sky
-                  locations:
-                    Break the Chandelier: 'True'
-                    Chandelier: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Break
-                      the Chandelier
-                    Complete Hot Soup Delivery: \Skyloft\Upper Skyloft\Sparring Hall\Delivered
-                      Hot Soup
-                    Crystal inside Lumpy Pumpkin: Night
-                    Harp Minigame: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Play
-                      the Harp with Kina
-                    Pick up Levias' Soup: Spiral Charge
-                    Play the Harp with Kina: "\\Sky\\South East\\Lumpy Pumpkin\\Pumpkin\
-                      \ Carrying & Goddess's Harp & Night"
-                    Start Hot Soup Delivery: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy\
-                      \ Pumpkin Building\\Break the Chandelier & \\Bottle"
-                  name: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-          toplevel_alias: null
-        South West:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits:
-            \Sky\Around Skyloft: 'True'
-            \Sky\South East: 'True'
-            \Sky\South West\Fun Fun Island: 'True'
-            \Sky\South West\Lanayru Pillar: 'True'
-            \Sky\South West\Orielle's Island: 'True'
-            \Sky\South West\Triple Island: 'True'
-            \Sky\South West\Volcanic Island: 'True'
-          hint_region: Sky
-          locations:
-            Chest in Breakable Boulder near Fun Fun Island: Spiral Charge
-          name: \Sky\South West
-          sub_areas:
-            Fun Fun Island:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sky\South West: Day
-              hint_region: Sky
-              locations:
-                Dodoh's Crystals: \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve
-                  Party Wheel
-                Fun Fun Island Minigame: \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve
-                  Party Wheel
-                Fun Fun Island Minigame -- 500 Rupees: \Sky\South West\Fun Fun Island\Fun
-                  Fun Island Minigame
-                Goddess Chest under Fun Fun Island: \Faron\Lake Floria\Waterfall\Goddess
-                  Cube in Floria Waterfall
-                Start Dodoh's Quest: 'True'
-              name: \Sky\South West\Fun Fun Island
-              sub_areas: {}
-              toplevel_alias: null
-            Lanayru Pillar:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-              exits:
-                Ancient Harbour Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru Sand\
-                  \ Sea\\Ancient Harbour\\Unlock Statue"
-                Desert Entrance Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\Entry\\\
-                  Unlock Statue"
-                Desert Gorge Statue Dive: "Amber Tablet & \\Lanayru\\Temple of Time\\\
-                  South East\\Unlock Statue"
-                First Time Dive: Amber Tablet
-                Lanayru Gorge Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru Sand\
-                  \ Sea\\Gorge\\Unlock Statue"
-                Lanayru Mine Entry Statue Dive: "Amber Tablet & \\Lanayru\\Mine\\\
-                  Entry\\Unlock Statue"
-                North Desert Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\North\
-                  \ Part\\Unlock Statue"
-                Pirate Stronghold Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru\
-                  \ Sand Sea\\Pirate Stronghold\\Unlock Statue"
-                Shipyard Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru Sand Sea\\\
-                  Shipyard\\Unlock Statue"
-                Skipper's Retreat Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru\
-                  \ Sand Sea\\Skipper's Retreat\\Unlock Statue"
-                Stone Cache Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\East\\\
-                  Unlock Statue"
-                Temple of Time Statue Dive: "Amber Tablet & \\Lanayru\\Temple of Time\\\
-                  Inside\\Unlock Statue"
-                West Desert Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\West Part\\\
-                  Unlock Statue"
-                \Sky\South West: 'True'
-              hint_region: Sky
-              locations: {}
-              name: \Sky\South West\Lanayru Pillar
-              sub_areas: {}
-              toplevel_alias: null
-            Orielle's Island:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sky\South West: Day
-              hint_region: Sky
-              locations:
-                Orielle's Crystals: \Sky\South West\Orielle's Island\Save Orielle
-                Save Orielle: \Bottle
-                Talk to Orielle: 'True'
-              name: \Sky\South West\Orielle's Island
-              sub_areas: {}
-              toplevel_alias: null
-            Triple Island:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sky\South West: Day
-              hint_region: Sky
-              locations:
-                Southwest Triple Island Cage Goddess Chest: "\\Lanayru\\Lanayru Sand\
-                  \ Sea\\Skipper's Retreat\\Past Rock\\Goddess Cube in Skipper's Retreat\
-                  \ & Clawshots"
-                Southwest Triple Island Lower Goddess Chest: \Lanayru\Desert\Near
-                  Caged Robot\Goddess Cube near Caged Robot
-                Southwest Triple Island Upper Goddess Chest: \Eldin\Volcano\Entry\Goddess
-                  Cube at Eldin Entrance
-              name: \Sky\South West\Triple Island
-              sub_areas: {}
-              toplevel_alias: null
-            Volcanic Island:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sky\South West: Day
-              hint_region: Sky
-              locations:
-                Goddess Chest inside Volcanic Island: "\\Faron\\Faron Woods\\Clawshot\
-                  \ Target Branch\\Goddess Cube on East Great Tree with Clawshots\
-                  \ Target & (Clawshots | Sky - Volcanic Island Dive Trick)"
-                Goddess Chest outside Volcanic Island: \Lanayru\Desert\Sand Oasis\Goddess
-                  Cube in Sand Oasis
-                Gossip Stone on Volcanic Island: 'True'
-              name: \Sky\South West\Volcanic Island
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-        Thunderhead:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance: null
-          exits:
-            Exit: 'True'
-            \Sky\Thunderhead\Bug Heaven: 'True'
-            \Sky\Thunderhead\East Island: 'True'
-            \Sky\Thunderhead\Isle of Songs: 'True'
-            \Sky\Thunderhead\Mogma Mitts Island: 'True'
-          hint_region: Thunderhead
-          locations:
-            Song from Levias: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy Pumpkin Building\\\
-              Pick up Levias' Soup & Spiral Charge & Scrapper & \\Sword"
-          name: \Sky\Thunderhead
-          sub_areas:
-            Bug Heaven:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sky\Thunderhead: Day
-              hint_region: Thunderhead
-              locations:
-                Bug Heaven -- 10 Bugs in 3 Minutes: \Bug Net
-                Bug Heaven Goddess Chest: \Eldin\Volcano Summit\Waterfall\Goddess
-                  Cube in Summit Waterfall
-                Gossip Stone near Bug Heaven: 'True'
-              name: \Sky\Thunderhead\Bug Heaven
-              sub_areas: {}
-              toplevel_alias: null
-            East Island:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sky\Thunderhead: Day
-              hint_region: Thunderhead
-              locations:
-                East Island Chest: "\\Digging Mitts | Thunderhead - East Island Dive\
-                  \ Trick"
-                East Island Goddess Chest: \Faron\Faron Woods\Rope Branch\Goddess
-                  Cube on East Great Tree with Rope
-              name: \Sky\Thunderhead\East Island
-              sub_areas: {}
-              toplevel_alias: null
-            Isle of Songs:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Inside: null
-              exits:
-                Exit to Inside: \Sky\Thunderhead\Isle of Songs\Puzzle Solved
-                \Sky\Thunderhead: Day
-              hint_region: Thunderhead
-              locations:
-                Goddess Chest on top of Isle of Songs: \Eldin\Volcano Summit\Outside
-                  Fire Sanctuary\Goddess Cube near Fire Sanctuary Entrance
-                Goddess Chest outside Isle of Songs: \Eldin\Mogma Turf\Pre Vent\Goddess
-                  Cube in Mogma Turf
-                Puzzle Solved: 'True'
-              name: \Sky\Thunderhead\Isle of Songs
-              sub_areas:
-                Inside:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Entrance: null
-                  exits:
-                    Exit: 'True'
-                  hint_region: Thunderhead
-                  locations:
-                    Strike Crest with Goddess Sword: \Goddess Sword
-                    Strike Crest with Longsword: \Goddess Longsword
-                    Strike Crest with White Sword: \Goddess White Sword
-                  name: \Sky\Thunderhead\Isle of Songs\Inside
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Mogma Mitts Island:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sky\Thunderhead: Day
-              hint_region: Thunderhead
-              locations:
-                First Goddess Chest on Mogma Mitts Island: "\\Eldin\\Volcano Summit\\\
-                  Goddess Cube inside Volcano Summit & \\Mogma Mitts"
-                Second Goddess Chest on Mogma Mitts Island: "\\Lanayru\\Lanayru Sand\
-                  \ Sea\\Gorge\\Beyond Bridge\\Goddess Cube in Lanayru Gorge & \\\
-                  Mogma Mitts"
-              name: \Sky\Thunderhead\Mogma Mitts Island
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-      toplevel_alias: null
-    Sky Keep:
-      abstract: false
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: Sky Keep
-      locations: {}
-      name: \Sky Keep
-      sub_areas:
-        Main:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Sky Keep
-          locations: {}
-          name: \Sky Keep\Main
-          sub_areas:
-            Ancient Cistern Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sky Keep\Main\Ancient Cistern Room\After Key: \Sky Keep\Main\Ancient
-                  Cistern Room\Unlock Key Door
-                \Sky Keep\Main\Ancient Cistern Room\Triforce Room: \Sky Keep\Main\Ancient
-                  Cistern Room\Triforce Room\Lever
-              hint_region: Sky Keep
-              locations:
-                Bottom Exit: 'True'
-                Right Exit: 'True'
-                Unlock Key Door: Sky Keep Small Key
-              name: \Sky Keep\Main\Ancient Cistern Room
-              sub_areas:
-                After Key:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Ancient Cistern Room\Triforce Room: \Sky Keep\Main\Ancient
-                      Cistern Room\After Key\Beat Trial
-                  hint_region: Sky Keep
-                  locations:
-                    Beat Trial: "\\Can Defeat Moblins & \\Can Defeat Bokoblins & \\\
-                      Can Defeat Stalfos & \\Bow & \\Can Defeat Cursed Bokoblins &\
-                      \ \\Can Defeat Stalmaster"
-                  name: \Sky Keep\Main\Ancient Cistern Room\After Key
-                  sub_areas: {}
-                  toplevel_alias: null
-                Triforce Room:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Ancient Cistern Room: \Sky Keep\Main\Ancient Cistern
-                      Room\Triforce Room\Lever
-                    \Sky Keep\Main\Ancient Cistern Room\After Key: 'True'
-                  hint_region: Sky Keep
-                  locations:
-                    Lever: 'True'
-                    Sacred Power of Farore: 'True'
-                  name: \Sky Keep\Main\Ancient Cistern Room\Triforce Room
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Earth Temple Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits: {}
-              hint_region: Sky Keep
-              locations:
-                Right Exit: 'False'
-                Top Exit: 'False'
-              name: \Sky Keep\Main\Earth Temple Room
-              sub_areas: {}
-              toplevel_alias: null
-            Fire Sanctuary Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits: {}
-              hint_region: Sky Keep
-              locations: {}
-              name: \Sky Keep\Main\Fire Sanctuary Room
-              sub_areas:
-                First Platform:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: "\\Beetle &\
-                      \ Clawshots"
-                  hint_region: Sky Keep
-                  locations:
-                    Lever: 'True'
-                    Rupee in Fire Sanctuary Room in Alcove: \Beetle
-                  name: \Sky Keep\Main\Fire Sanctuary Room\First Platform
-                  sub_areas: {}
-                  toplevel_alias: null
-                From Left:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: \Sky Keep\Main\Fire
-                      Sanctuary Room\Triforce Room\Lower Lever
-                  hint_region: Sky Keep
-                  locations:
-                    Left Exit: 'True'
-                  name: \Sky Keep\Main\Fire Sanctuary Room\From Left
-                  sub_areas: {}
-                  toplevel_alias: null
-                From Right:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Fire Sanctuary Room\First Platform: "\\Beetle |\
-                      \ \\Sky Keep\\Main\\Fire Sanctuary Room\\First Platform\\Lever"
-                    \Sky Keep\Main\Fire Sanctuary Room\OoB: "Clawshots & Sky Keep\
-                      \ - FS Room Clawshots Vine Clip Trick"
-                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: \Sky Keep\Main\Fire
-                      Sanctuary Room\Triforce Room\Upper Lever
-                  hint_region: Sky Keep
-                  locations:
-                    Right Exit: 'True'
-                  name: \Sky Keep\Main\Fire Sanctuary Room\From Right
-                  sub_areas: {}
-                  toplevel_alias: null
-                OoB:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: Clawshots
-                  hint_region: Sky Keep
-                  locations: {}
-                  name: \Sky Keep\Main\Fire Sanctuary Room\OoB
-                  sub_areas: {}
-                  toplevel_alias: null
-                Triforce Room:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Fire Sanctuary Room\From Left: \Sky Keep\Main\Fire
-                      Sanctuary Room\Triforce Room\Lower Lever
-                    \Sky Keep\Main\Fire Sanctuary Room\From Right: \Sky Keep\Main\Fire
-                      Sanctuary Room\Triforce Room\Upper Lever
-                  hint_region: Sky Keep
-                  locations:
-                    Lower Lever: 'True'
-                    Sacred Power of Din: 'True'
-                    Upper Lever: 'True'
-                  name: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            First Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Bottom Entrance: null
-              exits:
-                Bottom Exit: 'True'
-                \Sky Keep\Main\Puzzle Solving Meta Room: 'True'
-              hint_region: Sky Keep
-              locations:
-                First Chest: 'True'
-                Right Exit: 'True'
-              name: \Sky Keep\Main\First Room
-              sub_areas: {}
-              toplevel_alias: null
-            LMF Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits: {}
-              hint_region: Sky Keep
-              locations:
-                Bottom Exit: 'True'
-                Finish Room: "(Gust Bellows | Sky Keep - Shooting LMF Bow Switches\
-                  \ in Present Trick) & \\Bow"
-                Top Exit: \Sky Keep\Main\LMF Room\Finish Room
-              name: \Sky Keep\Main\LMF Room
-              sub_areas: {}
-              toplevel_alias: null
-            Mini Boss Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits: {}
-              hint_region: Sky Keep
-              locations: {}
-              name: \Sky Keep\Main\Mini Boss Room
-              sub_areas:
-                From Bottom:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Mini Boss Room\Near Chest: "\\Sky Keep\\Main\\\
-                      Mini Boss Room\\From Bottom\\Defeat Dreadfuse & Clawshots"
-                  hint_region: Sky Keep
-                  locations:
-                    Bottom Exit: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat
-                      Dreadfuse
-                    Defeat Dreadfuse: \Can Defeat Scervo/Dreadfuse
-                  name: \Sky Keep\Main\Mini Boss Room\From Bottom
-                  sub_areas: {}
-                  toplevel_alias: null
-                From Left:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Mini Boss Room\Near Chest: \Sky Keep\Main\Mini
-                      Boss Room\Near Chest\Unlock Door
-                  hint_region: Sky Keep
-                  locations:
-                    Left Exit: 'True'
-                  name: \Sky Keep\Main\Mini Boss Room\From Left
-                  sub_areas: {}
-                  toplevel_alias: null
-                Near Chest:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Mini Boss Room\From Left: \Sky Keep\Main\Mini Boss
-                      Room\Near Chest\Unlock Door
-                  hint_region: Sky Keep
-                  locations:
-                    Chest after Dreadfuse: 'True'
-                    Unlock Door: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat
-                      Dreadfuse
-                  name: \Sky Keep\Main\Mini Boss Room\Near Chest
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Puzzle Solving Meta Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sky Keep\Main\Ancient Cistern Room: \Sky Keep\Main\LMF Room\Top Exit
-                \Sky Keep\Main\Earth Temple Room: \Sky Keep\Main\LMF Room\Top Exit
-                \Sky Keep\Main\Fire Sanctuary Room\From Right: \Sky Keep\Main\Ancient
-                  Cistern Room\Bottom Exit
-                \Sky Keep\Main\LMF Room: \Sky Keep\Main\Skyview Room\End\Top Exit
-                \Sky Keep\Main\Mini Boss Room\From Bottom: \Sky Keep\Main\Fire Sanctuary
-                  Room\From Left\Left Exit
-                \Sky Keep\Main\Sandship Room: \Sky Keep\Main\Fire Sanctuary Room\From
-                  Left\Left Exit
-                \Sky Keep\Main\Skyview Room\Beginning: \Sky Keep\Main\First Room\Right
-                  Exit
-              hint_region: Sky Keep
-              locations: {}
-              name: \Sky Keep\Main\Puzzle Solving Meta Room
-              sub_areas: {}
-              toplevel_alias: null
-            Sandship Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Sky Keep\Main\Sandship Room\Triforce Area: "\\Sky Keep\\Main\\Sandship\
-                  \ Room\\Lower Eye & Clawshots"
-              hint_region: Sky Keep
-              locations:
-                Higher Eye: \Bow
-                Left Exit: 'True'
-                Lower Eye: "\\Sky Keep\\Main\\Sandship Room\\Higher Eye & \\Bow"
-              name: \Sky Keep\Main\Sandship Room
-              sub_areas:
-                Triforce Area:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Sandship Room: 'True'
-                  hint_region: Sky Keep
-                  locations:
-                    Sacred Power of Nayru: 'True'
-                  name: \Sky Keep\Main\Sandship Room\Triforce Area
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Skyview Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits: {}
-              hint_region: Sky Keep
-              locations: {}
-              name: \Sky Keep\Main\Skyview Room
-              sub_areas:
-                Beginning:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Skyview Room\End: "Whip & \\Sky Keep\\Main\\Skyview\
-                      \ Room\\Beginning\\Free Rope & Clawshots & \\Sky Keep\\Main\\\
-                      Skyview Room\\Beginning\\Kill Pyrups & Gust Bellows | \\Sky\
-                      \ Keep\\Main\\Skyview Room\\End\\Lever"
-                  hint_region: Sky Keep
-                  locations:
-                    Free Rope: "\\Beetle | \\Bow"
-                    Kill Pyrups: "Bomb Bag | \\Hook Beetle | \\Bow"
-                    Left Exit: 'True'
-                  name: \Sky Keep\Main\Skyview Room\Beginning
-                  sub_areas: {}
-                  toplevel_alias: null
-                End:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Sky Keep\Main\Skyview Room\Beginning: \Sky Keep\Main\Skyview
-                      Room\End\Lever
-                  hint_region: Sky Keep
-                  locations:
-                    Lever: 'True'
-                    Top Exit: 'True'
-                  name: \Sky Keep\Main\Skyview Room\End
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-          toplevel_alias: null
-      toplevel_alias: null
-    Skyloft:
-      abstract: false
-      allowed_time_of_day: 3
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: null
-      locations: {}
-      name: \Skyloft
-      sub_areas:
-        Beedle's Shop:
-          abstract: false
-          allowed_time_of_day: 3
-          can_save: false
-          can_sleep: true
-          entrances: !!set
-            Day Entrance: null
-            Night Entrance: null
-          exits:
-            Day Exit: Day
-            Night Exit: Night
-            \Skyloft\Beedle's Shop\Stall: Day
-          hint_region: Beedle's Shop
-          locations: {}
-          name: \Skyloft\Beedle's Shop
-          sub_areas:
-            Stall:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Skyloft\Beedle's Shop: 'True'
-              hint_region: Beedle's Shop
-              locations:
-                1000 Rupee Item: \Can Afford 1000 Rupees
-                1200 Rupee Item: \Can Afford 1200 Rupees
-                1600 Rupee Item: \Can Afford 1600 Rupees
-                300 Rupee Item: "\\Can Afford 300 Rupees & (\\Pouch | Randomized Beedle\
-                  \ option)"
-                50 Rupee Item: \Can Afford 50 Rupees
-                600 Rupee Item: \Can Afford 600 Rupees
-                800 Rupee Item: \Can Afford 800 Rupees
-                First 100 Rupee Item: \Can Afford 100 Rupees
-                Second 100 Rupee Item: \Can Afford 100 Rupees
-                Third 100 Rupee Item: "\\Can Afford 100 Rupees & \\Can Medium Rupee\
-                  \ Farm"
-              name: \Skyloft\Beedle's Shop\Stall
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: Beedle
-        Central Skyloft:
-          abstract: false
-          allowed_time_of_day: 3
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Bazaar North Entrance: null
-            Bazaar South Entrance: null
-            Bazaar West Entrance: null
-            Entrance from Beedle's Shop: null
-            Entrance from Sky: null
-            Orielle and Parrow's House Entrance: null
-            Peatrice's House Entrance: null
-            Piper's House Entrance: null
-            Trial Gate Entrance: null
-            Waterfall Cave Upper Entrance: null
-            Wryna's House Entrance: null
-          exits:
-            Bazaar North Exit: Day
-            Bazaar South Exit: Day
-            Bazaar West Exit: Day
-            Exit to Beedle's Shop: "Day & (\\Distance Activator | Beedle's Shop With\
-              \ Bombs Trick & Bomb Bag)"
-            Exit to Sky: Day
-            Orielle and Parrow's House Exit: 'True'
-            Peatrice's House Exit: 'True'
-            Piper's House Exit: 'True'
-            Trial Gate Exit: \Skyloft\Central Skyloft\Open Trial Gate
-            Waterfall Cave Upper Exit: \Skyloft\Central Skyloft\Open Cave Entrance
-            Wryna's House Exit: 'True'
-            \Skyloft\Central Skyloft\Near Temple Entrance: "Day & Clawshots"
-            \Skyloft\Central Skyloft\Waterfall Island: Clawshots
-            \Skyloft\Skyloft Village: 'True'
-            \Skyloft\Upper Skyloft: 'True'
-          hint_region: Central Skyloft
-          locations:
-            Crystal between Wooden Planks: Night
-            Crystal on Light Tower: Night
-            Crystal on Waterfall Island: "Night & \\Skyloft\\Central Skyloft\\Crystal\
-              \ on Waterfall Island from the ground"
-            Crystal on Waterfall Island from the ground: \Quick Beetle
-            Crystal on West Cliff: Night
-            Open Cave Entrance: "\\Sword | Bomb Bag"
-            Open Trial Gate: "Goddess's Harp & \\Song of the Hero"
-            Parrow's Crystals: "\\Sky\\South West\\Orielle's Island\\Save Orielle\
-              \ & Day"
-            Parrow's Gift: "\\Sky\\South West\\Orielle's Island\\Talk to Orielle &\
-              \ Day"
-            Shed Chest: Water Dragon's Scale
-            Shed Goddess Chest: "Water Dragon's Scale & \\Eldin\\Volcano\\Sand Slide\\\
-              Goddess Cube on Sand Slide"
-            Waterfall Cave Crystals from above: \Beetle
-            West Cliff Goddess Chest: \Faron\Faron Woods\West Branch\Goddess Cube
-              on West Great Tree near Exit
-            \Can Collect Water: 'True'
-            \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest: "Baby Rattle from\
-              \ Beedle's Shop Trick & Day & \\Distance Activator & Gust Bellows &\
-              \ (\\Beetle | Whip)"
-            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: "Night\
-              \ & \\Skyloft\\Central Skyloft\\Waterfall Cave Crystals from above"
-            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: "Night\
-              \ & \\Skyloft\\Central Skyloft\\Waterfall Cave Crystals from above"
-          name: \Skyloft\Central Skyloft
-          sub_areas:
-            Bazaar:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                North Entrance: null
-                South Entrance: null
-                West Entrance: null
-              exits:
-                North Exit: 'True'
-                South Exit: 'True'
-                West Exit: 'True'
-                \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades: Gondo Upgrades On
-                  option
-              hint_region: Central Skyloft
-              locations:
-                Bazaar Goddess Chest: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Goddess
-                  Cube in Ancient Harbour
-                Endurance Potion: "\\Bottle & \\Lanayru\\Raise Lanayru Mining Facility"
-                Item Check Access: 'True'
-                Potion Lady's Gift: 'True'
-                Repair Gondo's Junk: \Ancient Flower Farming
-                Talk to Peatrice: 'True'
-              name: \Skyloft\Central Skyloft\Bazaar
-              sub_areas:
-                Gondo's Upgrades:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Skyloft\Central Skyloft\Bazaar: 'True'
-                  hint_region: Central Skyloft
-                  locations:
-                    Upgrade to Quick Beetle: "\\Hook Beetle & \\Faron\\Faron Woods\\\
-                      Deep Woods\\Entry\\Hornet Larvae Farming & \\Ancient Flower\
-                      \ Farming & \\Sky\\North East\\Bamboo Island\\Inside\\Clean\
-                      \ Cut Minigame"
-                    Upgrade to Tough Beetle: "\\Quick Beetle & \\Faron\\Faron Woods\\\
-                      Amber Relic Farming & \\Ancient Flower Farming & \\Sky\\North\
-                      \ East\\Bamboo Island\\Inside\\Clean Cut Minigame"
-                  name: \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Bird Nest:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Skyloft\Central Skyloft: 'True'
-              hint_region: Central Skyloft
-              locations:
-                Item in Bird Nest: Gust Bellows
-              name: \Skyloft\Central Skyloft\Bird Nest
-              sub_areas: {}
-              toplevel_alias: null
-            Near Temple Entrance:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance from Sky Keep: null
-              exits:
-                Exit to Sky Keep: Stone of Trials
-                \Skyloft\Central Skyloft: Clawshots
-              hint_region: Central Skyloft
-              locations: {}
-              name: \Skyloft\Central Skyloft\Near Temple Entrance
-              sub_areas: {}
-              toplevel_alias: null
-            Orielle and Parrow's House:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: true
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Central Skyloft
-              locations:
-                Crystal in Orielle and Parrow's House: 'True'
-                Parrow's Crystals: "\\Sky\\South West\\Orielle's Island\\Save Orielle\
-                  \ & Night"
-                Parrow's Gift: "\\Sky\\South West\\Orielle's Island\\Talk to Orielle\
-                  \ & Night"
-              name: \Skyloft\Central Skyloft\Orielle and Parrow's House
-              sub_areas: {}
-              toplevel_alias: null
-            Past Waterfall Cave:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Waterfall Cave Lower Entrance: null
-              exits:
-                Waterfall Cave Lower Exit: 'True'
-                \Skyloft\Central Skyloft\Exit to Sky: Day
-              hint_region: Central Skyloft
-              locations:
-                Crystal after Waterfall Cave: Night
-                Crystal in Loftwing Prison: Night
-              name: \Skyloft\Central Skyloft\Past Waterfall Cave
-              sub_areas: {}
-              toplevel_alias: null
-            Peatrice's House:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: true
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Central Skyloft
-              locations:
-                Peater/Peatrice's Crystals: "\\Skyloft\\Central Skyloft\\Bazaar\\\
-                  Talk to Peatrice & Night"
-              name: \Skyloft\Central Skyloft\Peatrice's House
-              sub_areas: {}
-              toplevel_alias: null
-            Piper's House:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: true
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Central Skyloft
-              locations: {}
-              name: \Skyloft\Central Skyloft\Piper's House
-              sub_areas: {}
-              toplevel_alias: null
-            Waterfall Cave:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Lower Entrance: null
-                Upper Entrance: null
-              exits:
-                Lower Exit: 'True'
-                Upper Exit: 'True'
-              hint_region: Central Skyloft
-              locations:
-                Rupee Waterfall Cave Crawlspace: 'True'
-                Waterfall Cave First Chest: 'True'
-                Waterfall Cave Second Chest: 'True'
-              name: \Skyloft\Central Skyloft\Waterfall Cave
-              sub_areas: {}
-              toplevel_alias: null
-            Waterfall Island:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Skyloft\Central Skyloft: 'True'
-                \Skyloft\Central Skyloft\Bird Nest: 'True'
-                \Skyloft\Skyloft Village: 'True'
-              hint_region: Central Skyloft
-              locations:
-                Crystal on Waterfall Island: Night
-                Floating Island Goddess Chest: \Faron\Lake Floria\Below Rock\Emerged
-                  Area\Goddess Cube in Lake Floria
-                Gossip Stone on Waterfall Island: 'True'
-                Waterfall Goddess Chest: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside
-                  the Shark Head\Goddess Cube in Pirate Stronghold
-              name: \Skyloft\Central Skyloft\Waterfall Island
-              sub_areas: {}
-              toplevel_alias: null
-            Wryna's House:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: true
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Central Skyloft
-              locations:
-                Wryna's Crystals: 'True'
-              name: \Skyloft\Central Skyloft\Wryna's House
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-        Skyloft Silent Realm:
-          abstract: false
-          allowed_time_of_day: 3
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance: null
-          exits:
-            Exit: 'True'
-          hint_region: Skyloft Silent Realm
-          locations:
-            Relic 1: 'True'
-            Relic 10: 'True'
-            Relic 2: 'True'
-            Relic 3: 'True'
-            Relic 4: 'True'
-            Relic 5: 'True'
-            Relic 6: 'True'
-            Relic 7: 'True'
-            Relic 8: 'True'
-            Relic 9: 'True'
-            Trial Reward: 'True'
-          name: \Skyloft\Skyloft Silent Realm
-          sub_areas: {}
-          toplevel_alias: null
-        Skyloft Village:
-          abstract: false
-          allowed_time_of_day: 3
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Batreaux's House Entrance: null
-            Bertie's House Entrance: null
-            Gondo's House Entrance: null
-            Mallara's House Entrance: null
-            Rupin's House Entrance: null
-            Sparrot's House Entrance: null
-          exits:
-            Batreaux's House Exit: "\\Skyloft\\Skyloft Village\\Opened Shed | Gravestone\
-              \ Jump Trick"
-            Bertie's House Exit: 'True'
-            Gondo's House Exit: 'True'
-            Mallara's House Exit: 'True'
-            Rupin's House Exit: 'True'
-            Sparrot's House Exit: 'True'
-            \Skyloft\Central Skyloft: 'True'
-            \Skyloft\Central Skyloft\Exit to Sky: Day
-            \Skyloft\Central Skyloft\Past Waterfall Cave: "Waterfall Cave Jump Trick\
-              \ & Day"
-          hint_region: Skyloft Village
-          locations:
-            Crystal near Pumpkin Patch: Night
-            Opened Shed: Night
-          name: \Skyloft\Skyloft Village
-          sub_areas:
-            Batreaux's House:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Batreaux's House
-              locations:
-                10 Crystals: \10 Gratitude Crystals
-                30 Crystals: \30 Gratitude Crystals
-                30 Crystals Chest: \30 Gratitude Crystals
-                40 Crystals: \40 Gratitude Crystals
-                5 Crystals: \5 Gratitude Crystals
-                50 Crystals: \50 Gratitude Crystals
-                70 Crystals: \70 Gratitude Crystals
-                70 Crystals Second Reward: \70 Gratitude Crystals
-                80 Crystals: \80 Gratitude Crystals
-              name: \Skyloft\Skyloft Village\Batreaux's House
-              sub_areas: {}
-              toplevel_alias: null
-            Bertie's House:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: true
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Skyloft Village
-              locations:
-                Bertie's Crystals: "Baby Rattle & Night"
-              name: \Skyloft\Skyloft Village\Bertie's House
-              sub_areas: {}
-              toplevel_alias: null
-            Gondo's House:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: true
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Skyloft Village
-              locations: {}
-              name: \Skyloft\Skyloft Village\Gondo's House
-              sub_areas: {}
-              toplevel_alias: null
-            Mallara's House:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: true
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Skyloft Village
-              locations:
-                Mallara's Crystals: Gust Bellows
-              name: \Skyloft\Skyloft Village\Mallara's House
-              sub_areas: {}
-              toplevel_alias: null
-            Rupin's House:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: true
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Skyloft Village
-              locations: {}
-              name: \Skyloft\Skyloft Village\Rupin's House
-              sub_areas: {}
-              toplevel_alias: null
-            Sparrot's House:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: true
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Skyloft Village
-              locations:
-                Sparrot's Crystals: \Eldin\Volcano\Near Temple Entrance\Retrieve Crystal
-                  Ball
-                Start Sparrot's Quest: 'True'
-              name: \Skyloft\Skyloft Village\Sparrot's House
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-        Upper Skyloft:
-          abstract: false
-          allowed_time_of_day: 3
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Goddess Statue Entrance: null
-            Knight Academy Lower Left Door Entrance: null
-            Knight Academy Lower Right Door Entrance: null
-            Knight Academy Upper Left Door Entrance: null
-            Knight Academy Upper Right Door Entrance: null
-            Sparring Hall Left Door Entrance: null
-            Sparring Hall Right Door Entrance: null
-          exits:
-            Goddess Statue Exit: 'True'
-            Knight Academy Chimney Entrance: Clawshots
-            Knight Academy Lower Left Door Exit: Day
-            Knight Academy Lower Right Door Exit: Day
-            Knight Academy Upper Left Door Exit: 'True'
-            Knight Academy Upper Right Door Exit: 'True'
-            Sparring Hall Left Door Exit: 'True'
-            Sparring Hall Right Door Exit: 'True'
-            \Skyloft\Central Skyloft: 'True'
-          hint_region: Upper Skyloft
-          locations:
-            Chest near Goddess Statue: 'True'
-            Owlan's Gift: Day
-            Pumpkin Archery -- 600 Points: "\\Bow & Day"
-          name: \Skyloft\Upper Skyloft
-          sub_areas:
-            Goddess Statue:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Entrance: null
-              exits:
-                Exit: 'True'
-              hint_region: Upper Skyloft
-              locations:
-                First Goddess Sword Item in Goddess Statue: 'True'
-                Second Goddess Sword Item in Goddess Statue: 'True'
-              name: \Skyloft\Upper Skyloft\Goddess Statue
-              sub_areas: {}
-              toplevel_alias: null
-            Knight Academy:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: true
-              entrances: !!set
-                Lower Left Door Entrance: null
-                Lower Right Door Entrance: null
-                Upper Left Door Entrance: null
-                Upper Right Door Entrance: null
-              exits:
-                Lower Left Door Exit: Day
-                Lower Right Door Exit: Day
-                Upper Left Door Exit: 'True'
-                Upper Right Door Exit: 'True'
-                \Skyloft\Upper Skyloft\Knight Academy\Link's Room: 'True'
-                \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room: \Skyloft\Upper
-                  Skyloft\Knight Academy\Zelda's Room\Unlocked Zelda's Room
-              hint_region: Upper Skyloft
-              locations:
-                Crystal in Knight Academy Plant: Night
-                Fledge's Crystals: "\\Skyloft\\Central Skyloft\\Bazaar\\Endurance\
-                  \ Potion & Night"
-                Fledge's Gift: 'True'
-                Ghost/Pipit's Crystals: "Cawlin's Letter & Day"
-                Item from Cawlin: "\\Skyloft\\Upper Skyloft\\Knight Academy\\Knock\
-                  \ on Toilet Door & Day"
-                Knock on Toilet Door: "Goddess's Harp & Night"
-                Owlan's Crystals: "\\Faron\\Faron Woods\\Behind the Crawlspace and\
-                  \ Rope\\Retrieve Oolo & Day"
-                Start Owlan's Quest: \Faron\Faron Woods\All Kikwis Saved
-              name: \Skyloft\Upper Skyloft\Knight Academy
-              sub_areas:
-                Link's Room:
-                  abstract: false
-                  allowed_time_of_day: 3
-                  can_save: false
-                  can_sleep: true
-                  entrances: !!set
-                    Start Entrance: null
-                  exits:
-                    \Skyloft\Upper Skyloft\Knight Academy: 'True'
-                  hint_region: Upper Skyloft
-                  locations:
-                    Crystal in Link's Room: Night
-                  name: \Skyloft\Upper Skyloft\Knight Academy\Link's Room
-                  sub_areas: {}
-                  toplevel_alias: null
-                Zelda's Room:
-                  abstract: false
-                  allowed_time_of_day: 3
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Chimney: null
-                  exits:
-                    \Skyloft\Upper Skyloft\Knight Academy: 'True'
-                  hint_region: Upper Skyloft
-                  locations:
-                    Crystal in Zelda's Room: Night
-                    In Zelda's Closet: 'True'
-                    Unlocked Zelda's Room: 'True'
-                  name: \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            Sparring Hall:
-              abstract: false
-              allowed_time_of_day: 3
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Left Door Entrance: null
-                Right Door Entrance: null
-              exits:
-                Left Door Exit: 'True'
-                Right Door Exit: 'True'
-              hint_region: Upper Skyloft
-              locations:
-                Crystal in Sparring Hall: "\\Beetle & Night"
-                Delivered Hot Soup: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Start
-                  Hot Soup Delivery
-                Sparring Hall Chest: 'True'
-              name: \Skyloft\Upper Skyloft\Sparring Hall
-              sub_areas: {}
-              toplevel_alias: null
-          toplevel_alias: null
-      toplevel_alias: null
-    Skyview:
-      abstract: true
-      allowed_time_of_day: 1
-      can_save: false
-      can_sleep: false
-      entrances: !!set {}
-      exits: {}
-      hint_region: Skyview
-      locations:
-        Can Cut Tree: "\\Sword | Bomb Bag"
-        Can Hit High Skyview Switches: "\\Distance Activator | Bomb Bag & Bomb Throws\
-          \ Trick"
-        Skyview 2: Water Dragon's Scale
-      name: \Skyview
-      sub_areas:
-        Boss Room:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance from Dungeon: null
-            Entrance from Spring: null
-          exits:
-            Exit to Dungeon: \Skyview\Boss Room\Beat Ghirahim
-            Exit to Spring: \Skyview\Boss Room\Beat Ghirahim
-          hint_region: Skyview
-          locations:
-            Beat Ghirahim: \Sword
-            Heart Container: \Skyview\Boss Room\Beat Ghirahim
-          name: \Skyview\Boss Room
-          sub_areas: {}
-          toplevel_alias: null
-        Main:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set {}
-          exits: {}
-          hint_region: Skyview
-          locations: {}
-          name: \Skyview\Main
-          sub_areas:
-            Entry:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set
-                Main Entrance: null
-              exits:
-                Main Exit: 'True'
-                \Skyview\Main\First Room: \Skyview\Main\Entry\Cut Tree
-              hint_region: Skyview
-              locations:
-                Cut Tree: \Skyview\Can Cut Tree
-              name: \Skyview\Main\Entry
-              sub_areas: {}
-              toplevel_alias: null
-            First Hub:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Skyview\Main\First Hub\Left Room: \Skyview\Main\First Hub\Switch
-                  to Left Room
-                \Skyview\Main\First Hub\Right Room\Lower Area: \Skyview\Main\First
-                  Hub\Switch to Right Room
-                \Skyview\Main\First Hub\Right Room\Upper Area: "\\Skyview\\Main\\\
-                  First Hub\\Left Room\\Raise Water & \\Skyview\\Main\\First Hub\\\
-                  Right Room\\After Crawlspace\\Raise Water | Clawshots"
-                \Skyview\Main\First Room: \Skyview\Main\First Room\Destroy Barricade
-                \Skyview\Main\One Eye Room: \Skyview\Main\One Eye Room\Unlock Door
-                  to First Hub
-                \Skyview\Main\Second Hub: "\\Skyview\\Main\\First Hub\\One Water Raise\
-                  \ & Skyview Small Key"
-              hint_region: Skyview
-              locations:
-                One Water Raise: "\\Skyview\\Main\\First Hub\\Left Room\\Raise Water\
-                  \ | \\Skyview\\Main\\First Hub\\Right Room\\After Crawlspace\\Raise\
-                  \ Water"
-                Switch to Left Room: "\\Can Hit Switch | \\Skyview\\Main\\First Hub\\\
-                  One Water Raise & Water Dragon's Scale"
-                Switch to Right Room: \Skyview\Can Hit High Skyview Switches
-                \Skyview\Main\First Room\Destroy Barricade: 'True'
-              name: \Skyview\Main\First Hub
-              sub_areas:
-                Left Room:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Skyview\Main\First Hub: 'True'
-                  hint_region: Skyview
-                  locations:
-                    Chest on Tree Branch: "\\Skyview\\Main\\First Hub\\Left Room\\\
-                      Hit Vines | \\Skyview\\Main\\First Hub\\Left Room\\Spider Roll"
-                    Hit Vines: "\\Skyview\\Can Hit High Skyview Switches | \\Goddess\
-                      \ Sword | Whip"
-                    Raise Water: "\\Skyview\\Main\\First Hub\\Left Room\\Hit Vines\
-                      \ & \\Can Hit Switch | \\Skyview\\Main\\First Hub\\Left Room\\\
-                      Spider Roll & \\Skyview\\Can Hit High Skyview Switches"
-                    Spider Roll: Skyview - Spider Roll Trick
-                  name: \Skyview\Main\First Hub\Left Room
-                  sub_areas: {}
-                  toplevel_alias: null
-                Right Room:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits: {}
-                  hint_region: Skyview
-                  locations: {}
-                  name: \Skyview\Main\First Hub\Right Room
-                  sub_areas:
-                    After Crawlspace:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
-                      hint_region: Skyview
-                      locations:
-                        Digging Spot in Crawlspace: 'False'
-                        Raise Water: \Skyview\Can Hit High Skyview Switches
-                      name: \Skyview\Main\First Hub\Right Room\After Crawlspace
-                      sub_areas:
-                        With Water:
-                          abstract: false
-                          allowed_time_of_day: 1
-                          can_save: false
-                          can_sleep: false
-                          entrances: !!set {}
-                          exits:
-                            \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
-                          hint_region: Skyview
-                          locations:
-                            \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace: \Digging
-                              Mitts
-                          name: \Skyview\Main\First Hub\Right Room\After Crawlspace\With
-                            Water
-                          sub_areas: {}
-                          toplevel_alias: null
-                      toplevel_alias: null
-                    Lower Area:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Skyview\Main\First Hub: 'True'
-                        \Skyview\Main\First Hub\Right Room\After Crawlspace: 'True'
-                        \Skyview\Main\First Hub\Right Room\After Crawlspace\With Water: Water
-                          Dragon's Scale
-                      hint_region: Skyview
-                      locations: {}
-                      name: \Skyview\Main\First Hub\Right Room\Lower Area
-                      sub_areas: {}
-                      toplevel_alias: null
-                    Upper Area:
-                      abstract: false
-                      allowed_time_of_day: 1
-                      can_save: false
-                      can_sleep: false
-                      entrances: !!set {}
-                      exits:
-                        \Skyview\Main\First Hub: 'True'
-                        \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
-                      hint_region: Skyview
-                      locations:
-                        Chest behind Two Eyes: \Sword
-                      name: \Skyview\Main\First Hub\Right Room\Upper Area
-                      sub_areas: {}
-                      toplevel_alias: null
-                  toplevel_alias: null
-              toplevel_alias: null
-            First Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Skyview\Main\Entry: \Skyview\Main\Entry\Cut Tree
-                \Skyview\Main\First Hub: \Skyview\Main\First Room\Destroy Barricade
-                \Skyview\Main\One Eye Room: \Skyview\Main\First Room\Switch to One
-                  Eye Room
-              hint_region: Skyview
-              locations:
-                Destroy Barricade: "\\Skyview\\Skyview 2 | Bomb Bag"
-                Goddess Wall Trigger: "Ballad of the Goddess & Goddess's Harp"
-                Switch to One Eye Room: \Skyview\Can Hit High Skyview Switches
-                \Skyview\Main\Entry\Cut Tree: \Skyview\Can Cut Tree
-              name: \Skyview\Main\First Room
-              sub_areas: {}
-              toplevel_alias: null
-            Last Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits: {}
-              hint_region: Skyview
-              locations: {}
-              name: \Skyview\Main\Last Room
-              sub_areas:
-                After Rope:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set
-                    Boss Door Entrance: null
-                  exits:
-                    Boss Door Exit: Skyview Boss Key
-                    \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Before
-                      Rope\Deal with Archers
-                    \Skyview\Main\Last Room\Near Boss Key Chest: \Skyview\Main\Last
-                      Room\After Rope\Hit Vines
-                  hint_region: Skyview
-                  locations:
-                    Chest near Boss Door: 'True'
-                    Hit Vines: "\\Long Range Skyward Strike | \\Distance Activator"
-                    \Skyview\Main\Last Room\Before Rope\Deal with Archers: "\\Can\
-                      \ Defeat Bokoblins | \\Hook Beetle"
-                  name: \Skyview\Main\Last Room\After Rope
-                  sub_areas: {}
-                  toplevel_alias: null
-                Before Rope:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Skyview\Main\Last Room\After Rope: \Skyview\Main\Last Room\Before
-                      Rope\Deal with Archers
-                    \Skyview\Main\Last Room\Near East Entrance: \Skyview\Main\Last
-                      Room\Near East Entrance\Deal with Hanging Skulltula
-                    \Skyview\Main\Second Hub: \Skyview\Main\Last Room\Before Rope\Unlock
-                      Shortcut to Second Hub
-                  hint_region: Skyview
-                  locations:
-                    Deal with Archers: "\\Long Range Skyward Strike | \\Hook Beetle\
-                      \ | \\Bow"
-                    Unlock Shortcut to Second Hub: \Skyview\Can Hit High Skyview Switches
-                    \Skyview\Main\Last Room\Near East Entrance\Deal with Hanging Skulltula: "Bomb\
-                      \ Bag | \\Goddess Sword | \\Beetle | \\Bow | \\Skyview\\Skyview\
-                      \ 2"
-                  name: \Skyview\Main\Last Room\Before Rope
-                  sub_areas: {}
-                  toplevel_alias: null
-                Near Boss Key Chest:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Skyview\Main\Last Room\After Rope: \Skyview\Main\Last Room\After
-                      Rope\Hit Vines
-                    \Skyview\Main\Last Room\Before Rope: 'True'
-                  hint_region: Skyview
-                  locations:
-                    Boss Key Chest: 'True'
-                  name: \Skyview\Main\Last Room\Near Boss Key Chest
-                  sub_areas: {}
-                  toplevel_alias: null
-                Near East Entrance:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Near
-                      East Entrance\Deal with Hanging Skulltula
-                    \Skyview\Main\Second Hub\Staldra Room: 'True'
-                  hint_region: Skyview
-                  locations:
-                    Deal with Hanging Skulltula: "Bomb Bag | \\Goddess Sword | \\\
-                      Beetle | \\Bow | \\Skyview\\Skyview 2"
-                  name: \Skyview\Main\Last Room\Near East Entrance
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-            One Eye Room:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Skyview\Main\First Hub: \Skyview\Main\One Eye Room\Unlock Door to
-                  First Hub
-                \Skyview\Main\First Room: \Skyview\Main\First Room\Switch to One Eye
-                  Room
-              hint_region: Skyview
-              locations:
-                Unlock Door to First Hub: \Sword
-              name: \Skyview\Main\One Eye Room
-              sub_areas: {}
-              toplevel_alias: null
-            Second Hub:
-              abstract: false
-              allowed_time_of_day: 1
-              can_save: false
-              can_sleep: false
-              entrances: !!set {}
-              exits:
-                \Skyview\Main\First Hub: Skyview Small Key x 2
-                \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Before
-                  Rope\Unlock Shortcut to Second Hub
-                \Skyview\Main\Second Hub\Left Rooms: \Skyview\Main\Second Hub\Switch
-                  to Left Room
-                \Skyview\Main\Second Hub\Miniboss Room: \Skyview\Main\Second Hub\Switch
-                  to Miniboss Room
-                \Skyview\Main\Second Hub\Staldra Room: Skyview Small Key x 2
-              hint_region: Skyview
-              locations:
-                Item behind Bars: "\\Skyview\\Main\\Second Hub\\Switch for Bars |\
-                  \ Whip"
-                Rupee in East Tunnel: \Beetle
-                Rupee in Southeast Tunnel: \Beetle
-                Rupee in Southwest Tunnel: \Beetle
-                Switch for Bars: "\\Beetle | \\Slingshot & Skyview Slingshot Shot\
-                  \ Trick"
-                Switch to Left Room: \Beetle
-                Switch to Miniboss Room: \Distance Activator
-              name: \Skyview\Main\Second Hub
-              sub_areas:
-                Left Rooms:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Skyview\Main\Second Hub: "\\Sword & \\Projectile Item"
-                  hint_region: Skyview
-                  locations:
-                    Chest behind Three Eyes: "\\Beetle & \\Sword"
-                  name: \Skyview\Main\Second Hub\Left Rooms
-                  sub_areas: {}
-                  toplevel_alias: null
-                Miniboss Room:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Skyview\Main\Second Hub: 'True'
-                  hint_region: Skyview
-                  locations:
-                    Chest after Stalfos Fight: "\\Sword | \\Skyview\\Skyview 2"
-                  name: \Skyview\Main\Second Hub\Miniboss Room
-                  sub_areas: {}
-                  toplevel_alias: null
-                Staldra Room:
-                  abstract: false
-                  allowed_time_of_day: 1
-                  can_save: false
-                  can_sleep: false
-                  entrances: !!set {}
-                  exits:
-                    \Skyview\Main\Last Room\Near East Entrance: \Skyview\Main\Second
-                      Hub\Staldra Room\Can Defeat Staldra
-                    \Skyview\Main\Second Hub: Skyview Small Key
-                  hint_region: Skyview
-                  locations:
-                    Can Defeat Staldra: "\\Sword | Bomb Bag"
-                  name: \Skyview\Main\Second Hub\Staldra Room
-                  sub_areas: {}
-                  toplevel_alias: null
-              toplevel_alias: null
-          toplevel_alias: null
-        Spring:
-          abstract: false
-          allowed_time_of_day: 1
-          can_save: false
-          can_sleep: false
-          entrances: !!set
-            Entrance: null
-          exits:
-            Exit: 'True'
-          hint_region: Skyview
-          locations:
-            Goddess Cube in Skyview Spring: \Goddess Sword
-            Rupee on Spring Pillar: \Beetle
-            Sacred Water: "\\Bottle & \\Skyview\\Skyview 2"
-            Strike Crest: \Goddess Sword
-          name: \Skyview\Spring
-          sub_areas: {}
-          toplevel_alias: Skyview Spring
-      toplevel_alias: Skyview Temple
-  toplevel_alias: null
-checks:
-  \Ancient Cistern\Boss Room\Heart Container: Ancient Cistern - Heart Container
-  \Ancient Cistern\Flame Room\Farore's Flame: Ancient Cistern - Farore's Flame
-  \Ancient Cistern\Main\Basement Gutters\Past Skulltula\Bokoblin: Ancient Cistern
-    - Bokoblin
-  \Ancient Cistern\Main\Basement\Under the Statue\Boss Key Chest: Ancient Cistern
-    - Boss Key Chest
-  \Ancient Cistern\Main\East Part\Chest Ledge\Chest in East Part: Ancient Cistern
-    - Chest in East Part
-  \Ancient Cistern\Main\East Part\Second Room\First Rupee in East Part in Short Tunnel: Ancient
-    Cistern - First Rupee in East Part in Short Tunnel
-  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Cubby: Ancient
-    Cistern - Rupee in East Part in Cubby
-  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Main Tunnel: Ancient
-    Cistern - Rupee in East Part in Main Tunnel
-  \Ancient Cistern\Main\East Part\Second Room\Second Rupee in East Part in Short Tunnel: Ancient
-    Cistern - Second Rupee in East Part in Short Tunnel
-  \Ancient Cistern\Main\East Part\Second Room\Third Rupee in East Part in Short Tunnel: Ancient
-    Cistern - Third Rupee in East Part in Short Tunnel
-  \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest\Chest in Key Locked Room: Ancient
-    Cistern - Chest in Key Locked Room
-  \Ancient Cistern\Main\Main Room\After Gutters\Rupee under Lilypad: Ancient Cistern
-    - Rupee under Lilypad
-  \Ancient Cistern\Main\Main Room\After Whip Hooks\Chest after Whip Hooks: Ancient
-    Cistern - Chest after Whip Hooks
-  \Ancient Cistern\Main\Main Room\Behind the Waterfall\Chest behind the Waterfall: Ancient
-    Cistern - Chest behind the Waterfall
-  \Ancient Cistern\Main\Main Room\Rupee in East Hand: Ancient Cistern - Rupee in East
-    Hand
-  \Ancient Cistern\Main\Main Room\Rupee in West Hand: Ancient Cistern - Rupee in West
-    Hand
-  \Ancient Cistern\Main\Main Room\Vines Area\Chest near Vines: Ancient Cistern - Chest
-    near Vines
-  \Earth Temple\Boss Room\Slope\Heart Container: Earth Temple - Heart Container
-  \Earth Temple\Main\East Room\Chest after Double Lizalfos Fight: Earth Temple - Chest
-    after Double Lizalfos Fight
-  \Earth Temple\Main\First Room\Rupee above Drawbridge: Earth Temple - Rupee above
-    Drawbridge
-  \Earth Temple\Main\First Room\Vent Chest: Earth Temple - Vent Chest
-  \Earth Temple\Main\Hub Room\Chest Left of Main Room Bridge: Earth Temple - Chest
-    Left of Main Room Bridge
-  \Earth Temple\Main\Hub Room\Chest behind Bombable Rock: Earth Temple - Chest behind
-    Bombable Rock
-  \Earth Temple\Main\Hub Room\Ledd's Gift: Earth Temple - Ledd's Gift
-  \Earth Temple\Main\Hub Room\Past Lava Section\Chest Guarded by Lizalfos: Earth Temple
-    - Chest Guarded by Lizalfos
-  \Earth Temple\Main\Hub Room\Rupee in Lava Tunnel: Earth Temple - Rupee in Lava Tunnel
-  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Key Chest: Earth Temple
-    - Boss Key Chest
-  \Earth Temple\Main\West Room\Chest in West Room: Earth Temple - Chest in West Room
-  \Earth Temple\Spring\Strike Crest: Earth Temple - Strike Crest
-  \Eldin\Bokoblin Base\Before Drawbridge\Chest near Drawbridge: Bokoblin Base - Chest
-    near Drawbridge
-  \Eldin\Bokoblin Base\Bokoblin Base Summit\Chest in Volcano Summit Alcove: Bokoblin
-    Base - Chest in Volcano Summit Alcove
-  \Eldin\Bokoblin Base\Bokoblin Base Summit\First Chest in Volcano Summit: Bokoblin
-    Base - First Chest in Volcano Summit
-  \Eldin\Bokoblin Base\Bokoblin Base Summit\Raised Chest in Volcano Summit: Bokoblin
-    Base - Raised Chest in Volcano Summit
-  \Eldin\Bokoblin Base\Fire Dragon's Lair\Fire Dragon's Reward: Bokoblin Base - Fire
-    Dragon's Reward
-  \Eldin\Bokoblin Base\Outside Earth Temple\Chest East of Earth Temple Entrance: Bokoblin
-    Base - Chest East of Earth Temple Entrance
-  \Eldin\Bokoblin Base\Outside Earth Temple\Chest West of Earth Temple Entrance: Bokoblin
-    Base - Chest West of Earth Temple Entrance
-  \Eldin\Bokoblin Base\Prison\Plats' Gift: Bokoblin Base - Plats' Gift
-  \Eldin\Bokoblin Base\Volcano East\Chest near Bone Bridge: Bokoblin Base - Chest
-    near Bone Bridge
-  \Eldin\Bokoblin Base\Volcano East\Chest on Cliff: Bokoblin Base - Chest on Cliff
-  \Eldin\Eldin Silent Realm\Relic 1: Eldin Silent Realm - Relic 1
-  \Eldin\Eldin Silent Realm\Relic 10: Eldin Silent Realm - Relic 10
-  \Eldin\Eldin Silent Realm\Relic 2: Eldin Silent Realm - Relic 2
-  \Eldin\Eldin Silent Realm\Relic 3: Eldin Silent Realm - Relic 3
-  \Eldin\Eldin Silent Realm\Relic 4: Eldin Silent Realm - Relic 4
-  \Eldin\Eldin Silent Realm\Relic 5: Eldin Silent Realm - Relic 5
-  \Eldin\Eldin Silent Realm\Relic 6: Eldin Silent Realm - Relic 6
-  \Eldin\Eldin Silent Realm\Relic 7: Eldin Silent Realm - Relic 7
-  \Eldin\Eldin Silent Realm\Relic 8: Eldin Silent Realm - Relic 8
-  \Eldin\Eldin Silent Realm\Relic 9: Eldin Silent Realm - Relic 9
-  \Eldin\Eldin Silent Realm\Trial Reward: Eldin Silent Realm - Trial Reward
-  \Eldin\Mogma Turf\Past Vent\Chest behind Bombable Wall in Fire Maze: Mogma Turf
-    - Chest behind Bombable Wall in Fire Maze
-  \Eldin\Mogma Turf\Pre Vent\Chest behind Bombable Wall at Entrance: Mogma Turf -
-    Chest behind Bombable Wall at Entrance
-  \Eldin\Mogma Turf\Pre Vent\Defeat Bokoblins: Mogma Turf - Defeat Bokoblins
-  \Eldin\Mogma Turf\Pre Vent\Free Fall Chest: Mogma Turf - Free Fall Chest
-  \Eldin\Mogma Turf\Sand Slide Platform\Sand Slide Chest: Mogma Turf - Sand Slide
-    Chest
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Item behind Digging: Volcano
-    Summit - Item behind Digging
-  \Eldin\Volcano Summit\Waterfall\Higher Area\Chest behind Bombable Wall in Waterfall Area: Volcano
-    Summit - Chest behind Bombable Wall in Waterfall Area
-  \Eldin\Volcano\Ascent\Chest behind Bombable Wall near Volcano Ascent: Eldin Volcano
-    - Chest behind Bombable Wall near Volcano Ascent
-  \Eldin\Volcano\East\Chest after Crawlspace: Eldin Volcano - Chest after Crawlspace
-  \Eldin\Volcano\East\Chest behind Bombable Wall near Cliff: Eldin Volcano - Chest
-    behind Bombable Wall near Cliff
-  \Eldin\Volcano\East\Item on Cliff: Eldin Volcano - Item on Cliff
-  \Eldin\Volcano\East\North Rupee above Mogma Turf Entrance: Eldin Volcano - North
-    Rupee above Mogma Turf Entrance
-  \Eldin\Volcano\East\Southeast Rupee above Mogma Turf Entrance: Eldin Volcano - Southeast
-    Rupee above Mogma Turf Entrance
-  \Eldin\Volcano\Entry\Rupee on Ledge before First Room: Eldin Volcano - Rupee on
-    Ledge before First Room
-  \Eldin\Volcano\First Room\Chest behind Bombable Wall in First Room: Eldin Volcano
-    - Chest behind Bombable Wall in First Room
-  \Eldin\Volcano\First Room\Rupee behind Bombable Wall in First Room: Eldin Volcano
-    - Rupee behind Bombable Wall in First Room
-  \Eldin\Volcano\First Room\Rupee in Crawlspace in First Room: Eldin Volcano - Rupee
-    in Crawlspace in First Room
-  \Eldin\Volcano\Near Temple Entrance\Digging Spot behind Boulder on Sandy Slope: Eldin
-    Volcano - Digging Spot behind Boulder on Sandy Slope
-  \Eldin\Volcano\Near Temple Entrance\Digging Spot below Tower: Eldin Volcano - Digging
-    Spot below Tower
-  \Eldin\Volcano\Near Temple Entrance\Digging Spot in front of Earth Temple: Eldin
-    Volcano - Digging Spot in front of Earth Temple
-  \Eldin\Volcano\Near Thrill Digger Cave\Left Rupee behind Bombable Wall on First Slope: Eldin
-    Volcano - Left Rupee behind Bombable Wall on First Slope
-  \Eldin\Volcano\Near Thrill Digger Cave\Right Rupee behind Bombable Wall on First Slope: Eldin
-    Volcano - Right Rupee behind Bombable Wall on First Slope
-  \Eldin\Volcano\Past Slide\Digging Spot after Draining Lava: Eldin Volcano - Digging
-    Spot after Draining Lava
-  \Eldin\Volcano\Sand Slide\Digging Spot after Vents: Eldin Volcano - Digging Spot
-    after Vents
-  \Faron\Faron Silent Realm\Relic 1: Faron Silent Realm - Relic 1
-  \Faron\Faron Silent Realm\Relic 10: Faron Silent Realm - Relic 10
-  \Faron\Faron Silent Realm\Relic 2: Faron Silent Realm - Relic 2
-  \Faron\Faron Silent Realm\Relic 3: Faron Silent Realm - Relic 3
-  \Faron\Faron Silent Realm\Relic 4: Faron Silent Realm - Relic 4
-  \Faron\Faron Silent Realm\Relic 5: Faron Silent Realm - Relic 5
-  \Faron\Faron Silent Realm\Relic 6: Faron Silent Realm - Relic 6
-  \Faron\Faron Silent Realm\Relic 7: Faron Silent Realm - Relic 7
-  \Faron\Faron Silent Realm\Relic 8: Faron Silent Realm - Relic 8
-  \Faron\Faron Silent Realm\Relic 9: Faron Silent Realm - Relic 9
-  \Faron\Faron Silent Realm\Trial Reward: Faron Silent Realm - Trial Reward
-  \Faron\Faron Woods\Chest behind Upper Bombable Rock: Faron Woods - Chest behind
-    Upper Bombable Rock
-  \Faron\Faron Woods\Deep Woods\Deep Woods Chest: Faron Woods - Deep Woods Chest
-  \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest\Chest inside Great Tree: Faron
-    Woods - Chest inside Great Tree
-  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree North Branch: Faron Woods
-    - Rupee on Great Tree North Branch
-  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree West Branch: Faron Woods -
-    Rupee on Great Tree West Branch
-  \Faron\Faron Woods\Item behind Lower Bombable Rock: Faron Woods - Item behind Lower
-    Bombable Rock
-  \Faron\Faron Woods\Item on Tree: Faron Woods - Item on Tree
-  \Faron\Faron Woods\Kikwi Elder's Reward: Faron Woods - Kikwi Elder's Reward
-  \Faron\Faron Woods\Rupee on Hollow Tree Branch: Faron Woods - Rupee on Hollow Tree
-    Branch
-  \Faron\Faron Woods\Rupee on Hollow Tree Root: Faron Woods - Rupee on Hollow Tree
-    Root
-  \Faron\Faron Woods\Rupee on Platform near Floria Door: Faron Woods - Rupee on Platform
-    near Floria Door
-  \Faron\Flooded Faron Woods\16 Dark Blue Tadtones in the South West: Flooded Faron
-    Woods - 16 Dark Blue Tadtones in the South West
-  \Faron\Flooded Faron Woods\2 Dark Blue Tadtones in Grass West of Great Tree: Flooded
-    Faron Woods - 2 Dark Blue Tadtones in Grass West of Great Tree
-  \Faron\Flooded Faron Woods\2 Red Tadtones in Grass near Lower Bombable Rock: Flooded
-    Faron Woods - 2 Red Tadtones in Grass near Lower Bombable Rock
-  \Faron\Flooded Faron Woods\4 Light Blue Moving Tadtones under Kikwi Elder: Flooded
-    Faron Woods - 4 Light Blue Moving Tadtones under Kikwi Elder
-  \Faron\Flooded Faron Woods\4 Purple Moving Tadtones near Floria Gate: Flooded Faron
-    Woods - 4 Purple Moving Tadtones near Floria Gate
-  \Faron\Flooded Faron Woods\4 Purple Tadtones under Viewing Platform: Flooded Faron
-    Woods - 4 Purple Tadtones under Viewing Platform
-  \Faron\Flooded Faron Woods\4 Red Moving Tadtones North West of Great Tree: Flooded
-    Faron Woods - 4 Red Moving Tadtones North West of Great Tree
-  \Faron\Flooded Faron Woods\4 Yellow Tadtones under Small Hollow Tree: Flooded Faron
-    Woods - 4 Yellow Tadtones under Small Hollow Tree
-  \Faron\Flooded Faron Woods\8 Green Tadtones in West Tunnel: Flooded Faron Woods
-    - 8 Green Tadtones in West Tunnel
-  \Faron\Flooded Faron Woods\8 Light Blue Tadtones near Viewing Platform: Flooded
-    Faron Woods - 8 Light Blue Tadtones near Viewing Platform
-  \Faron\Flooded Faron Woods\8 Purple Tadtones in Clearing after Small Hollow Tree: Flooded
-    Faron Woods - 8 Purple Tadtones in Clearing after Small Hollow Tree
-  \Faron\Flooded Faron Woods\8 Yellow Tadtones near Kikwi Elder: Flooded Faron Woods
-    - 8 Yellow Tadtones near Kikwi Elder
-  \Faron\Flooded Faron Woods\Dark Blue Moving Tadtone inside Small Hollow Tree: Flooded
-    Faron Woods - Dark Blue Moving Tadtone inside Small Hollow Tree
-  \Faron\Flooded Faron Woods\Flooded Great Tree\Water Dragon's Reward: Flooded Faron
-    Woods - Water Dragon's Reward
-  \Faron\Flooded Faron Woods\Green Tadtone behind Upper Bombable Rock: Flooded Faron
-    Woods - Green Tadtone behind Upper Bombable Rock
-  \Faron\Flooded Faron Woods\Light Blue Tadtone under Great Tree Root: Flooded Faron
-    Woods - Light Blue Tadtone under Great Tree Root
-  \Faron\Flooded Faron Woods\Red Moving Tadtone near Viewing Platform: Flooded Faron
-    Woods - Red Moving Tadtone near Viewing Platform
-  \Faron\Flooded Faron Woods\Yellow Tadtone under Lilypad: Flooded Faron Woods - Yellow
-    Tadtone under Lilypad
-  \Faron\Lake Floria\Above Rock\Left Rupee behind Northwest Boulder: Lake Floria -
-    Left Rupee behind Northwest Boulder
-  \Faron\Lake Floria\Above Rock\Right Rupee behind Northwest Boulder: Lake Floria
-    - Right Rupee behind Northwest Boulder
-  \Faron\Lake Floria\Above Rock\Rupee behind Southwest Boulder: Lake Floria - Rupee
-    behind Southwest Boulder
-  \Faron\Lake Floria\Above Rock\Rupee under Central Boulder: Lake Floria - Rupee under
-    Central Boulder
-  \Faron\Lake Floria\Below Rock\Emerged Area\Lake Floria Chest: Lake Floria - Lake
-    Floria Chest
-  \Faron\Lake Floria\Farore's Lair\Dragon Lair East Chest: Lake Floria - Dragon Lair
-    East Chest
-  \Faron\Lake Floria\Farore's Lair\Dragon Lair South Chest: Lake Floria - Dragon Lair
-    South Chest
-  \Faron\Lake Floria\Waterfall\Rupee on High Ledge outside Ancient Cistern Entrance: Lake
-    Floria - Rupee on High Ledge outside Ancient Cistern Entrance
-  \Faron\Sealed Grounds\Behind the Temple\Gorko's Goddess Wall Reward: Sealed Grounds
-    - Gorko's Goddess Wall Reward
-  \Faron\Sealed Grounds\Hylia's Temple\Zelda's Blessing: Sealed Grounds - Zelda's
-    Blessing
-  \Faron\Sealed Grounds\Sealed Temple\Chest inside Sealed Temple: Sealed Grounds -
-    Chest inside Sealed Temple
-  \Faron\Sealed Grounds\Sealed Temple\Song from Impa: Sealed Grounds - Song from Impa
-  \Fire Sanctuary\Boss Room\Heart Container: Fire Sanctuary - Heart Container
-  \Fire Sanctuary\Flame Room\Din's Flame: Fire Sanctuary - Din's Flame
-  \Fire Sanctuary\Main\Boss Key Room\Boss Key Chest: Fire Sanctuary - Boss Key Chest
-  \Fire Sanctuary\Main\First Room\Past Water Plant\Chest in First Room: Fire Sanctuary
-    - Chest in First Room
-  \Fire Sanctuary\Main\First Trapped Mogma Room\Chest near First Trapped Mogma: Fire
-    Sanctuary - Chest near First Trapped Mogma
-  \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area\Rescue First Trapped Mogma: Fire
-    Sanctuary - Rescue First Trapped Mogma
-  \Fire Sanctuary\Main\Second Room\Balcony\Chest on Balcony: Fire Sanctuary - Chest
-    on Balcony
-  \Fire Sanctuary\Main\Second Room\Chest in Second Room: Fire Sanctuary - Chest in
-    Second Room
-  \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall\Chest after Bombable Wall: Fire
-    Sanctuary - Chest after Bombable Wall
-  \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Second Trapped Mogma: Fire
-    Sanctuary - Rescue Second Trapped Mogma
-  \Fire Sanctuary\Main\Staircase Room\Chest in Staircase Room: Fire Sanctuary - Chest
-    in Staircase Room
-  \Fire Sanctuary\Main\Water Fruit Room\First Chest in Water Fruit Room: Fire Sanctuary
-    - First Chest in Water Fruit Room
-  \Fire Sanctuary\Main\Water Fruit Room\Second Chest in Water Fruit Room: Fire Sanctuary
-    - Second Chest in Water Fruit Room
-  \Fire Sanctuary\Main\West of Boss Door\Plats' Chest: Fire Sanctuary - Plats' Chest
-  \Lanayru Mining Facility\Boss Room\After Sand Drain\Heart Container: Lanayru Mining
-    Facility - Heart Container
-  \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit Hall of Ancient Robots: Lanayru
-    Mining Facility - Exit Hall of Ancient Robots
-  \Lanayru Mining Facility\Main\Armos Fight Room\Chest after Armos Fight: Lanayru
-    Mining Facility - Chest after Armos Fight
-  \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes\First Chest in Hub Room: Lanayru
-    Mining Facility - First Chest in Hub Room
-  \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Shortcut Chest in Main Hub: Lanayru
-    Mining Facility - Shortcut Chest in Main Hub
-  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Chest behind First Crawlspace: Lanayru
-    Mining Facility - Chest behind First Crawlspace
-  \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Chest in Spike Maze: Lanayru
-    Mining Facility - Chest in Spike Maze
-  \Lanayru Mining Facility\Main\Boss Key Room\Boss Key Chest: Lanayru Mining Facility
-    - Boss Key Chest
-  \Lanayru Mining Facility\Main\First Room\Chest behind Bars: Lanayru Mining Facility
-    - Chest behind Bars
-  \Lanayru Mining Facility\Main\First West Room\Chest in First West Room: Lanayru
-    Mining Facility - Chest in First West Room
-  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Lower Chest in Hop across Boxes Room: Lanayru
-    Mining Facility - Lower Chest in Hop across Boxes Room
-  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Raised Chest in Hop across Boxes Room: Lanayru
-    Mining Facility - Raised Chest in Hop across Boxes Room
-  \Lanayru Mining Facility\Main\Key Locked Room\Chest in Key Locked Room: Lanayru
-    Mining Facility - Chest in Key Locked Room
-  \Lanayru\Caves\Chest: Lanayru Caves - Chest
-  \Lanayru\Caves\Golo's Gift: Lanayru Caves - Golo's Gift
-  \Lanayru\Desert\East\Chest on Platform near Fire Node: Lanayru Desert - Chest on
-    Platform near Fire Node
-  \Lanayru\Desert\East\Fire Node\Past after Grate\Left Ending Chest: Lanayru Desert
-    - Fire Node - Left Ending Chest
-  \Lanayru\Desert\East\Fire Node\Past after Grate\Right Ending Chest: Lanayru Desert
-    - Fire Node - Right Ending Chest
-  \Lanayru\Desert\East\Fire Node\Past\First Small Chest: Lanayru Desert - Fire Node
-    - First Small Chest
-  \Lanayru\Desert\East\Fire Node\Past\Second Small Chest: Lanayru Desert - Fire Node
-    - Second Small Chest
-  \Lanayru\Desert\East\Fire Node\Present after Sand\Shortcut Chest: Lanayru Desert
-    - Fire Node - Shortcut Chest
-  \Lanayru\Desert\Entry\High Ledge after Vines\Chest near Party Wheel: Lanayru Desert
-    - Chest near Party Wheel
-  \Lanayru\Desert\Near Caged Robot\Chest near Caged Robot: Lanayru Desert - Chest
-    near Caged Robot
-  \Lanayru\Desert\Near Caged Robot\Rescue Caged Robot: Lanayru Desert - Rescue Caged
-    Robot
-  \Lanayru\Desert\North Part\Chest on Platform near Lightning Node: Lanayru Desert
-    - Chest on Platform near Lightning Node
-  \Lanayru\Desert\North Part\Lightning Node\Past\First Chest: Lanayru Desert - Lightning
-    Node - First Chest
-  \Lanayru\Desert\North Part\Lightning Node\Past\Second Chest: Lanayru Desert - Lightning
-    Node - Second Chest
-  \Lanayru\Desert\North Part\Lightning Node\Present from afar\Raised Chest near Generator: Lanayru
-    Desert - Lightning Node - Raised Chest near Generator
-  \Lanayru\Desert\North Part\Secret Passageway\Secret Passageway Chest: Lanayru Desert
-    - Secret Passageway Chest
-  \Lanayru\Desert\Top of LMF\Chest on top of Lanayru Mining Facility: Lanayru Desert
-    - Chest on top of Lanayru Mining Facility
-  \Lanayru\Desert\Top of West Wall\Chest near Sand Oasis: Lanayru Desert - Chest near
-    Sand Oasis
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Left Rupee on Entrance Crown: Lanayru
-    Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Right Rupee on Entrance Crown: Lanayru
-    Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Rupee on First Pillar: Lanayru
-    Sand Sea - Ancient Harbour - Rupee on First Pillar
-  \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Digging Spot: Lanayru Gorge - Digging
-    Spot
-  \Lanayru\Lanayru Sand Sea\Gorge\Item on Pillar: Lanayru Gorge - Item on Pillar
-  \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward: Lanayru Gorge - Thunder
-    Dragon's Reward
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Chest: Lanayru Sand Sea
-    - Pirate Stronghold - First Chest
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Chest: Lanayru Sand Sea
-    - Pirate Stronghold - Second Chest
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Third Chest: Lanayru Sand Sea
-    - Pirate Stronghold - Third Chest
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose: Lanayru
-    Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar or Nose
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar: Lanayru Sand
-    Sea - Pirate Stronghold - Rupee on East Sea Pillar
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar: Lanayru Sand
-    Sea - Pirate Stronghold - Rupee on West Sea Pillar
-  \Lanayru\Lanayru Sand Sea\Shipyard\Rickety Coaster -- Heart Stopping Track in 1'05: Lanayru
-    Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Chest after Moblin: Lanayru
-    Sand Sea - Skipper's Retreat - Chest after Moblin
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Chest in Shack: Lanayru Sand Sea
-    - Skipper's Retreat - Chest in Shack
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform\Skydive Chest: Lanayru
-    Sand Sea - Skipper's Retreat - Skydive Chest
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Chest on top of Cacti Pillar: Lanayru
-    Sand Sea - Skipper's Retreat - Chest on top of Cacti Pillar
-  \Lanayru\Lanayru Silent Realm\Relic 1: Lanayru Silent Realm - Relic 1
-  \Lanayru\Lanayru Silent Realm\Relic 10: Lanayru Silent Realm - Relic 10
-  \Lanayru\Lanayru Silent Realm\Relic 2: Lanayru Silent Realm - Relic 2
-  \Lanayru\Lanayru Silent Realm\Relic 3: Lanayru Silent Realm - Relic 3
-  \Lanayru\Lanayru Silent Realm\Relic 4: Lanayru Silent Realm - Relic 4
-  \Lanayru\Lanayru Silent Realm\Relic 5: Lanayru Silent Realm - Relic 5
-  \Lanayru\Lanayru Silent Realm\Relic 6: Lanayru Silent Realm - Relic 6
-  \Lanayru\Lanayru Silent Realm\Relic 7: Lanayru Silent Realm - Relic 7
-  \Lanayru\Lanayru Silent Realm\Relic 8: Lanayru Silent Realm - Relic 8
-  \Lanayru\Lanayru Silent Realm\Relic 9: Lanayru Silent Realm - Relic 9
-  \Lanayru\Lanayru Silent Realm\Trial Reward: Lanayru Silent Realm - Trial Reward
-  \Lanayru\Mine\End\Chest at the End of Mine: Lanayru Mine - Chest at the End of Mine
-  \Lanayru\Mine\Entry\Chest near First Timeshift Stone: Lanayru Mine - Chest near
-    First Timeshift Stone
-  \Lanayru\Mine\Entry\Higher Area\Chest behind First Landing: Lanayru Mine - Chest
-    behind First Landing
-  \Lanayru\Mine\Statues Area\Chest behind Statue: Lanayru Mine - Chest behind Statue
-  \Sandship\Boss Room\Heart Container: Sandship - Heart Container
-  \Sandship\Boss Room\Nayru's Flame: Sandship - Nayru's Flame
-  \Sandship\Main\Before Boss Door\Chest behind Combination Lock: Sandship - Chest
-    behind Combination Lock
-  \Sandship\Main\Before Ship's Bow\Chest before 4-Door Corridor: Sandship - Chest
-    before 4-Door Corridor
-  \Sandship\Main\Brig Prison\Robot in Brig's Reward: Sandship - Robot in Brig's Reward
-  \Sandship\Main\Deck\Captain's Cabin\Boss Key Chest: Sandship - Boss Key Chest
-  \Sandship\Main\Deck\Stern\Chest at the Stern: Sandship - Chest at the Stern
-  \Sandship\Main\Ship's Bow\Chest after Scervo Fight: Sandship - Chest after Scervo
-    Fight
-  \Sandship\Main\Treasure Room\Treasure Room Fifth Chest: Sandship - Treasure Room
-    Fifth Chest
-  \Sandship\Main\Treasure Room\Treasure Room First Chest: Sandship - Treasure Room
-    First Chest
-  \Sandship\Main\Treasure Room\Treasure Room Fourth Chest: Sandship - Treasure Room
-    Fourth Chest
-  \Sandship\Main\Treasure Room\Treasure Room Second Chest: Sandship - Treasure Room
-    Second Chest
-  \Sandship\Main\Treasure Room\Treasure Room Third Chest: Sandship - Treasure Room
-    Third Chest
-  \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Sacred Power of Farore: Sky Keep
-    - Sacred Power of Farore
-  \Sky Keep\Main\Fire Sanctuary Room\First Platform\Rupee in Fire Sanctuary Room in Alcove: Sky
-    Keep - Rupee in Fire Sanctuary Room in Alcove
-  \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Sacred Power of Din: Sky Keep -
-    Sacred Power of Din
-  \Sky Keep\Main\First Room\First Chest: Sky Keep - First Chest
-  \Sky Keep\Main\Mini Boss Room\Near Chest\Chest after Dreadfuse: Sky Keep - Chest
-    after Dreadfuse
-  \Sky Keep\Main\Sandship Room\Triforce Area\Sacred Power of Nayru: Sky Keep - Sacred
-    Power of Nayru
-  \Sky\North East\Bamboo Island\Bamboo Island Goddess Chest: Sky - Bamboo Island Goddess
-    Chest
-  \Sky\North East\Beedle's Island\Beedle's Crystals: Sky - Beedle's Crystals
-  \Sky\North East\Beedle's Island\Cage\Beedle's Island Cage Goddess Chest: Sky - Beedle's
-    Island Cage Goddess Chest
-  \Sky\North East\Beedle's Island\Crystal on Beedle's Ship: Sky - Crystal on Beedle's
-    Ship
-  \Sky\North East\Beedle's Island\Top\Beedle's Island Goddess Chest: Sky - Beedle's
-    Island Goddess Chest
-  \Sky\North East\Goddess Chest in Cave on Island next to Bamboo Island: Sky - Goddess
-    Chest in Cave on Island next to Bamboo Island
-  \Sky\North East\Goddess Chest on Island next to Bamboo Island: Sky - Goddess Chest
-    on Island next to Bamboo Island
-  \Sky\North East\Northeast Island Cage Goddess Chest: Sky - Northeast Island Cage
-    Goddess Chest
-  \Sky\North East\Northeast Island Goddess Chest behind Bombable Rocks: Sky - Northeast
-    Island Goddess Chest behind Bombable Rocks
-  \Sky\South East\Chest in Breakable Boulder near Lumpy Pumpkin: Sky - Chest in Breakable
-    Boulder near Lumpy Pumpkin
-  \Sky\South East\Goddess Chest on Island Closest to Faron Pillar: Sky - Goddess Chest
-    on Island Closest to Faron Pillar
-  \Sky\South East\Lumpy Pumpkin\Crystal outside Lumpy Pumpkin: Sky - Crystal outside
-    Lumpy Pumpkin
-  \Sky\South East\Lumpy Pumpkin\Goddess Chest on the Roof: Sky - Lumpy Pumpkin - Goddess
-    Chest on the Roof
-  \Sky\South East\Lumpy Pumpkin\Kina's Crystals: Sky - Kina's Crystals
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Chandelier: Sky - Lumpy Pumpkin
-    - Chandelier
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Crystal inside Lumpy Pumpkin: Sky
-    - Crystal inside Lumpy Pumpkin
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Harp Minigame: Sky - Lumpy
-    Pumpkin - Harp Minigame
-  \Sky\South East\Lumpy Pumpkin\Outside Goddess Chest: Sky - Lumpy Pumpkin - Outside
-    Goddess Chest
-  \Sky\South West\Chest in Breakable Boulder near Fun Fun Island: Sky - Chest in Breakable
-    Boulder near Fun Fun Island
-  \Sky\South West\Fun Fun Island\Dodoh's Crystals: Sky - Dodoh's Crystals
-  \Sky\South West\Fun Fun Island\Fun Fun Island Minigame -- 500 Rupees: Sky - Fun
-    Fun Island Minigame -- 500 Rupees
-  \Sky\South West\Fun Fun Island\Goddess Chest under Fun Fun Island: Sky - Goddess
-    Chest under Fun Fun Island
-  \Sky\South West\Orielle's Island\Orielle's Crystals: Sky - Orielle's Crystals
-  \Sky\South West\Triple Island\Southwest Triple Island Cage Goddess Chest: Sky -
-    Southwest Triple Island Cage Goddess Chest
-  \Sky\South West\Triple Island\Southwest Triple Island Lower Goddess Chest: Sky -
-    Southwest Triple Island Lower Goddess Chest
-  \Sky\South West\Triple Island\Southwest Triple Island Upper Goddess Chest: Sky -
-    Southwest Triple Island Upper Goddess Chest
-  \Sky\South West\Volcanic Island\Goddess Chest inside Volcanic Island: Sky - Goddess
-    Chest inside Volcanic Island
-  \Sky\South West\Volcanic Island\Goddess Chest outside Volcanic Island: Sky - Goddess
-    Chest outside Volcanic Island
-  \Sky\Thunderhead\Bug Heaven\Bug Heaven -- 10 Bugs in 3 Minutes: Thunderhead - Bug
-    Heaven -- 10 Bugs in 3 Minutes
-  \Sky\Thunderhead\Bug Heaven\Bug Heaven Goddess Chest: Thunderhead - Bug Heaven Goddess
-    Chest
-  \Sky\Thunderhead\East Island\East Island Chest: Thunderhead - East Island Chest
-  \Sky\Thunderhead\East Island\East Island Goddess Chest: Thunderhead - East Island
-    Goddess Chest
-  \Sky\Thunderhead\Isle of Songs\Goddess Chest on top of Isle of Songs: Thunderhead
-    - Goddess Chest on top of Isle of Songs
-  \Sky\Thunderhead\Isle of Songs\Goddess Chest outside Isle of Songs: Thunderhead
-    - Goddess Chest outside Isle of Songs
-  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Goddess Sword: Thunderhead
-    - Isle of Songs - Strike Crest with Goddess Sword
-  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Longsword: Thunderhead -
-    Isle of Songs - Strike Crest with Longsword
-  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with White Sword: Thunderhead
-    - Isle of Songs - Strike Crest with White Sword
-  \Sky\Thunderhead\Mogma Mitts Island\First Goddess Chest on Mogma Mitts Island: Thunderhead
-    - First Goddess Chest on Mogma Mitts Island
-  \Sky\Thunderhead\Mogma Mitts Island\Second Goddess Chest on Mogma Mitts Island: Thunderhead
-    - Second Goddess Chest on Mogma Mitts Island
-  \Sky\Thunderhead\Song from Levias: Thunderhead - Song from Levias
-  \Skyloft\Beedle's Shop\Stall\1000 Rupee Item: Beedle's Shop - 1000 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\1200 Rupee Item: Beedle's Shop - 1200 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\1600 Rupee Item: Beedle's Shop - 1600 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\300 Rupee Item: Beedle's Shop - 300 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\50 Rupee Item: Beedle's Shop - 50 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\600 Rupee Item: Beedle's Shop - 600 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\800 Rupee Item: Beedle's Shop - 800 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\First 100 Rupee Item: Beedle's Shop - First 100 Rupee
-    Item
-  \Skyloft\Beedle's Shop\Stall\Second 100 Rupee Item: Beedle's Shop - Second 100 Rupee
-    Item
-  \Skyloft\Beedle's Shop\Stall\Third 100 Rupee Item: Beedle's Shop - Third 100 Rupee
-    Item
-  \Skyloft\Central Skyloft\Bazaar\Bazaar Goddess Chest: Central Skyloft - Bazaar Goddess
-    Chest
-  \Skyloft\Central Skyloft\Bazaar\Potion Lady's Gift: Central Skyloft - Potion Lady's
-    Gift
-  \Skyloft\Central Skyloft\Bazaar\Repair Gondo's Junk: Central Skyloft - Repair Gondo's
-    Junk
-  \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest: Central Skyloft - Item in
-    Bird Nest
-  \Skyloft\Central Skyloft\Crystal between Wooden Planks: Central Skyloft - Crystal
-    between Wooden Planks
-  \Skyloft\Central Skyloft\Crystal on Light Tower: Central Skyloft - Crystal on Light
-    Tower
-  \Skyloft\Central Skyloft\Crystal on Waterfall Island: Central Skyloft - Crystal
-    on Waterfall Island
-  \Skyloft\Central Skyloft\Crystal on West Cliff: Central Skyloft - Crystal on West
-    Cliff
-  \Skyloft\Central Skyloft\Orielle and Parrow's House\Crystal in Orielle and Parrow's House: Central
-    Skyloft - Crystal in Orielle and Parrow's House
-  \Skyloft\Central Skyloft\Parrow's Crystals: Central Skyloft - Parrow's Crystals
-  \Skyloft\Central Skyloft\Parrow's Gift: Central Skyloft - Parrow's Gift
-  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: Central
-    Skyloft - Crystal after Waterfall Cave
-  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: Central
-    Skyloft - Crystal in Loftwing Prison
-  \Skyloft\Central Skyloft\Peatrice's House\Peater/Peatrice's Crystals: Central Skyloft
-    - Peater/Peatrice's Crystals
-  \Skyloft\Central Skyloft\Shed Chest: Central Skyloft - Shed Chest
-  \Skyloft\Central Skyloft\Shed Goddess Chest: Central Skyloft - Shed Goddess Chest
-  \Skyloft\Central Skyloft\Waterfall Cave\Rupee Waterfall Cave Crawlspace: Central
-    Skyloft - Rupee Waterfall Cave Crawlspace
-  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave First Chest: Central Skyloft
-    - Waterfall Cave First Chest
-  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave Second Chest: Central Skyloft
-    - Waterfall Cave Second Chest
-  \Skyloft\Central Skyloft\Waterfall Island\Floating Island Goddess Chest: Central
-    Skyloft - Floating Island Goddess Chest
-  \Skyloft\Central Skyloft\Waterfall Island\Waterfall Goddess Chest: Central Skyloft
-    - Waterfall Goddess Chest
-  \Skyloft\Central Skyloft\West Cliff Goddess Chest: Central Skyloft - West Cliff
-    Goddess Chest
-  \Skyloft\Central Skyloft\Wryna's House\Wryna's Crystals: Central Skyloft - Wryna's
-    Crystals
-  \Skyloft\Skyloft Silent Realm\Relic 1: Skyloft Silent Realm - Relic 1
-  \Skyloft\Skyloft Silent Realm\Relic 10: Skyloft Silent Realm - Relic 10
-  \Skyloft\Skyloft Silent Realm\Relic 2: Skyloft Silent Realm - Relic 2
-  \Skyloft\Skyloft Silent Realm\Relic 3: Skyloft Silent Realm - Relic 3
-  \Skyloft\Skyloft Silent Realm\Relic 4: Skyloft Silent Realm - Relic 4
-  \Skyloft\Skyloft Silent Realm\Relic 5: Skyloft Silent Realm - Relic 5
-  \Skyloft\Skyloft Silent Realm\Relic 6: Skyloft Silent Realm - Relic 6
-  \Skyloft\Skyloft Silent Realm\Relic 7: Skyloft Silent Realm - Relic 7
-  \Skyloft\Skyloft Silent Realm\Relic 8: Skyloft Silent Realm - Relic 8
-  \Skyloft\Skyloft Silent Realm\Relic 9: Skyloft Silent Realm - Relic 9
-  \Skyloft\Skyloft Silent Realm\Trial Reward: Skyloft Silent Realm - Trial Reward
-  \Skyloft\Skyloft Village\Batreaux's House\10 Crystals: Batreaux's House - 10 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals: Batreaux's House - 30 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals Chest: Batreaux's House -
-    30 Crystals Chest
-  \Skyloft\Skyloft Village\Batreaux's House\40 Crystals: Batreaux's House - 40 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\5 Crystals: Batreaux's House - 5 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\50 Crystals: Batreaux's House - 50 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals: Batreaux's House - 70 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals Second Reward: Batreaux's
-    House - 70 Crystals Second Reward
-  \Skyloft\Skyloft Village\Batreaux's House\80 Crystals: Batreaux's House - 80 Crystals
-  \Skyloft\Skyloft Village\Bertie's House\Bertie's Crystals: Skyloft Village - Bertie's
-    Crystals
-  \Skyloft\Skyloft Village\Crystal near Pumpkin Patch: Skyloft Village - Crystal near
-    Pumpkin Patch
-  \Skyloft\Skyloft Village\Mallara's House\Mallara's Crystals: Skyloft Village - Mallara's
-    Crystals
-  \Skyloft\Skyloft Village\Sparrot's House\Sparrot's Crystals: Skyloft Village - Sparrot's
-    Crystals
-  \Skyloft\Upper Skyloft\Chest near Goddess Statue: Upper Skyloft - Chest near Goddess
-    Statue
-  \Skyloft\Upper Skyloft\Goddess Statue\First Goddess Sword Item in Goddess Statue: Upper
-    Skyloft - First Goddess Sword Item in Goddess Statue
-  \Skyloft\Upper Skyloft\Goddess Statue\Second Goddess Sword Item in Goddess Statue: Upper
-    Skyloft - Second Goddess Sword Item in Goddess Statue
-  \Skyloft\Upper Skyloft\Knight Academy\Crystal in Knight Academy Plant: Upper Skyloft
-    - Crystal in Knight Academy Plant
-  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Crystals: Upper Skyloft - Fledge's
-    Crystals
-  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Gift: Upper Skyloft - Fledge's Gift
-  \Skyloft\Upper Skyloft\Knight Academy\Ghost/Pipit's Crystals: Upper Skyloft - Ghost/Pipit's
-    Crystals
-  \Skyloft\Upper Skyloft\Knight Academy\Item from Cawlin: Upper Skyloft - Item from
-    Cawlin
-  \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Crystal in Link's Room: Upper
-    Skyloft - Crystal in Link's Room
-  \Skyloft\Upper Skyloft\Knight Academy\Owlan's Crystals: Upper Skyloft - Owlan's
-    Crystals
-  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Crystal in Zelda's Room: Upper
-    Skyloft - Crystal in Zelda's Room
-  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\In Zelda's Closet: Upper Skyloft
-    - In Zelda's Closet
-  \Skyloft\Upper Skyloft\Owlan's Gift: Upper Skyloft - Owlan's Gift
-  \Skyloft\Upper Skyloft\Pumpkin Archery -- 600 Points: Upper Skyloft - Pumpkin Archery
-    -- 600 Points
-  \Skyloft\Upper Skyloft\Sparring Hall\Crystal in Sparring Hall: Upper Skyloft - Crystal
-    in Sparring Hall
-  \Skyloft\Upper Skyloft\Sparring Hall\Sparring Hall Chest: Upper Skyloft - Sparring
-    Hall Chest
-  \Skyview\Boss Room\Heart Container: Skyview - Heart Container
-  \Skyview\Main\First Hub\Left Room\Chest on Tree Branch: Skyview - Chest on Tree
-    Branch
-  \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace: Skyview
-    - Digging Spot in Crawlspace
-  \Skyview\Main\First Hub\Right Room\Upper Area\Chest behind Two Eyes: Skyview - Chest
-    behind Two Eyes
-  \Skyview\Main\Last Room\After Rope\Chest near Boss Door: Skyview - Chest near Boss
-    Door
-  \Skyview\Main\Last Room\Near Boss Key Chest\Boss Key Chest: Skyview - Boss Key Chest
-  \Skyview\Main\Second Hub\Item behind Bars: Skyview - Item behind Bars
-  \Skyview\Main\Second Hub\Left Rooms\Chest behind Three Eyes: Skyview - Chest behind
-    Three Eyes
-  \Skyview\Main\Second Hub\Miniboss Room\Chest after Stalfos Fight: Skyview - Chest
-    after Stalfos Fight
-  \Skyview\Main\Second Hub\Rupee in East Tunnel: Skyview - Rupee in East Tunnel
-  \Skyview\Main\Second Hub\Rupee in Southeast Tunnel: Skyview - Rupee in Southeast
-    Tunnel
-  \Skyview\Main\Second Hub\Rupee in Southwest Tunnel: Skyview - Rupee in Southwest
-    Tunnel
-  \Skyview\Spring\Rupee on Spring Pillar: Skyview - Rupee on Spring Pillar
-  \Skyview\Spring\Strike Crest: Skyview - Strike Crest
-entrances:
-  \Ancient Cistern\Boss Room\Entrance from Dungeon:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2232
-    short_name: Ancient Cistern - Boss Room - Entrance from Dungeon
-    tod: 2
-    type: entrance
-  \Ancient Cistern\Boss Room\Entrance from Flame Room:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2233
-    short_name: Ancient Cistern - Boss Room - Entrance from Flame Room
-    tod: 2
-    type: entrance
-  \Ancient Cistern\Flame Room\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2234
-    short_name: Ancient Cistern - Flame Room - Entrance
-    tod: 2
-    type: entrance
-  \Ancient Cistern\Main\Inside Statue\Boss Door Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2231
-    short_name: Ancient Cistern - Boss Door Entrance
-    tod: 2
-    type: entrance
-  \Ancient Cistern\Main\Main Room\Main Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Faron Province
-    req_index: 2230
-    room: 0
-    short_name: Ancient Cistern - Main Entrance
-    stage: D101
-    tod: 2
-    type: entrance
-  \Earth Temple\Boss Room\Entry\Entrance from Dungeon:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2261
-    short_name: Earth Temple - Boss Room - Entrance from Dungeon
-    tod: 2
-    type: entrance
-  \Earth Temple\Boss Room\Slope\Entrance from Spring:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2262
-    short_name: Earth Temple - Boss Room - Entrance from Spring
-    tod: 2
-    type: entrance
-  \Earth Temple\Main\First Room\Main Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Eldin Province
-    req_index: 2259
-    room: 1
-    short_name: Earth Temple - Main Entrance
-    stage: D200
-    tod: 2
-    type: entrance
-  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2260
-    short_name: Earth Temple - Boss Door Entrance
-    tod: 2
-    type: entrance
-  \Earth Temple\Spring\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2263
-    short_name: Earth Temple - Spring - Entrance
-    tod: 2
-    type: entrance
-  \Eldin\Bokoblin Base\Prison\Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 1
-    province: Eldin Province
-    req_index: 2248
-    room: 1
-    short_name: Bokoblin Base - Entrance
-    stage: F202
-    tod: 2
-    type: entrance
-  \Eldin\Eldin Silent Realm\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2251
-    short_name: Eldin Silent Realm - Entrance
-    tod: 2
-    type: entrance
-  \Eldin\Mogma Turf\Pre Vent\Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Eldin Province
-    req_index: 2249
-    room: 0
-    short_name: Mogma Turf - Entrance
-    stage: F210
-    tod: 2
-    type: entrance
-  \Eldin\Volcano Summit\Entrance from Eldin Volcano:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 4
-    layer: 0
-    province: Eldin Province
-    req_index: 2254
-    room: 0
-    short_name: Volcano Summit - Entrance from Eldin Volcano
-    stage: F201_1
-    tod: 2
-    type: entrance
-  \Eldin\Volcano Summit\Entrance from Outside Fire Sanctuary:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 1
-    layer: 0
-    province: Eldin Province
-    req_index: 2252
-    room: 0
-    short_name: Volcano Summit - Entrance from Outside Fire Sanctuary
-    stage: F201_1
-    tod: 2
-    type: entrance
-  \Eldin\Volcano Summit\Entrance from Waterfall:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 2
-    layer: 0
-    province: Eldin Province
-    req_index: 2253
-    room: 0
-    short_name: Volcano Summit - Entrance from Waterfall
-    stage: F201_1
-    tod: 2
-    type: entrance
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Entrance from Summit:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Eldin Province
-    req_index: 2257
-    room: 0
-    short_name: Outside Fire Sanctuary - Entrance from Summit
-    stage: F201_3
-    tod: 2
-    type: entrance
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Entrance from Fire Sanctuary:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 1
-    layer: 0
-    province: Eldin Province
-    req_index: 2258
-    room: 0
-    short_name: Outside Fire Sanctuary - Entrance from Fire Sanctuary
-    stage: F201_3
-    tod: 2
-    type: entrance
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 3
-    layer: 0
-    province: Eldin Province
-    req_index: 2256
-    room: 0
-    short_name: Outside Fire Sanctuary - Statue Entrance
-    stage: F201_3
-    statue-name: Inside the Volcano
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Eldin\Volcano Summit\Waterfall\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Eldin Province
-    req_index: 2255
-    room: 0
-    short_name: Volcano Summit - Waterfall - Entrance
-    stage: F201_4
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Ascent\Trial Gate Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2245
-    short_name: Eldin Volcano - Trial Gate Entrance
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Ascent\Volcano Ascent Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 7
-    layer: 0
-    province: Eldin Province
-    req_index: 2238
-    room: 2
-    short_name: Eldin Volcano - Volcano Ascent Statue Entrance
-    stage: F200
-    statue-name: Volcano Ascent
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\East\Entrance from Bokoblin Base:
-    allowed_time_of_day: 1
-    entrance: 5
-    layer: 1
-    province: Eldin Province
-    req_index: 2247
-    room: 1
-    short_name: Eldin Volcano - Entrance from Bokoblin Base
-    stage: F200
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\East\First Vent from Mogma Turf:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Eldin Province
-    req_index: 2240
-    room: 2
-    short_name: Eldin Volcano - First Vent from Mogma Turf
-    stage: F200
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\East\Volcano East Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 6
-    layer: 0
-    province: Eldin Province
-    req_index: 2237
-    room: 2
-    short_name: Eldin Volcano - Volcano East Statue Entrance
-    stage: F200
-    statue-name: Volcano East
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Entry\First Time Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Eldin Province
-    req_index: 2235
-    room: 0
-    short_name: Eldin Volcano - First Time Entrance
-    stage: F200
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Entry\Volcano Entrance Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: Eldin Province
-    req_index: 2236
-    room: 0
-    short_name: Eldin Volcano - Volcano Entrance Statue Entrance
-    stage: F200
-    statue-name: Volcano Entry
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Hot Cave\Entrance from Summit:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 2
-    layer: 0
-    province: Eldin Province
-    req_index: 2244
-    room: 5
-    short_name: Eldin Volcano - Entrance from Summit
-    stage: F200
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Hot Cave\Vent Entrance near Hot Cave:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2246
-    short_name: Eldin Volcano - Vent Entrance near Hot Cave
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Near Temple Entrance\Entrance from Earth Temple:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Eldin Province
-    req_index: 2242
-    room: 4
-    short_name: Eldin Volcano - Entrance from Earth Temple
-    stage: F200
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 7
-    layer: 0
-    province: Eldin Province
-    req_index: 2239
-    room: 4
-    short_name: Eldin Volcano - Temple Entrance Statue Entrance
-    stage: F200
-    statue-name: Temple Entrance
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Entrance:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: Eldin Province
-    req_index: 2243
-    room: 4
-    short_name: Eldin Volcano - Thrill Digger Cave Entrance
-    stage: F200
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Past Mogma Turf\Second Vent from Mogma Turf:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: Eldin Province
-    req_index: 2241
-    room: 2
-    short_name: Eldin Volcano - Second Vent from Mogma Turf
-    stage: F200
-    tod: 2
-    type: entrance
-  \Eldin\Volcano\Thrill Digger Cave\Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 1
-    province: Eldin Province
-    req_index: 2250
-    room: 0
-    short_name: Thrill Digger Cave - Entrance
-    stage: F211
-    tod: 2
-    type: entrance
-  \Faron\Faron Silent Realm\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2197
-    short_name: Faron Silent Realm - Entrance
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Deep Woods\Deep Woods Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 14
-    layer: 0
-    province: Faron Province
-    req_index: 2213
-    room: 0
-    short_name: Deep Woods - Deep Woods Statue Entrance
-    stage: F101
-    statue-name: Deep Woods
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Deep Woods\Entrance from Skyview Temple:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 1
-    layer: 0
-    province: Faron Province
-    req_index: 2215
-    room: 0
-    short_name: Deep Woods - Entrance from Skyview Temple
-    stage: F101
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Deep Woods\Entry\Entrance from Faron Woods:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Faron Province
-    req_index: 2214
-    room: 0
-    short_name: Deep Woods - Entrance from Faron Woods
-    stage: F101
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Deep Woods\Forest Temple Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 13
-    layer: 0
-    province: Faron Province
-    req_index: 2212
-    room: 0
-    short_name: Deep Woods - Forest Temple Statue Entrance
-    stage: F101
-    statue-name: Forest Temple
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Entry\Entrance from Behind the Temple:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Faron Province
-    req_index: 2193
-    room: 0
-    short_name: Faron Woods - Entrance from Behind the Temple
-    stage: F100
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Entry\Faron Woods Entry Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 50
-    layer: 0
-    province: Faron Province
-    req_index: 2189
-    room: 0
-    short_name: Faron Woods - Faron Woods Entry Statue Entrance
-    stage: F100
-    statue-name: Faron Woods Entry
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Entrance from Platforms:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Faron Province
-    req_index: 2202
-    room: 0
-    short_name: Great Tree - Lower Entrance from Platforms
-    stage: F100_1
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 4
-    layer: 0
-    province: Faron Province
-    req_index: 2205
-    room: 0
-    short_name: Great Tree - Underwater Tunnel Entrance
-    stage: F100_1
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 7
-    layer: 0
-    province: Faron Province
-    req_index: 2201
-    room: 0
-    short_name: Great Tree - Underwater Hole Entrance
-    stage: F100
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Great Tree\Platforms\Lower Entrance from Great Tree:
-    allowed_time_of_day: 1
-    entrance: 4
-    layer: 0
-    province: Faron Province
-    req_index: 2198
-    room: 0
-    short_name: Great Tree - Platforms - Lower Entrance from Great Tree
-    stage: F100
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Great Tree\Platforms\Upper Entrance from Great Tree:
-    allowed_time_of_day: 1
-    entrance: 5
-    layer: 0
-    province: Faron Province
-    req_index: 2199
-    room: 0
-    short_name: Great Tree - Platforms - Upper Entrance from Great Tree
-    stage: F100
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Great Tree\Top\The Great Tree Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 53
-    layer: 0
-    province: Faron Province
-    req_index: 2192
-    room: 0
-    short_name: Great Tree - The Great Tree Statue Entrance
-    stage: F100
-    statue-name: Great Tree Top
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Great Tree\Top\Top Entrance from Great Tree:
-    allowed_time_of_day: 1
-    entrance: 6
-    layer: 0
-    province: Faron Province
-    req_index: 2200
-    room: 0
-    short_name: Great Tree - Top Entrance from Great Tree
-    stage: F100
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Flooded Great Tree:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2206
-    short_name: Great Tree - Entrance from Flooded Great Tree
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Top:
-    allowed_time_of_day: 1
-    entrance: 3
-    layer: 0
-    province: Faron Province
-    req_index: 2204
-    room: 0
-    short_name: Great Tree - Entrance from Top
-    stage: F100_1
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Great Tree\Upper Area\Upper Entrance from Platforms:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: Faron Province
-    req_index: 2203
-    room: 0
-    short_name: Great Tree - Upper Entrance from Platforms
-    stage: F100_1
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\In the Woods Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 51
-    layer: 0
-    province: Faron Province
-    req_index: 2190
-    room: 0
-    short_name: Faron Woods - In the Woods Statue Entrance
-    stage: F100
-    statue-name: In the Woods
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Ledge To Deep Woods\Entrance from Deep Woods:
-    allowed_time_of_day: 1
-    entrance: 45
-    layer: 0
-    province: Faron Province
-    req_index: 2195
-    room: 0
-    short_name: Faron Woods - Entrance from Deep Woods
-    stage: F100
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Entrance from Floria Waterfall:
-    allowed_time_of_day: 1
-    entrance: 17
-    layer: 0
-    province: Faron Province
-    req_index: 2194
-    room: 0
-    short_name: Faron Woods - Shortcut Entrance from Floria Waterfall
-    stage: F100
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Trial Gate Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2196
-    short_name: Faron Woods - Trial Gate Entrance
-    tod: 2
-    type: entrance
-  \Faron\Faron Woods\Viewing Platform Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 52
-    layer: 0
-    province: Faron Province
-    req_index: 2191
-    room: 0
-    short_name: Faron Woods - Viewing Platform Statue Entrance
-    stage: F100
-    statue-name: Viewing Platform
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Faron\Flooded Faron Woods\Entrance from Lower Flooded Great Tree:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2211
-    short_name: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
-    tod: 2
-    type: entrance
-  \Faron\Flooded Faron Woods\Entrance from Upper Flooded Great Tree:
-    allowed_time_of_day: 1
-    req_index: 2210
-    short_name: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
-    type: entrance
-  \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance:
-    allowed_time_of_day: 1
-    req_index: 2207
-    short_name: Flooded Great Tree - Entrance
-    type: entrance
-  \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Lower Flooded Faron Woods:
-    allowed_time_of_day: 1
-    req_index: 2209
-    short_name: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
-    type: entrance
-  \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Upper Flooded Faron Woods:
-    allowed_time_of_day: 1
-    req_index: 2208
-    short_name: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
-    type: entrance
-  \Faron\Lake Floria\Above Rock\Dive from Faron Woods:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Faron Province
-    req_index: 2217
-    room: 0
-    short_name: Lake Floria - Dive from Faron Woods
-    stage: F102
-    tod: 2
-    type: entrance
-  \Faron\Lake Floria\Below Rock\Emerged Area\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: Faron Province
-    req_index: 2216
-    room: 3
-    short_name: Lake Floria - Below Rock - Statue Entrance
-    stage: F102
-    statue-name: Lake Floria
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Faron\Lake Floria\Below Rock\Entrance from Farore's Lair:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 1
-    layer: 0
-    province: Faron Province
-    req_index: 2218
-    room: 4
-    short_name: Lake Floria - Entrance from Farore's Lair
-    stage: F102
-    tod: 2
-    type: entrance
-  \Faron\Lake Floria\Farore's Lair\Entrance from Lake Floria:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Faron Province
-    req_index: 2219
-    room: 0
-    short_name: Farore's Lair - Entrance from Lake Floria
-    stage: F102_2
-    tod: 2
-    type: entrance
-  \Faron\Lake Floria\Farore's Lair\Entrance from Waterfall:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Faron Province
-    req_index: 2220
-    room: 0
-    short_name: Farore's Lair - Entrance from Waterfall
-    stage: F102_2
-    tod: 2
-    type: entrance
-  \Faron\Lake Floria\Waterfall\Entrance from Ancient Cistern:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Faron Province
-    req_index: 2223
-    room: 0
-    short_name: Floria Waterfall - Entrance from Ancient Cistern
-    stage: F102_1
-    statue-name: Floria Waterfall
-    tod: 2
-    type: entrance
-  \Faron\Lake Floria\Waterfall\Entrance from Faron Woods:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: Faron Province
-    req_index: 2224
-    room: 0
-    short_name: Floria Waterfall - Entrance from Faron Woods
-    stage: F102_1
-    tod: 2
-    type: entrance
-  \Faron\Lake Floria\Waterfall\Entrance from Farore's Lair:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Faron Province
-    req_index: 2222
-    room: 0
-    short_name: Floria Waterfall - Entrance from Farore's Lair
-    stage: F102_1
-    tod: 2
-    type: entrance
-  \Faron\Lake Floria\Waterfall\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 5
-    layer: 0
-    province: Faron Province
-    req_index: 2221
-    room: 0
-    short_name: Floria Waterfall - Statue Entrance
-    stage: F102_1
-    statue-name: Floria Waterfall
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Behind the Temple\Door Entrance:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Faron Province
-    req_index: 2186
-    room: 0
-    short_name: Behind the Temple - Door Entrance
-    stage: F400
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Behind the Temple\Entrance from Faron Woods:
-    allowed_time_of_day: 1
-    entrance: 3
-    layer: 0
-    province: Faron Province
-    req_index: 2188
-    room: 0
-    short_name: Behind the Temple - Entrance from Faron Woods
-    stage: F400
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Behind the Temple\Shortcut Entrance from Spiral:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 2
-    layer: 0
-    province: Faron Province
-    req_index: 2187
-    room: 0
-    short_name: Behind the Temple - Shortcut Entrance from Spiral
-    stage: F400
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Behind the Temple\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 10
-    layer: 0
-    province: Faron Province
-    req_index: 2185
-    room: 0
-    short_name: Behind the Temple - Statue Entrance
-    stage: F400
-    statue-name: Behind the Temple
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 1
-    layer: 0
-    province: Faron Province
-    req_index: 2184
-    room: 2
-    short_name: Hylia's Temple - Gate of Time Entrance
-    stage: F404
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Sealed Temple\Gate of Time Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 11
-    layer: 0
-    province: Faron Province
-    req_index: 2183
-    room: 2
-    short_name: Sealed Temple - Gate of Time Entrance
-    stage: F402
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Sealed Temple\Main Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Faron Province
-    req_index: 2181
-    room: 2
-    short_name: Sealed Temple - Main Entrance
-    stage: F402
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Sealed Temple\Side Entrance:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Faron Province
-    req_index: 2182
-    room: 2
-    short_name: Sealed Temple - Side Entrance
-    stage: F402
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Spiral\Door Entrance:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: Faron Province
-    req_index: 2180
-    room: 1
-    short_name: Sealed Grounds Spiral - Door Entrance
-    stage: F401
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Entrance from Behind the Temple:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Faron Province
-    req_index: 2179
-    room: 1
-    short_name: Sealed Grounds Spiral - Shortcut Entrance from Behind the Temple
-    stage: F401
-    tod: 2
-    type: entrance
-  \Faron\Sealed Grounds\Spiral\Upper Part\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 8
-    layer: 0
-    province: Faron Province
-    req_index: 2178
-    room: 1
-    short_name: Sealed Grounds Spiral - Statue Entrance
-    stage: F401
-    statue-name: Sealed Grounds
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Fire Sanctuary\Boss Room\Entrance from Dungeon:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2271
-    short_name: Fire Sanctuary - Boss Room - Entrance from Dungeon
-    tod: 2
-    type: entrance
-  \Fire Sanctuary\Boss Room\Entrance from Flame Room:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2272
-    short_name: Fire Sanctuary - Boss Room - Entrance from Flame Room
-    tod: 2
-    type: entrance
-  \Fire Sanctuary\Flame Room\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2273
-    short_name: Fire Sanctuary - Flame Room - Entrance
-    tod: 2
-    type: entrance
-  \Fire Sanctuary\Main\First Room\Main Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Eldin Province
-    req_index: 2265
-    room: 0
-    short_name: Fire Sanctuary - Main Entrance
-    stage: D201
-    tod: 2
-    type: entrance
-  \Fire Sanctuary\Main\First Room\Past Water Plant\Entrance from Second Room:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2266
-    short_name: Fire Sanctuary - First Room - Entrance from Second Room
-    tod: 2
-    type: entrance
-  \Fire Sanctuary\Main\Front of Boss Door\Boss Door Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2270
-    short_name: Fire Sanctuary - Boss Door Entrance
-    tod: 2
-    type: entrance
-  \Fire Sanctuary\Main\Front of Boss Door\Statue Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 2
-    layer: 0
-    province: Eldin Province
-    req_index: 2264
-    room: 10
-    short_name: Fire Sanctuary - Statue Entrance
-    stage: D201
-    statue-name: Inside the Fire Sanctuary
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Entrance from West of Boss Door:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2268
-    short_name: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss
-      Door
-    tod: 2
-    type: entrance
-  \Fire Sanctuary\Main\Second Room\Outside Section\Entrance from First Room:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2267
-    short_name: Fire Sanctuary - Second Room - Entrance from First Room
-    tod: 2
-    type: entrance
-  \Fire Sanctuary\Main\West of Boss Door\Entry\Entrance from Magmanos Fight Room:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Eldin Province
-    req_index: 2269
-    short_name: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight
-      Room
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Boss Room\After Sand Drain\Entrance from Hall of Ancient Robots:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2337
-    short_name: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient
-      Robots
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Boss Room\Entrance from Dungeon:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2336
-    short_name: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Hall of Ancient Robots\End\Entrance from Temple of Time:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2339
-    room: 0
-    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Temple
-      of Time
-    stage: F300_5
-    subtype: vanilla
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Entrance from Boss Room:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2338
-    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
-      Room
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Main\Armos Fight Room\Entrance from Big Hub:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2331
-    short_name: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Main\Big Hub\Entry\Entrance from First Hub:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2332
-    short_name: Lanayru Mining Facility - Big Hub - Entrance from First Hub
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Entrance from Hop Across Boxes Room:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2333
-    short_name: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes
-      Room
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Entrance from Armos Fight Room:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2334
-    short_name: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Main\First Hub\Entrance from Big Hub:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2329
-    short_name: Lanayru Mining Facility - First Hub - Entrance from Big Hub
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Main\First Room\Main Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2328
-    room: 0
-    short_name: Lanayru Mining Facility - Main Entrance
-    stage: D300
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Entrance from Big Hub:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2330
-    short_name: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big
-      Hub
-    tod: 2
-    type: entrance
-  \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2335
-    short_name: Lanayru Mining Facility - Boss Door Entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Caves\Entrance from Desert:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2299
-    room: 0
-    short_name: Lanayru Caves - Entrance from Desert
-    stage: F303
-    tod: 2
-    type: entrance
-  \Lanayru\Caves\Entrance from Mine:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2298
-    room: 0
-    short_name: Lanayru Caves - Entrance from Mine
-    stage: F303
-    tod: 2
-    type: entrance
-  \Lanayru\Caves\Past Crawlspace\Entrance from Gorge:
-    allowed_time_of_day: 1
-    entrance: 3
-    layer: 0
-    province: Lanayru Province
-    req_index: 2301
-    room: 0
-    short_name: Lanayru Caves - Entrance from Gorge
-    stage: F303
-    tod: 2
-    type: entrance
-  \Lanayru\Caves\Past Door to Lanayru Sand Sea\Entrance from Lanayru Sand Sea:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 2
-    layer: 0
-    province: Lanayru Province
-    req_index: 2300
-    room: 0
-    short_name: Lanayru Caves - Entrance from Lanayru Sand Sea
-    stage: F303
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\East\Fire Node Entrance:
-    allowed_time_of_day: 1
-    entrance: 3
-    layer: 0
-    province: Lanayru Province
-    req_index: 2285
-    room: 0
-    short_name: Lanayru Desert - Fire Node Entrance
-    stage: F300
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\East\Fire Node\Present\Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2292
-    room: 0
-    short_name: Fire Node - Entrance
-    stage: F300_3
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\East\Stone Cache Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 18
-    layer: 0
-    province: Lanayru Province
-    req_index: 2281
-    room: 0
-    short_name: Lanayru Desert - Stone Cache Statue Entrance
-    stage: F300
-    statue-name: Stone Cache
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\Entry\Desert Entrance Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 15
-    layer: 0
-    province: Lanayru Province
-    req_index: 2278
-    room: 0
-    short_name: Lanayru Desert - Desert Entrance Statue Entrance
-    stage: F300
-    statue-name: Desert Entrance
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\Entry\Entrance from Mine:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: Lanayru Province
-    req_index: 2284
-    room: 0
-    short_name: Lanayru Desert - Entrance from Mine
-    stage: F300
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Entrance from Caves:
-    allowed_time_of_day: 1
-    entrance: 6
-    layer: 0
-    province: Lanayru Province
-    req_index: 2287
-    room: 0
-    short_name: Lanayru Desert - Entrance from Caves
-    stage: F300
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\Near South Exit to Temple of Time\South Entrance from Temple of Time:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2282
-    room: 0
-    short_name: Lanayru Desert - South Entrance from Temple of Time
-    stage: F300
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\North Part\Lightning Node Entrance:
-    allowed_time_of_day: 1
-    entrance: 7
-    layer: 0
-    province: Lanayru Province
-    req_index: 2288
-    room: 0
-    short_name: Lanayru Desert - Lightning Node Entrance
-    stage: F300
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\North Part\Lightning Node\Present\Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2291
-    room: 0
-    short_name: Lightning Node - Entrance
-    stage: F300_2
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\North Part\North Desert Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 17
-    layer: 0
-    province: Lanayru Province
-    req_index: 2280
-    room: 0
-    short_name: Lanayru Desert - North Desert Statue Entrance
-    stage: F300
-    statue-name: North Desert
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\North Part\North Entrance from Temple of Time:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2283
-    room: 0
-    short_name: Lanayru Desert - North Entrance from Temple of Time
-    stage: F300
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\North Part\Trial Gate Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2289
-    short_name: Lanayru Desert - Trial Gate Entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\Top of LMF\Entrance from Lanayru Mining Facility:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 5
-    layer: 0
-    province: Lanayru Province
-    req_index: 2286
-    room: 0
-    short_name: Lanayru Desert - Entrance from Lanayru Mining Facility
-    stage: F300
-    tod: 2
-    type: entrance
-  \Lanayru\Desert\West Part\West Desert Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 16
-    layer: 0
-    province: Lanayru Province
-    req_index: 2279
-    room: 0
-    short_name: Lanayru Desert - West Desert Statue Entrance
-    stage: F300
-    statue-name: West Desert
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2304
-    room: 0
-    short_name: Lanayru Sand Sea - Ancient Harbour Dock Entrance
-    stage: F301_1
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Entrance:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2311
-    room: 0
-    short_name: Lanayru Sand Sea Docks - Dock Entrance
-    stage: F301
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Entrance from Caves:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2310
-    room: 0
-    short_name: Lanayru Sand Sea Docks - Entrance from Caves
-    stage: F301
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 10
-    layer: 0
-    province: Lanayru Province
-    req_index: 2309
-    room: 0
-    short_name: Lanayru Sand Sea Docks - Statue Entrance
-    stage: F301
-    statue-name: Ancient Harbour
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Gorge\Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 2
-    province: Lanayru Province
-    req_index: 2302
-    room: 0
-    short_name: Lanayru Gorge - Entrance
-    stage: F302
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Gorge\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 12
-    layer: 0
-    province: Lanayru Province
-    req_index: 2303
-    room: 0
-    short_name: Lanayru Gorge - Statue Entrance
-    stage: F302
-    statue-name: Lanayru Gorge
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Entrance:
-    allowed_time_of_day: 1
-    entrance: 3
-    layer: 0
-    province: Lanayru Province
-    req_index: 2307
-    room: 0
-    short_name: Lanayru Sand Sea - Pirate Stronghold Dock Entrance
-    stage: F301_1
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2323
-    room: 0
-    short_name: Pirate Stronghold - Dock Entrance
-    stage: F301_6
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 2
-    layer: 0
-    province: Lanayru Province
-    req_index: 2325
-    room: 0
-    short_name: Pirate Stronghold - Top Entrance
-    stage: F301_6
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2326
-    room: 1
-    short_name: Pirate Stronghold - Inside - First Door Entrance
-    stage: F301_2
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2327
-    room: 1
-    short_name: Pirate Stronghold - Inside - Second Door Entrance
-    stage: F301_2
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Entrance:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2324
-    room: 0
-    short_name: Pirate Stronghold - Side Entrance
-    stage: F301_6
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 10
-    layer: 0
-    province: Lanayru Province
-    req_index: 2322
-    room: 0
-    short_name: Pirate Stronghold - Statue Entrance
-    stage: F301_6
-    statue-name: Pirate Stronghold
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Sandship Dock Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 4
-    layer: 0
-    province: Lanayru Province
-    req_index: 2308
-    room: 0
-    short_name: Lanayru Sand Sea - Sandship Dock Entrance
-    stage: F301_1
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard Dock Entrance:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: Lanayru Province
-    req_index: 2306
-    room: 0
-    short_name: Lanayru Sand Sea - Shipyard Dock Entrance
-    stage: F301_1
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2318
-    room: 0
-    short_name: Shipyard - Construction Bay Lower Entrance
-    stage: F301_4
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 4
-    layer: 0
-    province: Lanayru Province
-    req_index: 2319
-    room: 0
-    short_name: Shipyard - Construction Bay Upper Entrance
-    stage: F301_4
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2321
-    room: 0
-    short_name: Shipyard - Construction Bay - Lower Entrance
-    stage: F301_7
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2320
-    room: 0
-    short_name: Shipyard - Construction Bay - Upper Entrance
-    stage: F301_7
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Dock Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2317
-    room: 0
-    short_name: Shipyard - Dock Entrance
-    stage: F301_4
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 10
-    layer: 0
-    province: Lanayru Province
-    req_index: 2316
-    room: 0
-    short_name: Shipyard - Statue Entrance
-    stage: F301_4
-    statue-name: Lanayru Shipyard
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Entrance:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2305
-    room: 0
-    short_name: Lanayru Sand Sea - Skipper's Retreat Dock Entrance
-    stage: F301_1
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2313
-    room: 0
-    short_name: Skipper's Retreat - Dock Entrance
-    stage: F301_3
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2315
-    room: 0
-    short_name: Skipper's Retreat - Shack - Entrance
-    stage: F301_5
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 10
-    layer: 0
-    province: Lanayru Province
-    req_index: 2312
-    room: 0
-    short_name: Skipper's Retreat - Statue Entrance
-    stage: F301_3
-    statue-name: Skipper's Retreat
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Entrance:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2314
-    room: 0
-    short_name: Skipper's Retreat - Shack Entrance
-    stage: F301_3
-    tod: 2
-    type: entrance
-  \Lanayru\Lanayru Silent Realm\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2290
-    short_name: Lanayru Silent Realm - Entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Mine\End\In Minecart\Entrance from Desert:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2277
-    room: 2
-    short_name: Lanayru Mine - Entrance from Desert
-    stage: F300_1
-    tod: 2
-    type: entrance
-  \Lanayru\Mine\Entry\Caves Entrance\Entrance from Caves:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2275
-    room: 0
-    short_name: Lanayru Mine - Entrance from Caves
-    stage: F300_1
-    tod: 2
-    type: entrance
-  \Lanayru\Mine\Entry\First Time Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2274
-    room: 0
-    short_name: Lanayru Mine - First Time Entrance
-    stage: F300_1
-    tod: 2
-    type: entrance
-  \Lanayru\Mine\Entry\Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: Lanayru Province
-    req_index: 2276
-    room: 0
-    short_name: Lanayru Mine - Statue Entrance
-    stage: F300_1
-    statue-name: Lanayru Mine Entry
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Temple of Time\Inside\Entrance from Lanayru Mining Facility:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 5
-    layer: 2
-    province: Lanayru Province
-    req_index: 2297
-    room: 0
-    short_name: Temple of Time - Entrance from Lanayru Mining Facility
-    stage: F300_4
-    subtype: vanilla
-    tod: 2
-    type: entrance
-  \Lanayru\Temple of Time\Inside\Temple of Time Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 17
-    layer: 0
-    province: Lanayru Province
-    req_index: 2294
-    room: 0
-    short_name: Temple of Time - Temple of Time Statue Entrance
-    stage: F300_4
-    statue-name: Temple of Time
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Temple of Time\North East\North Entrance from Desert:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: Lanayru Province
-    req_index: 2296
-    room: 0
-    short_name: Temple of Time - North Entrance from Desert
-    stage: F300_4
-    tod: 2
-    type: entrance
-  \Lanayru\Temple of Time\South East\Desert Gorge Statue Entrance:
-    allowed_time_of_day: 1
-    entrance: 16
-    layer: 0
-    province: Lanayru Province
-    req_index: 2293
-    room: 0
-    short_name: Temple of Time - Desert Gorge Statue Entrance
-    stage: F300_4
-    statue-name: Desert Gorge
-    subtype: bird-statue-entrance
-    tod: 2
-    type: entrance
-  \Lanayru\Temple of Time\South East\South Entrance from Desert:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: Lanayru Province
-    req_index: 2295
-    room: 0
-    short_name: Temple of Time - South Entrance from Desert
-    stage: F300_4
-    tod: 2
-    type: entrance
-  \Sandship\Boss Room\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Lanayru Province
-    req_index: 2341
-    short_name: Sandship - Boss Room - Entrance
-    tod: 2
-    type: entrance
-  \Sandship\Main\Deck\Main Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 1
-    province: Lanayru Province
-    req_index: 2340
-    room: 0
-    short_name: Sandship - Main Entrance
-    stage: D301
-    tod: 2
-    type: entrance
-  \Sky Keep\Main\First Room\Bottom Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 4
-    layer: 0
-    province: The Sky
-    req_index: 2342
-    room: 0
-    short_name: Sky Keep - First Room - Bottom Entrance
-    stage: D003_7
-    tod: 2
-    type: entrance
-  \Sky\Around Skyloft\Entrance from Skyloft:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: The Sky
-    req_index: 2155
-    short_name: Sky - Entrance from Skyloft
-    tod: 2
-    type: entrance
-  \Sky\Around Skyloft\Entrance from Thunderhead:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 28
-    layer: 0
-    province: The Sky
-    req_index: 2174
-    room: 0
-    short_name: Sky - Entrance from Thunderhead
-    stage: F020
-    tod: 2
-    type: entrance
-  \Sky\North East\Bamboo Island\Entrance from Inside:
-    allowed_time_of_day: 1
-    entrance: 11
-    layer: 0
-    province: The Sky
-    req_index: 2157
-    room: 0
-    short_name: Bamboo Island - Entrance from Inside
-    stage: F020
-    tod: 2
-    type: entrance
-  \Sky\North East\Bamboo Island\Inside\Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 1
-    province: The Sky
-    req_index: 2156
-    room: 0
-    short_name: Bamboo Island - Inside - Entrance
-    stage: F019r
-    tod: 2
-    type: entrance
-  \Sky\North East\Beedle's Island\Beedle's Ship Entrance:
-    allowed-time-of-day: NightOnly
-    allowed_time_of_day: 2
-    entrance: 0
-    layer: 4
-    province: The Sky
-    req_index: 2158
-    room: 0
-    short_name: Sky - Beedle's Island - Beedle's Ship Entrance
-    stage: F020
-    tod: 1
-    type: entrance
-  \Sky\North East\Eldin Pillar\Entrance:
-    allowed_time_of_day: 1
-    entrance: 13
-    layer: 0
-    province: The Sky
-    req_index: 2159
-    room: 0
-    short_name: Sky - Eldin Pillar - Entrance
-    stage: F020
-    statue-name: Volcano Entry
-    tod: 2
-    type: entrance
-  \Sky\South East\Faron Pillar\Entrance:
-    allowed_time_of_day: 1
-    entrance: 12
-    layer: 0
-    province: The Sky
-    req_index: 2172
-    room: 0
-    short_name: Sky - Faron Pillar - Entrance
-    stage: F020
-    statue-name: Sealed Grounds
-    tod: 2
-    type: entrance
-  \Sky\South East\Lumpy Pumpkin\Back Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 24
-    layer: 0
-    province: The Sky
-    req_index: 2170
-    room: 0
-    short_name: Lumpy Pumpkin - Back Door Entrance
-    stage: F020
-    tod: 2
-    type: entrance
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 3
-    layer: 0
-    province: The Sky
-    req_index: 2164
-    room: 0
-    short_name: Lumpy Pumpkin Building - Back Door Entrance
-    stage: F011r
-    tod: 2
-    type: entrance
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 2
-    layer: 0
-    province: The Sky
-    req_index: 2162
-    room: 0
-    short_name: Lumpy Pumpkin Building - Main Left Door Entrance
-    stage: F011r
-    tod: 2
-    type: entrance
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2160
-    room: 0
-    short_name: Lumpy Pumpkin Building - Main Right Door Entrance
-    stage: F011r
-    tod: 2
-    type: entrance
-  \Sky\South East\Lumpy Pumpkin\Main Left Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 22
-    layer: 0
-    province: The Sky
-    req_index: 2166
-    room: 0
-    short_name: Lumpy Pumpkin - Main Left Door Entrance
-    stage: F020
-    tod: 2
-    type: entrance
-  \Sky\South East\Lumpy Pumpkin\Main Right Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 23
-    layer: 0
-    province: The Sky
-    req_index: 2168
-    room: 0
-    short_name: Lumpy Pumpkin - Main Right Door Entrance
-    stage: F020
-    tod: 2
-    type: entrance
-  \Sky\South West\Lanayru Pillar\Entrance:
-    allowed_time_of_day: 1
-    entrance: 14
-    layer: 0
-    province: The Sky
-    req_index: 2173
-    room: 0
-    short_name: Sky - Lanayru Pillar - Entrance
-    stage: F020
-    tod: 2
-    type: entrance
-  \Sky\Thunderhead\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2175
-    room: 0
-    short_name: Thunderhead - Entrance
-    stage: F023
-    tod: 2
-    type: entrance
-  \Sky\Thunderhead\Isle of Songs\Entrance from Inside:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 4
-    layer: 0
-    province: The Sky
-    req_index: 2177
-    room: 0
-    short_name: Isle of Songs - Entrance from Inside
-    stage: F023
-    tod: 2
-    type: entrance
-  \Sky\Thunderhead\Isle of Songs\Inside\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: The Sky
-    req_index: 2176
-    room: 0
-    short_name: Isle of Songs - Entrance
-    stage: F010r
-    tod: 2
-    type: entrance
-  \Skyloft\Beedle's Shop\Day Entrance:
-    allowed_time_of_day: 3
-    entrance: 0
-    layer: 0
-    province: The Sky
-    req_index: 2103
-    room: 0
-    short_name: Beedle's Shop - Day Entrance
-    stage: F002r
-    tod: 2
-    type: entrance
-  \Skyloft\Beedle's Shop\Night Entrance:
-    allowed-time-of-day: NightOnly
-    allowed_time_of_day: 2
-    entrance: 0
-    layer: 0
-    province: The Sky
-    req_index: 2105
-    room: 0
-    short_name: Beedle's Shop - Night Entrance
-    stage: F002r
-    tod: 1
-    type: entrance
-  \Skyloft\Central Skyloft\Bazaar North Entrance:
-    allowed_time_of_day: 3
-    entrance: 2
-    layer: 0
-    province: The Sky
-    req_index: 2097
-    room: 0
-    short_name: Bazaar North Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Bazaar South Entrance:
-    allowed_time_of_day: 3
-    entrance: 3
-    layer: 0
-    province: The Sky
-    req_index: 2099
-    room: 0
-    short_name: Bazaar South Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Bazaar West Entrance:
-    allowed_time_of_day: 3
-    entrance: 20
-    layer: 0
-    province: The Sky
-    req_index: 2101
-    room: 0
-    short_name: Bazaar West Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Bazaar\North Entrance:
-    allowed_time_of_day: 1
-    entrance: 0
-    layer: 0
-    province: The Sky
-    req_index: 2094
-    room: 0
-    short_name: Bazaar - North Entrance
-    stage: F004r
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Bazaar\South Entrance:
-    allowed_time_of_day: 1
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2095
-    room: 0
-    short_name: Bazaar - South Entrance
-    stage: F004r
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Bazaar\West Entrance:
-    allowed_time_of_day: 1
-    entrance: 2
-    layer: 0
-    province: The Sky
-    req_index: 2096
-    room: 0
-    short_name: Bazaar - West Entrance
-    stage: F004r
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Entrance from Beedle's Shop:
-    allowed_time_of_day: 3
-    entrance: 0
-    layer: 0
-    province: The Sky
-    req_index: 2106
-    room: 0
-    short_name: Skyloft - Entrance from Beedle's Shop
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Entrance from Sky:
-    allowed_time_of_day: 3
-    can-start-at: false
-    province: The Sky
-    req_index: 2153
-    short_name: Skyloft - Entrance from Sky
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Near Temple Entrance\Entrance from Sky Keep:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 53
-    layer: 0
-    province: The Sky
-    req_index: 2112
-    room: 0
-    short_name: Skyloft - Entrance from Sky Keep
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Orielle and Parrow's House Entrance:
-    allowed_time_of_day: 3
-    entrance: 30
-    layer: 0
-    province: The Sky
-    req_index: 2115
-    room: 0
-    short_name: Orielle and Parrow's House Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Orielle and Parrow's House\Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2113
-    room: 0
-    short_name: Orielle and Parrow's House - Entrance
-    stage: F005r
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Entrance:
-    allowed_time_of_day: 3
-    entrance: 8
-    layer: 0
-    province: The Sky
-    req_index: 2092
-    room: 0
-    short_name: Waterfall Cave Lower Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Peatrice's House Entrance:
-    allowed_time_of_day: 3
-    entrance: 38
-    layer: 0
-    province: The Sky
-    req_index: 2119
-    room: 0
-    short_name: Peatrice's House Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Peatrice's House\Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2117
-    room: 0
-    short_name: Peatrice's House - Entrance
-    stage: F018r
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Piper's House Entrance:
-    allowed_time_of_day: 3
-    entrance: 32
-    layer: 0
-    province: The Sky
-    req_index: 2151
-    room: 0
-    short_name: Piper's House Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Piper's House\Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2149
-    room: 0
-    short_name: Piper's House - Entrance
-    stage: F007r
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Trial Gate Entrance:
-    allowed_time_of_day: 3
-    can-start-at: false
-    province: The Sky
-    req_index: 2110
-    short_name: Skyloft - Trial Gate Entrance
-    tod: 0
-    type: entrance
-  \Skyloft\Central Skyloft\Waterfall Cave Upper Entrance:
-    allowed_time_of_day: 3
-    entrance: 7
-    layer: 0
-    province: The Sky
-    req_index: 2090
-    room: 0
-    short_name: Waterfall Cave Upper Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Waterfall Cave\Lower Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2088
-    room: 0
-    short_name: Waterfall Cave - Lower Entrance
-    stage: D000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Waterfall Cave\Upper Entrance:
-    allowed_time_of_day: 3
-    entrance: 0
-    layer: 0
-    province: The Sky
-    req_index: 2086
-    room: 0
-    short_name: Waterfall Cave - Upper Entrance
-    stage: D000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Wryna's House Entrance:
-    allowed_time_of_day: 3
-    entrance: 31
-    layer: 0
-    province: The Sky
-    req_index: 2123
-    room: 0
-    short_name: Wryna's House Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Central Skyloft\Wryna's House\Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2121
-    room: 0
-    short_name: Wryna's House - Entrance
-    stage: F006r
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Silent Realm\Entrance:
-    allowed_time_of_day: 3
-    can-start-at: false
-    province: The Sky
-    req_index: 2108
-    short_name: Skyloft Silent Realm - Entrance
-    tod: 0
-    type: entrance
-  \Skyloft\Skyloft Village\Batreaux's House Entrance:
-    allowed_time_of_day: 3
-    entrance: 29
-    layer: 0
-    province: The Sky
-    req_index: 2139
-    room: 0
-    short_name: Batreaux's House Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Batreaux's House\Entrance:
-    allowed_time_of_day: 3
-    entrance: 0
-    layer: 0
-    province: The Sky
-    req_index: 2137
-    room: 0
-    short_name: Batreaux's House - Entrance
-    stage: F012r
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Bertie's House Entrance:
-    allowed_time_of_day: 3
-    entrance: 34
-    layer: 0
-    province: The Sky
-    req_index: 2127
-    room: 0
-    short_name: Bertie's House Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Bertie's House\Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2125
-    room: 0
-    short_name: Bertie's House - Entrance
-    stage: F014r
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Gondo's House Entrance:
-    allowed_time_of_day: 3
-    entrance: 35
-    layer: 0
-    province: The Sky
-    req_index: 2143
-    room: 0
-    short_name: Gondo's House Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Gondo's House\Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2141
-    room: 0
-    short_name: Gondo's House - Entrance
-    stage: F015r
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Mallara's House Entrance:
-    allowed_time_of_day: 3
-    entrance: 36
-    layer: 0
-    province: The Sky
-    req_index: 2133
-    room: 0
-    short_name: Skyloft - Mallara's House Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Mallara's House\Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2135
-    room: 0
-    short_name: Mallara's House - Entrance
-    stage: F016r
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Rupin's House Entrance:
-    allowed_time_of_day: 3
-    entrance: 37
-    layer: 0
-    province: The Sky
-    req_index: 2147
-    room: 0
-    short_name: Rupin's House Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Rupin's House\Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2145
-    room: 0
-    short_name: Rupin's House - Entrance
-    stage: F017r
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Sparrot's House Entrance:
-    allowed_time_of_day: 3
-    entrance: 33
-    layer: 0
-    province: The Sky
-    req_index: 2131
-    room: 0
-    short_name: Sparrot's House Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Skyloft Village\Sparrot's House\Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2129
-    room: 0
-    short_name: Sparrot's House - Entrance
-    stage: F013r
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Goddess Statue Entrance:
-    allowed_time_of_day: 3
-    entrance: 6
-    layer: 0
-    province: The Sky
-    req_index: 2084
-    room: 0
-    short_name: Goddess Statue Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Goddess Statue\Entrance:
-    allowed_time_of_day: 3
-    entrance: 0
-    layer: 0
-    province: The Sky
-    req_index: 2082
-    room: 0
-    short_name: Goddess Statue - Entrance
-    stage: F008r
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 5
-    layer: 0
-    province: The Sky
-    req_index: 2068
-    room: 0
-    short_name: Skyloft - Knight Academy Lower Left Door Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 4
-    layer: 0
-    province: The Sky
-    req_index: 2066
-    room: 0
-    short_name: Skyloft - Knight Academy Lower Right Door Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 23
-    layer: 0
-    province: The Sky
-    req_index: 2070
-    room: 0
-    short_name: Skyloft - Knight Academy Upper Left Door Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 24
-    layer: 0
-    province: The Sky
-    req_index: 2072
-    room: 0
-    short_name: Skyloft - Knight Academy Upper Right Door Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Start Entrance:
-    allowed-time-of-day: DayOnly
-    allowed_time_of_day: 1
-    entrance: 5
-    layer: 0
-    province: The Sky
-    req_index: 2055
-    room: 1
-    short_name: Skyloft - Knight Academy - Start Entrance
-    stage: F001r
-    statue-name: Link's Room
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 2
-    layer: 0
-    province: The Sky
-    req_index: 2060
-    room: 0
-    short_name: Skyloft - Knight Academy - Lower Left Door Entrance
-    stage: F001r
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2058
-    room: 0
-    short_name: Skyloft - Knight Academy - Lower Right Door Entrance
-    stage: F001r
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 4
-    layer: 0
-    province: The Sky
-    req_index: 2064
-    room: 0
-    short_name: Skyloft - Knight Academy - Upper Left Door Entrance
-    stage: F001r
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 3
-    layer: 0
-    province: The Sky
-    req_index: 2062
-    room: 0
-    short_name: Skyloft - Knight Academy - Upper Right Door Entrance
-    stage: F001r
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Chimney:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2056
-    room: 6
-    short_name: Skyloft - Knight Academy - Chimney
-    stage: F001r
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Sparring Hall Left Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 21
-    layer: 0
-    province: The Sky
-    req_index: 2078
-    room: 0
-    short_name: Skyloft - Sparring Hall Left Door Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Sparring Hall Right Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 26
-    layer: 0
-    province: The Sky
-    req_index: 2080
-    room: 0
-    short_name: Skyloft - Sparring Hall Right Door Entrance
-    stage: F000
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Sparring Hall\Left Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 2
-    layer: 0
-    province: The Sky
-    req_index: 2076
-    room: 0
-    short_name: Sparring Hall - Left Door Entrance
-    stage: F009r
-    tod: 2
-    type: entrance
-  \Skyloft\Upper Skyloft\Sparring Hall\Right Door Entrance:
-    allowed_time_of_day: 3
-    entrance: 1
-    layer: 0
-    province: The Sky
-    req_index: 2074
-    room: 0
-    short_name: Sparring Hall - Right Door Entrance
-    stage: F009r
-    tod: 2
-    type: entrance
-  \Skyview\Boss Room\Entrance from Dungeon:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2227
-    short_name: Skyview Temple - Boss Room - Entrance from Dungeon
-    tod: 2
-    type: entrance
-  \Skyview\Boss Room\Entrance from Spring:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2228
-    short_name: Skyview Temple - Boss Room - Entrance from Spring
-    tod: 2
-    type: entrance
-  \Skyview\Main\Entry\Main Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    entrance: 0
-    layer: 0
-    province: Faron Province
-    req_index: 2225
-    room: 0
-    short_name: Skyview Temple - Main Entrance
-    stage: D100
-    tod: 2
-    type: entrance
-  \Skyview\Main\Last Room\After Rope\Boss Door Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2226
-    short_name: Skyview Temple - Boss Door Entrance
-    tod: 2
-    type: entrance
-  \Skyview\Spring\Entrance:
-    allowed_time_of_day: 1
-    can-start-at: false
-    province: Faron Province
-    req_index: 2229
-    short_name: Skyview Temple - Spring - Entrance
-    tod: 2
-    type: entrance
-exits:
-  \Ancient Cistern\Boss Room\Exit to Dungeon:
-    req_index: 1950
-    short_name: Ancient Cistern - Boss Room - Exit to Dungeon
-    type: exit
-    vanilla: Ancient Cistern - Boss Door Entrance
-  \Ancient Cistern\Boss Room\Exit to Flame Room:
-    req_index: 1951
-    short_name: Ancient Cistern - Boss Room - Exit to Flame Room
-    type: exit
-    vanilla: Ancient Cistern - Flame Room - Entrance
-  \Ancient Cistern\Flame Room\Exit:
-    req_index: 1952
-    short_name: Ancient Cistern - Flame Room - Exit
-    type: exit
-    vanilla: Ancient Cistern - Boss Room - Entrance from Flame Room
-  \Ancient Cistern\Main\Inside Statue\Boss Door Exit:
-    req_index: 1949
-    short_name: Ancient Cistern - Boss Door Exit
-    type: exit
-    vanilla: Ancient Cistern - Boss Room - Entrance from Dungeon
-  \Ancient Cistern\Main\Main Room\Main Exit:
-    req_index: 1948
-    short_name: Ancient Cistern - Main Exit
-    type: exit
-    vanilla: Floria Waterfall - Entrance from Ancient Cistern
-  \Earth Temple\Boss Room\Entry\Exit to Dungeon:
-    req_index: 1977
-    short_name: Earth Temple - Boss Room - Exit to Dungeon
-    type: exit
-    vanilla: Earth Temple - Boss Door Entrance
-  \Earth Temple\Boss Room\Slope\Exit to Spring:
-    req_index: 1978
-    short_name: Earth Temple - Boss Room - Exit to Spring
-    type: exit
-    vanilla: Earth Temple - Spring - Entrance
-  \Earth Temple\Main\First Room\Main Exit:
-    req_index: 1975
-    short_name: Earth Temple - Main Exit
-    type: exit
-    vanilla: Eldin Volcano - Entrance from Earth Temple
-  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Exit:
-    req_index: 1976
-    short_name: Earth Temple - Boss Door Exit
-    type: exit
-    vanilla: Earth Temple - Boss Room - Entrance from Dungeon
-  \Earth Temple\Spring\Exit:
-    req_index: 1979
-    short_name: Earth Temple - Spring - Exit
-    type: exit
-    vanilla: Earth Temple - Boss Room - Entrance from Spring
-  \Eldin\Bokoblin Base\Prison\Exit:
-    req_index: 1963
-    short_name: Bokoblin Base - Exit
-    type: exit
-    vanilla: Entrance from Bokoblin Base
-  \Eldin\Eldin Silent Realm\Exit:
-    req_index: 1967
-    short_name: Eldin Silent Realm - Exit
-    type: exit
-    vanilla: Eldin Volcano - Trial Gate Entrance
-  \Eldin\Mogma Turf\Past Vent\Second Vent:
-    index: 1
-    req_index: 1965
-    room: 0
-    short_name: Mogma Turf - Second Vent
-    stage: F210
-    type: exit
-    vanilla: Eldin Volcano - Second Vent from Mogma Turf
-  \Eldin\Mogma Turf\Pre Vent\First Vent:
-    index: 0
-    req_index: 1964
-    room: 0
-    short_name: Mogma Turf - First Vent
-    stage: F210
-    type: exit
-    vanilla: Eldin Volcano - First Vent from Mogma Turf
-  \Eldin\Volcano Summit\Exit to Eldin Volcano:
-    index: 0
-    req_index: 1968
-    room: 0
-    short_name: Volcano Summit - Exit to Eldin Volcano
-    stage: F201_1
-    type: exit
-    vanilla: Eldin Volcano - Entrance from Summit
-  \Eldin\Volcano Summit\Exit to Outside Fire Sanctuary:
-    index: 2
-    req_index: 1970
-    room: 0
-    short_name: Volcano Summit - Exit to Outside Fire Sanctuary
-    stage: F201_1
-    type: exit
-    vanilla: Outside Fire Sanctuary - Entrance from Summit
-  \Eldin\Volcano Summit\Exit to Waterfall:
-    index: 1
-    req_index: 1969
-    room: 0
-    short_name: Volcano Summit - Exit to Waterfall
-    stage: F201_1
-    type: exit
-    vanilla: Volcano Summit - Waterfall - Entrance
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Exit to Summit:
-    index: 0
-    req_index: 1973
-    room: 0
-    short_name: Outside Fire Sanctuary - Exit to Summit
-    stage: F201_3
-    type: exit
-    vanilla: Volcano Summit - Entrance from Outside Fire Sanctuary
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Exit to Fire Sanctuary:
-    index: 1
-    req_index: 1974
-    room: 0
-    short_name: Outside Fire Sanctuary - Exit to Fire Sanctuary
-    stage: F201_3
-    type: exit
-    vanilla: Fire Sanctuary - Main Entrance
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Exit:
-    index: 2
-    req_index: 1972
-    room: 0
-    short_name: Outside Fire Sanctuary - Statue Exit
-    stage: F201_3
-    type: exit
-    vanilla: Sky - Eldin Pillar - Entrance
-  \Eldin\Volcano Summit\Waterfall\Exit:
-    index: 0
-    req_index: 1971
-    room: 0
-    short_name: Volcano Summit - Waterfall - Exit
-    stage: F201_4
-    type: exit
-    vanilla: Volcano Summit - Entrance from Waterfall
-  \Eldin\Volcano\Ascent\Trial Gate Exit:
-    req_index: 1960
-    short_name: Eldin Volcano - Trial Gate Exit
-    type: exit
-    vanilla: Eldin Silent Realm - Entrance
-  \Eldin\Volcano\East\Dive to Mogma Turf:
-    index: 1
-    req_index: 1956
-    room: 2
-    short_name: Eldin Volcano - Dive to Mogma Turf
-    stage: F200
-    type: exit
-    vanilla: Mogma Turf - Entrance
-  \Eldin\Volcano\East\Exit to Bokoblin Base:
-    req_index: 1962
-    short_name: Eldin Volcano - Exit to Bokoblin Base
-    type: exit
-    vanilla: Bokoblin Base - Entrance
-  \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit:
-    index: 2
-    req_index: 1954
-    room: 2
-    short_name: Eldin Volcano - Volcano East / Volcano Ascent Statue Exit
-    stage: F200
-    type: exit
-    vanilla: Sky - Eldin Pillar - Entrance
-  \Eldin\Volcano\Entry\Volcano Entrance Statue Exit:
-    index: 0
-    req_index: 1953
-    room: 0
-    short_name: Eldin Volcano - Volcano Entrance Statue Exit
-    stage: F200
-    type: exit
-    vanilla: Sky - Eldin Pillar - Entrance
-  \Eldin\Volcano\Hot Cave\Exit to Summit:
-    index: 1
-    req_index: 1959
-    room: 5
-    short_name: Eldin Volcano - Exit to Summit
-    stage: F200
-    type: exit
-    vanilla: Volcano Summit - Entrance from Eldin Volcano
-  \Eldin\Volcano\Near Temple Entrance\Exit to Earth Temple:
-    index: 0
-    req_index: 1957
-    room: 4
-    short_name: Eldin Volcano - Exit to Earth Temple
-    stage: F200
-    type: exit
-    vanilla: Earth Temple - Main Entrance
-  \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Exit:
-    index: 2
-    req_index: 1955
-    room: 4
-    short_name: Eldin Volcano - Temple Entrance Statue Exit
-    stage: F200
-    type: exit
-    vanilla: Sky - Eldin Pillar - Entrance
-  \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Exit:
-    index: 1
-    req_index: 1958
-    room: 4
-    short_name: Eldin Volcano - Thrill Digger Cave Exit
-    stage: F200
-    type: exit
-    vanilla: Thrill Digger Cave - Entrance
-  \Eldin\Volcano\Past Slide\Vent Exit near Ascent:
-    req_index: 1961
-    short_name: Eldin Volcano - Vent Exit near Ascent
-    type: exit
-    vanilla: Eldin Volcano - Vent Entrance near Hot Cave
-  \Eldin\Volcano\Thrill Digger Cave\Exit:
-    index: 0
-    req_index: 1966
-    room: 0
-    short_name: Thrill Digger Cave - Exit
-    stage: F211
-    type: exit
-    vanilla: Eldin Volcano - Thrill Digger Cave Entrance
-  \Faron\Faron Silent Realm\Exit:
-    req_index: 1917
-    short_name: Faron Silent Realm - Exit
-    type: exit
-    vanilla: Faron Woods - Trial Gate Entrance
-  \Faron\Faron Woods\Deep Woods\Entry\Exit to Faron Woods:
-    index: 0
-    req_index: 1933
-    room: 0
-    short_name: Deep Woods - Exit to Faron Woods
-    stage: F101
-    type: exit
-    vanilla: Faron Woods - Entrance from Deep Woods
-  \Faron\Faron Woods\Deep Woods\Exit to Skyview Temple:
-    index: 1
-    req_index: 1934
-    room: 0
-    short_name: Deep Woods - Exit to Skyview Temple
-    stage: F101
-    type: exit
-    vanilla: Skyview Temple - Main Entrance
-  \Faron\Faron Woods\Deep Woods\Shared Statue Exit:
-    index: 2
-    req_index: 1932
-    room: 0
-    short_name: Deep Woods - Shared Statue Exit
-    stage: F101
-    type: exit
-    vanilla: Sky - Faron Pillar - Entrance
-  \Faron\Faron Woods\Entry\Exit to Behind the Temple:
-    index: 0
-    req_index: 1912
-    room: 0
-    short_name: Faron Woods - Exit to Behind the Temple
-    stage: F100
-    type: exit
-    vanilla: Behind the Temple - Entrance from Faron Woods
-  \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Exit to Platforms:
-    index: 1
-    req_index: 1922
-    room: 0
-    short_name: Great Tree - Lower Exit to Platforms
-    stage: F100_1
-    type: exit
-    vanilla: Great Tree - Platforms - Lower Entrance from Great Tree
-  \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Exit:
-    index: 4
-    req_index: 1925
-    room: 0
-    short_name: Great Tree - Underwater Tunnel Exit
-    stage: F100_1
-    type: exit
-    vanilla: Great Tree - Underwater Hole Entrance
-  \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Exit:
-    index: 6
-    req_index: 1921
-    room: 0
-    short_name: Great Tree - Underwater Hole Exit
-    stage: F100
-    type: exit
-    vanilla: Great Tree - Underwater Tunnel Entrance
-  \Faron\Faron Woods\Great Tree\Platforms\Lower Exit to Great Tree:
-    index: 3
-    req_index: 1918
-    room: 0
-    short_name: Great Tree - Platforms - Lower Exit to Great Tree
-    stage: F100
-    type: exit
-    vanilla: Great Tree - Lower Entrance from Platforms
-  \Faron\Faron Woods\Great Tree\Platforms\Upper Exit to Great Tree:
-    index: 4
-    req_index: 1919
-    room: 0
-    short_name: Great Tree - Platforms - Upper Exit to Great Tree
-    stage: F100
-    type: exit
-    vanilla: Great Tree - Upper Entrance from Platforms
-  \Faron\Faron Woods\Great Tree\Top\Top Exit to Great Tree:
-    index: 5
-    req_index: 1920
-    room: 0
-    short_name: Great Tree - Top Exit to Great Tree
-    stage: F100
-    type: exit
-    vanilla: Great Tree - Entrance from Top
-  \Faron\Faron Woods\Great Tree\Upper Area\Exit to Flooded Great Tree:
-    req_index: 1926
-    short_name: Great Tree - Exit to Flooded Great Tree
-    type: exit
-    vanilla: Flooded Great Tree - Entrance
-  \Faron\Faron Woods\Great Tree\Upper Area\Exit to Top:
-    index: 3
-    req_index: 1924
-    room: 0
-    short_name: Great Tree - Exit to Top
-    stage: F100_1
-    type: exit
-    vanilla: Great Tree - Top Entrance from Great Tree
-  \Faron\Faron Woods\Great Tree\Upper Area\Upper Exit to Platforms:
-    index: 2
-    req_index: 1923
-    room: 0
-    short_name: Great Tree - Upper Exit to Platforms
-    stage: F100_1
-    type: exit
-    vanilla: Great Tree - Platforms - Upper Entrance from Great Tree
-  \Faron\Faron Woods\Lake Floria Dive:
-    index: 9
-    req_index: 1914
-    room: 0
-    short_name: Faron Woods - Lake Floria Dive
-    stage: F100
-    type: exit
-    vanilla: Lake Floria - Dive from Faron Woods
-  \Faron\Faron Woods\Ledge To Deep Woods\Exit to Deep Woods:
-    index: 1
-    req_index: 1913
-    room: 0
-    short_name: Faron Woods - Exit to Deep Woods
-    stage: F100
-    type: exit
-    vanilla: Deep Woods - Entrance from Faron Woods
-  \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Exit to Floria Waterfall:
-    index: 11
-    req_index: 1915
-    room: 0
-    short_name: Faron Woods - Shortcut Exit to Floria Waterfall
-    stage: F100
-    type: exit
-    vanilla: Floria Waterfall - Entrance from Faron Woods
-  \Faron\Faron Woods\Shared Statue Exit:
-    index: 10
-    req_index: 1911
-    room: 0
-    short_name: Faron Woods - Shared Statue Exit
-    stage: F100
-    type: exit
-    vanilla: Sky - Faron Pillar - Entrance
-  \Faron\Faron Woods\Trial Gate Exit:
-    req_index: 1916
-    short_name: Faron Woods - Trial Gate Exit
-    type: exit
-    vanilla: Faron Silent Realm - Entrance
-  \Faron\Flooded Faron Woods\Exit to Lower Flooded Great Tree:
-    req_index: 1931
-    short_name: Flooded Faron Woods - Exit to Lower Flooded Great Tree
-    type: exit
-    vanilla: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
-  \Faron\Flooded Faron Woods\Exit to Upper Flooded Great Tree:
-    req_index: 1930
-    short_name: Flooded Faron Woods - Exit to Upper Flooded Great Tree
-    type: exit
-    vanilla: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
-  \Faron\Flooded Faron Woods\Flooded Great Tree\Exit:
-    req_index: 1927
-    short_name: Flooded Great Tree - Exit
-    type: exit
-    vanilla: Entrance from Flooded Great Tree
-  \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Lower Flooded Faron Woods:
-    req_index: 1929
-    short_name: Flooded Great Tree - Exit to Lower Flooded Faron Woods
-    type: exit
-    vanilla: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
-  \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Upper Flooded Faron Woods:
-    req_index: 1928
-    short_name: Flooded Great Tree - Exit to Upper Flooded Faron Woods
-    type: exit
-    vanilla: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
-  \Faron\Lake Floria\Below Rock\Emerged Area\Statue Exit:
-    index: 0
-    req_index: 1935
-    room: 3
-    short_name: Lake Floria - Below Rock - Statue Exit
-    stage: F102
-    type: exit
-    vanilla: Sky - Faron Pillar - Entrance
-  \Faron\Lake Floria\Below Rock\Exit to Farore's Lair:
-    index: 0
-    req_index: 1936
-    room: 4
-    short_name: Lake Floria - Exit to Farore's Lair
-    stage: F102
-    type: exit
-    vanilla: Farore's Lair - Entrance from Lake Floria
-  \Faron\Lake Floria\Farore's Lair\Exit to Lake Floria:
-    index: 0
-    req_index: 1937
-    room: 0
-    short_name: Farore's Lair - Exit to Lake Floria
-    stage: F102_2
-    type: exit
-    vanilla: Lake Floria - Entrance from Farore's Lair
-  \Faron\Lake Floria\Farore's Lair\Exit to Waterfall:
-    index: 1
-    req_index: 1938
-    room: 0
-    short_name: Farore's Lair - Exit to Waterfall
-    stage: F102_2
-    type: exit
-    vanilla: Floria Waterfall - Entrance from Farore's Lair
-  \Faron\Lake Floria\Waterfall\Exit to Ancient Cistern:
-    index: 1
-    req_index: 1941
-    room: 0
-    short_name: Floria Waterfall - Exit to Ancient Cistern
-    stage: F102_1
-    type: exit
-    vanilla: Ancient Cistern - Main Entrance
-  \Faron\Lake Floria\Waterfall\Exit to Faron Woods:
-    index: 2
-    req_index: 1942
-    room: 0
-    short_name: Floria Waterfall - Exit to Faron Woods
-    stage: F102_1
-    type: exit
-    vanilla: Faron Woods - Shortcut Entrance from Floria Waterfall
-  \Faron\Lake Floria\Waterfall\Exit to Farore's Lair:
-    index: 0
-    req_index: 1940
-    room: 0
-    short_name: Floria Waterfall - Exit to Farore's Lair
-    stage: F102_1
-    type: exit
-    vanilla: Farore's Lair - Entrance from Waterfall
-  \Faron\Lake Floria\Waterfall\Statue Exit:
-    index: 3
-    req_index: 1939
-    room: 0
-    short_name: Floria Waterfall - Statue Exit
-    stage: F102_1
-    type: exit
-    vanilla: Sky - Faron Pillar - Entrance
-  \Faron\Sealed Grounds\Behind the Temple\Door Exit:
-    index: 1
-    req_index: 1909
-    room: 0
-    short_name: Behind the Temple - Door Exit
-    stage: F400
-    type: exit
-    vanilla: Sealed Temple - Side Entrance
-  \Faron\Sealed Grounds\Behind the Temple\Exit to Faron Woods:
-    index: 2
-    req_index: 1910
-    room: 0
-    short_name: Behind the Temple - Exit to Faron Woods
-    stage: F400
-    type: exit
-    vanilla: Faron Woods - Entrance from Behind the Temple
-  \Faron\Sealed Grounds\Behind the Temple\Shortcut Exit to Spiral:
-    index: 0
-    req_index: 1908
-    room: 0
-    short_name: Behind the Temple - Shortcut Exit to Spiral
-    stage: F400
-    type: exit
-    vanilla: Sealed Grounds Spiral - Shortcut Entrance from Behind the Temple
-  \Faron\Sealed Grounds\Behind the Temple\Statue Exit:
-    index: 5
-    req_index: 1907
-    room: 0
-    short_name: Behind the Temple - Statue Exit
-    stage: F400
-    type: exit
-    vanilla: Sky - Faron Pillar - Entrance
-  \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Exit:
-    index: 1
-    req_index: 1906
-    room: 2
-    short_name: Hylia's Temple - Gate of Time Exit
-    stage: F404
-    type: exit
-    vanilla: Sealed Temple - Gate of Time Entrance
-  \Faron\Sealed Grounds\Sealed Temple\Gate of Time Exit:
-    index: 5
-    req_index: 1905
-    room: 2
-    short_name: Sealed Temple - Gate of Time Exit
-    stage: F402
-    type: exit
-    vanilla: Hylia's Temple - Gate of Time Entrance
-  \Faron\Sealed Grounds\Sealed Temple\Main Exit:
-    index: 0
-    req_index: 1903
-    room: 2
-    short_name: Sealed Temple - Main Exit
-    stage: F402
-    type: exit
-    vanilla: Sealed Grounds Spiral - Door Entrance
-  \Faron\Sealed Grounds\Sealed Temple\Side Exit:
-    index: 1
-    req_index: 1904
-    room: 2
-    short_name: Sealed Temple - Side Exit
-    stage: F402
-    type: exit
-    vanilla: Behind the Temple - Door Entrance
-  \Faron\Sealed Grounds\Spiral\Door Exit:
-    index: 0
-    req_index: 1901
-    room: 1
-    short_name: Sealed Grounds Spiral - Door Exit
-    stage: F401
-    type: exit
-    vanilla: Sealed Temple - Main Entrance
-  \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Exit to Behind the Temple:
-    index: 1
-    req_index: 1902
-    room: 1
-    short_name: Sealed Grounds Spiral - Shortcut Exit to Behind the Temple
-    stage: F401
-    type: exit
-    vanilla: Behind the Temple - Shortcut Entrance from Spiral
-  \Faron\Sealed Grounds\Spiral\Upper Part\Statue Exit:
-    index: 19
-    req_index: 1900
-    room: 1
-    short_name: Sealed Grounds Spiral - Statue Exit
-    stage: F401
-    type: exit
-    vanilla: Sky - Faron Pillar - Entrance
-  \Fire Sanctuary\Boss Room\Exit to Dungeon:
-    req_index: 1987
-    short_name: Fire Sanctuary - Boss Room - Exit to Dungeon
-    type: exit
-    vanilla: Fire Sanctuary - Boss Door Entrance
-  \Fire Sanctuary\Boss Room\Exit to Flame Room:
-    req_index: 1988
-    short_name: Fire Sanctuary - Boss Room - Exit to Flame Room
-    type: exit
-    vanilla: Fire Sanctuary - Flame Room - Entrance
-  \Fire Sanctuary\Flame Room\Exit:
-    req_index: 1989
-    short_name: Fire Sanctuary - Flame Room - Exit
-    type: exit
-    vanilla: Fire Sanctuary - Boss Room - Entrance from Flame Room
-  \Fire Sanctuary\Main\First Room\Main Exit:
-    req_index: 1981
-    short_name: Fire Sanctuary - Main Exit
-    type: exit
-    vanilla: Outside Fire Sanctuary - Entrance from Fire Sanctuary
-  \Fire Sanctuary\Main\First Room\Past Water Plant\Exit to Second Room:
-    req_index: 1982
-    short_name: Fire Sanctuary - First Room - Exit to Second Room
-    type: exit
-    vanilla: Fire Sanctuary - Second Room - Entrance from First Room
-  \Fire Sanctuary\Main\Front of Boss Door\Boss Door Exit:
-    req_index: 1986
-    short_name: Fire Sanctuary - Boss Door Exit
-    type: exit
-    vanilla: Fire Sanctuary - Boss Room - Entrance from Dungeon
-  \Fire Sanctuary\Main\Front of Boss Door\Statue Exit:
-    index: 3
-    req_index: 1980
-    room: 10
-    short_name: Fire Sanctuary - Statue Exit
-    stage: D201
-    type: exit
-    vanilla: Sky - Eldin Pillar - Entrance
-  \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Exit to West of Boss Door:
-    req_index: 1984
-    short_name: Fire Sanctuary - Magmanos Fight Room - Exit to West of Boss Door
-    type: exit
-    vanilla: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight Room
-  \Fire Sanctuary\Main\Second Room\Outside Section\Exit to First Room:
-    req_index: 1983
-    short_name: Fire Sanctuary - Second Room - Exit to First Room
-    type: exit
-    vanilla: Fire Sanctuary - First Room - Entrance from Second Room
-  \Fire Sanctuary\Main\West of Boss Door\Entry\Exit to Magmanos Fight Room:
-    req_index: 1985
-    short_name: Fire Sanctuary - West of Boss Door - Exit to Magmanos Fight Room
-    type: exit
-    vanilla: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss Door
-  \Lanayru Mining Facility\Boss Room\After Sand Drain\Exit to Hall of Ancient Robots:
-    req_index: 2049
-    short_name: Lanayru Mining Facility - Boss Room - Exit to Hall of Ancient Robots
-    type: exit
-    vanilla: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
-      Room
-  \Lanayru Mining Facility\Boss Room\Exit to Dungeon:
-    req_index: 2048
-    short_name: Lanayru Mining Facility - Boss Room - Exit to Dungeon
-    type: exit
-    vanilla: Lanayru Mining Facility - Boss Door Entrance
-  \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit to Temple of Time:
-    index: 1
-    req_index: 2051
-    room: 0
-    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Temple
-      of Time
-    stage: F300_5
-    subtype: vanilla
-    type: exit
-    vanilla: Temple of Time - Entrance from Lanayru Mining Facility
-  \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Exit to Boss Room:
-    req_index: 2050
-    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Boss Room
-    type: exit
-    vanilla: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient Robots
-  \Lanayru Mining Facility\Main\Armos Fight Room\Exit to Big Hub:
-    req_index: 2043
-    short_name: Lanayru Mining Facility - Armos Fight Room - Exit to Big Hub
-    type: exit
-    vanilla: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
-  \Lanayru Mining Facility\Main\Big Hub\Entry\Exit to First Hub:
-    req_index: 2044
-    short_name: Lanayru Mining Facility - Big Hub - Exit to First Hub
-    type: exit
-    vanilla: Lanayru Mining Facility - First Hub - Entrance from Big Hub
-  \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Exit to Hop Across Boxes Room:
-    req_index: 2045
-    short_name: Lanayru Mining Facility - Big Hub - Exit to Hop Across Boxes Room
-    type: exit
-    vanilla: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big Hub
-  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Exit to Armos Fight Room:
-    req_index: 2046
-    short_name: Lanayru Mining Facility - Big Hub - Exit to Armos Fight Room
-    type: exit
-    vanilla: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
-  \Lanayru Mining Facility\Main\First Hub\Exit to Big Hub:
-    req_index: 2041
-    short_name: Lanayru Mining Facility - First Hub - Exit to Big Hub
-    type: exit
-    vanilla: Lanayru Mining Facility - Big Hub - Entrance from First Hub
-  \Lanayru Mining Facility\Main\First Room\Main Exit:
-    req_index: 2040
-    short_name: Lanayru Mining Facility - Main Exit
-    type: exit
-    vanilla: Lanayru Desert - Entrance from Lanayru Mining Facility
-  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Exit to Big Hub:
-    req_index: 2042
-    short_name: Lanayru Mining Facility - Hop Across Boxes Room - Exit to Big Hub
-    type: exit
-    vanilla: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes Room
-  \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Exit:
-    req_index: 2047
-    short_name: Lanayru Mining Facility - Boss Door Exit
-    type: exit
-    vanilla: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
-  \Lanayru\Caves\Exit to Desert:
-    index: 1
-    req_index: 2010
-    room: 0
-    short_name: Lanayru Caves - Exit to Desert
-    stage: F303
-    type: exit
-    vanilla: Lanayru Desert - Entrance from Caves
-  \Lanayru\Caves\Exit to Mine:
-    index: 0
-    req_index: 2009
-    room: 0
-    short_name: Lanayru Caves - Exit to Mine
-    stage: F303
-    type: exit
-    vanilla: Lanayru Mine - Entrance from Caves
-  \Lanayru\Caves\Past Crawlspace\Exit to Gorge:
-    req_index: 2012
-    short_name: Lanayru Caves - Exit to Gorge
-    type: exit
-    vanilla: Lanayru Gorge - Entrance
-  \Lanayru\Caves\Past Door to Lanayru Sand Sea\Exit to Lanayru Sand Sea:
-    index: 2
-    req_index: 2011
-    room: 0
-    short_name: Lanayru Caves - Exit to Lanayru Sand Sea
-    stage: F303
-    type: exit
-    vanilla: Lanayru Sand Sea Docks - Entrance from Caves
-  \Lanayru\Desert\East\Fire Node Exit:
-    index: 2
-    req_index: 1996
-    room: 0
-    short_name: Lanayru Desert - Fire Node Exit
-    stage: F300
-    type: exit
-    vanilla: Fire Node - Entrance
-  \Lanayru\Desert\East\Fire Node\Present\Exit:
-    index: 0
-    req_index: 2004
-    room: 0
-    short_name: Fire Node - Exit
-    stage: F300_3
-    type: exit
-    vanilla: Lanayru Desert - Fire Node Entrance
-  \Lanayru\Desert\Entry\Exit to Mine:
-    index: 1
-    req_index: 1995
-    room: 0
-    short_name: Lanayru Desert - Exit to Mine
-    stage: F300
-    type: exit
-    vanilla: Lanayru Mine - Entrance from Desert
-  \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Exit to Caves:
-    index: 8
-    req_index: 2000
-    room: 0
-    short_name: Lanayru Desert - Exit to Caves
-    stage: F300
-    type: exit
-    vanilla: Lanayru Caves - Entrance from Desert
-  \Lanayru\Desert\Near South Exit to Temple of Time\South Exit to Temple of Time:
-    index: 3
-    req_index: 1997
-    room: 0
-    short_name: Lanayru Desert - South Exit to Temple of Time
-    stage: F300
-    type: exit
-    vanilla: Temple of Time - South Entrance from Desert
-  \Lanayru\Desert\North Part\Lightning Node Exit:
-    index: 0
-    req_index: 1994
-    room: 0
-    short_name: Lanayru Desert - Lightning Node Exit
-    stage: F300
-    type: exit
-    vanilla: Lightning Node - Entrance
-  \Lanayru\Desert\North Part\Lightning Node\Present\Exit:
-    index: 0
-    req_index: 2003
-    room: 0
-    short_name: Lightning Node - Exit
-    stage: F300_2
-    type: exit
-    vanilla: Lanayru Desert - Lightning Node Entrance
-  \Lanayru\Desert\North Part\North Exit to Temple of Time:
-    index: 4
-    req_index: 1998
-    room: 0
-    short_name: Lanayru Desert - North Exit to Temple of Time
-    stage: F300
-    type: exit
-    vanilla: Temple of Time - North Entrance from Desert
-  \Lanayru\Desert\North Part\Trial Gate Exit:
-    req_index: 2001
-    short_name: Lanayru Desert - Trial Gate Exit
-    type: exit
-    vanilla: Lanayru Silent Realm - Entrance
-  \Lanayru\Desert\Shared Statue Exit:
-    index: 6
-    req_index: 1993
-    room: 0
-    short_name: Lanayru Desert - Shared Statue Exit
-    stage: F300
-    type: exit
-    vanilla: Sky - Lanayru Pillar - Entrance
-  \Lanayru\Desert\Top of LMF\Exit to Lanayru Mining Facility:
-    index: 5
-    req_index: 1999
-    room: 0
-    short_name: Lanayru Desert - Exit to Lanayru Mining Facility
-    stage: F300
-    type: exit
-    vanilla: Lanayru Mining Facility - Main Entrance
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Exit:
-    index: 0
-    req_index: 2015
-    room: 0
-    short_name: Lanayru Sand Sea - Ancient Harbour Dock Exit
-    stage: F301_1
-    type: exit
-    vanilla: Lanayru Sand Sea Docks - Dock Entrance
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Exit:
-    index: 2
-    req_index: 2023
-    room: 0
-    short_name: Lanayru Sand Sea Docks - Dock Exit
-    stage: F301
-    type: exit
-    vanilla: Lanayru Sand Sea - Ancient Harbour Dock Entrance
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Exit to Sandship:
-    index: 0
-    req_index: 2021
-    room: 0
-    short_name: Lanayru Sand Sea Docks - Exit to Sandship
-    stage: F301
-    type: exit
-    vanilla: Sandship - Main Entrance
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Exit to Caves:
-    index: 1
-    req_index: 2022
-    room: 0
-    short_name: Lanayru Sand Sea Docks - Exit to Caves
-    stage: F301
-    type: exit
-    vanilla: Lanayru Caves - Entrance from Lanayru Sand Sea
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Exit:
-    index: 3
-    req_index: 2020
-    room: 0
-    short_name: Lanayru Sand Sea Docks - Statue Exit
-    stage: F301
-    type: exit
-    vanilla: Sky - Lanayru Pillar - Entrance
-  \Lanayru\Lanayru Sand Sea\Gorge\Exit:
-    req_index: 2013
-    short_name: Lanayru Gorge - Exit
-    type: exit
-    vanilla: Lanayru Caves - Entrance from Gorge
-  \Lanayru\Lanayru Sand Sea\Gorge\Statue Exit:
-    req_index: 2014
-    short_name: Lanayru Gorge - Statue Exit
-    type: exit
-    vanilla: Sky - Lanayru Pillar - Entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Exit:
-    index: 4
-    req_index: 2019
-    room: 0
-    short_name: Lanayru Sand Sea - Pirate Stronghold Dock Exit
-    stage: F301_1
-    type: exit
-    vanilla: Pirate Stronghold - Dock Entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Exit:
-    index: 0
-    req_index: 2035
-    room: 0
-    short_name: Pirate Stronghold - Dock Exit
-    stage: F301_6
-    type: exit
-    vanilla: Lanayru Sand Sea - Pirate Stronghold Dock Entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Exit:
-    index: 2
-    req_index: 2037
-    room: 0
-    short_name: Pirate Stronghold - Top Exit
-    stage: F301_6
-    type: exit
-    vanilla: Pirate Stronghold - Inside - Second Door Entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Exit:
-    index: 0
-    req_index: 2038
-    room: 1
-    short_name: Pirate Stronghold - Inside - First Door Exit
-    stage: F301_2
-    type: exit
-    vanilla: Pirate Stronghold - Side Entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Exit:
-    index: 2
-    req_index: 2039
-    room: 1
-    short_name: Pirate Stronghold - Inside - Second Door Exit
-    stage: F301_2
-    type: exit
-    vanilla: Pirate Stronghold - Top Entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Exit:
-    index: 1
-    req_index: 2036
-    room: 0
-    short_name: Pirate Stronghold - Side Exit
-    stage: F301_6
-    type: exit
-    vanilla: Pirate Stronghold - Inside - First Door Entrance
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Exit:
-    index: 3
-    req_index: 2034
-    room: 0
-    short_name: Pirate Stronghold - Statue Exit
-    stage: F301_6
-    type: exit
-    vanilla: Sky - Lanayru Pillar - Entrance
-  \Lanayru\Lanayru Sand Sea\Sandship Dock Exit:
-    index: 1
-    req_index: 2016
-    room: 0
-    short_name: Lanayru Sand Sea - Sandship Dock Exit
-    stage: F301_1
-    type: exit
-    vanilla: Sandship - Main Entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard Dock Exit:
-    index: 3
-    req_index: 2018
-    room: 0
-    short_name: Lanayru Sand Sea - Shipyard Dock Exit
-    stage: F301_1
-    type: exit
-    vanilla: Shipyard - Dock Entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Exit:
-    index: 4
-    req_index: 2031
-    room: 0
-    short_name: Shipyard - Construction Bay Lower Exit
-    stage: F301_4
-    type: exit
-    vanilla: Shipyard - Construction Bay - Lower Entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Exit:
-    index: 3
-    req_index: 2030
-    room: 0
-    short_name: Shipyard - Construction Bay Upper Exit
-    stage: F301_4
-    type: exit
-    vanilla: Shipyard - Construction Bay - Upper Entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Exit:
-    index: 0
-    req_index: 2032
-    room: 0
-    short_name: Shipyard - Construction Bay - Lower Exit
-    stage: F301_7
-    type: exit
-    vanilla: Shipyard - Construction Bay Lower Entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Exit:
-    index: 1
-    req_index: 2033
-    room: 0
-    short_name: Shipyard - Construction Bay - Upper Exit
-    stage: F301_7
-    type: exit
-    vanilla: Shipyard - Construction Bay Upper Entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Dock Exit:
-    index: 2
-    req_index: 2029
-    room: 0
-    short_name: Shipyard - Dock Exit
-    stage: F301_4
-    type: exit
-    vanilla: Lanayru Sand Sea - Shipyard Dock Entrance
-  \Lanayru\Lanayru Sand Sea\Shipyard\Statue Exit:
-    index: 1
-    req_index: 2028
-    room: 0
-    short_name: Shipyard - Statue Exit
-    stage: F301_4
-    type: exit
-    vanilla: Sky - Lanayru Pillar - Entrance
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Exit:
-    index: 2
-    req_index: 2017
-    room: 0
-    short_name: Lanayru Sand Sea - Skipper's Retreat Dock Exit
-    stage: F301_1
-    type: exit
-    vanilla: Skipper's Retreat - Dock Entrance
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Exit:
-    index: 2
-    req_index: 2025
-    room: 0
-    short_name: Skipper's Retreat - Dock Exit
-    stage: F301_3
-    type: exit
-    vanilla: Lanayru Sand Sea - Skipper's Retreat Dock Entrance
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Exit:
-    index: 0
-    req_index: 2027
-    room: 0
-    short_name: Skipper's Retreat - Shack - Exit
-    stage: F301_5
-    type: exit
-    vanilla: Skipper's Retreat - Shack Entrance
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Exit:
-    index: 1
-    req_index: 2024
-    room: 0
-    short_name: Skipper's Retreat - Statue Exit
-    stage: F301_3
-    type: exit
-    vanilla: Sky - Lanayru Pillar - Entrance
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Exit:
-    index: 3
-    req_index: 2026
-    room: 0
-    short_name: Skipper's Retreat - Shack Exit
-    stage: F301_3
-    type: exit
-    vanilla: Skipper's Retreat - Shack - Entrance
-  \Lanayru\Lanayru Silent Realm\Exit:
-    req_index: 2002
-    short_name: Lanayru Silent Realm - Exit
-    type: exit
-    vanilla: Lanayru Desert - Trial Gate Entrance
-  \Lanayru\Mine\End\In Minecart\Exit to Desert:
-    index: 0
-    req_index: 1992
-    room: 2
-    short_name: Lanayru Mine - Exit to Desert
-    stage: F300_1
-    type: exit
-    vanilla: Lanayru Desert - Entrance from Mine
-  \Lanayru\Mine\Entry\Caves Entrance\Exit to Caves:
-    index: 1
-    req_index: 1991
-    room: 0
-    short_name: Lanayru Mine - Exit to Caves
-    stage: F300_1
-    type: exit
-    vanilla: Lanayru Caves - Entrance from Mine
-  \Lanayru\Mine\Entry\Statue Exit:
-    index: 0
-    req_index: 1990
-    room: 0
-    short_name: Lanayru Mine - Statue Exit
-    stage: F300_1
-    type: exit
-    vanilla: Sky - Lanayru Pillar - Entrance
-  \Lanayru\Temple of Time\Inside\Exit to Lanayru Mining Facility:
-    index: 4
-    req_index: 2008
-    room: 0
-    short_name: Temple of Time - Exit to Lanayru Mining Facility
-    stage: F300_4
-    subtype: vanilla
-    type: exit
-  \Lanayru\Temple of Time\North East\North Exit to Desert:
-    index: 1
-    req_index: 2007
-    room: 0
-    short_name: Temple of Time - North Exit to Desert
-    stage: F300_4
-    type: exit
-    vanilla: Lanayru Desert - North Entrance from Temple of Time
-  \Lanayru\Temple of Time\Shared Statue Exit:
-    index: 2
-    req_index: 2005
-    room: 0
-    short_name: Temple of Time - Shared Statue Exit
-    stage: F300_4
-    type: exit
-    vanilla: Sky - Lanayru Pillar - Entrance
-  \Lanayru\Temple of Time\South East\South Exit to Desert:
-    index: 0
-    req_index: 2006
-    room: 0
-    short_name: Temple of Time - South Exit to Desert
-    stage: F300_4
-    type: exit
-    vanilla: Lanayru Desert - South Entrance from Temple of Time
-  \Sandship\Main\Before Boss Door\Boss Door one-way Exit:
-    req_index: 2053
-    short_name: Sandship - Boss Door one-way Exit
-    type: exit
-    vanilla: Sandship - Boss Room - Entrance
-  \Sandship\Main\Deck\Main Exit:
-    req_index: 2052
-    short_name: Sandship - Main Exit
-    type: exit
-    vanilla: Lanayru Sand Sea - Sandship Dock Entrance
-  \Sky Keep\Main\First Room\Bottom Exit:
-    req_index: 2054
-    short_name: Sky Keep - First Room - Bottom Exit
-    type: exit
-    vanilla: Skyloft - Entrance from Sky Keep
-  \Sky\Around Skyloft\Exit to Skyloft:
-    req_index: 1855
-    short_name: Sky - Exit to Skyloft
-    type: exit
-    vanilla: Skyloft - Entrance from Sky
-  \Sky\Around Skyloft\Exit to Thunderhead:
-    index: 25
-    req_index: 1896
-    room: 0
-    short_name: Sky - Exit to Thunderhead
-    stage: F020
-    type: exit
-    vanilla: Thunderhead - Entrance
-  \Sky\North East\Bamboo Island\Exit to Inside:
-    index: 13
-    req_index: 1857
-    room: 0
-    short_name: Bamboo Island - Exit to Inside
-    stage: F020
-    type: exit
-    vanilla: Bamboo Island - Inside - Entrance
-  \Sky\North East\Bamboo Island\Inside\Exit:
-    index: 2
-    req_index: 1856
-    room: 0
-    short_name: Bamboo Island - Inside - Exit
-    stage: F019r
-    type: exit
-    vanilla: Bamboo Island - Entrance from Inside
-  \Sky\North East\Beedle's Island\Beedle's Ship Exit:
-    allowed-time-of-day: NightOnly
-    index: 14
-    req_index: 1858
-    room: 0
-    short_name: Sky - Beedle's Island - Beedle's Ship Exit
-    stage: F020
-    type: exit
-    vanilla: Beedle's Shop - Night Entrance
-  \Sky\North East\Eldin Pillar\Fire Sanctuary Statue Dive:
-    index: 55
-    req_index: 1865
-    room: 0
-    short_name: Sky - Eldin Pillar - Fire Sanctuary Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Fire Sanctuary - Statue Entrance
-  \Sky\North East\Eldin Pillar\First Time Dive:
-    index: 1
-    req_index: 1859
-    room: 0
-    short_name: Sky - Eldin Pillar - First Time Dive
-    stage: F020
-    type: exit
-    vanilla: Eldin Volcano - First Time Entrance
-  \Sky\North East\Eldin Pillar\Inside the Volcano Statue Dive:
-    index: 30
-    req_index: 1861
-    room: 0
-    short_name: Sky - Eldin Pillar - Inside the Volcano Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Outside Fire Sanctuary - Statue Entrance
-  \Sky\North East\Eldin Pillar\Temple Entrance Statue Dive:
-    index: 29
-    req_index: 1860
-    room: 0
-    short_name: Sky - Eldin Pillar - Temple Entrance Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Eldin Volcano - Temple Entrance Statue Entrance
-  \Sky\North East\Eldin Pillar\Volcano Ascent Statue Dive:
-    index: 52
-    req_index: 1864
-    room: 0
-    short_name: Sky - Eldin Pillar - Volcano Ascent Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Eldin Volcano - Volcano Ascent Statue Entrance
-  \Sky\North East\Eldin Pillar\Volcano East Statue Dive:
-    index: 51
-    req_index: 1863
-    room: 0
-    short_name: Sky - Eldin Pillar - Volcano East Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Eldin Volcano - Volcano East Statue Entrance
-  \Sky\North East\Eldin Pillar\Volcano Entrance Statue Dive:
-    index: 50
-    req_index: 1862
-    room: 0
-    short_name: Sky - Eldin Pillar - Volcano Entrance Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Eldin Volcano - Volcano Entrance Statue Entrance
-  \Sky\South East\Faron Pillar\Behind the Temple Statue Dive:
-    index: 40
-    req_index: 1875
-    room: 0
-    short_name: Sky - Faron Pillar - Behind the Temple Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Behind the Temple - Statue Entrance
-  \Sky\South East\Faron Pillar\Deep Woods Statue Dive:
-    index: 46
-    req_index: 1880
-    room: 0
-    short_name: Sky - Faron Pillar - Deep Woods Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Deep Woods - Deep Woods Statue Entrance
-  \Sky\South East\Faron Pillar\Faron Woods Entry Statue Dive:
-    index: 41
-    req_index: 1876
-    room: 0
-    short_name: Sky - Faron Pillar - Faron Woods Entry Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Faron Woods - Faron Woods Entry Statue Entrance
-  \Sky\South East\Faron Pillar\First Time Dive:
-    index: 0
-    req_index: 1872
-    room: 0
-    short_name: Sky - Faron Pillar - First Time Dive
-    stage: F020
-    type: exit
-    vanilla: Sealed Grounds Spiral - Statue Entrance
-  \Sky\South East\Faron Pillar\Floria Waterfall Statue Dive:
-    index: 48
-    req_index: 1882
-    room: 0
-    short_name: Sky - Faron Pillar - Floria Waterfall Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Floria Waterfall - Statue Entrance
-  \Sky\South East\Faron Pillar\Forest Temple Statue Dive:
-    index: 27
-    req_index: 1874
-    room: 0
-    short_name: Sky - Faron Pillar - Forest Temple Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Deep Woods - Forest Temple Statue Entrance
-  \Sky\South East\Faron Pillar\In the Woods Statue Dive:
-    index: 42
-    req_index: 1877
-    room: 0
-    short_name: Sky - Faron Pillar - In the Woods Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Faron Woods - In the Woods Statue Entrance
-  \Sky\South East\Faron Pillar\Lake Floria Statue Dive:
-    index: 47
-    req_index: 1881
-    room: 0
-    short_name: Sky - Faron Pillar - Lake Floria Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Lake Floria - Below Rock - Statue Entrance
-  \Sky\South East\Faron Pillar\Sealed Grounds Statue Dive:
-    index: 68
-    req_index: 1873
-    room: 0
-    short_name: Sky - Faron Pillar - Sealed Grounds Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Sealed Grounds Spiral - Statue Entrance
-  \Sky\South East\Faron Pillar\The Great Tree Statue Dive:
-    index: 44
-    req_index: 1879
-    room: 0
-    short_name: Sky - Faron Pillar - The Great Tree Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Great Tree - The Great Tree Statue Entrance
-  \Sky\South East\Faron Pillar\Viewing Platform Statue Dive:
-    index: 43
-    req_index: 1878
-    room: 0
-    short_name: Sky - Faron Pillar - Viewing Platform Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Faron Woods - Viewing Platform Statue Entrance
-  \Sky\South East\Lumpy Pumpkin\Back Door Exit:
-    index: 20
-    req_index: 1871
-    room: 0
-    short_name: Lumpy Pumpkin - Back Door Exit
-    stage: F020
-    type: exit
-    vanilla: Lumpy Pumpkin Building - Back Door Entrance
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Exit:
-    index: 2
-    req_index: 1868
-    room: 0
-    short_name: Lumpy Pumpkin Building - Back Door Exit
-    stage: F011r
-    type: exit
-    vanilla: Lumpy Pumpkin - Back Door Entrance
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Exit:
-    index: 1
-    req_index: 1867
-    room: 0
-    short_name: Lumpy Pumpkin Building - Main Left Door Exit
-    stage: F011r
-    type: exit
-    vanilla: Lumpy Pumpkin - Main Right Door Entrance
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Exit:
-    index: 0
-    req_index: 1866
-    room: 0
-    short_name: Lumpy Pumpkin Building - Main Right Door Exit
-    stage: F011r
-    type: exit
-    vanilla: Lumpy Pumpkin - Main Left Door Entrance
-  \Sky\South East\Lumpy Pumpkin\Main Left Door Exit:
-    index: 19
-    req_index: 1870
-    room: 0
-    short_name: Lumpy Pumpkin - Main Left Door Exit
-    stage: F020
-    type: exit
-    vanilla: Lumpy Pumpkin Building - Main Right Door Entrance
-  \Sky\South East\Lumpy Pumpkin\Main Right Door Exit:
-    index: 18
-    req_index: 1869
-    room: 0
-    short_name: Lumpy Pumpkin - Main Right Door Exit
-    stage: F020
-    type: exit
-    vanilla: Lumpy Pumpkin Building - Main Left Door Entrance
-  \Sky\South West\Lanayru Pillar\Ancient Harbour Statue Dive:
-    index: 63
-    req_index: 1891
-    room: 0
-    short_name: Sky - Lanayru Pillar - Ancient Harbour Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Lanayru Sand Sea Docks - Statue Entrance
-  \Sky\South West\Lanayru Pillar\Desert Entrance Statue Dive:
-    index: 57
-    req_index: 1885
-    room: 0
-    short_name: Sky - Lanayru Pillar - Desert Entrance Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Lanayru Desert - Desert Entrance Statue Entrance
-  \Sky\South West\Lanayru Pillar\Desert Gorge Statue Dive:
-    index: 61
-    req_index: 1889
-    room: 0
-    short_name: Sky - Lanayru Pillar - Desert Gorge Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Temple of Time - Desert Gorge Statue Entrance
-  \Sky\South West\Lanayru Pillar\First Time Dive:
-    index: 2
-    req_index: 1883
-    room: 0
-    short_name: Sky - Lanayru Pillar - First Time Dive
-    stage: F020
-    type: exit
-    vanilla: Lanayru Mine - First Time Entrance
-  \Sky\South West\Lanayru Pillar\Lanayru Gorge Statue Dive:
-    req_index: 1895
-    short_name: Sky - Lanayru Pillar - Lanayru Gorge Statue Dive
-    type: exit
-    vanilla: Lanayru Gorge - Statue Entrance
-  \Sky\South West\Lanayru Pillar\Lanayru Mine Entry Statue Dive:
-    index: 56
-    req_index: 1884
-    room: 0
-    short_name: Sky - Lanayru Pillar - Lanayru Mine Entry Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Lanayru Mine - Statue Entrance
-  \Sky\South West\Lanayru Pillar\North Desert Statue Dive:
-    index: 59
-    req_index: 1887
-    room: 0
-    short_name: Sky - Lanayru Pillar - North Desert Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Lanayru Desert - North Desert Statue Entrance
-  \Sky\South West\Lanayru Pillar\Pirate Stronghold Statue Dive:
-    index: 66
-    req_index: 1894
-    room: 0
-    short_name: Sky - Lanayru Pillar - Pirate Stronghold Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Pirate Stronghold - Statue Entrance
-  \Sky\South West\Lanayru Pillar\Shipyard Statue Dive:
-    index: 65
-    req_index: 1893
-    room: 0
-    short_name: Sky - Lanayru Pillar - Shipyard Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Shipyard - Statue Entrance
-  \Sky\South West\Lanayru Pillar\Skipper's Retreat Statue Dive:
-    index: 64
-    req_index: 1892
-    room: 0
-    short_name: Sky - Lanayru Pillar - Skipper's Retreat Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Skipper's Retreat - Statue Entrance
-  \Sky\South West\Lanayru Pillar\Stone Cache Statue Dive:
-    index: 60
-    req_index: 1888
-    room: 0
-    short_name: Sky - Lanayru Pillar - Stone Cache Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Lanayru Desert - Stone Cache Statue Entrance
-  \Sky\South West\Lanayru Pillar\Temple of Time Statue Dive:
-    index: 62
-    req_index: 1890
-    room: 0
-    short_name: Sky - Lanayru Pillar - Temple of Time Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Temple of Time - Temple of Time Statue Entrance
-  \Sky\South West\Lanayru Pillar\West Desert Statue Dive:
-    index: 58
-    req_index: 1886
-    room: 0
-    short_name: Sky - Lanayru Pillar - West Desert Statue Dive
-    stage: F020
-    type: exit
-    vanilla: Lanayru Desert - West Desert Statue Entrance
-  \Sky\Thunderhead\Exit:
-    index: 1
-    req_index: 1897
-    room: 0
-    short_name: Thunderhead - Exit
-    stage: F023
-    type: exit
-    vanilla: Sky - Entrance from Thunderhead
-  \Sky\Thunderhead\Isle of Songs\Exit to Inside:
-    index: 2
-    req_index: 1899
-    room: 0
-    short_name: Isle of Songs - Exit to Inside
-    stage: F023
-    type: exit
-    vanilla: Isle of Songs - Entrance
-  \Sky\Thunderhead\Isle of Songs\Inside\Exit:
-    index: 0
-    req_index: 1898
-    room: 0
-    short_name: Isle of Songs - Exit
-    stage: F010r
-    type: exit
-    vanilla: Isle of Songs - Entrance from Inside
-  \Skyloft\Beedle's Shop\Day Exit:
-    index: 0
-    req_index: 1828
-    room: 0
-    short_name: Beedle's Shop - Day Exit
-    stage: F002r
-    type: exit
-    vanilla: Skyloft - Entrance from Beedle's Shop
-  \Skyloft\Beedle's Shop\Night Exit:
-    allowed-time-of-day: NightOnly
-    index: 2
-    req_index: 1829
-    room: 0
-    short_name: Beedle's Shop - Night Exit
-    stage: F002r
-    type: exit
-    vanilla: Sky - Beedle's Island - Beedle's Ship Entrance
-  \Skyloft\Central Skyloft\Bazaar North Exit:
-    index: 1
-    req_index: 1825
-    room: 0
-    short_name: Bazaar North Exit
-    stage: F000
-    type: exit
-    vanilla: Bazaar - North Entrance
-  \Skyloft\Central Skyloft\Bazaar South Exit:
-    index: 2
-    req_index: 1826
-    room: 0
-    short_name: Bazaar South Exit
-    stage: F000
-    type: exit
-    vanilla: Bazaar - South Entrance
-  \Skyloft\Central Skyloft\Bazaar West Exit:
-    index: 19
-    req_index: 1827
-    room: 0
-    short_name: Bazaar West Exit
-    stage: F000
-    type: exit
-    vanilla: Bazaar - West Entrance
-  \Skyloft\Central Skyloft\Bazaar\North Exit:
-    index: 0
-    req_index: 1822
-    room: 0
-    short_name: Bazaar - North Exit
-    stage: F004r
-    type: exit
-    vanilla: Bazaar North Entrance
-  \Skyloft\Central Skyloft\Bazaar\South Exit:
-    index: 1
-    req_index: 1823
-    room: 0
-    short_name: Bazaar - South Exit
-    stage: F004r
-    type: exit
-    vanilla: Bazaar South Entrance
-  \Skyloft\Central Skyloft\Bazaar\West Exit:
-    index: 2
-    req_index: 1824
-    room: 0
-    short_name: Bazaar - West Exit
-    stage: F004r
-    type: exit
-    vanilla: Bazaar West Entrance
-  \Skyloft\Central Skyloft\Exit to Beedle's Shop:
-    index: 26
-    req_index: 1830
-    room: 0
-    short_name: Skyloft - Exit to Beedle's Shop
-    stage: F000
-    type: exit
-    vanilla: Beedle's Shop - Day Entrance
-  \Skyloft\Central Skyloft\Exit to Sky:
-    req_index: 1854
-    short_name: Skyloft - Exit to Sky
-    type: exit
-    vanilla: Sky - Entrance from Skyloft
-  \Skyloft\Central Skyloft\Near Temple Entrance\Exit to Sky Keep:
-    index: 48
-    req_index: 1833
-    room: 0
-    short_name: Skyloft - Exit to Sky Keep
-    stage: F000
-    type: exit
-    vanilla: Sky Keep - First Room - Bottom Entrance
-  \Skyloft\Central Skyloft\Orielle and Parrow's House Exit:
-    index: 31
-    req_index: 1835
-    room: 0
-    short_name: Orielle and Parrow's House Exit
-    stage: F000
-    type: exit
-    vanilla: Orielle and Parrow's House - Entrance
-  \Skyloft\Central Skyloft\Orielle and Parrow's House\Exit:
-    index: 0
-    req_index: 1834
-    room: 0
-    short_name: Orielle and Parrow's House - Exit
-    stage: F005r
-    type: exit
-    vanilla: Orielle and Parrow's House Entrance
-  \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Exit:
-    index: 7
-    req_index: 1821
-    room: 0
-    short_name: Waterfall Cave Lower Exit
-    stage: F000
-    type: exit
-    vanilla: Waterfall Cave - Lower Entrance
-  \Skyloft\Central Skyloft\Peatrice's House Exit:
-    index: 38
-    req_index: 1837
-    room: 0
-    short_name: Peatrice's House Exit
-    stage: F000
-    type: exit
-    vanilla: Peatrice's House - Entrance
-  \Skyloft\Central Skyloft\Peatrice's House\Exit:
-    index: 0
-    req_index: 1836
-    room: 0
-    short_name: Peatrice's House - Exit
-    stage: F018r
-    type: exit
-    vanilla: Peatrice's House Entrance
-  \Skyloft\Central Skyloft\Piper's House Exit:
-    index: 32
-    req_index: 1853
-    room: 0
-    short_name: Piper's House Exit
-    stage: F000
-    type: exit
-    vanilla: Piper's House - Entrance
-  \Skyloft\Central Skyloft\Piper's House\Exit:
-    index: 0
-    req_index: 1852
-    room: 0
-    short_name: Piper's House - Exit
-    stage: F007r
-    type: exit
-    vanilla: Piper's House Entrance
-  \Skyloft\Central Skyloft\Trial Gate Exit:
-    req_index: 1832
-    short_name: Skyloft - Trial Gate Exit
-    type: exit
-    vanilla: Skyloft Silent Realm - Entrance
-  \Skyloft\Central Skyloft\Waterfall Cave Upper Exit:
-    index: 6
-    req_index: 1820
-    room: 0
-    short_name: Waterfall Cave Upper Exit
-    stage: F000
-    type: exit
-    vanilla: Waterfall Cave - Upper Entrance
-  \Skyloft\Central Skyloft\Waterfall Cave\Lower Exit:
-    index: 1
-    req_index: 1819
-    room: 0
-    short_name: Waterfall Cave - Lower Exit
-    stage: D000
-    type: exit
-    vanilla: Waterfall Cave Lower Entrance
-  \Skyloft\Central Skyloft\Waterfall Cave\Upper Exit:
-    index: 0
-    req_index: 1818
-    room: 0
-    short_name: Waterfall Cave - Upper Exit
-    stage: D000
-    type: exit
-    vanilla: Waterfall Cave Upper Entrance
-  \Skyloft\Central Skyloft\Wryna's House Exit:
-    index: 10
-    req_index: 1839
-    room: 0
-    short_name: Wryna's House Exit
-    stage: F000
-    type: exit
-    vanilla: Wryna's House - Entrance
-  \Skyloft\Central Skyloft\Wryna's House\Exit:
-    index: 0
-    req_index: 1838
-    room: 0
-    short_name: Wryna's House - Exit
-    stage: F006r
-    type: exit
-    vanilla: Wryna's House Entrance
-  \Skyloft\Skyloft Silent Realm\Exit:
-    req_index: 1831
-    short_name: Skyloft Silent Realm - Exit
-    type: exit
-    vanilla: Skyloft - Trial Gate Entrance
-  \Skyloft\Skyloft Village\Batreaux's House Exit:
-    index: 30
-    req_index: 1847
-    room: 0
-    short_name: Batreaux's House Exit
-    stage: F000
-    type: exit
-    vanilla: Batreaux's House - Entrance
-  \Skyloft\Skyloft Village\Batreaux's House\Exit:
-    index: 0
-    req_index: 1846
-    room: 0
-    short_name: Batreaux's House - Exit
-    stage: F012r
-    type: exit
-    vanilla: Batreaux's House Entrance
-  \Skyloft\Skyloft Village\Bertie's House Exit:
-    index: 34
-    req_index: 1841
-    room: 0
-    short_name: Bertie's House Exit
-    stage: F000
-    type: exit
-    vanilla: Bertie's House - Entrance
-  \Skyloft\Skyloft Village\Bertie's House\Exit:
-    index: 0
-    req_index: 1840
-    room: 0
-    short_name: Bertie's House - Exit
-    stage: F014r
-    type: exit
-    vanilla: Bertie's House Entrance
-  \Skyloft\Skyloft Village\Gondo's House Exit:
-    index: 35
-    req_index: 1849
-    room: 0
-    short_name: Gondo's House Exit
-    stage: F000
-    type: exit
-    vanilla: Gondo's House - Entrance
-  \Skyloft\Skyloft Village\Gondo's House\Exit:
-    index: 0
-    req_index: 1848
-    room: 0
-    short_name: Gondo's House - Exit
-    stage: F015r
-    type: exit
-    vanilla: Gondo's House Entrance
-  \Skyloft\Skyloft Village\Mallara's House Exit:
-    index: 36
-    req_index: 1844
-    room: 0
-    short_name: Skyloft - Mallara's House Exit
-    stage: F000
-    type: exit
-    vanilla: Mallara's House - Entrance
-  \Skyloft\Skyloft Village\Mallara's House\Exit:
-    index: 0
-    req_index: 1845
-    room: 0
-    short_name: Mallara's House - Exit
-    stage: F016r
-    type: exit
-    vanilla: Mallara's House Entrance
-  \Skyloft\Skyloft Village\Rupin's House Exit:
-    index: 37
-    req_index: 1851
-    room: 0
-    short_name: Rupin's House Exit
-    stage: F000
-    type: exit
-    vanilla: Rupin's House - Entrance
-  \Skyloft\Skyloft Village\Rupin's House\Exit:
-    index: 1
-    req_index: 1850
-    room: 0
-    short_name: Rupin's House - Exit
-    stage: F017r
-    type: exit
-    vanilla: Rupin's House Entrance
-  \Skyloft\Skyloft Village\Sparrot's House Exit:
-    index: 33
-    req_index: 1843
-    room: 0
-    short_name: Sparrot's House Exit
-    stage: F000
-    type: exit
-    vanilla: Sparrot's House - Entrance
-  \Skyloft\Skyloft Village\Sparrot's House\Exit:
-    index: 0
-    req_index: 1842
-    room: 0
-    short_name: Sparrot's House - Exit
-    stage: F013r
-    type: exit
-    vanilla: Sparrot's House Entrance
-  \Skyloft\Upper Skyloft\Goddess Statue Exit:
-    index: 5
-    req_index: 1817
-    room: 0
-    short_name: Goddess Statue Exit
-    stage: F000
-    type: exit
-    vanilla: Goddess Statue - Entrance
-  \Skyloft\Upper Skyloft\Goddess Statue\Exit:
-    index: 0
-    req_index: 1816
-    room: 0
-    short_name: Goddess Statue - Exit
-    stage: F008r
-    type: exit
-    vanilla: Goddess Statue Entrance
-  \Skyloft\Upper Skyloft\Knight Academy Chimney Entrance:
-    index: 57
-    req_index: 1811
-    room: 0
-    short_name: Skyloft - Knight Academy Chimney Entrance
-    stage: F000
-    type: exit
-    vanilla: Skyloft - Knight Academy - Chimney
-  \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Exit:
-    index: 4
-    req_index: 1808
-    room: 0
-    short_name: Skyloft - Knight Academy Lower Left Door Exit
-    stage: F000
-    type: exit
-    vanilla: Skyloft - Knight Academy - Lower Right Door Entrance
-  \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Exit:
-    index: 3
-    req_index: 1807
-    room: 0
-    short_name: Skyloft - Knight Academy Lower Right Door Exit
-    stage: F000
-    type: exit
-    vanilla: Skyloft - Knight Academy - Lower Left Door Entrance
-  \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Exit:
-    index: 23
-    req_index: 1809
-    room: 0
-    short_name: Skyloft - Knight Academy Upper Left Door Exit
-    stage: F000
-    type: exit
-    vanilla: Skyloft - Knight Academy - Upper Right Door Entrance
-  \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Exit:
-    index: 24
-    req_index: 1810
-    room: 0
-    short_name: Skyloft - Knight Academy Upper Right Door Exit
-    stage: F000
-    type: exit
-    vanilla: Skyloft - Knight Academy - Upper Left Door Entrance
-  \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Exit:
-    index: 0
-    req_index: 1803
-    room: 0
-    short_name: Skyloft - Knight Academy - Lower Left Door Exit
-    stage: F001r
-    type: exit
-    vanilla: Skyloft - Knight Academy Lower Right Door Entrance
-  \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Exit:
-    index: 1
-    req_index: 1804
-    room: 0
-    short_name: Skyloft - Knight Academy - Lower Right Door Exit
-    stage: F001r
-    type: exit
-    vanilla: Skyloft - Knight Academy Lower Left Door Entrance
-  \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Exit:
-    index: 3
-    req_index: 1806
-    room: 0
-    short_name: Skyloft - Knight Academy - Upper Left Door Exit
-    stage: F001r
-    type: exit
-    vanilla: Skyloft - Knight Academy Upper Right Door Entrance
-  \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Exit:
-    index: 2
-    req_index: 1805
-    room: 0
-    short_name: Skyloft - Knight Academy - Upper Right Door Exit
-    stage: F001r
-    type: exit
-    vanilla: Skyloft - Knight Academy Upper Left Door Entrance
-  \Skyloft\Upper Skyloft\Sparring Hall Left Door Exit:
-    index: 20
-    req_index: 1814
-    room: 0
-    short_name: Skyloft - Sparring Hall Left Door Exit
-    stage: F000
-    type: exit
-    vanilla: Sparring Hall - Right Door Entrance
-  \Skyloft\Upper Skyloft\Sparring Hall Right Door Exit:
-    index: 27
-    req_index: 1815
-    room: 0
-    short_name: Skyloft - Sparring Hall Right Door Exit
-    stage: F000
-    type: exit
-    vanilla: Sparring Hall - Left Door Entrance
-  \Skyloft\Upper Skyloft\Sparring Hall\Left Door Exit:
-    index: 1
-    req_index: 1813
-    room: 0
-    short_name: Sparring Hall - Left Door Exit
-    stage: F009r
-    type: exit
-    vanilla: Skyloft - Sparring Hall Right Door Entrance
-  \Skyloft\Upper Skyloft\Sparring Hall\Right Door Exit:
-    index: 0
-    req_index: 1812
-    room: 0
-    short_name: Sparring Hall - Right Door Exit
-    stage: F009r
-    type: exit
-    vanilla: Skyloft - Sparring Hall Left Door Entrance
-  \Skyview\Boss Room\Exit to Dungeon:
-    req_index: 1945
-    short_name: Skyview Temple - Boss Room - Exit to Dungeon
-    type: exit
-    vanilla: Skyview Temple - Boss Door Entrance
-  \Skyview\Boss Room\Exit to Spring:
-    req_index: 1946
-    short_name: Skyview Temple - Boss Room - Exit to Spring
-    type: exit
-    vanilla: Skyview Temple - Spring - Entrance
-  \Skyview\Main\Entry\Main Exit:
-    req_index: 1943
-    short_name: Skyview Temple - Main Exit
-    type: exit
-    vanilla: Deep Woods - Entrance from Skyview Temple
-  \Skyview\Main\Last Room\After Rope\Boss Door Exit:
-    req_index: 1944
-    short_name: Skyview Temple - Boss Door Exit
-    type: exit
-    vanilla: Skyview Temple - Boss Room - Entrance from Dungeon
-  \Skyview\Spring\Exit:
-    req_index: 1947
-    short_name: Skyview Temple - Spring - Exit
-    type: exit
-    vanilla: Skyview Temple - Boss Room - Entrance from Spring
-  \Start:
-    index: 2
-    req_index: 1802
-    room: 1
-    short_name: Start
-    stage: F001r
-    type: exit
-    vanilla: Skyloft - Knight Academy - Start Entrance
-gossip_stones:
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Gossip Stone near Second Thirsty Frog: Volcano
-    Summit - Gossip Stone near Second Thirsty Frog
-  \Eldin\Volcano Summit\Waterfall\Higher Area\Gossip Stone in Waterfall Area: Volcano
-    Summit - Gossip Stone in Waterfall Area
-  \Eldin\Volcano\Lower Platform Cave\Gossip Stone in Lower Platform Cave: Eldin Volcano
-    - Gossip Stone in Lower Platform Cave
-  \Eldin\Volcano\Near Temple Entrance\Gossip Stone next to Earth Temple: Eldin Volcano
-    - Gossip Stone next to Earth Temple
-  \Eldin\Volcano\Thrill Digger Cave\Gossip Stone in Thrill Digger Cave: Eldin Volcano
-    - Gossip Stone in Thrill Digger Cave
-  \Eldin\Volcano\Upper Platform Cave\Gossip Stone in Upper Platform Cave: Eldin Volcano
-    - Gossip Stone in Upper Platform Cave
-  \Faron\Faron Woods\Deep Woods\Gossip Stone in Deep Woods: Faron Woods - Gossip Stone
-    in Deep Woods
-  \Faron\Lake Floria\Waterfall\Gossip Stone outside Ancient Cistern: Lake Floria -
-    Gossip Stone outside Ancient Cistern
-  \Faron\Sealed Grounds\Behind the Temple\Gossip Stone behind the Temple: Sealed Grounds
-    - Gossip Stone behind the Temple
-  \Lanayru\Caves\Gossip Stone in Center: Lanayru Caves - Gossip Stone in Center
-  \Lanayru\Caves\Past Crawlspace\Gossip Stone towards Lanayru Gorge: Lanayru Caves
-    - Gossip Stone towards Lanayru Gorge
-  \Lanayru\Lanayru Sand Sea\Shipyard\Gossip Stone in Shipyard: Lanayru Sand Sea -
-    Gossip Stone in Shipyard
-  \Lanayru\Temple of Time\Front\Gossip Stone in Temple of Time Area: Temple of Time
-    - Gossip Stone in Temple of Time Area
-  \Sky\North East\Bamboo Island\Inside\Gossip Stone on Bamboo Island: Sky - Gossip
-    Stone on Bamboo Island
-  \Sky\South East\Lumpy Pumpkin\Gossip Stone on Lumpy Pumpkin: Sky - Gossip Stone
-    on Lumpy Pumpkin
-  \Sky\South West\Volcanic Island\Gossip Stone on Volcanic Island: Sky - Gossip Stone
-    on Volcanic Island
-  \Sky\Thunderhead\Bug Heaven\Gossip Stone near Bug Heaven: Thunderhead - Gossip Stone
-    near Bug Heaven
-  \Skyloft\Central Skyloft\Waterfall Island\Gossip Stone on Waterfall Island: Central
-    Skyloft - Gossip Stone on Waterfall Island
 items:
 - Day
 - Night
@@ -13853,3 +2373,11483 @@ items:
 - \Sandship\Main\Deck\Main Entrance
 - \Sandship\Boss Room\Entrance
 - \Sky Keep\Main\First Room\Bottom Entrance
+areas:
+  abstract: true
+  allowed_time_of_day: 3
+  can_save: false
+  can_sleep: false
+  entrances: !!set {}
+  exits:
+    Start: 'True'
+  hint_region: null
+  locations:
+    Practice Sword: Progressive Sword
+    Goddess Sword: Progressive Sword x 2
+    Goddess Longsword: Progressive Sword x 3
+    Goddess White Sword: Progressive Sword x 4
+    Master Sword: Progressive Sword x 5
+    True Master Sword: Progressive Sword x 6
+    Beetle: Progressive Beetle
+    Hook Beetle: Progressive Beetle x 2
+    Three Beetles: Progressive Beetle x 3
+    Quick Beetle: "\\Three Beetles | \\Skyloft\\Central Skyloft\\Bazaar\\Gondo's Upgrades\\\
+      Upgrade to Quick Beetle"
+    Tough Beetle: "Progressive Beetle x 4 | \\Skyloft\\Central Skyloft\\Bazaar\\Gondo's\
+      \ Upgrades\\Upgrade to Tough Beetle"
+    Bow: Progressive Bow
+    Slingshot: Progressive Slingshot
+    Bug Net: Progressive Bug Net
+    Digging Mitts: Progressive Mitts
+    Mogma Mitts: Progressive Mitts x 2
+    Pouch: Progressive Pouch
+    Medium Wallet: Progressive Wallet
+    Big Wallet: Progressive Wallet x 2
+    Giant Wallet: Progressive Wallet x 3
+    Tycoon Wallet: Progressive Wallet x 4
+    1 Extra Wallet: Extra Wallet
+    2 Extra Wallets: Extra Wallet x 2
+    3 Extra Wallets: Extra Wallet x 3
+    Can Afford 50 Rupees: 'True'
+    Can Afford 100 Rupees: 'True'
+    Can Afford 300 Rupees: \Can Medium Rupee Farm
+    Can Afford 600 Rupees: "\\Can High Rupee Farm & (\\1 Extra Wallet | \\Big Wallet)"
+    Can Afford 800 Rupees: "\\Can High Rupee Farm & (\\2 Extra Wallets | \\Medium\
+      \ Wallet & \\1 Extra Wallet | \\Big Wallet)"
+    Can Afford 1000 Rupees: "\\Can High Rupee Farm & (\\3 Extra Wallets | \\Medium\
+      \ Wallet & \\2 Extra Wallets | \\Big Wallet)"
+    Can Afford 1200 Rupees: "\\Can High Rupee Farm & (\\3 Extra Wallets | \\Medium\
+      \ Wallet & \\3 Extra Wallets | \\Big Wallet & \\1 Extra Wallet | \\Giant Wallet)"
+    Can Afford 1600 Rupees: "\\Can High Rupee Farm & (\\Big Wallet & \\2 Extra Wallets\
+      \ | \\Giant Wallet)"
+    Can Medium Rupee Farm: "\\Sky\\North East\\Bamboo Island\\Inside\\Clean Cut Minigame\
+      \ | \\Can High Rupee Farm"
+    Can High Rupee Farm: "\\Sky\\South West\\Fun Fun Island\\Fun Fun Island Minigame\
+      \ | \\Eldin\\Volcano\\Thrill Digger Cave\\Thrill Digger Minigame"
+    Song of the Hero: "Faron Song of the Hero Part & Eldin Song of the Hero Part &\
+      \ Lanayru Song of the Hero Part"
+    Complete Triforce: "Triforce of Courage & Triforce of Wisdom & Triforce of Power"
+    Empty Bottle_: Empty Bottle
+    Bottle: "\\Pouch & \\Skyloft\\Central Skyloft\\Bazaar\\Item Check Access & \\\
+      Empty Bottle_"
+    Can Collect Water: 'False'
+    Water Bottle: "\\Bottle & \\Can Collect Water"
+    Ancient Flower Farming: 'False'
+    5 Single Gratitude Crystals: Gratitude Crystal x 5
+    10 Single Gratitude Crystals: Gratitude Crystal x 10
+    15 Single Gratitude Crystals: Gratitude Crystal x 15
+    1 Gratitude Crystal Pack: Gratitude Crystal Pack
+    2 Gratitude Crystal Packs: Gratitude Crystal Pack x 2
+    3 Gratitude Crystal Packs: Gratitude Crystal Pack x 3
+    4 Gratitude Crystal Packs: Gratitude Crystal Pack x 4
+    5 Gratitude Crystal Packs: Gratitude Crystal Pack x 5
+    6 Gratitude Crystal Packs: Gratitude Crystal Pack x 6
+    7 Gratitude Crystal Packs: Gratitude Crystal Pack x 7
+    8 Gratitude Crystal Packs: Gratitude Crystal Pack x 8
+    9 Gratitude Crystal Packs: Gratitude Crystal Pack x 9
+    10 Gratitude Crystal Packs: Gratitude Crystal Pack x 10
+    11 Gratitude Crystal Packs: Gratitude Crystal Pack x 11
+    12 Gratitude Crystal Packs: Gratitude Crystal Pack x 12
+    13 Gratitude Crystal Packs: Gratitude Crystal Pack x 13
+    5 Gratitude Crystals: "\\5 Single Gratitude Crystals | \\1 Gratitude Crystal Pack"
+    10 Gratitude Crystals: "\\10 Single Gratitude Crystals | \\5 Single Gratitude\
+      \ Crystals & \\1 Gratitude Crystal Pack | \\2 Gratitude Crystal Packs"
+    30 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\3 Gratitude Crystal\
+      \ Packs | \\10 Single Gratitude Crystals & \\4 Gratitude Crystal Packs | \\\
+      5 Single Gratitude Crystals & \\5 Gratitude Crystal Packs | \\6 Gratitude Crystal\
+      \ Packs"
+    40 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\5 Gratitude Crystal\
+      \ Packs | \\10 Single Gratitude Crystals & \\6 Gratitude Crystal Packs | \\\
+      5 Single Gratitude Crystals & \\7 Gratitude Crystal Packs | \\8 Gratitude Crystal\
+      \ Packs"
+    50 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\7 Gratitude Crystal\
+      \ Packs | \\10 Single Gratitude Crystals & \\8 Gratitude Crystal Packs | \\\
+      5 Single Gratitude Crystals & \\9 Gratitude Crystal Packs | \\10 Gratitude Crystal\
+      \ Packs"
+    70 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\11 Gratitude Crystal\
+      \ Packs | \\10 Single Gratitude Crystals & \\12 Gratitude Crystal Packs | \\\
+      5 Single Gratitude Crystals & \\13 Gratitude Crystal Packs"
+    80 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\13 Gratitude Crystal\
+      \ Packs"
+    Sword: \Practice Sword
+    Long Range Skyward Strike: "\\Goddess Sword & Upgraded Skyward Strike option |\
+      \ \\True Master Sword"
+    Damaging Item: "\\Sword | Bomb Bag | \\Bow"
+    Projectile Item: "\\Slingshot | \\Beetle | \\Bow"
+    Distance Activator: "\\Slingshot | \\Beetle | Clawshots | \\Bow"
+    Can Cut Tree: "\\Sword | Bomb Bag"
+    Can Unlock Combination Lock: "\\Sword | Whip | Clawshots | \\Slingshot | \\Bow"
+    Can Hit Switch: "\\Sword | Bomb Bag | Whip | \\Distance Activator"
+    Can Hit Timeshift Stone: "\\Sword | Bomb Bag | Whip | \\Distance Activator"
+    Can Hit Timeshift Stone in Minecart: "\\Sword | Bomb Bag | \\Distance Activator"
+    Early Lake Floria Tricks: "Early Lake Floria - Fence Hop Trick & \\Practice Sword\
+      \ | Early Lake Floria - Swordless Rope Floria Trick"
+    Can bypass Boko Base Watch Tower: "\\Bow | Bomb Bag | \\Slingshot"
+    Can Defeat Bokoblins: \Damaging Item
+    Can Defeat Moblins: \Damaging Item
+    Can Defeat Keeses: "\\Sword | \\Slingshot | \\Beetle | Whip | Clawshots | \\Bow\
+      \ | Bomb Bag"
+    Can Defeat Lizalfos: "\\Sword | Advanced Lizalfos Combat Trick & (Bomb Bag | \\\
+      Bow)"
+    Can Defeat Ampilus: \Damaging Item
+    Can Defeat Armos: "Gust Bellows & \\Sword"
+    Can Defeat Beamos: "\\Sword | \\Bow"
+    Can Defeat Cursed Bokoblins: "\\Sword | Bomb Bag"
+    Can Defeat Stalfos: \Sword
+    Can Defeat Stalmaster: \Sword
+    Can Defeat Scervo/Dreadfuse: \Sword
+  name: ''
+  sub_areas:
+    Ancient Cistern:
+      abstract: true
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Ancient Cistern
+      locations:
+        Can Lower Statue: \Ancient Cistern\Can Freely Raise and Lower Statue
+        Can Freely Raise and Lower Statue: 'False'
+      name: \Ancient Cistern
+      sub_areas:
+        Main:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Ancient Cistern
+          locations: {}
+          name: \Ancient Cistern\Main
+          sub_areas:
+            Main Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: 'True'
+                \Ancient Cistern\Main\East Part: \Ancient Cistern\Main\Main Room\Lever
+                  to East Part
+                \Ancient Cistern\Main\Main Room\After Whip Hooks: Whip
+                \Ancient Cistern\Main\Main Room\Vines Area: "\\Ancient Cistern\\Main\\\
+                  Main Room\\Vines Area\\Activate Water Geyser | Whip & Clawshots"
+                \Ancient Cistern\Main\Main Room\Behind the Waterfall: "\\Ancient Cistern\\\
+                  Main\\Main Room\\Lever to Block Waterfall & Water Dragon's Scale"
+                \Ancient Cistern\Main\Inside Statue: "\\Ancient Cistern\\Can Lower\
+                  \ Statue | Ancient Cistern Small Key x 2"
+                \Ancient Cistern\Main\Basement\Under the Statue: Ancient Cistern -
+                  Cistern Clip Trick
+                \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest: "Ancient\
+                  \ Cistern - Cistern Clip Trick & Ancient Cistern - Cistern Whip\
+                  \ Room Clip Trick & Water Dragon's Scale"
+              hint_region: Ancient Cistern
+              locations:
+                Lock Combination Knowledge: 'True'
+                Lever to East Part: 'True'
+                Lever to Block Waterfall: Whip
+                Rupee in East Hand: Water Dragon's Scale
+                Rupee in West Hand: Water Dragon's Scale
+              name: \Ancient Cistern\Main\Main Room
+              sub_areas:
+                After Whip Hooks:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Main Room\Vines Area: Clawshots
+                    \Ancient Cistern\Main\Main Room\After Gutters: \Ancient Cistern\Main\Main
+                      Room\After Gutters\Lower Lever
+                    \Ancient Cistern\Main\Main Room: 'True'
+                  hint_region: Ancient Cistern
+                  locations:
+                    Chest after Whip Hooks: 'True'
+                  name: \Ancient Cistern\Main\Main Room\After Whip Hooks
+                  sub_areas: {}
+                  toplevel_alias: null
+                Vines Area:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Main Room\After Whip Hooks: "\\Sword & Ancient\
+                      \ Cistern - Map Chest Jump Trick"
+                    \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: \Ancient
+                      Cistern\Main\Main Room\After Gutters\Upper Area\Upper Lever
+                    \Ancient Cistern\Main\Main Room\Spider Thread Area: \Ancient Cistern\Main\Main
+                      Room\Spider Thread Area\Extend Platform
+                    \Ancient Cistern\Main\Main Room: 'True'
+                  hint_region: Ancient Cistern
+                  locations:
+                    Chest near Vines: 'True'
+                    Activate Water Geyser: Whip
+                    \Ancient Cistern\Can Lower Statue: Whip
+                    \Ancient Cistern\Main\Main Room\Lever to Block Waterfall: Ancient
+                      Cistern - Lever Jump Trick
+                  name: \Ancient Cistern\Main\Main Room\Vines Area
+                  sub_areas: {}
+                  toplevel_alias: null
+                Behind the Waterfall:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement Gutters: \Ancient Cistern\Main\Main
+                      Room\Behind the Waterfall\Toilet Flush
+                  hint_region: Ancient Cistern
+                  locations:
+                    Chest behind the Waterfall: 'True'
+                    First Lever: Whip
+                    Second Lever: "\\Ancient Cistern\\Main\\Main Room\\Behind the\
+                      \ Waterfall\\First Lever & Whip"
+                    Toilet Flush: "\\Ancient Cistern\\Main\\Main Room\\Behind the\
+                      \ Waterfall\\First Lever & \\Ancient Cistern\\Main\\Main Room\\\
+                      Behind the Waterfall\\Second Lever & Whip"
+                  name: \Ancient Cistern\Main\Main Room\Behind the Waterfall
+                  sub_areas: {}
+                  toplevel_alias: null
+                After Gutters:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Main Room\After Whip Hooks: 'True'
+                    \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: "\\\
+                      Ancient Cistern\\Main\\Main Room\\After Gutters\\Flip First\
+                      \ Lilypad & \\Ancient Cistern\\Main\\Main Room\\After Gutters\\\
+                      Activate Water Geyser & \\Ancient Cistern\\Main\\Main Room\\\
+                      After Gutters\\Flip Second Lilypad 2"
+                  hint_region: Ancient Cistern
+                  locations:
+                    Lower Lever: 'True'
+                    Flip First Lilypad: "Water Dragon's Scale & Whip"
+                    Flip Second Lilypad 1: \Ancient Cistern\Main\Main Room\After Gutters\Flip
+                      First Lilypad
+                    Rupee under Lilypad: "\\Ancient Cistern\\Main\\Main Room\\After\
+                      \ Gutters\\Flip Second Lilypad 1 & Water Dragon's Scale"
+                    Activate Water Geyser: "\\Ancient Cistern\\Main\\Main Room\\After\
+                      \ Gutters\\Flip Second Lilypad 1 & Water Dragon's Scale"
+                    Flip Second Lilypad 2: "\\Ancient Cistern\\Main\\Main Room\\After\
+                      \ Gutters\\Flip First Lilypad & \\Ancient Cistern\\Main\\Main\
+                      \ Room\\After Gutters\\Activate Water Geyser & Whip"
+                  name: \Ancient Cistern\Main\Main Room\After Gutters
+                  sub_areas:
+                    Upper Area:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Ancient Cistern\Main\Main Room\After Gutters: 'True'
+                        \Ancient Cistern\Main\Main Room\Vines Area: \Ancient Cistern\Main\Main
+                          Room\After Gutters\Upper Area\Upper Lever
+                      hint_region: Ancient Cistern
+                      locations:
+                        Upper Lever: Whip
+                      name: \Ancient Cistern\Main\Main Room\After Gutters\Upper Area
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+                Spider Thread Area:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Main Room\Vines Area: \Ancient Cistern\Main\Main
+                      Room\Spider Thread Area\Extend Platform
+                    \Ancient Cistern\Main\Main Room: 'True'
+                    \Ancient Cistern\Main\Basement: 'True'
+                  hint_region: Ancient Cistern
+                  locations:
+                    Extend Platform: 'True'
+                    \Ancient Cistern\Can Freely Raise and Lower Statue: Whip
+                  name: \Ancient Cistern\Main\Main Room\Spider Thread Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            East Part:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Ancient Cistern\Main\Main Room: 'True'
+                \Ancient Cistern\Main\East Part\Second Room: \Ancient Cistern\Main\East
+                  Part\Unlock Combination Lock Door
+              hint_region: Ancient Cistern
+              locations:
+                Unlock Combination Lock Door: "\\Can Unlock Combination Lock & \\\
+                  Ancient Cistern\\Main\\Main Room\\Lock Combination Knowledge"
+              name: \Ancient Cistern\Main\East Part
+              sub_areas:
+                Second Room:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\East Part: 'True'
+                    \Ancient Cistern\Main\East Part\Chest Ledge: "\\Ancient Cistern\\\
+                      Main\\East Part\\Second Room\\Flip Main Lilypad & Water Dragon's\
+                      \ Scale"
+                  hint_region: Ancient Cistern
+                  locations:
+                    Flip Side Lilypad: 'True'
+                    Flip Main Lilypad: 'True'
+                    Rupee in East Part in Cubby: "\\Ancient Cistern\\Main\\East Part\\\
+                      Second Room\\Flip Side Lilypad & Water Dragon's Scale"
+                    First Rupee in East Part in Short Tunnel: Water Dragon's Scale
+                    Second Rupee in East Part in Short Tunnel: Water Dragon's Scale
+                    Third Rupee in East Part in Short Tunnel: Water Dragon's Scale
+                    Rupee in East Part in Main Tunnel: "\\Ancient Cistern\\Main\\\
+                      East Part\\Second Room\\Flip Main Lilypad & Water Dragon's Scale"
+                  name: \Ancient Cistern\Main\East Part\Second Room
+                  sub_areas: {}
+                  toplevel_alias: null
+                Chest Ledge:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Main Room: 'True'
+                  hint_region: Ancient Cistern
+                  locations:
+                    Chest in East Part: 'True'
+                  name: \Ancient Cistern\Main\East Part\Chest Ledge
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Basement Gutters:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Ancient Cistern\Main\Basement Gutters\Past Skulltula: "\\Ancient\
+                  \ Cistern\\Main\\Basement Gutters\\Can Get Past Skulltula & Water\
+                  \ Dragon's Scale"
+              hint_region: Ancient Cistern
+              locations:
+                Can Get Past Skulltula: "\\Beetle | \\Bow"
+              name: \Ancient Cistern\Main\Basement Gutters
+              sub_areas:
+                Past Skulltula:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement Gutters: Water Dragon's Scale
+                    \Ancient Cistern\Main\Main Room\After Gutters: Ancient Cistern
+                      Small Key x 2
+                  hint_region: Ancient Cistern
+                  locations:
+                    Bokoblin: Whip
+                  name: \Ancient Cistern\Main\Basement Gutters\Past Skulltula
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Basement:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Ancient Cistern\Main\Inside Statue: 'True'
+                \Ancient Cistern\Main\Basement\Rotating Vines: "Whip & \\Ancient Cistern\\\
+                  Main\\Basement\\Blow Rock | Clawshots"
+                \Ancient Cistern\Main\Basement\Spider Thread: "\\Ancient Cistern\\\
+                  Main\\Basement\\Spider Thread\\Activate Water Geyser | Ancient Cistern\
+                  \ - Basement Highflip Trick"
+                \Ancient Cistern\Main\Basement\Under the Statue: Ancient Cistern -
+                  Basement Highflip Trick
+              hint_region: Ancient Cistern
+              locations:
+                Stop Cursed Waterfall: \Beetle
+                Blow Rock: "\\Hook Beetle | Bomb Bag & Bomb Throws Trick"
+              name: \Ancient Cistern\Main\Basement
+              sub_areas:
+                Rotating Vines:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement: 'True'
+                    \Ancient Cistern\Main\Basement\Spider Thread: Whip
+                  hint_region: Ancient Cistern
+                  locations: {}
+                  name: \Ancient Cistern\Main\Basement\Rotating Vines
+                  sub_areas: {}
+                  toplevel_alias: null
+                Spider Thread:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement: 'True'
+                    \Ancient Cistern\Main\Basement\Under the Statue: \Ancient Cistern\Can
+                      Freely Raise and Lower Statue
+                    \Ancient Cistern\Main\Main Room\Spider Thread Area: 'True'
+                  hint_region: Ancient Cistern
+                  locations:
+                    Activate Water Geyser: Whip
+                  name: \Ancient Cistern\Main\Basement\Spider Thread
+                  sub_areas: {}
+                  toplevel_alias: null
+                Under the Statue:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Basement: 'True'
+                  hint_region: Ancient Cistern
+                  locations:
+                    \Ancient Cistern\Can Lower Statue: 'True'
+                    Boss Key Chest: \Ancient Cistern\Can Lower Statue
+                  name: \Ancient Cistern\Main\Basement\Under the Statue
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Inside Statue:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Boss Door Entrance: null
+              exits:
+                \Ancient Cistern\Main\Basement: \Ancient Cistern\Can Lower Statue
+                \Ancient Cistern\Main\Main Room: \Ancient Cistern\Main\Inside Statue\Activate
+                  Water Geysers
+                Boss Door Exit: "Ancient Cistern Boss Key & \\Ancient Cistern\\Main\\\
+                  Inside Statue\\Activate Water Geysers"
+                \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest: "Ancient\
+                  \ Cistern Small Key x 2 & (\\Can Defeat Stalmaster | \\Ancient Cistern\\\
+                  Can Lower Statue)"
+              hint_region: Ancient Cistern
+              locations:
+                Activate Water Geysers: Whip
+              name: \Ancient Cistern\Main\Inside Statue
+              sub_areas:
+                Key Locked Room with Chest:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Ancient Cistern\Main\Inside Statue: Ancient Cistern Small Key
+                      x 2
+                  hint_region: Ancient Cistern
+                  locations:
+                    Chest in Key Locked Room: 'True'
+                  name: \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+        Boss Room:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Dungeon: null
+            Entrance from Flame Room: null
+          exits:
+            Exit to Dungeon: \Ancient Cistern\Boss Room\Beat Koloktos
+            Exit to Flame Room: \Ancient Cistern\Boss Room\Beat Koloktos
+          hint_region: Ancient Cistern
+          locations:
+            Beat Koloktos: "Whip & (\\Sword | Bomb Bag | \\Bow)"
+            Heart Container: \Ancient Cistern\Boss Room\Beat Koloktos
+          name: \Ancient Cistern\Boss Room
+          sub_areas: {}
+          toplevel_alias: null
+        Flame Room:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: 'True'
+          hint_region: Ancient Cistern
+          locations:
+            Farore's Flame: \Goddess Sword
+          name: \Ancient Cistern\Flame Room
+          sub_areas: {}
+          toplevel_alias: null
+      toplevel_alias: null
+    Earth Temple:
+      abstract: false
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Earth Temple
+      locations: {}
+      name: \Earth Temple
+      sub_areas:
+        Main:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Earth Temple
+          locations: {}
+          name: \Earth Temple\Main
+          sub_areas:
+            First Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: 'True'
+                \Earth Temple\Main\Hub Room: "\\Earth Temple\\Main\\First Room\\Lower\
+                  \ Drawbridge & \\Earth Temple\\Main\\First Room\\Dislodge Boulder"
+              hint_region: Earth Temple
+              locations:
+                Vent Chest: \Digging Mitts
+                Rupee above Drawbridge: \Beetle
+                Lower Drawbridge: "\\Beetle | \\Bow | \\Long Range Skyward Strike\
+                  \ & Earth Temple - Keese Yeet Trick"
+                Dislodge Boulder: "\\Slingshot | \\Beetle & (Advanced Lizalfos Combat\
+                  \ Trick | \\Can Defeat Lizalfos) | Clawshots | \\Bow | \\Long Range\
+                  \ Skyward Strike"
+              name: \Earth Temple\Main\First Room
+              sub_areas: {}
+              toplevel_alias: null
+            Hub Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Earth Temple\Main\Hub Room\Past Lava Section: "\\Earth Temple\\Main\\\
+                  Hub Room\\Access to Boulder & (\\Earth Temple\\Main\\Hub Room\\\
+                  Wall to Lava Section & \\Earth Temple\\Main\\Hub Room\\Lower Lava\
+                  \ Section Portcullis | \\Earth Temple\\Main\\Hub Room\\Raise Bridge)"
+                \Earth Temple\Main\East Room: \Earth Temple\Main\Hub Room\Access to
+                  Boulder
+                \Earth Temple\Main\West Room: \Earth Temple\Main\Hub Room\Rock to
+                  West Room
+                \Earth Temple\Main\Room with Slopes: \Earth Temple\Main\Hub Room\Raise
+                  Bridge
+              hint_region: Earth Temple
+              locations:
+                Access to Boulder: \Earth Temple\Main\First Room\Dislodge Boulder
+                \Earth Temple\Main\First Room\Rupee above Drawbridge: \Beetle
+                Chest behind Bombable Rock: \Earth Temple\Main\Hub Room\Access to
+                  Boulder
+                Chest Left of Main Room Bridge: \Earth Temple\Main\Hub Room\Access
+                  to Boulder
+                Ledd's Gift: \Can Defeat Lizalfos
+                Rock to West Room: "Bomb Bag | \\Hook Beetle"
+                Wall to Lava Section: "Bomb Bag | \\Hook Beetle & \\Earth Temple\\\
+                  Main\\Hub Room\\Access to Boulder"
+                Rupee in Lava Tunnel: "\\Earth Temple\\Main\\Hub Room\\Wall to Lava\
+                  \ Section & \\Beetle"
+                Lower Lava Section Portcullis: "\\Earth Temple\\Main\\Hub Room\\Wall\
+                  \ to Lava Section & \\Beetle"
+                Left Peg: \Earth Temple\Main\Hub Room\Access to Boulder
+                Raise Bridge: "\\Earth Temple\\Main\\Hub Room\\Left Peg & \\Earth\
+                  \ Temple\\Main\\Hub Room\\Past Lava Section\\Right Peg"
+              name: \Earth Temple\Main\Hub Room
+              sub_areas:
+                Past Lava Section:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Earth Temple\Main\Hub Room: 'True'
+                  hint_region: Earth Temple
+                  locations:
+                    Chest Guarded by Lizalfos: 'True'
+                    Right Peg: 'True'
+                  name: \Earth Temple\Main\Hub Room\Past Lava Section
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            East Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Earth Temple\Main\Hub Room: 'True'
+              hint_region: Earth Temple
+              locations:
+                Chest after Double Lizalfos Fight: \Can Defeat Lizalfos
+              name: \Earth Temple\Main\East Room
+              sub_areas: {}
+              toplevel_alias: null
+            West Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Earth Temple\Main\Hub Room: \Earth Temple\Main\West Room\Rock to
+                  Hub Room
+              hint_region: Earth Temple
+              locations:
+                Chest in West Room: 'True'
+                Rock to Hub Room: "Bomb Bag | \\Hook Beetle"
+              name: \Earth Temple\Main\West Room
+              sub_areas: {}
+              toplevel_alias: null
+            Room with Slopes:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Earth Temple\Main\Room with Slopes\Front of Boss Door: "\\Earth Temple\\\
+                  Main\\Room with Slopes\\Rock in Second Slope Resting Area | Earth\
+                  \ Temple - Slope Stuttersprint Trick"
+                \Earth Temple\Main\Hub Room: 'True'
+              hint_region: Earth Temple
+              locations:
+                Rock in Second Slope Resting Area: "\\Digging Mitts & Bomb Bag | \\\
+                  Hook Beetle"
+              name: \Earth Temple\Main\Room with Slopes
+              sub_areas:
+                Front of Boss Door:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Boss Door Entrance: null
+                  exits:
+                    \Earth Temple\Main\Room with Slopes: 'True'
+                    Boss Door Exit: \Earth Temple\Main\Room with Slopes\Front of Boss
+                      Door\Open Boss Door
+                  hint_region: Earth Temple
+                  locations:
+                    Boss Key Chest: 'True'
+                    Open Boss Door: Earth Temple Boss Key
+                  name: \Earth Temple\Main\Room with Slopes\Front of Boss Door
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+        Boss Room:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Earth Temple
+          locations: {}
+          name: \Earth Temple\Boss Room
+          sub_areas:
+            Entry:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Dungeon: null
+              exits:
+                Exit to Dungeon: \Earth Temple\Boss Room\Slope\Beat Scaldera
+                \Earth Temple\Boss Room\Slope: 'True'
+              hint_region: Earth Temple
+              locations: {}
+              name: \Earth Temple\Boss Room\Entry
+              sub_areas: {}
+              toplevel_alias: null
+            Slope:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Spring: null
+              exits:
+                Exit to Spring: \Earth Temple\Boss Room\Slope\Beat Scaldera
+              hint_region: Earth Temple
+              locations:
+                Goddess Sword Strat: "\\Goddess Sword & Upgraded Skyward Strike option"
+                Longsword Strat: "\\Goddess Longsword & Upgraded Skyward Strike option"
+                Master Sword Strat: \Master Sword
+                Bomb Flower Scaldera: "Earth Temple - Bomb Flower Scaldera Trick &\
+                  \ (\\Earth Temple\\Boss Room\\Slope\\Goddess Sword Strat | \\Earth\
+                  \ Temple\\Boss Room\\Slope\\Longsword Strat | \\Earth Temple\\Boss\
+                  \ Room\\Slope\\Master Sword Strat)"
+                Beat Scaldera: "Bomb Bag & \\Sword | \\Earth Temple\\Boss Room\\Slope\\\
+                  Bomb Flower Scaldera"
+                Heart Container: \Earth Temple\Boss Room\Slope\Beat Scaldera
+              name: \Earth Temple\Boss Room\Slope
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Spring:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: 'True'
+          hint_region: Earth Temple
+          locations:
+            Strike Crest: \Goddess Sword
+          name: \Earth Temple\Spring
+          sub_areas: {}
+          toplevel_alias: null
+      toplevel_alias: null
+    Eldin:
+      abstract: true
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: null
+      locations:
+        Can Survive Hot Cave: "Nonlethal Hot Cave | Fireshield Earrings"
+      name: \Eldin
+      sub_areas:
+        Volcano:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Eldin Volcano
+          locations: {}
+          name: \Eldin\Volcano
+          sub_areas:
+            Entry:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Volcano Entrance Statue Entrance: null
+                First Time Entrance: null
+              exits:
+                Volcano Entrance Statue Exit: \Eldin\Volcano\Entry\Unlock Statue
+                \Eldin\Volcano\Ascent: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
+                \Eldin\Volcano\First Room: 'True'
+              hint_region: Eldin Volcano
+              locations:
+                Goddess Cube at Eldin Entrance: \Goddess Sword
+                Unlock Statue: 'True'
+                Rupee on Ledge before First Room: 'True'
+                \Eldin\Volcano\Ascent\Unlock Shortcut to Entry: Bomb Bag
+              name: \Eldin\Volcano\Entry
+              sub_areas: {}
+              toplevel_alias: null
+            First Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Volcano\East: \Eldin\Volcano\First Room\Blow up Rock to East
+              hint_region: Eldin Volcano
+              locations:
+                Chest behind Bombable Wall in First Room: 'True'
+                Rupee behind Bombable Wall in First Room: 'True'
+                Rupee in Crawlspace in First Room: 'True'
+                Blow up Rock to East: 'True'
+              name: \Eldin\Volcano\First Room
+              sub_areas: {}
+              toplevel_alias: null
+            East:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                First Vent from Mogma Turf: null
+                Volcano East Statue Entrance: null
+                Entrance from Bokoblin Base: null
+              exits:
+                Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\East\Unlock
+                  Statue
+                \Eldin\Volcano\Entry: Clawshots
+                Dive to Mogma Turf: \Eldin\Volcano\East\Drain Lava
+                \Eldin\Volcano\First Room: \Eldin\Volcano\First Room\Blow up Rock
+                  to East
+                \Eldin\Volcano\Past Mogma Turf: \Eldin\Volcano\Past Mogma Turf\Unlock
+                  Shortcut to Pre Turf
+                Exit to Bokoblin Base: 'True'
+              hint_region: Eldin Volcano
+              locations:
+                \Eldin\Volcano\First Room\Blow up Rock to East: Bomb Bag
+                Unlock Statue: 'True'
+                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
+                Chest after Crawlspace: 'True'
+                Chest behind Bombable Wall near Cliff: 'True'
+                Item on Cliff: 'True'
+                Drain Lava: 'True'
+                Southeast Rupee above Mogma Turf Entrance: \Beetle
+                North Rupee above Mogma Turf Entrance: \Beetle
+                \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf: "Bomb\
+                  \ Bag | \\Hook Beetle"
+              name: \Eldin\Volcano\East
+              sub_areas: {}
+              toplevel_alias: null
+            Past Mogma Turf:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Second Vent from Mogma Turf: null
+              exits:
+                \Eldin\Volcano\East: \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut
+                  to Pre Turf
+                \Eldin\Volcano\Ascent: \Eldin\Volcano\Past Mogma Turf\Watch Bridge
+                  Cutscene
+              hint_region: Eldin Volcano
+              locations:
+                Unlock Shortcut to Pre Turf: 'True'
+                Watch Bridge Cutscene: 'True'
+                Southeast Rupee above Mogma Turf Entrance: \Beetle
+                North Rupee above Mogma Turf Entrance: \Beetle
+                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
+              name: \Eldin\Volcano\Past Mogma Turf
+              sub_areas: {}
+              toplevel_alias: null
+            Ascent:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Trial Gate Entrance: null
+                Volcano Ascent Statue Entrance: null
+              exits:
+                \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\Ascent\Unlock
+                  Statue
+                Trial Gate Exit: \Eldin\Volcano\Ascent\Open Trial Gate
+                \Eldin\Volcano\Entry: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
+                \Eldin\Volcano\Near Thrill Digger Cave: "\\Eldin\\Volcano\\Ascent\\\
+                  Defeat Slope Bokoblins | Stuttersprint Trick"
+                \Eldin\Volcano\Past Slide: \Eldin\Volcano\Past Slide\Unlock Shortcut
+                  to Ascent
+              hint_region: Eldin Volcano
+              locations:
+                Chest behind Bombable Wall near Volcano Ascent: 'True'
+                Unlock Statue: 'True'
+                Unlock Shortcut to Entry: 'True'
+                \Eldin\Volcano\Past Slide\Unlock Shortcut to Ascent: "Bomb Bag | \\\
+                  Hook Beetle"
+                Defeat Slope Bokoblins: "\\Bow | \\Slingshot"
+                Open Trial Gate: "Goddess's Harp & Din's Power"
+              name: \Eldin\Volcano\Ascent
+              sub_areas: {}
+              toplevel_alias: null
+            Near Thrill Digger Cave:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Thrill Digger Cave Entrance: null
+              exits:
+                \Eldin\Volcano\Ascent: 'True'
+                \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Thrill Digger
+                  Cave\Blow down Watchtower
+                Thrill Digger Cave Exit: 'True'
+              hint_region: Eldin Volcano
+              locations:
+                Left Rupee behind Bombable Wall on First Slope: 'True'
+                Right Rupee behind Bombable Wall on First Slope: 'True'
+                Blow down Watchtower: 'True'
+              name: \Eldin\Volcano\Near Thrill Digger Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Thrill Digger Cave:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Eldin Volcano
+              locations:
+                Thrill Digger Minigame: \Digging Mitts
+                Gossip Stone in Thrill Digger Cave: 'True'
+              name: \Eldin\Volcano\Thrill Digger Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Near Temple Entrance:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Temple Entrance Statue Entrance: null
+                Entrance from Earth Temple: null
+              exits:
+                Temple Entrance Statue Exit: \Eldin\Volcano\Near Temple Entrance\Unlock
+                  Statue
+                \Eldin\Volcano\Near Thrill Digger Cave: \Eldin\Volcano\Near Thrill
+                  Digger Cave\Blow down Watchtower
+                Exit to Earth Temple: "Open ET option | Key Piece x 5"
+                \Eldin\Volcano\Upper Platform Cave: \Eldin\Bokoblin Base\Fire Dragon's
+                  Lair\Beaten Boko Base
+                \Eldin\Volcano\Hot Cave: \Eldin\Volcano\Near Temple Entrance\Blow
+                  down Watchtower to Hot Cave
+              hint_region: Eldin Volcano
+              locations:
+                Unlock Statue: 'True'
+                Blow down Watchtower to Hot Cave: 'True'
+                Retrieve Crystal Ball: "Clawshots & Scrapper & \\Skyloft\\Skyloft\
+                  \ Village\\Sparrot's House\\Start Sparrot's Quest"
+                Goddess Cube West of Earth Temple Entrance: "\\Digging Mitts & \\\
+                  Goddess Sword"
+                Gossip Stone next to Earth Temple: \Digging Mitts
+                Goddess Cube East of Earth Temple Entrance: \Goddess Sword
+                Digging Spot in front of Earth Temple: \Digging Mitts
+                Digging Spot below Tower: \Digging Mitts
+                Digging Spot behind Boulder on Sandy Slope: \Digging Mitts
+              name: \Eldin\Volcano\Near Temple Entrance
+              sub_areas: {}
+              toplevel_alias: null
+            Upper Platform Cave:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Volcano\Near Temple Entrance: "\\Eldin\\Bokoblin Base\\Fire\
+                  \ Dragon's Lair\\Beaten Boko Base | Clawshots"
+              hint_region: Eldin Volcano
+              locations:
+                Gossip Stone in Upper Platform Cave: 'True'
+              name: \Eldin\Volcano\Upper Platform Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Hot Cave:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Vent Entrance near Hot Cave: null
+                Entrance from Summit: null
+              exits:
+                Exit to Summit: Fireshield Earrings
+                \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Temple Entrance\Blow
+                  down Watchtower to Hot Cave
+                \Eldin\Volcano\Sand Slide: \Eldin\Can Survive Hot Cave
+              hint_region: Eldin Volcano
+              locations:
+                \Eldin\Volcano\Near Temple Entrance\Blow down Watchtower to Hot Cave: 'False'
+              name: \Eldin\Volcano\Hot Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Sand Slide:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Volcano\Past Slide: 'True'
+              hint_region: Eldin Volcano
+              locations:
+                Goddess Cube on Sand Slide: \Goddess Sword
+                Digging Spot after Vents: \Digging Mitts
+              name: \Eldin\Volcano\Sand Slide
+              sub_areas: {}
+              toplevel_alias: null
+            Past Slide:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Volcano\Ascent: \Eldin\Volcano\Past Slide\Unlock Shortcut to
+                  Ascent
+                Vent Exit near Ascent: 'True'
+                \Eldin\Volcano\Lower Platform Cave: \Eldin\Bokoblin Base\Fire Dragon's
+                  Lair\Beaten Boko Base
+              hint_region: Eldin Volcano
+              locations:
+                Digging Spot after Draining Lava: \Digging Mitts
+                Unlock Shortcut to Ascent: 'True'
+              name: \Eldin\Volcano\Past Slide
+              sub_areas: {}
+              toplevel_alias: null
+            Lower Platform Cave:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Volcano\Past Slide: Clawshots
+                \Eldin\Volcano\Past Mogma Turf: \Eldin\Bokoblin Base\Fire Dragon's
+                  Lair\Beaten Boko Base
+                \Eldin\Volcano\East: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten
+                  Boko Base
+              hint_region: Eldin Volcano
+              locations:
+                Gossip Stone in Lower Platform Cave: 'True'
+              name: \Eldin\Volcano\Lower Platform Cave
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Eldin Volcano
+        Mogma Turf:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Mogma Turf
+          locations: {}
+          name: \Eldin\Mogma Turf
+          sub_areas:
+            Pre Vent:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                First Vent: 'True'
+                \Eldin\Mogma Turf\Past Vent: \Eldin\Mogma Turf\Pre Vent\Open Vent
+              hint_region: Mogma Turf
+              locations:
+                Free Fall Chest: 'True'
+                Goddess Cube in Mogma Turf: \Goddess Sword
+                Chest behind Bombable Wall at Entrance: 'True'
+                Pick up Guld: "\\Sky\\South East\\Lumpy Pumpkin\\Start Kina's Quest\
+                  \ & Scrapper"
+                Defeat Bokoblins: \Can Defeat Bokoblins
+                Open Vent: \Digging Mitts
+              name: \Eldin\Mogma Turf\Pre Vent
+              sub_areas: {}
+              toplevel_alias: null
+            Sand Slide Platform:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Mogma Turf\Pre Vent: 'True'
+              hint_region: Mogma Turf
+              locations:
+                Sand Slide Chest: 'True'
+              name: \Eldin\Mogma Turf\Sand Slide Platform
+              sub_areas: {}
+              toplevel_alias: null
+            Past Vent:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Mogma Turf\Pre Vent: 'True'
+                \Eldin\Mogma Turf\Sand Slide Platform: 'True'
+                Second Vent: 'True'
+              hint_region: Mogma Turf
+              locations:
+                Chest behind Bombable Wall in Fire Maze: 'True'
+              name: \Eldin\Mogma Turf\Past Vent
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Eldin Silent Realm:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: 'True'
+          hint_region: Eldin Silent Realm
+          locations:
+            Trial Reward: 'True'
+            Relic 1: 'True'
+            Relic 2: 'True'
+            Relic 3: 'True'
+            Relic 4: 'True'
+            Relic 5: 'True'
+            Relic 6: 'True'
+            Relic 7: 'True'
+            Relic 8: 'True'
+            Relic 9: 'True'
+            Relic 10: 'True'
+          name: \Eldin\Eldin Silent Realm
+          sub_areas: {}
+          toplevel_alias: null
+        Volcano Summit:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Outside Fire Sanctuary: null
+            Entrance from Waterfall: null
+            Entrance from Eldin Volcano: null
+          exits:
+            Exit to Eldin Volcano: Fireshield Earrings
+            Exit to Waterfall: Fireshield Earrings
+            Exit to Outside Fire Sanctuary: Fireshield Earrings
+          hint_region: Volcano Summit
+          locations:
+            Goddess Cube inside Volcano Summit: "Fireshield Earrings & \\Long Range\
+              \ Skyward Strike"
+          name: \Eldin\Volcano Summit
+          sub_areas:
+            Waterfall:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+                \Eldin\Volcano Summit\Waterfall\Higher Area: Clawshots
+              hint_region: Volcano Summit
+              locations:
+                Goddess Cube in Summit Waterfall: \Goddess Sword
+                \Can Collect Water: 'True'
+              name: \Eldin\Volcano Summit\Waterfall
+              sub_areas:
+                Higher Area:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Eldin\Volcano Summit\Waterfall: 'True'
+                  hint_region: Volcano Summit
+                  locations:
+                    Chest behind Bombable Wall in Waterfall Area: 'True'
+                    Gossip Stone in Waterfall Area: 'True'
+                  name: \Eldin\Volcano Summit\Waterfall\Higher Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Outside Fire Sanctuary:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Statue Entrance: null
+                Entrance from Fire Sanctuary: null
+              exits:
+                Statue Exit: \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
+                \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: \Eldin\Volcano
+                  Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Hydrate Second
+                  Frog
+                Exit to Fire Sanctuary: \Eldin\Volcano Summit\Outside Fire Sanctuary\Hydrate
+                  Giant Frog
+              hint_region: Volcano Summit
+              locations:
+                Goddess Cube near Fire Sanctuary Entrance: "Clawshots & \\Goddess\
+                  \ Sword"
+                Hydrate Giant Frog: 'True'
+                Unlock Statue: 'True'
+              name: \Eldin\Volcano Summit\Outside Fire Sanctuary
+              sub_areas:
+                Before Thirsty Frogs:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Summit: null
+                  exits:
+                    Exit to Summit: 'True'
+                    \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: \Eldin\Volcano
+                      Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Hydrate First
+                      Frog
+                  hint_region: Volcano Summit
+                  locations:
+                    Hydrate First Frog: \Water Bottle
+                  name: \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty
+                    Frogs
+                  sub_areas: {}
+                  toplevel_alias: null
+                Between Thirsty Frogs:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs: \Eldin\Volcano
+                      Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Hydrate First
+                      Frog
+                    \Eldin\Volcano Summit\Outside Fire Sanctuary: \Eldin\Volcano Summit\Outside
+                      Fire Sanctuary\Between Thirsty Frogs\Hydrate Second Frog
+                  hint_region: Volcano Summit
+                  locations:
+                    Item behind Digging: \Mogma Mitts
+                    Gossip Stone near Second Thirsty Frog: 'True'
+                    Hydrate Second Frog: "Clawshots & \\Water Bottle"
+                  name: \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty
+                    Frogs
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+        Bokoblin Base:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Bokoblin Base
+          locations: {}
+          name: \Eldin\Bokoblin Base
+          sub_areas:
+            Prison:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+                \Eldin\Bokoblin Base\Volcano East: \Mogma Mitts
+              hint_region: Bokoblin Base
+              locations:
+                Plats' Gift: 'True'
+              name: \Eldin\Bokoblin Base\Prison
+              sub_areas: {}
+              toplevel_alias: null
+            Volcano East:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Prison: \Mogma Mitts
+                \Eldin\Bokoblin Base\Before Drawbridge: 'True'
+                \Eldin\Bokoblin Base\After Drawbridge: "Clawshots & Bomb Bag"
+              hint_region: Bokoblin Base
+              locations:
+                Chest near Bone Bridge: "\\Can bypass Boko Base Watch Tower | \\Mogma\
+                  \ Mitts | Gust Bellows"
+                Chest on Cliff: "(\\Can bypass Boko Base Watch Tower | \\Mogma Mitts)\
+                  \ & Gust Bellows"
+                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
+              name: \Eldin\Bokoblin Base\Volcano East
+              sub_areas: {}
+              toplevel_alias: null
+            Before Drawbridge:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Volcano East: 'True'
+                \Eldin\Bokoblin Base\After Drawbridge: "Whip & Clawshots"
+              hint_region: Bokoblin Base
+              locations:
+                Chest near Drawbridge: "Clawshots | \\Can bypass Boko Base Watch Tower"
+              name: \Eldin\Bokoblin Base\Before Drawbridge
+              sub_areas: {}
+              toplevel_alias: null
+            After Drawbridge:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Before Drawbridge: Clawshots
+                \Eldin\Bokoblin Base\Lower Platform Cave: 'True'
+                \Eldin\Bokoblin Base\Volcano East: 'True'
+                \Eldin\Bokoblin Base\Outside Earth Temple: 'True'
+              hint_region: Bokoblin Base
+              locations: {}
+              name: \Eldin\Bokoblin Base\After Drawbridge
+              sub_areas: {}
+              toplevel_alias: null
+            Lower Platform Cave:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\After Drawbridge: Clawshots
+                \Eldin\Bokoblin Base\Before Drawbridge: 'True'
+                \Eldin\Bokoblin Base\Volcano East: 'True'
+              hint_region: Bokoblin Base
+              locations:
+                Gossip Stone in Lower Platform Cave: 'True'
+              name: \Eldin\Bokoblin Base\Lower Platform Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Outside Earth Temple:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Hot Cave: 'True'
+                \Eldin\Bokoblin Base\Upper Platform Cave: 'True'
+              hint_region: Bokoblin Base
+              locations:
+                Chest East of Earth Temple Entrance: 'True'
+                Goddess Cube East of Earth Temple Entrance: \Goddess Sword
+                Chest West of Earth Temple Entrance: "(\\Slingshot | \\Bow | Bomb\
+                  \ Bag | \\Goddess Sword) & \\Can bypass Boko Base Watch Tower &\
+                  \ \\Mogma Mitts"
+                Goddess Cube West of Earth Temple Entrance: "\\Goddess Sword & \\\
+                  Can bypass Boko Base Watch Tower & \\Mogma Mitts"
+              name: \Eldin\Bokoblin Base\Outside Earth Temple
+              sub_areas: {}
+              toplevel_alias: null
+            Upper Platform Cave:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Outside Earth Temple: 'True'
+              hint_region: Bokoblin Base
+              locations:
+                Gossip Stone in Upper Platform Cave: 'True'
+              name: \Eldin\Bokoblin Base\Upper Platform Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Hot Cave:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\After Drawbridge: "Fireshield Earrings & Bomb\
+                  \ Bag"
+                \Eldin\Bokoblin Base\Bokoblin Base Summit: "Fireshield Earrings &\
+                  \ Bomb Bag"
+              hint_region: Bokoblin Base
+              locations: {}
+              name: \Eldin\Bokoblin Base\Hot Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Bokoblin Base Summit:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Hot Cave: Fireshield Earrings
+                \Eldin\Bokoblin Base\Fire Dragon's Lair: Fireshield Earrings
+              hint_region: Bokoblin Base
+              locations:
+                First Chest in Volcano Summit: Fireshield Earrings
+                Raised Chest in Volcano Summit: Fireshield Earrings
+                Chest in Volcano Summit Alcove: "Fireshield Earrings & \\Practice\
+                  \ Sword"
+                Goddess Cube inside Volcano Summit: Fireshield Earrings
+              name: \Eldin\Bokoblin Base\Bokoblin Base Summit
+              sub_areas: {}
+              toplevel_alias: null
+            Fire Dragon's Lair:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Eldin\Bokoblin Base\Bokoblin Base Summit: 'True'
+              hint_region: Bokoblin Base
+              locations:
+                Beaten Boko Base: "\\Bow | \\Beetle"
+                Fire Dragon's Reward: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten
+                  Boko Base
+              name: \Eldin\Bokoblin Base\Fire Dragon's Lair
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Bokoblin Base
+      toplevel_alias: null
+    Faron:
+      abstract: false
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: null
+      locations: {}
+      name: \Faron
+      sub_areas:
+        Sealed Grounds:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Sealed Grounds
+          locations: {}
+          name: \Faron\Sealed Grounds
+          sub_areas:
+            Spiral:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Door Entrance: null
+              exits:
+                \Faron\Sealed Grounds\Spiral\Upper Part: \Faron\Sealed Grounds\Spiral\Defeat
+                  Imprisoned 2
+                Door Exit: 'True'
+              hint_region: Sealed Grounds
+              locations:
+                Defeat Imprisoned 2: "\\Faron\\Sealed Grounds\\Sealed Temple\\Start\
+                  \ Imprisoned 2 & \\Goddess Sword"
+              name: \Faron\Sealed Grounds\Spiral
+              sub_areas:
+                Upper Part:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Statue Entrance: null
+                  exits:
+                    Statue Exit: \Faron\Sealed Grounds\Spiral\Upper Part\Unlock Statue
+                    \Faron\Sealed Grounds\Spiral: 'True'
+                    \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple: 'True'
+                  hint_region: Sealed Grounds
+                  locations:
+                    Unlock Statue: 'True'
+                  name: \Faron\Sealed Grounds\Spiral\Upper Part
+                  sub_areas:
+                    From Behind the Temple:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set
+                        Shortcut Entrance from Behind the Temple: null
+                      exits:
+                        \Faron\Sealed Grounds\Spiral\Upper Part: 'True'
+                        Shortcut Exit to Behind the Temple: 'True'
+                      hint_region: Sealed Grounds
+                      locations: {}
+                      name: \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the
+                        Temple
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+              toplevel_alias: Sealed Grounds Spiral
+            Sealed Temple:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+                Gate of Time Entrance: null
+                Side Entrance: null
+              exits:
+                Main Exit: 'True'
+                Side Exit: 'True'
+                Gate of Time Exit: \Faron\Sealed Grounds\Sealed Temple\Open Gate of
+                  Time
+              hint_region: Sealed Grounds
+              locations:
+                Chest inside Sealed Temple: 'True'
+                Song from Impa: Goddess's Harp
+                Raise Gate of Time: GoT Raising Requirement
+                Start Imprisoned 2: "\\Faron\\Sealed Grounds\\Sealed Temple\\Raise\
+                  \ Gate of Time & GoT Opening Requirement"
+                Open Gate of Time: "\\Faron\\Sealed Grounds\\Sealed Temple\\Raise\
+                  \ Gate of Time & GoT Opening Requirement & \\Faron\\Sealed Grounds\\\
+                  Spiral\\Defeat Imprisoned 2"
+              name: \Faron\Sealed Grounds\Sealed Temple
+              sub_areas: {}
+              toplevel_alias: null
+            Hylia's Temple:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Gate of Time Entrance: null
+              exits:
+                Gate of Time Exit: 'True'
+              hint_region: Sealed Grounds
+              locations:
+                Zelda's Blessing: 'True'
+                Defeat Demise: "Horde Door Requirement & \\Sword"
+              name: \Faron\Sealed Grounds\Hylia's Temple
+              sub_areas: {}
+              toplevel_alias: null
+            Behind the Temple:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Faron Woods: null
+                Statue Entrance: null
+                Door Entrance: null
+                Shortcut Entrance from Spiral: null
+              exits:
+                Statue Exit: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
+                Door Exit: 'True'
+                Exit to Faron Woods: 'True'
+                Shortcut Exit to Spiral: 'True'
+              hint_region: Sealed Grounds
+              locations:
+                Unlock Statue: 'True'
+                Gossip Stone behind the Temple: 'True'
+                Gorko's Goddess Wall Reward: "Goddess's Harp & Ballad of the Goddess\
+                  \ & \\Goddess Sword"
+              name: \Faron\Sealed Grounds\Behind the Temple
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Faron Woods:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            In the Woods Statue Entrance: null
+            Trial Gate Entrance: null
+            Viewing Platform Statue Entrance: null
+          exits:
+            \Faron\Faron Woods\Entry: 'True'
+            Shared Statue Exit: "\\Faron\\Faron Woods\\Unlock In the Woods Statue\
+              \ | \\Faron\\Faron Woods\\Unlock Viewing Platform Statue"
+            Trial Gate Exit: \Faron\Faron Woods\Open Trial Gate
+            \Faron\Faron Woods\Great Tree\Near Underwater Hole: Water Dragon's Scale
+            \Faron\Faron Woods\Great Tree\Platforms: Clawshots
+            \Faron\Faron Woods\Clawshot Target Branch: Clawshots
+            Lake Floria Dive: "\\Faron\\Faron Woods\\Open Door to Lake Floria | \\\
+              Early Lake Floria Tricks"
+            \Faron\Faron Woods\Ledge to Lake Floria: \Faron\Faron Woods\Ledge to Lake
+              Floria\Push Log
+            \Faron\Faron Woods\Ledge To Deep Woods: \Faron\Faron Woods\Hit Vine to
+              Deep Woods
+            \Faron\Faron Woods\Behind the Crawlspace and Rope: "Bomb Bag | \\Faron\\\
+              Faron Woods\\Ledge to Lake Floria\\Push Log"
+          hint_region: Faron Woods
+          locations:
+            Unlock Viewing Platform Statue: 'True'
+            Unlock In the Woods Statue: 'True'
+            Push Log to Sealed Grounds: 'True'
+            Amber Relic Farming: 'True'
+            Hit Vine to Deep Woods: \Distance Activator
+            Open Trial Gate: "Goddess's Harp & Farore's Courage"
+            Open Door to Lake Floria: "Open Lake Floria option & Water Dragon's Scale\
+              \ | \\Faron\\Faron Woods\\Great Tree\\Top\\Talk to Yerbal & (\\Goddess\
+              \ Sword | Talk to Yerbal option)"
+            Rupee on Hollow Tree Root: 'True'
+            Rupee on Hollow Tree Branch: \Beetle
+            Rupee on Platform near Floria Door: \Beetle
+            All Kikwis Saved: "(\\Sword | \\Beetle) & \\Can Defeat Bokoblins"
+            Kikwi Elder's Reward: \Faron\Faron Woods\All Kikwis Saved
+            Item on Tree: 'True'
+            Item behind Lower Bombable Rock: Bomb Bag
+            Chest behind Upper Bombable Rock: Bomb Bag
+          name: \Faron\Faron Woods
+          sub_areas:
+            Entry:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Faron Woods Entry Statue Entrance: null
+                Entrance from Behind the Temple: null
+              exits:
+                \Faron\Faron Woods\Shared Statue Exit: \Faron\Faron Woods\Entry\Unlock
+                  Statue
+                \Faron\Faron Woods: "\\Sword | Bomb Bag | Clawshots | \\Faron\\Faron\
+                  \ Woods\\Push Log to Sealed Grounds"
+                Exit to Behind the Temple: 'True'
+              hint_region: Faron Woods
+              locations:
+                Unlock Statue: 'True'
+              name: \Faron\Faron Woods\Entry
+              sub_areas: {}
+              toplevel_alias: null
+            Ledge to Lake Floria:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Shortcut Entrance from Floria Waterfall: null
+              exits:
+                \Faron\Faron Woods: 'True'
+                Shortcut Exit to Floria Waterfall: "\\Faron\\Faron Woods\\Open Door\
+                  \ to Lake Floria | \\Early Lake Floria Tricks"
+              hint_region: Faron Woods
+              locations:
+                Push Log: 'True'
+              name: \Faron\Faron Woods\Ledge to Lake Floria
+              sub_areas: {}
+              toplevel_alias: null
+            Ledge To Deep Woods:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Deep Woods: null
+              exits:
+                \Faron\Faron Woods: 'True'
+                Exit to Deep Woods: 'True'
+              hint_region: Faron Woods
+              locations: {}
+              name: \Faron\Faron Woods\Ledge To Deep Woods
+              sub_areas: {}
+              toplevel_alias: null
+            Behind the Crawlspace and Rope:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Faron\Faron Woods: 'True'
+              hint_region: Faron Woods
+              locations:
+                Push Log: 'True'
+                Retrieve Oolo: "Scrapper & \\Skyloft\\Upper Skyloft\\Knight Academy\\\
+                  Start Owlan's Quest"
+              name: \Faron\Faron Woods\Behind the Crawlspace and Rope
+              sub_areas: {}
+              toplevel_alias: null
+            West Branch:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Faron\Faron Woods: 'True'
+              hint_region: Faron Woods
+              locations:
+                Goddess Cube on West Great Tree near Exit: \Goddess Sword
+              name: \Faron\Faron Woods\West Branch
+              sub_areas: {}
+              toplevel_alias: null
+            Clawshot Target Branch:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Faron\Faron Woods: 'True'
+              hint_region: Faron Woods
+              locations:
+                Goddess Cube on East Great Tree with Clawshots Target: \Goddess Sword
+              name: \Faron\Faron Woods\Clawshot Target Branch
+              sub_areas: {}
+              toplevel_alias: null
+            Rope Branch:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Faron\Faron Woods: 'True'
+              hint_region: Faron Woods
+              locations:
+                Goddess Cube on East Great Tree with Rope: \Goddess Sword
+              name: \Faron\Faron Woods\Rope Branch
+              sub_areas: {}
+              toplevel_alias: null
+            Great Tree:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Faron Woods
+              locations: {}
+              name: \Faron\Faron Woods\Great Tree
+              sub_areas:
+                Near Underwater Hole:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Underwater Hole Entrance: null
+                  exits:
+                    \Faron\Faron Woods: 'True'
+                    Underwater Hole Exit: Water Dragon's Scale
+                  hint_region: Faron Woods
+                  locations: {}
+                  name: \Faron\Faron Woods\Great Tree\Near Underwater Hole
+                  sub_areas: {}
+                  toplevel_alias: null
+                Lower Area:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Underwater Tunnel Entrance: null
+                  exits:
+                    Underwater Tunnel Exit: Water Dragon's Scale
+                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: Gust Bellows
+                    \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: Gust Bellows
+                  hint_region: Faron Woods
+                  locations: {}
+                  name: \Faron\Faron Woods\Great Tree\Lower Area
+                  sub_areas:
+                    Path to Chest:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Faron\Faron Woods\Great Tree\Lower Area: 'True'
+                        \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: 'True'
+                      hint_region: Faron Woods
+                      locations:
+                        Chest inside Great Tree: 'True'
+                      name: \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Near Exit:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set
+                        Lower Entrance from Platforms: null
+                      exits:
+                        \Faron\Faron Woods\Great Tree\Lower Area: 'True'
+                        Lower Exit to Platforms: 'True'
+                      hint_region: Faron Woods
+                      locations: {}
+                      name: \Faron\Faron Woods\Great Tree\Lower Area\Near Exit
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+                Platforms:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Upper Entrance from Great Tree: null
+                    Lower Entrance from Great Tree: null
+                  exits:
+                    Lower Exit to Great Tree: 'True'
+                    Upper Exit to Great Tree: 'True'
+                    \Faron\Faron Woods\West Branch: 'True'
+                    \Faron\Faron Woods: 'True'
+                  hint_region: Faron Woods
+                  locations: {}
+                  name: \Faron\Faron Woods\Great Tree\Platforms
+                  sub_areas: {}
+                  toplevel_alias: null
+                Upper Area:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Top: null
+                    Upper Entrance from Platforms: null
+                    Entrance from Flooded Great Tree: null
+                  exits:
+                    \Faron\Faron Woods\Great Tree\Lower Area: \Faron\Faron Woods\Great
+                      Tree\Upper Area\Remove Void Plane
+                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: \Faron\Faron
+                      Woods\Great Tree\Upper Area\Remove Void Plane
+                    Exit to Flooded Great Tree: 'True'
+                    Upper Exit to Platforms: 'True'
+                    Exit to Top: 'True'
+                  hint_region: Faron Woods
+                  locations:
+                    Remove Void Plane: \Can Defeat Moblins
+                  name: \Faron\Faron Woods\Great Tree\Upper Area
+                  sub_areas: {}
+                  toplevel_alias: null
+                Top:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Top Entrance from Great Tree: null
+                    The Great Tree Statue Entrance: null
+                  exits:
+                    \Faron\Faron Woods\Shared Statue Exit: \Faron\Faron Woods\Great
+                      Tree\Top\Unlock Statue
+                    Top Exit to Great Tree: 'True'
+                    \Faron\Faron Woods\Great Tree\Platforms: 'True'
+                    \Faron\Faron Woods\Rope Branch: 'True'
+                    \Faron\Faron Woods\Clawshot Target Branch: 'True'
+                  hint_region: Faron Woods
+                  locations:
+                    Unlock Statue: 'True'
+                    Rupee on Great Tree North Branch: \Beetle
+                    Rupee on Great Tree West Branch: \Beetle
+                    Talk to Yerbal: "Water Dragon's Scale & (\\Slingshot | \\Beetle)"
+                  name: \Faron\Faron Woods\Great Tree\Top
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Deep Woods:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Deep Woods Statue Entrance: null
+                Forest Temple Statue Entrance: null
+                Entrance from Skyview Temple: null
+              exits:
+                Shared Statue Exit: 'True'
+                \Faron\Faron Woods\Deep Woods\Entry: 'True'
+                Exit to Skyview Temple: \Distance Activator
+              hint_region: Faron Woods
+              locations:
+                Deep Woods Chest: 'True'
+                Unlock Deep Woods Statue: 'True'
+                Unlock Forest Temple Statue: 'True'
+                Push Shortcut Logs: 'True'
+                Gossip Stone in Deep Woods: 'True'
+                Initial Goddess Cube: \Goddess Sword
+                Goddess Cube in Deep Woods: \Goddess Sword
+                Goddess Cube on top of Skyview: "\\Goddess Sword & Clawshots"
+              name: \Faron\Faron Woods\Deep Woods
+              sub_areas:
+                Entry:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Faron Woods: null
+                  exits:
+                    Exit to Faron Woods: 'True'
+                    \Faron\Faron Woods\Deep Woods: "\\Faron\\Faron Woods\\Deep Woods\\\
+                      Push Shortcut Logs | \\Distance Activator | \\Goddess Sword"
+                  hint_region: Faron Woods
+                  locations:
+                    Hornet Larvae Farming: 'True'
+                  name: \Faron\Faron Woods\Deep Woods\Entry
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: Faron Woods
+        Faron Silent Realm:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: 'True'
+          hint_region: Faron Silent Realm
+          locations:
+            Trial Reward: 'True'
+            Relic 1: 'True'
+            Relic 2: 'True'
+            Relic 3: 'True'
+            Relic 4: 'True'
+            Relic 5: 'True'
+            Relic 6: 'True'
+            Relic 7: 'True'
+            Relic 8: 'True'
+            Relic 9: 'True'
+            Relic 10: 'True'
+          name: \Faron\Faron Silent Realm
+          sub_areas: {}
+          toplevel_alias: null
+        Flooded Faron Woods:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Lower Flooded Great Tree: null
+            Entrance from Upper Flooded Great Tree: null
+          exits:
+            Exit to Upper Flooded Great Tree: 'True'
+            Exit to Lower Flooded Great Tree: Water Dragon's Scale
+          hint_region: Flooded Faron Woods
+          locations:
+            Yellow Tadtone under Lilypad: Water Dragon's Scale
+            8 Light Blue Tadtones near Viewing Platform: Water Dragon's Scale
+            4 Purple Tadtones under Viewing Platform: Water Dragon's Scale
+            Red Moving Tadtone near Viewing Platform: Water Dragon's Scale
+            Light Blue Tadtone under Great Tree Root: Water Dragon's Scale
+            8 Yellow Tadtones near Kikwi Elder: Water Dragon's Scale
+            4 Light Blue Moving Tadtones under Kikwi Elder: Water Dragon's Scale
+            4 Red Moving Tadtones North West of Great Tree: Water Dragon's Scale
+            Green Tadtone behind Upper Bombable Rock: Water Dragon's Scale
+            2 Dark Blue Tadtones in Grass West of Great Tree: Water Dragon's Scale
+            8 Green Tadtones in West Tunnel: Water Dragon's Scale
+            2 Red Tadtones in Grass near Lower Bombable Rock: Water Dragon's Scale
+            16 Dark Blue Tadtones in the South West: Water Dragon's Scale
+            4 Purple Moving Tadtones near Floria Gate: Water Dragon's Scale
+            Dark Blue Moving Tadtone inside Small Hollow Tree: Water Dragon's Scale
+            4 Yellow Tadtones under Small Hollow Tree: Water Dragon's Scale
+            8 Purple Tadtones in Clearing after Small Hollow Tree: Water Dragon's
+              Scale
+            \Faron\Faron Woods\Behind the Crawlspace and Rope\Retrieve Oolo: "Scrapper\
+              \ & \\Skyloft\\Upper Skyloft\\Knight Academy\\Start Owlan's Quest"
+            Can Watch Completed Tadtones Cutscene: 'True'
+          name: \Faron\Flooded Faron Woods
+          sub_areas:
+            Flooded Great Tree:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Upper Flooded Faron Woods: null
+                Entrance: null
+                Entrance from Lower Flooded Faron Woods: null
+              exits:
+                Exit: 'True'
+                Exit to Upper Flooded Faron Woods: 'True'
+                Exit to Lower Flooded Faron Woods: Water Dragon's Scale
+              hint_region: Flooded Faron Woods
+              locations:
+                Water Dragon's Reward: "Group of Tadtones x 17 & \\Faron\\Flooded\
+                  \ Faron Woods\\Can Watch Completed Tadtones Cutscene"
+              name: \Faron\Flooded Faron Woods\Flooded Great Tree
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Flooded Faron Woods
+        Lake Floria:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Lake Floria
+          locations: {}
+          name: \Faron\Lake Floria
+          sub_areas:
+            Above Rock:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Dive from Faron Woods: null
+              exits:
+                \Faron\Lake Floria\Below Rock: "\\Faron\\Lake Floria\\Above Rock\\\
+                  Blow Rock & Water Dragon's Scale"
+              hint_region: Lake Floria
+              locations:
+                Rupee behind Southwest Boulder: Water Dragon's Scale
+                Left Rupee behind Northwest Boulder: Water Dragon's Scale
+                Right Rupee behind Northwest Boulder: Water Dragon's Scale
+                Rupee under Central Boulder: Water Dragon's Scale
+                Blow Rock: Water Dragon's Scale
+              name: \Faron\Lake Floria\Above Rock
+              sub_areas: {}
+              toplevel_alias: null
+            Below Rock:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Farore's Lair: null
+              exits:
+                \Faron\Lake Floria\Below Rock\Emerged Area: Water Dragon's Scale
+                \Faron\Lake Floria\Above Rock: Water Dragon's Scale
+                Exit to Farore's Lair: Water Dragon's Scale
+              hint_region: Lake Floria
+              locations: {}
+              name: \Faron\Lake Floria\Below Rock
+              sub_areas:
+                Emerged Area:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Statue Entrance: null
+                  exits:
+                    Statue Exit: \Faron\Lake Floria\Below Rock\Emerged Area\Unlock
+                      Statue
+                    \Faron\Lake Floria\Below Rock: Water Dragon's Scale
+                  hint_region: Lake Floria
+                  locations:
+                    Lake Floria Chest: 'True'
+                    Goddess Cube in Lake Floria: \Goddess Sword
+                    Unlock Statue: 'True'
+                  name: \Faron\Lake Floria\Below Rock\Emerged Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Farore's Lair:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Waterfall: null
+                Entrance from Lake Floria: null
+              exits:
+                Exit to Waterfall: 'True'
+                Exit to Lake Floria: Water Dragon's Scale
+              hint_region: Lake Floria
+              locations:
+                Dragon Lair South Chest: Water Dragon's Scale
+                Dragon Lair East Chest: 'True'
+                Talk to Farore: 'True'
+              name: \Faron\Lake Floria\Farore's Lair
+              sub_areas: {}
+              toplevel_alias: null
+            Waterfall:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Faron Woods: null
+                Statue Entrance: null
+                Entrance from Farore's Lair: null
+                Entrance from Ancient Cistern: null
+              exits:
+                Statue Exit: \Faron\Lake Floria\Waterfall\Unlock Statue
+                Exit to Farore's Lair: 'True'
+                Exit to Faron Woods: 'True'
+                Exit to Ancient Cistern: Water Dragon's Scale
+              hint_region: Lake Floria
+              locations:
+                Unlock Statue: 'True'
+                Gossip Stone outside Ancient Cistern: 'True'
+                Goddess Cube in Floria Waterfall: "Clawshots & \\Goddess Sword"
+                Rupee on High Ledge outside Ancient Cistern Entrance: \Beetle
+              name: \Faron\Lake Floria\Waterfall
+              sub_areas: {}
+              toplevel_alias: Floria Waterfall
+          toplevel_alias: null
+      toplevel_alias: null
+    Fire Sanctuary:
+      abstract: false
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Fire Sanctuary
+      locations: {}
+      name: \Fire Sanctuary
+      sub_areas:
+        Main:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Fire Sanctuary
+          locations: {}
+          name: \Fire Sanctuary\Main
+          sub_areas:
+            First Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: 'True'
+                \Fire Sanctuary\Main\First Room\Past Water Plant: \Fire Sanctuary\Main\First
+                  Room\Hit Water Plant
+              hint_region: Fire Sanctuary
+              locations:
+                Hit Water Plant: "\\Distance Activator | Bomb Bag"
+              name: \Fire Sanctuary\Main\First Room
+              sub_areas:
+                Past Water Plant:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Second Room: null
+                  exits:
+                    \Fire Sanctuary\Main\First Room: \Fire Sanctuary\Main\First Room\Hit
+                      Water Plant
+                    Exit to Second Room: Fire Sanctuary Small Key
+                  hint_region: Fire Sanctuary
+                  locations:
+                    \Fire Sanctuary\Main\First Room\Hit Water Plant: "\\Distance Activator\
+                      \ | Bomb Bag"
+                    Defeat Last Bokoblin: \Can Defeat Bokoblins
+                    Chest in First Room: \Fire Sanctuary\Main\First Room\Past Water
+                      Plant\Defeat Last Bokoblin
+                  name: \Fire Sanctuary\Main\First Room\Past Water Plant
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Second Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Second Room\Outside Section: 'True'
+                \Fire Sanctuary\Main\Second Room\Balcony: \Fire Sanctuary\Main\Second
+                  Room\Defeat Magmanos
+                \Fire Sanctuary\Main\First Bridge: 'True'
+              hint_region: Fire Sanctuary
+              locations:
+                Chest in Second Room: 'True'
+                Open Doors to Water Fruit: \Mogma Mitts
+                Defeat Magmanos: "\\Fire Sanctuary\\Main\\Second Room\\Open Doors\
+                  \ to Water Fruit & \\Sword"
+              name: \Fire Sanctuary\Main\Second Room
+              sub_areas:
+                Outside Section:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from First Room: null
+                  exits:
+                    Exit to First Room: 'True'
+                    \Fire Sanctuary\Main\Second Room: 'True'
+                  hint_region: Fire Sanctuary
+                  locations: {}
+                  name: \Fire Sanctuary\Main\Second Room\Outside Section
+                  sub_areas: {}
+                  toplevel_alias: null
+                Balcony:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Second Room: \Fire Sanctuary\Main\Second
+                      Room\Defeat Magmanos
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Chest on Balcony: 'True'
+                  name: \Fire Sanctuary\Main\Second Room\Balcony
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            First Bridge:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Second Room: \Fire Sanctuary\Main\First Bridge\Lizalfos
+                  Fight
+                \Fire Sanctuary\Main\Room with Water Plant: \Fire Sanctuary\Main\First
+                  Bridge\Lizalfos Fight
+                \Fire Sanctuary\Main\Second Bridge\Left: \Fire Sanctuary\Main\Second
+                  Bridge\Left\Unlock Shortcut to First Bridge
+              hint_region: Fire Sanctuary
+              locations:
+                Lizalfos Fight: \Can Defeat Lizalfos
+              name: \Fire Sanctuary\Main\First Bridge
+              sub_areas: {}
+              toplevel_alias: null
+            Room with Water Plant:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\First Bridge: 'True'
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: "\\Fire Sanctuary\\\
+                  Main\\Room with Water Plant\\Blow up Rock & \\Fire Sanctuary\\Main\\\
+                  Room with Water Plant\\Hit Water Plant"
+              hint_region: Fire Sanctuary
+              locations:
+                Blow up Rock: \Hook Beetle
+                Hit Water Plant: "\\Distance Activator | Bomb Bag"
+              name: \Fire Sanctuary\Main\Room with Water Plant
+              sub_areas:
+                Past Lava:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Room with Water Plant: "Clawshots | \\Fire\
+                      \ Sanctuary\\Main\\Room with Water Plant\\Blow up Rock"
+                    \Fire Sanctuary\Main\First Trapped Mogma Room: 'True'
+                    \Fire Sanctuary\Main\Water Fruit Room: \Fire Sanctuary\Main\Room
+                      with Water Plant\Past Lava\Unlock Key Door
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Unlock Key Door: Fire Sanctuary Small Key x 2
+                  name: \Fire Sanctuary\Main\Room with Water Plant\Past Lava
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            First Trapped Mogma Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: 'True'
+                \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: \Fire Sanctuary\Main\Magmanos
+                  Fight Room\Upper Part\Magmanos Fight
+              hint_region: Fire Sanctuary
+              locations:
+                Chest near First Trapped Mogma: "Gust Bellows | Clawshots"
+              name: \Fire Sanctuary\Main\First Trapped Mogma Room
+              sub_areas:
+                Lower Area:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\First Trapped Mogma Room: \Fire Sanctuary\Main\Magmanos
+                      Fight Room\Upper Part\Magmanos Fight
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part: \Fire Sanctuary\Main\Magmanos
+                      Fight Room\Upper Part\Magmanos Fight
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: "\\Mogma\
+                      \ Mitts & \\Fire Sanctuary\\Main\\First Trapped Mogma Room\\\
+                      Lower Area\\Blow up Rock in Tunnel"
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Rescue First Trapped Mogma: 'True'
+                    Blow up Rock in Tunnel: \Mogma Mitts
+                  name: \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Water Fruit Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: \Fire Sanctuary\Main\Room
+                  with Water Plant\Past Lava\Unlock Key Door
+                \Fire Sanctuary\Main\Water Fruit Room\After Frog: \Fire Sanctuary\Main\Water
+                  Fruit Room\Hydrate Frog
+              hint_region: Fire Sanctuary
+              locations:
+                First Chest in Water Fruit Room: 'True'
+                Second Chest in Water Fruit Room: 'True'
+                Hydrate Frog: \Sword
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava\Unlock Key Door: Fire
+                  Sanctuary Small Key x 2
+              name: \Fire Sanctuary\Main\Water Fruit Room
+              sub_areas:
+                After Frog:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Water Fruit Room: \Fire Sanctuary\Main\Water
+                      Fruit Room\Hydrate Frog
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part: 'True'
+                  hint_region: Fire Sanctuary
+                  locations: {}
+                  name: \Fire Sanctuary\Main\Water Fruit Room\After Frog
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Magmanos Fight Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Fire Sanctuary
+              locations: {}
+              name: \Fire Sanctuary\Main\Magmanos Fight Room
+              sub_areas:
+                Upper Part:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Water Fruit Room\After Frog: \Fire Sanctuary\Main\Magmanos
+                      Fight Room\Upper Part\Magmanos Fight
+                    \Fire Sanctuary\Main\First Trapped Mogma Room: \Fire Sanctuary\Main\Magmanos
+                      Fight Room\Upper Part\Magmanos Fight
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Magmanos Fight: \Sword
+                  name: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part
+                  sub_areas: {}
+                  toplevel_alias: null
+                Lower Part:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from West of Boss Door: null
+                  exits:
+                    \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: "\\\
+                      Mogma Mitts & \\Fire Sanctuary\\Main\\First Trapped Mogma Room\\\
+                      Lower Area\\Blow up Rock in Tunnel"
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Past Sliding Door: \Fire
+                      Sanctuary\Main\Magmanos Fight Room\Lower Part\Move Sliding Door
+                    Exit to West of Boss Door: \Fire Sanctuary\Main\Magmanos Fight
+                      Room\Lower Part\Unlock Key Door
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Unlock Key Door: Fire Sanctuary Small Key x 3
+                    Uncover Dig Spot: Gust Bellows
+                    Move Sliding Door: "\\Fire Sanctuary\\Main\\Magmanos Fight Room\\\
+                      Lower Part\\Uncover Dig Spot & \\Mogma Mitts"
+                  name: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part
+                  sub_areas:
+                    Past Sliding Door:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: \Fire
+                          Sanctuary\Main\Magmanos Fight Room\Lower Part\Move Sliding
+                          Door
+                        \Fire Sanctuary\Main\Second Bridge\Left: 'True'
+                      hint_region: Fire Sanctuary
+                      locations: {}
+                      name: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Past
+                        Sliding Door
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+              toplevel_alias: null
+            Second Bridge:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Fire Sanctuary
+              locations: {}
+              name: \Fire Sanctuary\Main\Second Bridge
+              sub_areas:
+                Left:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\First Bridge: \Fire Sanctuary\Main\Second
+                      Bridge\Left\Unlock Shortcut to First Bridge
+                    \Fire Sanctuary\Main\Second Bridge\Bottom Part: 'True'
+                    \Fire Sanctuary\Main\Second Bridge\Right: Clawshots
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Unlock Shortcut to First Bridge: 'True'
+                  name: \Fire Sanctuary\Main\Second Bridge\Left
+                  sub_areas: {}
+                  toplevel_alias: null
+                Bottom Part:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Second Bridge\Left: Clawshots
+                    \Fire Sanctuary\Main\Second Bridge\Right: Clawshots
+                  hint_region: Fire Sanctuary
+                  locations: {}
+                  name: \Fire Sanctuary\Main\Second Bridge\Bottom Part
+                  sub_areas: {}
+                  toplevel_alias: null
+                Right:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Second Bridge\Bottom Part: 'True'
+                    \Fire Sanctuary\Main\Second Bridge\Left: Clawshots
+                    \Fire Sanctuary\Main\Second Trapped Mogma Room: 'True'
+                  hint_region: Fire Sanctuary
+                  locations: {}
+                  name: \Fire Sanctuary\Main\Second Bridge\Right
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Second Trapped Mogma Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Second Bridge\Right: 'True'
+                \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall: "\\\
+                  Fire Sanctuary\\Main\\Second Trapped Mogma Room\\Hydrate Frog &\
+                  \ \\Fire Sanctuary\\Main\\Second Trapped Mogma Room\\Blow up Wall\
+                  \ & \\Mogma Mitts"
+              hint_region: Fire Sanctuary
+              locations:
+                Move Sliding Doors Correctly: \Mogma Mitts
+                Hydrate Frog: "\\Fire Sanctuary\\Main\\Second Trapped Mogma Room\\\
+                  Move Sliding Doors Correctly & \\Sword"
+                Rescue Mogma: \Fire Sanctuary\Main\Second Trapped Mogma Room\Hydrate
+                  Frog
+                Rescue Second Trapped Mogma: \Fire Sanctuary\Main\Second Trapped Mogma
+                  Room\Rescue Mogma
+                Blow up Wall: "\\Fire Sanctuary\\Main\\Second Trapped Mogma Room\\\
+                  Hydrate Frog & Bomb Bag"
+              name: \Fire Sanctuary\Main\Second Trapped Mogma Room
+              sub_areas:
+                Past Bombable Wall:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Second Trapped Mogma Room: 'True'
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Chest after Bombable Wall: 'True'
+                  name: \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable
+                    Wall
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            West of Boss Door:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\West of Boss Door\Entry: \Fire Sanctuary\Main\West
+                  of Boss Door\Hit Water Plant
+                \Fire Sanctuary\Main\Front of Boss Door: "\\Fire Sanctuary\\Main\\\
+                  West of Boss Door\\Hit Water Plant & \\Fire Sanctuary\\Main\\West\
+                  \ of Boss Door\\Past Plats\\Release Lava"
+                \Fire Sanctuary\Main\West of Boss Door\Past Plats: "\\Fire Sanctuary\\\
+                  Main\\West of Boss Door\\Catch Plats & (\\Distance Activator | Bomb\
+                  \ Bag) | \\Fire Sanctuary\\Main\\West of Boss Door\\Past Plats\\\
+                  Unlock Shortcut to Pre Plats"
+              hint_region: Fire Sanctuary
+              locations:
+                Hit Water Plant: "\\Distance Activator | Bomb Bag"
+                Catch Plats: \Mogma Mitts
+                Plats' Chest: \Fire Sanctuary\Main\West of Boss Door\Catch Plats
+              name: \Fire Sanctuary\Main\West of Boss Door
+              sub_areas:
+                Entry:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Magmanos Fight Room: null
+                  exits:
+                    Exit to Magmanos Fight Room: 'True'
+                    \Fire Sanctuary\Main\West of Boss Door: \Fire Sanctuary\Main\West
+                      of Boss Door\Hit Water Plant
+                    \Fire Sanctuary\Main\Front of Boss Door: "\\Fire Sanctuary\\Main\\\
+                      West of Boss Door\\Hit Water Plant & \\Fire Sanctuary\\Main\\\
+                      West of Boss Door\\Past Plats\\Release Lava"
+                  hint_region: Fire Sanctuary
+                  locations:
+                    \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant: "\\Distance\
+                      \ Activator | Bomb Bag"
+                  name: \Fire Sanctuary\Main\West of Boss Door\Entry
+                  sub_areas: {}
+                  toplevel_alias: null
+                Past Plats:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: true
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\West of Boss Door: \Fire Sanctuary\Main\West
+                      of Boss Door\Past Plats\Unlock Shortcut to Pre Plats
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Unlock Shortcut to Pre Plats: 'True'
+                    Release Lava: "\\Mogma Mitts | FS Lava Flow option"
+                  name: \Fire Sanctuary\Main\West of Boss Door\Past Plats
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Front of Boss Door:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Statue Entrance: null
+                Boss Door Entrance: null
+              exits:
+                Statue Exit: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
+                Boss Door Exit: Fire Sanctuary Boss Key
+                \Fire Sanctuary\Main\Lizalfos Fight Room: 'True'
+                \Fire Sanctuary\Main\Front of Boss Door\Past Bars: \Fire Sanctuary\Main\Front
+                  of Boss Door\Past Bars\Unlock Way to Front
+              hint_region: Fire Sanctuary
+              locations:
+                Unlock Statue: 'True'
+              name: \Fire Sanctuary\Main\Front of Boss Door
+              sub_areas:
+                Past Bars:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Boss Key Room: 'True'
+                    \Fire Sanctuary\Main\Front of Boss Door: \Fire Sanctuary\Main\Front
+                      of Boss Door\Past Bars\Unlock Way to Front
+                  hint_region: Fire Sanctuary
+                  locations:
+                    Unlock Way to Front: 'True'
+                  name: \Fire Sanctuary\Main\Front of Boss Door\Past Bars
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Lizalfos Fight Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Staircase Room: \Fire Sanctuary\Main\Lizalfos
+                  Fight Room\Fight
+              hint_region: Fire Sanctuary
+              locations:
+                Fight: \Can Defeat Lizalfos
+              name: \Fire Sanctuary\Main\Lizalfos Fight Room
+              sub_areas: {}
+              toplevel_alias: null
+            Staircase Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Staircase Room\Upper Part: Clawshots
+              hint_region: Fire Sanctuary
+              locations:
+                Chest in Staircase Room: Clawshots
+              name: \Fire Sanctuary\Main\Staircase Room
+              sub_areas:
+                Upper Part:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Fire Sanctuary\Main\Staircase Room: 'True'
+                    \Fire Sanctuary\Main\Boss Key Room: 'True'
+                  hint_region: Fire Sanctuary
+                  locations: {}
+                  name: \Fire Sanctuary\Main\Staircase Room\Upper Part
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Boss Key Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Fire Sanctuary\Main\Staircase Room\Upper Part: 'True'
+                \Fire Sanctuary\Main\Front of Boss Door\Past Bars: 'True'
+              hint_region: Fire Sanctuary
+              locations:
+                Solve Puzzle: \Mogma Mitts
+                Defeat Moldorm: "\\Fire Sanctuary\\Main\\Boss Key Room\\Solve Puzzle\
+                  \ & \\Mogma Mitts"
+                Boss Key Chest: "\\Fire Sanctuary\\Main\\Boss Key Room\\Solve Puzzle\
+                  \ & \\Fire Sanctuary\\Main\\Boss Key Room\\Defeat Moldorm"
+              name: \Fire Sanctuary\Main\Boss Key Room
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Boss Room:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Dungeon: null
+            Entrance from Flame Room: null
+          exits:
+            Exit to Dungeon: \Fire Sanctuary\Boss Room\Beat Ghirahim
+            Exit to Flame Room: \Fire Sanctuary\Boss Room\Beat Ghirahim
+          hint_region: Fire Sanctuary
+          locations:
+            Beat Ghirahim: \Sword
+            Heart Container: \Fire Sanctuary\Boss Room\Beat Ghirahim
+          name: \Fire Sanctuary\Boss Room
+          sub_areas: {}
+          toplevel_alias: null
+        Flame Room:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: 'True'
+          hint_region: Fire Sanctuary
+          locations:
+            Din's Flame: \Goddess Sword
+          name: \Fire Sanctuary\Flame Room
+          sub_areas: {}
+          toplevel_alias: null
+      toplevel_alias: null
+    Lanayru Mining Facility:
+      abstract: true
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Lanayru Mining Facility
+      locations:
+        Can Activate Minecart Timeshift Stone: "\\Sword | Whip | Bomb Bag | \\Distance\
+          \ Activator"
+      name: \Lanayru Mining Facility
+      sub_areas:
+        Main:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Lanayru Mining Facility
+          locations: {}
+          name: \Lanayru Mining Facility\Main
+          sub_areas:
+            First Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                \Lanayru Mining Facility\Main\First Hub: \Lanayru Mining Facility\Main\First
+                  Room\Left Lever
+                Main Exit: 'True'
+              hint_region: Lanayru Mining Facility
+              locations:
+                Left Lever: "\\Hook Beetle | Whip & LMF - Whip First Room Switch Trick"
+                Right Lever: 'True'
+                Chest behind Bars: \Lanayru Mining Facility\Main\First Room\Right
+                  Lever
+              name: \Lanayru Mining Facility\Main\First Room
+              sub_areas: {}
+              toplevel_alias: null
+            First Hub:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Big Hub: null
+              exits:
+                \Lanayru Mining Facility\Main\First Room: 'True'
+                Exit to Big Hub: 'True'
+                \Lanayru Mining Facility\Main\Key Locked Room: Lanayru Mining Facility
+                  Small Key
+                \Lanayru Mining Facility\Main\First West Room: \Lanayru Mining Facility\Main\First
+                  Hub\Push Box on Switch
+              hint_region: Lanayru Mining Facility
+              locations:
+                Push Box on Switch: Gust Bellows
+              name: \Lanayru Mining Facility\Main\First Hub
+              sub_areas: {}
+              toplevel_alias: null
+            Key Locked Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru Mining Facility\Main\First Hub: 'True'
+                \Lanayru Mining Facility\Main\Hop Across Boxes Room: \Lanayru Mining
+                  Facility\Main\Key Locked Room\Activate Timeshift Stone
+              hint_region: Lanayru Mining Facility
+              locations:
+                Blow Up Boxes: "\\Hook Beetle | Bomb Bag & Bomb Throws Trick"
+                Activate Timeshift Stone: "\\Lanayru Mining Facility\\Main\\Key Locked\
+                  \ Room\\Blow Up Boxes & (\\Bow | \\Beetle | \\Slingshot & LMF -\
+                  \ Keylocked Slingshot Trickshot Trick)"
+                Chest in Key Locked Room: \Lanayru Mining Facility\Main\Key Locked
+                  Room\Activate Timeshift Stone
+              name: \Lanayru Mining Facility\Main\Key Locked Room
+              sub_areas: {}
+              toplevel_alias: null
+            Hop Across Boxes Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit: "\\\
+                  Lanayru Mining Facility\\Main\\Hop Across Boxes Room\\Blow Up Rocks\
+                  \ | \\Lanayru Mining Facility\\Main\\Hop Across Boxes Room\\Near\
+                  \ Exit\\Push Shortcut Box"
+              hint_region: Lanayru Mining Facility
+              locations:
+                Blow Up Rocks: "\\Sword | \\Slingshot | \\Beetle | Bomb Bag | Gust\
+                  \ Bellows | Whip | Clawshots | \\Bow"
+                Raised Chest in Hop across Boxes Room: \Lanayru Mining Facility\Main\Hop
+                  Across Boxes Room\Blow Up Rocks
+                Lower Chest in Hop across Boxes Room: \Lanayru Mining Facility\Main\Hop
+                  Across Boxes Room\Blow Up Rocks
+              name: \Lanayru Mining Facility\Main\Hop Across Boxes Room
+              sub_areas:
+                Near Exit:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Big Hub: null
+                  exits:
+                    Exit to Big Hub: \Lanayru Mining Facility\Main\Hop Across Boxes
+                      Room\Near Exit\Remove Dust Pile at Door
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Push Shortcut Box: 'True'
+                    Remove Dust Pile at Door: 'True'
+                  name: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            First West Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru Mining Facility\Main\First Hub: 'True'
+                \Lanayru Mining Facility\Main\Armos Fight Room: "Gust Bellows & \\\
+                  Can Defeat Beamos"
+              hint_region: Lanayru Mining Facility
+              locations:
+                Chest in First West Room: Gust Bellows
+              name: \Lanayru Mining Facility\Main\First West Room
+              sub_areas: {}
+              toplevel_alias: null
+            Armos Fight Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Big Hub: null
+              exits:
+                Exit to Big Hub: \Lanayru Mining Facility\Main\Armos Fight Room\Defeat
+                  Armos
+              hint_region: Lanayru Mining Facility
+              locations:
+                Activate Timeshift Stone: "Gust Bellows & (\\Slingshot | \\Bow | \\\
+                  Goddess Sword | LMF - Whip Armos Room Timeshift Stone Trick & Whip)"
+                Defeat Armos: "\\Lanayru Mining Facility\\Main\\Armos Fight Room\\\
+                  Activate Timeshift Stone & \\Can Defeat Armos"
+                Chest after Armos Fight: \Lanayru Mining Facility\Main\Armos Fight
+                  Room\Defeat Armos
+              name: \Lanayru Mining Facility\Main\Armos Fight Room
+              sub_areas: {}
+              toplevel_alias: null
+            Big Hub:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Lanayru Mining Facility
+              locations: {}
+              name: \Lanayru Mining Facility\Main\Big Hub
+              sub_areas:
+                Entry:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from First Hub: null
+                  exits:
+                    Exit to First Hub: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: \Lanayru
+                      Mining Facility\Main\Big Hub\Entry\Blow Up Boxes
+                    \Lanayru Mining Facility\Main\Big Hub\Past West Gate: \Lanayru
+                      Mining Facility\Main\Big Hub\Past West Gate\Open Gate
+                    \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: \Lanayru
+                      Mining Facility\Main\Big Hub\Between Wind Gates\Open First Wind
+                      Gate
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Blow Up Boxes: "Bomb Bag | \\Hook Beetle"
+                  name: \Lanayru Mining Facility\Main\Big Hub\Entry
+                  sub_areas: {}
+                  toplevel_alias: null
+                After Wooden Boxes:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru Mining Facility\Main\Big Hub\Entry: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room: \Lanayru
+                      Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Push
+                      Box
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    First Chest in Hub Room: 'True'
+                  name: \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near Exit to Hop Across Boxes Room:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Hop Across Boxes Room: null
+                  exits:
+                    Exit to Hop Across Boxes Room: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: 'True'
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Push Box: 'True'
+                  name: \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across
+                    Boxes Room
+                  sub_areas: {}
+                  toplevel_alias: null
+                Past West Gate:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Armos Fight Room: null
+                  exits:
+                    \Lanayru Mining Facility\Main\Big Hub\Entry: \Lanayru Mining Facility\Main\Big
+                      Hub\Past West Gate\Open Gate
+                    Exit to Armos Fight Room: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze: \Lanayru
+                      Mining Facility\Main\Big Hub\Past West Gate\Blow Off Pile for
+                      Second Crawlspace
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Blow Off Pile for First Crawlspace: Gust Bellows
+                    Blow Off Pile for Second Crawlspace: Gust Bellows
+                    Open Gate: 'True'
+                    Chest behind First Crawlspace: \Lanayru Mining Facility\Main\Big
+                      Hub\Past West Gate\Blow Off Pile for First Crawlspace
+                  name: \Lanayru Mining Facility\Main\Big Hub\Past West Gate
+                  sub_areas: {}
+                  toplevel_alias: null
+                Sand Spike Maze:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru Mining Facility\Main\Near Boss Door: "\\Lanayru Mining\
+                      \ Facility\\Main\\Big Hub\\Sand Spike Maze\\Switch under Sand\
+                      \ & \\Lanayru Mining Facility\\Can Activate Minecart Timeshift\
+                      \ Stone"
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Switch under Sand: Gust Bellows
+                    Chest in Spike Maze: Gust Bellows
+                  name: \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near Boss Key Room First Exit:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru Mining Facility\Main\Boss Key Room: \Lanayru Mining Facility\Main\Big
+                      Hub\Between Wind Gates\Unlock Exit to Boss Key Room
+                  hint_region: Lanayru Mining Facility
+                  locations: {}
+                  name: \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First
+                    Exit
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near Boss Key Room Second Exit:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: 'True'
+                    \Lanayru Mining Facility\Main\Near Boss Door: "Gust Bellows |\
+                      \ LMF - Minecart Jump Trick & \\Sword & (Bomb Bag | \\Beetle)"
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Push Box: 'True'
+                    Shortcut Chest in Main Hub: 'True'
+                  name: \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second
+                    Exit
+                  sub_areas: {}
+                  toplevel_alias: null
+                Between Wind Gates:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru Mining Facility\Main\Big Hub\Entry: \Lanayru Mining Facility\Main\Big
+                      Hub\Between Wind Gates\Open First Wind Gate
+                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: \Lanayru
+                      Mining Facility\Main\Big Hub\Between Wind Gates\Activate Minecart
+                      Stone to Boss Key Room
+                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: \Lanayru
+                      Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Push
+                      Box
+                  hint_region: Lanayru Mining Facility
+                  locations:
+                    Get Minecart: \Lanayru Mining Facility\Main\Near Boss Door\Open
+                      Second Wind Gate
+                    Open First Wind Gate: "\\Lanayru Mining Facility\\Main\\Big Hub\\\
+                      Between Wind Gates\\Get Minecart & \\Lanayru Mining Facility\\\
+                      Can Activate Minecart Timeshift Stone & Gust Bellows"
+                    Activate Minecart Stone to Boss Key Room: "Gust Bellows & \\Lanayru\
+                      \ Mining Facility\\Can Activate Minecart Timeshift Stone"
+                    Unlock Exit to Boss Key Room: "\\Lanayru Mining Facility\\Main\\\
+                      Big Hub\\Between Wind Gates\\Activate Minecart Stone to Boss\
+                      \ Key Room & Gust Bellows"
+                  name: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Near Boss Door:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Boss Door Entrance: null
+              exits:
+                Boss Door Exit: "Lanayru Mining Facility Boss Key & \\Lanayru Mining\
+                  \ Facility\\Can Activate Minecart Timeshift Stone"
+                \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: "LMF\
+                  \ - Minecart Jump Trick & \\Sword & (Bomb Bag | \\Beetle)"
+                \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: "\\Lanayru\
+                  \ Mining Facility\\Main\\Near Boss Door\\Open Second Wind Gate &\
+                  \ \\Can Defeat Beamos"
+              hint_region: Lanayru Mining Facility
+              locations:
+                Get Minecart to Wind Gate: "Gust Bellows & \\Lanayru Mining Facility\\\
+                  Can Activate Minecart Timeshift Stone"
+                Open Second Wind Gate: "\\Lanayru Mining Facility\\Main\\Near Boss\
+                  \ Door\\Get Minecart to Wind Gate & Gust Bellows"
+              name: \Lanayru Mining Facility\Main\Near Boss Door
+              sub_areas: {}
+              toplevel_alias: null
+            Boss Key Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: \Lanayru
+                  Mining Facility\Main\Boss Key Room\Can Beat Room
+              hint_region: Lanayru Mining Facility
+              locations:
+                Can Beat Room: "Bomb Bag & Gust Bellows & \\Sword"
+                Boss Key Chest: \Lanayru Mining Facility\Main\Boss Key Room\Can Beat
+                  Room
+              name: \Lanayru Mining Facility\Main\Boss Key Room
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Boss Room:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Dungeon: null
+          exits:
+            Exit to Dungeon: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat
+              Moldarach
+            \Lanayru Mining Facility\Boss Room\After Sand Drain: 'True'
+          hint_region: Lanayru Mining Facility
+          locations: {}
+          name: \Lanayru Mining Facility\Boss Room
+          sub_areas:
+            After Sand Drain:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Hall of Ancient Robots: null
+              exits:
+                Exit to Hall of Ancient Robots: \Lanayru Mining Facility\Boss Room\After
+                  Sand Drain\Beat Moldarach
+              hint_region: Lanayru Mining Facility
+              locations:
+                Beat Moldarach: "(Gust Bellows | LMF - Moldarach without Gust Bellows\
+                  \ Trick) & \\Sword"
+                Heart Container: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat
+                  Moldarach
+              name: \Lanayru Mining Facility\Boss Room\After Sand Drain
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Hall of Ancient Robots:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Lanayru Mining Facility
+          locations: {}
+          name: \Lanayru Mining Facility\Hall of Ancient Robots
+          sub_areas:
+            Entry:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Boss Room: null
+              exits:
+                Exit to Boss Room: 'True'
+                \Lanayru Mining Facility\Hall of Ancient Robots\End: \Lanayru Mining
+                  Facility\Hall of Ancient Robots\Entry\Hit Timeshift Stone
+              hint_region: Lanayru Mining Facility
+              locations:
+                Hit Timeshift Stone: "\\Beetle | \\Bow"
+              name: \Lanayru Mining Facility\Hall of Ancient Robots\Entry
+              sub_areas: {}
+              toplevel_alias: null
+            End:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Temple of Time: null
+              exits:
+                Exit to Temple of Time: 'True'
+              hint_region: Lanayru Mining Facility
+              locations:
+                Exit Hall of Ancient Robots: 'True'
+              name: \Lanayru Mining Facility\Hall of Ancient Robots\End
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Lanayru:
+      abstract: true
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: null
+      locations:
+        All Three Nodes: "LMF Nodes On option | \\Lanayru\\Desert\\North Part\\Water\
+          \ Node & \\Lanayru\\Desert\\North Part\\Lightning Node\\Past\\Lightning\
+          \ Node & \\Lanayru\\Desert\\East\\Fire Node\\Past after Grate\\Fire Node"
+        Raise Lanayru Mining Facility: "Open LMF option | \\Lanayru\\Desert\\North\
+          \ Part\\Activate Main Node"
+        Can Navigate in Oasis: "\\Can Defeat Ampilus | \\Hook Beetle | \\Skyloft\\\
+          Central Skyloft\\Bazaar\\Endurance Potion | Brakeslide Trick | Stuttersprint\
+          \ Trick"
+      name: \Lanayru
+      sub_areas:
+        Mine:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Lanayru Mine
+          locations: {}
+          name: \Lanayru\Mine
+          sub_areas:
+            Entry:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Statue Entrance: null
+                First Time Entrance: null
+              exits:
+                Statue Exit: \Lanayru\Mine\Entry\Unlock Statue
+                \Lanayru\Mine\Statues Area: \Lanayru\Mine\Entry\Timeshift Stone
+                \Lanayru\Mine\Entry\Higher Area: Clawshots
+              hint_region: Lanayru Mine
+              locations:
+                Unlock Statue: 'True'
+                Goddess Cube at Lanayru Mine Entrance: \Goddess Sword
+                Timeshift Stone: "\\Can Hit Timeshift Stone | Itemless First Timeshift\
+                  \ Stone Trick"
+                \Ancient Flower Farming: \Lanayru\Mine\Entry\Timeshift Stone
+                Chest near First Timeshift Stone: \Lanayru\Mine\Entry\Timeshift Stone
+              name: \Lanayru\Mine\Entry
+              sub_areas:
+                Higher Area:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru\Mine\Entry: 'True'
+                    \Lanayru\Mine\Entry\Caves Entrance: Clawshots
+                  hint_region: Lanayru Mine
+                  locations:
+                    Chest behind First Landing: 'True'
+                  name: \Lanayru\Mine\Entry\Higher Area
+                  sub_areas: {}
+                  toplevel_alias: null
+                Caves Entrance:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Caves: null
+                  exits:
+                    \Lanayru\Mine\Entry\Higher Area: Clawshots
+                    Exit to Caves: 'True'
+                  hint_region: Lanayru Mine
+                  locations: {}
+                  name: \Lanayru\Mine\Entry\Caves Entrance
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Statues Area:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Mine\Entry: 'True'
+                \Lanayru\Mine\End: "\\Lanayru\\Mine\\Statues Area\\Blow Statues Down\
+                  \ | Brakeslide Trick | \\Skyloft\\Central Skyloft\\Bazaar\\Endurance\
+                  \ Potion"
+              hint_region: Lanayru Mine
+              locations:
+                Blow Statues Down: "Bomb Bag | \\Hook Beetle"
+                Chest behind Statue: \Lanayru\Mine\Statues Area\Blow Statues Down
+              name: \Lanayru\Mine\Statues Area
+              sub_areas: {}
+              toplevel_alias: null
+            End:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Mine\Statues Area: "\\Lanayru\\Mine\\Statues Area\\Blow Statues\
+                  \ Down | Brakeslide Trick | \\Skyloft\\Central Skyloft\\Bazaar\\\
+                  Endurance Potion"
+                \Lanayru\Mine\End\In Minecart: \Lanayru\Mine\End\Blow up Rock on Track
+              hint_region: Lanayru Mine
+              locations:
+                Blow up Rock on Track: 'True'
+                Chest at the End of Mine: 'True'
+                \Ancient Flower Farming: \Can Hit Timeshift Stone
+              name: \Lanayru\Mine\End
+              sub_areas:
+                In Minecart:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Desert: null
+                  exits:
+                    Exit to Desert: 'True'
+                  hint_region: Lanayru Mine
+                  locations:
+                    Blow up Rock on Track: "Bomb Bag & Lanayru Mine - Quick Bomb Trick"
+                  name: \Lanayru\Mine\End\In Minecart
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: Lanayru Mine
+        Desert:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits:
+            Shared Statue Exit: 'False'
+          hint_region: Lanayru Desert
+          locations: {}
+          name: \Lanayru\Desert
+          sub_areas:
+            Entry:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Desert Entrance Statue Entrance: null
+                Entrance from Mine: null
+              exits:
+                Exit to Mine: \Lanayru\Desert\Entry\Timeshift Stone
+                \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\Entry\Unlock Statue
+                \Lanayru\Desert\Near Caged Robot: 'True'
+                \Lanayru\Desert\Entry\High Ledge after Vines: \Lanayru\Desert\Entry\Timeshift
+                  Stone
+              hint_region: Lanayru Desert
+              locations:
+                Unlock Statue: 'True'
+                Blow up Rock for Timeshift Stone: Bomb Bag
+                Timeshift Stone: "\\Lanayru\\Desert\\Entry\\Blow up Rock for Timeshift\
+                  \ Stone & \\Can Hit Timeshift Stone"
+              name: \Lanayru\Desert\Entry
+              sub_areas:
+                High Ledge after Vines:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits: {}
+                  hint_region: Lanayru Desert
+                  locations:
+                    Retrieve Party Wheel: "Scrapper & \\Sky\\South West\\Fun Fun Island\\\
+                      Start Dodoh's Quest"
+                    Chest near Party Wheel: 'True'
+                    \Ancient Flower Farming: 'True'
+                  name: \Lanayru\Desert\Entry\High Ledge after Vines
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Near Caged Robot:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Desert\Entry: 'True'
+                \Lanayru\Desert\Top of West Wall: Clawshots
+                \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
+                \Lanayru\Desert\East: "Temple of Time Skip - Brakeslide Trick | \\\
+                  Lanayru\\Desert\\East\\Open Wall Shortcut | Clawshots | \\Skyloft\\\
+                  Central Skyloft\\Bazaar\\Endurance Potion"
+                \Lanayru\Desert\Sand Oasis: \Lanayru\Desert\Near Caged Robot\Get Past
+                  Spume to Sand Oasis
+              hint_region: Lanayru Desert
+              locations:
+                Chest near Caged Robot: 'True'
+                Goddess Cube near Caged Robot: \Long Range Skyward Strike
+                Blow up Rock for Timeshift Stone: "Bomb Bag | \\Hook Beetle | Lanayru\
+                  \ Desert - Ampilus Bomb Toss Trick"
+                Rescue Caged Robot: "\\Lanayru\\Desert\\Near Caged Robot\\Blow up\
+                  \ Rock for Timeshift Stone & \\Can Defeat Bokoblins"
+                Blow Statues to Sand Oasis Down: \Hook Beetle
+                Get Past Spume to Sand Oasis: "\\Lanayru\\Desert\\Near Caged Robot\\\
+                  Blow Statues to Sand Oasis Down | \\Skyloft\\Central Skyloft\\Bazaar\\\
+                  Endurance Potion | Brakeslide Trick & Stuttersprint Trick & (Bomb\
+                  \ Bag | \\Bow | \\Long Range Skyward Strike)"
+              name: \Lanayru\Desert\Near Caged Robot
+              sub_areas: {}
+              toplevel_alias: null
+            Sand Oasis:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Desert\Near Caged Robot: 'True'
+                \Lanayru\Desert\Top of West Wall: "Clawshots | \\Lanayru\\Desert\\\
+                  Top of West Wall\\Push Minecart"
+                \Lanayru\Desert\West Part: "\\Lanayru\\Can Navigate in Oasis | \\\
+                  Lanayru\\Desert\\West Part\\Push Minecart"
+              hint_region: Lanayru Desert
+              locations:
+                Goddess Cube in Sand Oasis: "\\Lanayru\\Can Navigate in Oasis & \\\
+                  Goddess Sword"
+              name: \Lanayru\Desert\Sand Oasis
+              sub_areas: {}
+              toplevel_alias: null
+            West Part:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                West Desert Statue Entrance: null
+              exits:
+                \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\West Part\Unlock
+                  Statue
+                \Lanayru\Desert\Sand Oasis: 'True'
+                \Lanayru\Desert\Top of West Wall: Clawshots
+                \Lanayru\Desert\Near South Exit to Temple of Time: "\\Lanayru\\Can\
+                  \ Navigate in Oasis | \\Lanayru\\Desert\\Near South Exit to Temple\
+                  \ of Time\\Push Minecart"
+              hint_region: Lanayru Desert
+              locations:
+                Unlock Statue: 'True'
+                \Lanayru\Desert\Sand Oasis\Goddess Cube in Sand Oasis: \Goddess Sword
+                Push Minecart: 'True'
+              name: \Lanayru\Desert\West Part
+              sub_areas: {}
+              toplevel_alias: null
+            Near South Exit to Temple of Time:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                South Entrance from Temple of Time: null
+              exits:
+                South Exit to Temple of Time: 'True'
+                \Lanayru\Desert\West Part: 'True'
+                \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves: Clawshots
+              hint_region: Lanayru Desert
+              locations:
+                Push Minecart: 'True'
+              name: \Lanayru\Desert\Near South Exit to Temple of Time
+              sub_areas:
+                Ledge to Caves:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Caves: null
+                  exits:
+                    \Lanayru\Desert\Near South Exit to Temple of Time: 'True'
+                    Exit to Caves: 'True'
+                  hint_region: Lanayru Desert
+                  locations: {}
+                  name: \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to
+                    Caves
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Top of West Wall:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Desert\Near Caged Robot: 'True'
+                \Lanayru\Desert\Sand Oasis: 'True'
+                \Lanayru\Desert\West Part: 'True'
+              hint_region: Lanayru Desert
+              locations:
+                Chest near Sand Oasis: 'True'
+                \Lanayru\Desert\Near Caged Robot\Goddess Cube near Caged Robot: \Goddess
+                  Sword
+                Push Minecart: 'True'
+              name: \Lanayru\Desert\Top of West Wall
+              sub_areas: {}
+              toplevel_alias: null
+            Top of LMF:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Lanayru Mining Facility: null
+              exits:
+                \Lanayru\Desert\North Part: 'True'
+                \Lanayru\Desert\East: 'True'
+                \Lanayru\Desert\Near Caged Robot: 'True'
+                Exit to Lanayru Mining Facility: 'True'
+              hint_region: Lanayru Desert
+              locations:
+                Chest on top of Lanayru Mining Facility: 'True'
+              name: \Lanayru\Desert\Top of LMF
+              sub_areas: {}
+              toplevel_alias: null
+            North Part:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Trial Gate Entrance: null
+                North Desert Statue Entrance: null
+                Lightning Node Entrance: null
+                North Entrance from Temple of Time: null
+              exits:
+                North Exit to Temple of Time: 'True'
+                \Lanayru\Desert\East: 'True'
+                \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
+                \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\North Part\Unlock
+                  Statue
+                Trial Gate Exit: \Lanayru\Desert\North Part\Open Trial Gate
+                Lightning Node Exit: \Lanayru\Desert\North Part\Open Lightning Node
+                \Lanayru\Desert\North Part\Secret Passageway: \Lanayru\Desert\North
+                  Part\Open Secret Passageway
+              hint_region: Lanayru Desert
+              locations:
+                Water Node: "(Bomb Bag | \\Hook Beetle) & \\Sword"
+                Blow up Main Node Timeshift Stone Rock: "Bomb Bag | \\Hook Beetle"
+                Main Node Timeshift Stone: "\\Lanayru\\Desert\\North Part\\Blow up\
+                  \ Main Node Timeshift Stone Rock & \\Can Hit Timeshift Stone"
+                Activate Main Node: "\\Lanayru\\All Three Nodes & \\Lanayru\\Desert\\\
+                  North Part\\Main Node Timeshift Stone & \\Sword"
+                Unlock Statue: 'True'
+                Open Trial Gate: "Nayru's Wisdom & Goddess's Harp"
+                Open Secret Passageway: "Bomb Bag | \\Hook Beetle & Secret Passageway\
+                  \ Hook Beetle Opening Trick | \\Tough Beetle"
+                Chest on Platform near Lightning Node: Clawshots
+                Open Lightning Node: 'True'
+                \Ancient Flower Farming: \Lanayru\Desert\North Part\Main Node Timeshift
+                  Stone
+              name: \Lanayru\Desert\North Part
+              sub_areas:
+                Secret Passageway:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru\Desert\North Part: 'True'
+                  hint_region: Lanayru Desert
+                  locations:
+                    Secret Passageway Chest: 'True'
+                    Goddess Cube in Secret Passageway: "Clawshots & \\Goddess Sword"
+                  name: \Lanayru\Desert\North Part\Secret Passageway
+                  sub_areas: {}
+                  toplevel_alias: null
+                Lightning Node:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits: {}
+                  hint_region: Lanayru Desert
+                  locations: {}
+                  name: \Lanayru\Desert\North Part\Lightning Node
+                  sub_areas:
+                    Present:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set
+                        Entrance: null
+                      exits:
+                        Exit: 'True'
+                        \Lanayru\Desert\North Part\Lightning Node\Past: \Lanayru\Desert\North
+                          Part\Lightning Node\Present\Timeshift Stone
+                      hint_region: Lanayru Desert
+                      locations:
+                        Blow up Rock for Timeshift Stone: Bomb Bag
+                        Timeshift Stone: "\\Lanayru\\Desert\\North Part\\Lightning\
+                          \ Node\\Present\\Blow up Rock for Timeshift Stone & \\Can\
+                          \ Hit Timeshift Stone"
+                      name: \Lanayru\Desert\North Part\Lightning Node\Present
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Past:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\North Part\Lightning Node\Present\Exit: 'True'
+                        \Lanayru\Desert\North Part\Lightning Node\Present: \Projectile
+                          Item
+                        \Lanayru\Desert\North Part\Lightning Node\Present from afar: "\\\
+                          Beetle | \\Bow | Lightning Node End with Bombs Trick & Bomb\
+                          \ Bag"
+                      hint_region: Lanayru Desert
+                      locations:
+                        First Chest: 'True'
+                        Second Chest: 'True'
+                        Lightning Node: \Sword
+                      name: \Lanayru\Desert\North Part\Lightning Node\Past
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Present from afar:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\North Part\Lightning Node\Past: "\\Beetle\
+                          \ | \\Bow"
+                        \Lanayru\Desert\North Part\Lightning Node\Present: 'True'
+                      hint_region: Lanayru Desert
+                      locations:
+                        Raised Chest near Generator: 'True'
+                      name: \Lanayru\Desert\North Part\Lightning Node\Present from
+                        afar
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+              toplevel_alias: null
+            East:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Fire Node Entrance: null
+                Stone Cache Statue Entrance: null
+              exits:
+                \Lanayru\Desert\North Part: 'True'
+                \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
+                \Lanayru\Desert\Near Caged Robot: "\\Lanayru\\Desert\\East\\Open Wall\
+                  \ Shortcut | Temple of Time Skip - Brakeslide Trick"
+                \Lanayru\Desert\Shared Statue Exit: 'True'
+                Fire Node Exit: 'True'
+              hint_region: Lanayru Desert
+              locations:
+                Open Wall Shortcut: 'True'
+                Unlock Statue: 'True'
+                Chest on Platform near Fire Node: Clawshots
+              name: \Lanayru\Desert\East
+              sub_areas:
+                Fire Node:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits: {}
+                  hint_region: Lanayru Desert
+                  locations: {}
+                  name: \Lanayru\Desert\East\Fire Node
+                  sub_areas:
+                    Present:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set
+                        Entrance: null
+                      exits:
+                        Exit: 'True'
+                        \Lanayru\Desert\East\Fire Node\Past: \Lanayru\Desert\East\Fire
+                          Node\Present\Timeshift Stone
+                        \Lanayru\Desert\East\Fire Node\Present after Sand: "\\Can\
+                          \ Defeat Ampilus | Brakeslide Trick | \\Lanayru\\Desert\\\
+                          East\\Fire Node\\Present after Sand\\Push Box"
+                      hint_region: Lanayru Desert
+                      locations:
+                        Blow up Rock for Timeshift Stone: Bomb Bag
+                        Timeshift Stone: "\\Lanayru\\Desert\\East\\Fire Node\\Present\\\
+                          Blow up Rock for Timeshift Stone & \\Can Hit Timeshift Stone"
+                      name: \Lanayru\Desert\East\Fire Node\Present
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Present after Sand:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\East\Fire Node\Past after Void: "\\Lanayru\\\
+                          Desert\\East\\Fire Node\\Present\\Timeshift Stone & \\Projectile\
+                          \ Item"
+                        \Lanayru\Desert\East\Fire Node\Present: 'True'
+                      hint_region: Lanayru Desert
+                      locations:
+                        Shortcut Chest: 'True'
+                        Push Box: 'True'
+                      name: \Lanayru\Desert\East\Fire Node\Present after Sand
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Past:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\East\Fire Node\Present\Exit: 'True'
+                        \Lanayru\Desert\East\Fire Node\Present: "\\Projectile Item\
+                          \ | Bomb Bag"
+                        \Lanayru\Desert\East\Fire Node\Past after Void: \Lanayru\Desert\East\Fire
+                          Node\Present after Sand\Push Box
+                      hint_region: Lanayru Desert
+                      locations:
+                        First Small Chest: 'True'
+                        Second Small Chest: 'True'
+                      name: \Lanayru\Desert\East\Fire Node\Past
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Past after Void:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\East\Fire Node\Past: 'True'
+                        \Lanayru\Desert\East\Fire Node\Past after Grate: \Lanayru\Desert\East\Fire
+                          Node\Past after Void\Open Grate
+                      hint_region: Lanayru Desert
+                      locations:
+                        Open Grate: \Hook Beetle
+                      name: \Lanayru\Desert\East\Fire Node\Past after Void
+                      sub_areas: {}
+                      toplevel_alias: null
+                    Past after Grate:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Lanayru\Desert\East\Fire Node\Past after Void: 'True'
+                      hint_region: Lanayru Desert
+                      locations:
+                        Left Ending Chest: 'True'
+                        Right Ending Chest: 'True'
+                        Fire Node: \Sword
+                      name: \Lanayru\Desert\East\Fire Node\Past after Grate
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: Lanayru Desert
+        Temple of Time:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits:
+            Shared Statue Exit: 'False'
+          hint_region: null
+          locations: {}
+          name: \Lanayru\Temple of Time
+          sub_areas:
+            South East:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                South Entrance from Desert: null
+                Desert Gorge Statue Entrance: null
+              exits:
+                South Exit to Desert: 'True'
+                \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\South
+                  East\Unlock Statue
+                \Lanayru\Temple of Time\Front: "\\Hook Beetle | \\Slingshot & Temple\
+                  \ of Time - Slingshot Shot Trick"
+              hint_region: null
+              locations:
+                Unlock Statue: 'True'
+                \Ancient Flower Farming: \Distance Activator
+              name: \Lanayru\Temple of Time\South East
+              sub_areas: {}
+              toplevel_alias: null
+            Front:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Temple of Time\Inside: 'True'
+                \Lanayru\Temple of Time\Near Goddess Cube: \Lanayru\Temple of Time\Near
+                  Goddess Cube\Timeshift Stone
+              hint_region: null
+              locations:
+                Gossip Stone in Temple of Time Area: 'True'
+                Blow up Rock for Timeshift Stone: "\\Hook Beetle | Bomb Throws Trick\
+                  \ & (Bomb Bag | Cactus Bomb Whip Trick & Whip)"
+                Timeshift Stone: "\\Lanayru\\Temple of Time\\Front\\Blow up Rock for\
+                  \ Timeshift Stone & \\Distance Activator"
+                Save Robot: "\\Lanayru\\Temple of Time\\Front\\Timeshift Stone & \\\
+                  Can Defeat Bokoblins"
+                \Lanayru\Temple of Time\Near Goddess Cube\Timeshift Stone: "\\Long\
+                  \ Range Skyward Strike | \\Distance Activator"
+                \Ancient Flower Farming: \Hook Beetle
+              name: \Lanayru\Temple of Time\Front
+              sub_areas: {}
+              toplevel_alias: null
+            Inside:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Temple of Time Statue Entrance: null
+                Entrance from Lanayru Mining Facility: null
+              exits:
+                \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\Inside\Unlock
+                  Statue
+                Exit to Lanayru Mining Facility: 'True'
+                \Lanayru\Temple of Time\Front: 'True'
+              hint_region: null
+              locations:
+                Unlock Statue: 'True'
+              name: \Lanayru\Temple of Time\Inside
+              sub_areas: {}
+              toplevel_alias: null
+            Near Goddess Cube:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Lanayru\Temple of Time\North East: 'True'
+              hint_region: null
+              locations:
+                Timeshift Stone: 'False'
+                Goddess Cube at Ride near Temple of Time: \Goddess Sword
+              name: \Lanayru\Temple of Time\Near Goddess Cube
+              sub_areas: {}
+              toplevel_alias: null
+            North East:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                North Entrance from Desert: null
+              exits:
+                \Lanayru\Temple of Time\South East: \Distance Activator
+                North Exit to Desert: 'True'
+                \Ancient Flower Farming: \Distance Activator
+              hint_region: null
+              locations: {}
+              name: \Lanayru\Temple of Time\North East
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Lanayru Silent Realm:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: 'True'
+          hint_region: Lanayru Silent Realm
+          locations:
+            Trial Reward: 'True'
+            Relic 1: 'True'
+            Relic 2: 'True'
+            Relic 3: 'True'
+            Relic 4: 'True'
+            Relic 5: 'True'
+            Relic 6: 'True'
+            Relic 7: 'True'
+            Relic 8: 'True'
+            Relic 9: 'True'
+            Relic 10: 'True'
+          name: \Lanayru\Lanayru Silent Realm
+          sub_areas: {}
+          toplevel_alias: null
+        Caves:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Desert: null
+            Entrance from Mine: null
+          exits:
+            \Lanayru\Caves\Past Door to Lanayru Sand Sea: "Clawshots & Lanayru Caves\
+              \ Small Key"
+            \Lanayru\Caves\Past Crawlspace: 'True'
+            Exit to Mine: 'True'
+            Exit to Desert: 'True'
+          hint_region: Lanayru Caves
+          locations:
+            Chest: 'True'
+            Golo's Gift: 'True'
+            Gossip Stone in Center: 'True'
+          name: \Lanayru\Caves
+          sub_areas:
+            Past Door to Lanayru Sand Sea:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Lanayru Sand Sea: null
+              exits:
+                \Lanayru\Caves: Lanayru Caves Small Key
+                Exit to Lanayru Sand Sea: 'True'
+              hint_region: Lanayru Caves
+              locations: {}
+              name: \Lanayru\Caves\Past Door to Lanayru Sand Sea
+              sub_areas: {}
+              toplevel_alias: null
+            Past Crawlspace:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Gorge: null
+              exits:
+                \Lanayru\Caves: Bomb Bag
+                Exit to Gorge: 'True'
+              hint_region: Lanayru Caves
+              locations:
+                Gossip Stone towards Lanayru Gorge: 'True'
+              name: \Lanayru\Caves\Past Crawlspace
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Lanayru Caves
+        Lanayru Sand Sea:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Sandship Dock Entrance: null
+            Pirate Stronghold Dock Entrance: null
+            Ancient Harbour Dock Entrance: null
+            Shipyard Dock Entrance: null
+            Skipper's Retreat Dock Entrance: null
+          exits:
+            Ancient Harbour Dock Exit: 'True'
+            Sandship Dock Exit: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
+            Skipper's Retreat Dock Exit: 'True'
+            Shipyard Dock Exit: 'True'
+            Pirate Stronghold Dock Exit: 'True'
+          hint_region: Lanayru Sand Sea
+          locations:
+            Shoot down Sandship: "Sea Chart & \\Sword"
+          name: \Lanayru\Lanayru Sand Sea
+          sub_areas:
+            Ancient Harbour:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Statue Entrance: null
+                Dock Entrance: null
+              exits:
+                Dock Exit: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Ship Timeshift
+                  Stone
+                Exit to Sandship: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
+                Statue Exit: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Unlock Statue
+                \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves: Clawshots
+              hint_region: Lanayru Sand Sea
+              locations:
+                Goddess Cube in Ancient Harbour: "Clawshots & \\Goddess Sword"
+                Unlock Statue: 'True'
+                Ship Timeshift Stone: "\\Distance Activator | \\Sword | Bomb Bag"
+              name: \Lanayru\Lanayru Sand Sea\Ancient Harbour
+              sub_areas:
+                Near Exit to Caves:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance from Caves: null
+                  exits:
+                    Exit to Caves: 'True'
+                    \Lanayru\Lanayru Sand Sea\Ancient Harbour: Clawshots
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Left Rupee on Entrance Crown: \Quick Beetle
+                    Right Rupee on Entrance Crown: \Quick Beetle
+                    Rupee on First Pillar: \Beetle
+                  name: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: Lanayru Sand Sea Docks
+            Skipper's Retreat:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Statue Entrance: null
+                Dock Entrance: null
+              exits:
+                Statue Exit: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Unlock Statue
+                Dock Exit: 'True'
+                \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: "\\Lanayru\\\
+                  Lanayru Sand Sea\\Skipper's Retreat\\Blow up Rock & Clawshots"
+              hint_region: Lanayru Sand Sea
+              locations:
+                Unlock Statue: 'True'
+                Blow up Rock: "Bomb Bag | \\Hook Beetle | Whip & Cactus Bomb Whip\
+                  \ Trick"
+              name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat
+              sub_areas:
+                Past Rock:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat: 'True'
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part: "Clawshots\
+                      \ & \\Lanayru\\Lanayru Sand Sea\\Skipper's Retreat\\Past Rock\\\
+                      Whip Peahat & \\Lanayru\\Lanayru Sand Sea\\Skipper's Retreat\\\
+                      Past Rock\\Deal with Deku Baba"
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Chest after Moblin: 'True'
+                    Goddess Cube in Skipper's Retreat: "Clawshots & \\Goddess Sword"
+                    Whip Peahat: "Clawshots & Whip"
+                    Deal with Deku Baba: "\\Projectile Item | Skipper's Retreat Fast\
+                      \ Clawshots Trick & Clawshots"
+                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock
+                  sub_areas: {}
+                  toplevel_alias: null
+                Top Part:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Shack Entrance: null
+                  exits:
+                    Shack Exit: 'True'
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: 'True'
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform: 'True'
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Chest on top of Cacti Pillar: Clawshots
+                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part
+                  sub_areas: {}
+                  toplevel_alias: null
+                Shack:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance: null
+                  exits:
+                    Exit: 'True'
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Chest in Shack: Gust Bellows
+                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack
+                  sub_areas: {}
+                  toplevel_alias: null
+                Skydive Platform:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat: Clawshots
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Skydive Chest: 'True'
+                  name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Shipyard:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Statue Entrance: null
+                Construction Bay Upper Entrance: null
+                Dock Entrance: null
+                Construction Bay Lower Entrance: null
+              exits:
+                Statue Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
+                Dock Exit: 'True'
+                Construction Bay Upper Exit: 'True'
+                Construction Bay Lower Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Construction
+                  Bay\Defeat Moldarach
+              hint_region: Lanayru Sand Sea
+              locations:
+                Unlock Statue: 'True'
+                Gossip Stone in Shipyard: 'True'
+                Rickety Coaster -- Heart Stopping Track in 1'05: \Lanayru\Lanayru
+                  Sand Sea\Shipyard\Construction Bay\Defeat Moldarach
+              name: \Lanayru\Lanayru Sand Sea\Shipyard
+              sub_areas:
+                Construction Bay:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Lower Entrance: null
+                    Upper Entrance: null
+                  exits:
+                    Upper Exit: 'True'
+                    Lower Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
+                      Moldarach
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    Defeat Moldarach: "Gust Bellows & \\Sword"
+                  name: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Pirate Stronghold:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Statue Entrance: null
+                Dock Entrance: null
+                Side Entrance: null
+              exits:
+                Statue Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
+                Dock Exit: 'True'
+                Side Exit: 'True'
+                \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head: \Lanayru\Lanayru
+                  Sand Sea\Pirate Stronghold\Inside\Finish Minidungeon
+              hint_region: Lanayru Sand Sea
+              locations:
+                Unlock Statue: 'True'
+                Rupee on West Sea Pillar: \Quick Beetle
+                Rupee on East Sea Pillar: \Quick Beetle
+                Rupee on Bird Statue Pillar or Nose: \Beetle
+              name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold
+              sub_areas:
+                Inside the Shark Head:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Top Entrance: null
+                  exits:
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold: "Clawshots | \\Lanayru\\\
+                      Lanayru Sand Sea\\Pirate Stronghold\\Inside\\Finish Minidungeon"
+                    Top Exit: 'True'
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar: \Quick
+                      Beetle
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar: \Quick
+                      Beetle
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose: \Beetle
+                    Goddess Cube in Pirate Stronghold: "Clawshots & \\Goddess Sword"
+                  name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark
+                    Head
+                  sub_areas: {}
+                  toplevel_alias: null
+                Inside:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    First Door Entrance: null
+                    Second Door Entrance: null
+                  exits:
+                    First Door Exit: 'True'
+                    Second Door Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
+                      Minidungeon
+                  hint_region: Lanayru Sand Sea
+                  locations:
+                    First Chest: 'True'
+                    Second Chest: 'True'
+                    Third Chest: 'True'
+                    Finish Minidungeon: "\\Can Defeat Beamos & \\Can Defeat Armos"
+                    \Ancient Flower Farming: 'True'
+                  name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Gorge:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Statue Entrance: null
+                Entrance: null
+              exits:
+                Statue Exit: \Lanayru\Lanayru Sand Sea\Gorge\Unlock Statue
+                \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge: \Lanayru\Lanayru Sand
+                  Sea\Gorge\Activate Timeshift Stone
+                Exit: 'True'
+              hint_region: Lanayru Gorge
+              locations:
+                Unlock Statue: 'True'
+                Item on Pillar: \Beetle
+                Activate Timeshift Stone: \Can Hit Timeshift Stone in Minecart
+                Thunder Dragon's Reward: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Activate\
+                  \ Timeshift Stone & Life Tree Fruit"
+                Boss Rush -- 4 Bosses: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Thunder\
+                  \ Dragon's Reward & False"
+                Boss Rush -- 8 Bosses: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Thunder\
+                  \ Dragon's Reward & False"
+              name: \Lanayru\Lanayru Sand Sea\Gorge
+              sub_areas:
+                Beyond Bridge:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Lanayru\Lanayru Sand Sea\Gorge: "\\Beetle | \\Bow"
+                  hint_region: Lanayru Gorge
+                  locations:
+                    Activate Timeshift Stone: "Gust Bellows & \\Can Hit Timeshift\
+                      \ Stone"
+                    Goddess Cube in Lanayru Gorge: \Goddess Sword
+                    Digging Spot: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Beyond Bridge\\\
+                      Activate Timeshift Stone & \\Digging Mitts"
+                    \Ancient Flower Farming: \Lanayru\Lanayru Sand Sea\Gorge\Beyond
+                      Bridge\Activate Timeshift Stone
+                  name: \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: Lanayru Gorge
+          toplevel_alias: Lanayru Sand Sea
+      toplevel_alias: null
+    Sandship:
+      abstract: true
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Sandship
+      locations:
+        Pass Spume: "\\Goddess Sword | \\Bow | Bomb Bag | \\Slingshot | Sandship -\
+          \ Itemless Spume Skip Trick"
+      name: \Sandship
+      sub_areas:
+        Main:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Sandship
+          locations: {}
+          name: \Sandship\Main
+          sub_areas:
+            Deck:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: 'True'
+                \Sandship\Main\Before Ship's Bow: 'True'
+                \Sandship\Main\Deck\Captain's Cabin: "Sandship Small Key x 2 & (\\\
+                  Sandship\\Main\\Deck\\Start Mast Sequence | \\Sandship\\Main\\Deck\\\
+                  Freely Usable Timeshift Stone)"
+                \Sandship\Main\Starboard Rooms: "\\Sandship\\Main\\Starboard Rooms\\\
+                  Switch & \\Bow"
+                \Sandship\Main\Deck\Mast: "\\Sandship\\Main\\Deck\\Start Mast Sequence\
+                  \ | \\Sandship\\Main\\Deck\\Freely Usable Timeshift Stone"
+              hint_region: Sandship
+              locations:
+                Raise Timeshift Stone: \Bow
+                Start Mast Sequence: "\\Sandship\\Main\\Deck\\Raise Timeshift Stone\
+                  \ & \\Bow"
+                Freely Usable Timeshift Stone: "\\Sandship\\Main\\Deck\\Mast\\Finish\
+                  \ Mast Sequence & \\Bow"
+              name: \Sandship\Main\Deck
+              sub_areas:
+                Mast:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sandship\Main\Deck: 'True'
+                    \Sandship\Main\Deck\Stern: "\\Bow & (Clawshots | Sandship - Mast\
+                      \ Jump Trick)"
+                  hint_region: Sandship
+                  locations:
+                    Finish Mast Sequence: "\\Bow & \\Sword"
+                  name: \Sandship\Main\Deck\Mast
+                  sub_areas: {}
+                  toplevel_alias: null
+                Stern:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sandship\Main\Deck: Clawshots
+                  hint_region: Sandship
+                  locations:
+                    Chest at the Stern: 'True'
+                  name: \Sandship\Main\Deck\Stern
+                  sub_areas: {}
+                  toplevel_alias: null
+                Captain's Cabin:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sandship\Main\Deck: Sandship Small Key x 2
+                  hint_region: Sandship
+                  locations:
+                    Switch: "\\Bow & \\Sandship\\Main\\Deck\\Freely Usable Timeshift\
+                      \ Stone"
+                    Bars: \Can Defeat Beamos
+                    Boss Key Chest: "\\Sandship\\Main\\Deck\\Captain's Cabin\\Switch\
+                      \ & \\Sandship\\Main\\Deck\\Captain's Cabin\\Bars"
+                  name: \Sandship\Main\Deck\Captain's Cabin
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Before Ship's Bow:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Ship's Bow: Sandship Small Key x 2
+                \Sandship\Main\Corridor: "\\Sandship\\Pass Spume | \\Sandship\\Main\\\
+                  Deck\\Freely Usable Timeshift Stone"
+              hint_region: Sandship
+              locations:
+                Chest before 4-Door Corridor: \Sandship\Main\Deck\Freely Usable Timeshift
+                  Stone
+              name: \Sandship\Main\Before Ship's Bow
+              sub_areas: {}
+              toplevel_alias: null
+            Ship's Bow:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Before Ship's Bow: \Lanayru\Caves\Chest
+              hint_region: Sandship
+              locations:
+                Chest after Scervo Fight: \Can Defeat Scervo/Dreadfuse
+              name: \Sandship\Main\Ship's Bow
+              sub_areas: {}
+              toplevel_alias: null
+            Corridor:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Before Ship's Bow: "\\Sandship\\Pass Spume | \\Sandship\\\
+                  Main\\Deck\\Freely Usable Timeshift Stone"
+                \Sandship\Main\Starboard Rooms: \Sandship\Main\Deck\Freely Usable
+                  Timeshift Stone
+                \Sandship\Main\Port Rooms: \Sandship\Main\Port Rooms\Switch
+                \Sandship\Main\Before Boss Door: 'True'
+              hint_region: Sandship
+              locations:
+                \Sandship\Main\Port Rooms\Switch: \Bow
+              name: \Sandship\Main\Corridor
+              sub_areas: {}
+              toplevel_alias: null
+            Starboard Rooms:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Deck: "\\Sandship\\Main\\Starboard Rooms\\Switch &\
+                  \ \\Bow"
+                \Sandship\Main\Brig: \Sandship\Main\Starboard Rooms\Switch
+                \Sandship\Main\Corridor: \Sandship\Main\Deck\Freely Usable Timeshift
+                  Stone
+              hint_region: Sandship
+              locations:
+                Switch: 'True'
+                Generator: "\\Bow & \\Sandship\\Main\\Deck\\Freely Usable Timeshift\
+                  \ Stone"
+              name: \Sandship\Main\Starboard Rooms
+              sub_areas: {}
+              toplevel_alias: null
+            Port Rooms:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Corridor: \Sandship\Main\Port Rooms\Switch
+              hint_region: Sandship
+              locations:
+                Switch: \Bow
+                Generator: "\\Bow & \\Sandship\\Main\\Deck\\Freely Usable Timeshift\
+                  \ Stone"
+              name: \Sandship\Main\Port Rooms
+              sub_areas: {}
+              toplevel_alias: null
+            Before Boss Door:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Corridor: 'True'
+                Boss Door one-way Exit: \Sandship\Main\Before Boss Door\Open Boss
+                  Door
+              hint_region: Sandship
+              locations:
+                Combination Lock: "(Gust Bellows | \\Sandship\\Main\\Deck\\Freely\
+                  \ Usable Timeshift Stone | Sandship - No Combination Hint Trick)\
+                  \ & \\Can Unlock Combination Lock"
+                Chest behind Combination Lock: \Sandship\Main\Before Boss Door\Combination
+                  Lock
+                Open Boss Door: "\\Sandship\\Main\\Deck\\Freely Usable Timeshift Stone\
+                  \ & Sandship Boss Key"
+              name: \Sandship\Main\Before Boss Door
+              sub_areas: {}
+              toplevel_alias: null
+            Brig:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Treasure Room: "\\Sandship\\Main\\Starboard Rooms\\\
+                  Generator & Whip"
+                \Sandship\Main\Brig Prison: "\\Sandship\\Main\\Starboard Rooms\\Generator\
+                  \ & Whip & \\Sandship\\Main\\Port Rooms\\Generator"
+                \Sandship\Main\Starboard Rooms: \Sandship\Main\Starboard Rooms\Switch
+              hint_region: Sandship
+              locations: {}
+              name: \Sandship\Main\Brig
+              sub_areas: {}
+              toplevel_alias: null
+            Treasure Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Brig: 'True'
+              hint_region: Sandship
+              locations:
+                Treasure Room First Chest: 'True'
+                Treasure Room Second Chest: 'True'
+                Treasure Room Third Chest: 'True'
+                Treasure Room Fourth Chest: 'True'
+                Treasure Room Fifth Chest: 'True'
+              name: \Sandship\Main\Treasure Room
+              sub_areas: {}
+              toplevel_alias: null
+            Brig Prison:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sandship\Main\Brig: 'True'
+              hint_region: Sandship
+              locations:
+                Robot in Brig's Reward: 'True'
+              name: \Sandship\Main\Brig Prison
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Boss Room:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits: {}
+          hint_region: Sandship
+          locations:
+            Beat Tentalus: \Bow
+            Heart Container: \Sandship\Boss Room\Beat Tentalus
+            Nayru's Flame: "\\Sandship\\Boss Room\\Beat Tentalus & \\Goddess Sword"
+          name: \Sandship\Boss Room
+          sub_areas: {}
+          toplevel_alias: null
+      toplevel_alias: null
+    Sky Keep:
+      abstract: false
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Sky Keep
+      locations: {}
+      name: \Sky Keep
+      sub_areas:
+        Main:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Sky Keep
+          locations: {}
+          name: \Sky Keep\Main
+          sub_areas:
+            First Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Bottom Entrance: null
+              exits:
+                Bottom Exit: 'True'
+                \Sky Keep\Main\Puzzle Solving Meta Room: 'True'
+              hint_region: Sky Keep
+              locations:
+                First Chest: 'True'
+                Right Exit: 'True'
+              name: \Sky Keep\Main\First Room
+              sub_areas: {}
+              toplevel_alias: null
+            Skyview Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Sky Keep
+              locations: {}
+              name: \Sky Keep\Main\Skyview Room
+              sub_areas:
+                Beginning:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Skyview Room\End: "Whip & \\Sky Keep\\Main\\Skyview\
+                      \ Room\\Beginning\\Free Rope & Clawshots & \\Sky Keep\\Main\\\
+                      Skyview Room\\Beginning\\Kill Pyrups & Gust Bellows | \\Sky\
+                      \ Keep\\Main\\Skyview Room\\End\\Lever"
+                  hint_region: Sky Keep
+                  locations:
+                    Free Rope: "\\Beetle | \\Bow"
+                    Kill Pyrups: "Bomb Bag | \\Hook Beetle | \\Bow"
+                    Left Exit: 'True'
+                  name: \Sky Keep\Main\Skyview Room\Beginning
+                  sub_areas: {}
+                  toplevel_alias: null
+                End:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Skyview Room\Beginning: \Sky Keep\Main\Skyview
+                      Room\End\Lever
+                  hint_region: Sky Keep
+                  locations:
+                    Lever: 'True'
+                    Top Exit: 'True'
+                  name: \Sky Keep\Main\Skyview Room\End
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            LMF Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Sky Keep
+              locations:
+                Finish Room: "(Gust Bellows | Sky Keep - Shooting LMF Bow Switches\
+                  \ in Present Trick) & \\Bow"
+                Bottom Exit: 'True'
+                Top Exit: \Sky Keep\Main\LMF Room\Finish Room
+              name: \Sky Keep\Main\LMF Room
+              sub_areas: {}
+              toplevel_alias: null
+            Earth Temple Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Sky Keep
+              locations:
+                Right Exit: 'False'
+                Top Exit: 'False'
+              name: \Sky Keep\Main\Earth Temple Room
+              sub_areas: {}
+              toplevel_alias: null
+            Mini Boss Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Sky Keep
+              locations: {}
+              name: \Sky Keep\Main\Mini Boss Room
+              sub_areas:
+                From Bottom:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Mini Boss Room\Near Chest: "\\Sky Keep\\Main\\\
+                      Mini Boss Room\\From Bottom\\Defeat Dreadfuse & Clawshots"
+                  hint_region: Sky Keep
+                  locations:
+                    Defeat Dreadfuse: \Can Defeat Scervo/Dreadfuse
+                    Bottom Exit: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat
+                      Dreadfuse
+                  name: \Sky Keep\Main\Mini Boss Room\From Bottom
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near Chest:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Mini Boss Room\From Left: \Sky Keep\Main\Mini Boss
+                      Room\Near Chest\Unlock Door
+                  hint_region: Sky Keep
+                  locations:
+                    Chest after Dreadfuse: 'True'
+                    Unlock Door: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat
+                      Dreadfuse
+                  name: \Sky Keep\Main\Mini Boss Room\Near Chest
+                  sub_areas: {}
+                  toplevel_alias: null
+                From Left:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Mini Boss Room\Near Chest: \Sky Keep\Main\Mini
+                      Boss Room\Near Chest\Unlock Door
+                  hint_region: Sky Keep
+                  locations:
+                    Left Exit: 'True'
+                  name: \Sky Keep\Main\Mini Boss Room\From Left
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Ancient Cistern Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky Keep\Main\Ancient Cistern Room\After Key: \Sky Keep\Main\Ancient
+                  Cistern Room\Unlock Key Door
+                \Sky Keep\Main\Ancient Cistern Room\Triforce Room: \Sky Keep\Main\Ancient
+                  Cistern Room\Triforce Room\Lever
+              hint_region: Sky Keep
+              locations:
+                Unlock Key Door: Sky Keep Small Key
+                Right Exit: 'True'
+                Bottom Exit: 'True'
+              name: \Sky Keep\Main\Ancient Cistern Room
+              sub_areas:
+                After Key:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Ancient Cistern Room\Triforce Room: \Sky Keep\Main\Ancient
+                      Cistern Room\After Key\Beat Trial
+                  hint_region: Sky Keep
+                  locations:
+                    Beat Trial: "\\Can Defeat Moblins & \\Can Defeat Bokoblins & \\\
+                      Can Defeat Stalfos & \\Bow & \\Can Defeat Cursed Bokoblins &\
+                      \ \\Can Defeat Stalmaster"
+                  name: \Sky Keep\Main\Ancient Cistern Room\After Key
+                  sub_areas: {}
+                  toplevel_alias: null
+                Triforce Room:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Ancient Cistern Room\After Key: 'True'
+                    \Sky Keep\Main\Ancient Cistern Room: \Sky Keep\Main\Ancient Cistern
+                      Room\Triforce Room\Lever
+                  hint_region: Sky Keep
+                  locations:
+                    Sacred Power of Farore: 'True'
+                    Lever: 'True'
+                  name: \Sky Keep\Main\Ancient Cistern Room\Triforce Room
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Fire Sanctuary Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Sky Keep
+              locations: {}
+              name: \Sky Keep\Main\Fire Sanctuary Room
+              sub_areas:
+                From Right:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Fire Sanctuary Room\First Platform: "\\Beetle |\
+                      \ \\Sky Keep\\Main\\Fire Sanctuary Room\\First Platform\\Lever"
+                    \Sky Keep\Main\Fire Sanctuary Room\OoB: "Clawshots & Sky Keep\
+                      \ - FS Room Clawshots Vine Clip Trick"
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: \Sky Keep\Main\Fire
+                      Sanctuary Room\Triforce Room\Upper Lever
+                  hint_region: Sky Keep
+                  locations:
+                    Right Exit: 'True'
+                  name: \Sky Keep\Main\Fire Sanctuary Room\From Right
+                  sub_areas: {}
+                  toplevel_alias: null
+                OoB:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: Clawshots
+                  hint_region: Sky Keep
+                  locations: {}
+                  name: \Sky Keep\Main\Fire Sanctuary Room\OoB
+                  sub_areas: {}
+                  toplevel_alias: null
+                First Platform:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: "\\Beetle &\
+                      \ Clawshots"
+                  hint_region: Sky Keep
+                  locations:
+                    Lever: 'True'
+                    Rupee in Fire Sanctuary Room in Alcove: \Beetle
+                  name: \Sky Keep\Main\Fire Sanctuary Room\First Platform
+                  sub_areas: {}
+                  toplevel_alias: null
+                Triforce Room:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Fire Sanctuary Room\From Left: \Sky Keep\Main\Fire
+                      Sanctuary Room\Triforce Room\Lower Lever
+                    \Sky Keep\Main\Fire Sanctuary Room\From Right: \Sky Keep\Main\Fire
+                      Sanctuary Room\Triforce Room\Upper Lever
+                  hint_region: Sky Keep
+                  locations:
+                    Sacred Power of Din: 'True'
+                    Lower Lever: 'True'
+                    Upper Lever: 'True'
+                  name: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room
+                  sub_areas: {}
+                  toplevel_alias: null
+                From Left:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: \Sky Keep\Main\Fire
+                      Sanctuary Room\Triforce Room\Lower Lever
+                  hint_region: Sky Keep
+                  locations:
+                    Left Exit: 'True'
+                  name: \Sky Keep\Main\Fire Sanctuary Room\From Left
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Sandship Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky Keep\Main\Sandship Room\Triforce Area: "\\Sky Keep\\Main\\Sandship\
+                  \ Room\\Lower Eye & Clawshots"
+              hint_region: Sky Keep
+              locations:
+                Higher Eye: \Bow
+                Lower Eye: "\\Sky Keep\\Main\\Sandship Room\\Higher Eye & \\Bow"
+                Left Exit: 'True'
+              name: \Sky Keep\Main\Sandship Room
+              sub_areas:
+                Triforce Area:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky Keep\Main\Sandship Room: 'True'
+                  hint_region: Sky Keep
+                  locations:
+                    Sacred Power of Nayru: 'True'
+                  name: \Sky Keep\Main\Sandship Room\Triforce Area
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Puzzle Solving Meta Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky Keep\Main\Skyview Room\Beginning: \Sky Keep\Main\First Room\Right
+                  Exit
+                \Sky Keep\Main\LMF Room: \Sky Keep\Main\Skyview Room\End\Top Exit
+                \Sky Keep\Main\Earth Temple Room: \Sky Keep\Main\LMF Room\Top Exit
+                \Sky Keep\Main\Mini Boss Room\From Bottom: \Sky Keep\Main\Fire Sanctuary
+                  Room\From Left\Left Exit
+                \Sky Keep\Main\Ancient Cistern Room: \Sky Keep\Main\LMF Room\Top Exit
+                \Sky Keep\Main\Fire Sanctuary Room\From Right: \Sky Keep\Main\Ancient
+                  Cistern Room\Bottom Exit
+                \Sky Keep\Main\Sandship Room: \Sky Keep\Main\Fire Sanctuary Room\From
+                  Left\Left Exit
+              hint_region: Sky Keep
+              locations: {}
+              name: \Sky Keep\Main\Puzzle Solving Meta Room
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Sky:
+      abstract: false
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Sky
+      locations: {}
+      name: \Sky
+      sub_areas:
+        North East:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits:
+            \Sky\North East\Beedle's Island\Top: 'True'
+            \Sky\North East\Beedle's Island\Cage: Sky - Beedle's Island Cage Chest
+              Dive Trick
+            \Sky\South East: 'True'
+            \Sky\Around Skyloft: 'True'
+            \Sky\North East\Eldin Pillar: 'True'
+            \Sky\North East\Bamboo Island: 'True'
+            \Sky\North East\Beedle's Island: 'True'
+          hint_region: Sky
+          locations:
+            Goddess Chest on Island next to Bamboo Island: \Eldin\Volcano\East\Goddess
+              Cube near Mogma Turf Entrance
+            Goddess Chest in Cave on Island next to Bamboo Island: "\\Lanayru\\Desert\\\
+              North Part\\Secret Passageway\\Goddess Cube in Secret Passageway & Water\
+              \ Dragon's Scale"
+            Northeast Island Goddess Chest behind Bombable Rocks: "\\Lanayru\\Mine\\\
+              Entry\\Goddess Cube at Lanayru Mine Entrance & Bomb Bag"
+            Northeast Island Cage Goddess Chest: \Eldin\Volcano\Near Temple Entrance\Goddess
+              Cube East of Earth Temple Entrance
+          name: \Sky\North East
+          sub_areas:
+            Eldin Pillar:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                First Time Dive: Ruby Tablet
+                Volcano Entrance Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\Entry\\\
+                  Unlock Statue"
+                Volcano East Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\East\\\
+                  Unlock Statue"
+                Volcano Ascent Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\Ascent\\\
+                  Unlock Statue"
+                Temple Entrance Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\Near\
+                  \ Temple Entrance\\Unlock Statue"
+                Inside the Volcano Statue Dive: "Ruby Tablet & \\Eldin\\Volcano Summit\\\
+                  Outside Fire Sanctuary\\Unlock Statue"
+                Fire Sanctuary Statue Dive: "Ruby Tablet & \\Fire Sanctuary\\Main\\\
+                  Front of Boss Door\\Unlock Statue"
+                \Sky\North East: 'True'
+              hint_region: Sky
+              locations: {}
+              name: \Sky\North East\Eldin Pillar
+              sub_areas: {}
+              toplevel_alias: null
+            Bamboo Island:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Inside: null
+              exits:
+                \Sky\North East: Day
+                Exit to Inside: 'True'
+              hint_region: Sky
+              locations:
+                Bamboo Island Goddess Chest: \Eldin\Volcano\Near Temple Entrance\Goddess
+                  Cube West of Earth Temple Entrance
+              name: \Sky\North East\Bamboo Island
+              sub_areas:
+                Inside:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance: null
+                  exits:
+                    Exit: 'True'
+                  hint_region: Sky
+                  locations:
+                    Clean Cut Minigame: \Sword
+                    Gossip Stone on Bamboo Island: 'True'
+                  name: \Sky\North East\Bamboo Island\Inside
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Beedle's Island:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Beedle's Ship Entrance: null
+              exits:
+                \Sky\North East: Day
+                Beedle's Ship Exit: Night
+                \Sky\North East\Beedle's Island\Cage: Night
+              hint_region: Sky
+              locations:
+                Crystal on Beedle's Ship: "Night & \\Beetle"
+                Beedle's Crystals: "Horned Colossus Beetle & Night"
+              name: \Sky\North East\Beedle's Island
+              sub_areas:
+                Top:
+                  abstract: false
+                  allowed_time_of_day: 3
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky\North East\Beedle's Island: 'True'
+                  hint_region: Sky
+                  locations:
+                    Beedle's Island Goddess Chest: \Lanayru\Temple of Time\Near Goddess
+                      Cube\Goddess Cube at Ride near Temple of Time
+                  name: \Sky\North East\Beedle's Island\Top
+                  sub_areas: {}
+                  toplevel_alias: null
+                Cage:
+                  abstract: false
+                  allowed_time_of_day: 3
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Sky\North East\Beedle's Island: 'True'
+                  hint_region: Sky
+                  locations:
+                    Beedle's Island Cage Goddess Chest: \Faron\Faron Woods\Deep Woods\Goddess
+                      Cube on top of Skyview
+                  name: \Sky\North East\Beedle's Island\Cage
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+        South East:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits:
+            \Sky\North East: 'True'
+            \Sky\South West: 'True'
+            \Sky\Around Skyloft: 'True'
+            \Sky\South East\Faron Pillar: 'True'
+            \Sky\South East\Lumpy Pumpkin: 'True'
+          hint_region: Sky
+          locations:
+            Chest in Breakable Boulder near Lumpy Pumpkin: Spiral Charge
+            Goddess Chest on Island Closest to Faron Pillar: \Faron\Faron Woods\Deep
+              Woods\Goddess Cube in Deep Woods
+          name: \Sky\South East
+          sub_areas:
+            Faron Pillar:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                First Time Dive: Emerald Tablet
+                Sealed Grounds Statue Dive: "Emerald Tablet & \\Faron\\Sealed Grounds\\\
+                  Spiral\\Upper Part\\Unlock Statue"
+                Behind the Temple Statue Dive: "Emerald Tablet & \\Faron\\Sealed Grounds\\\
+                  Behind the Temple\\Unlock Statue"
+                Faron Woods Entry Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
+                  Entry\\Unlock Statue"
+                Viewing Platform Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
+                  Unlock Viewing Platform Statue"
+                In the Woods Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
+                  Unlock In the Woods Statue"
+                Deep Woods Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\Deep\
+                  \ Woods\\Unlock Deep Woods Statue"
+                Forest Temple Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
+                  Deep Woods\\Unlock Forest Temple Statue"
+                The Great Tree Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
+                  Great Tree\\Top\\Unlock Statue"
+                Lake Floria Statue Dive: "Emerald Tablet & \\Faron\\Lake Floria\\\
+                  Below Rock\\Emerged Area\\Unlock Statue"
+                Floria Waterfall Statue Dive: "Emerald Tablet & \\Faron\\Lake Floria\\\
+                  Waterfall\\Unlock Statue"
+                \Sky\South East: 'True'
+              hint_region: Sky
+              locations: {}
+              name: \Sky\South East\Faron Pillar
+              sub_areas: {}
+              toplevel_alias: null
+            Lumpy Pumpkin:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Right Door Entrance: null
+                Main Left Door Entrance: null
+                Back Door Entrance: null
+              exits:
+                \Sky\South East: Day
+                Main Right Door Exit: 'True'
+                Main Left Door Exit: 'True'
+                Back Door Exit: 'True'
+              hint_region: Sky
+              locations:
+                Crystal outside Lumpy Pumpkin: Night
+                Outside Goddess Chest: \Faron\Faron Woods\Deep Woods\Initial Goddess
+                  Cube
+                Goddess Chest on the Roof: "\\Skyview\\Spring\\Goddess Cube in Skyview\
+                  \ Spring & Day"
+                Start Kina's Quest: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy Pumpkin\
+                  \ Building\\Complete Hot Soup Delivery & Day"
+                Kina's Crystals: "\\Eldin\\Mogma Turf\\Pre Vent\\Pick up Guld & Day"
+                Gossip Stone on Lumpy Pumpkin: 'True'
+                Pumpkin Carrying: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy Pumpkin\
+                  \ Building\\Complete Hot Soup Delivery & Day"
+              name: \Sky\South East\Lumpy Pumpkin
+              sub_areas:
+                Lumpy Pumpkin Building:
+                  abstract: false
+                  allowed_time_of_day: 3
+                  can_save: false
+                  can_sleep: true
+                  entrances: !!set
+                    Main Right Door Entrance: null
+                    Main Left Door Entrance: null
+                    Back Door Entrance: null
+                  exits:
+                    Main Right Door Exit: 'True'
+                    Main Left Door Exit: 'True'
+                    Back Door Exit: 'True'
+                  hint_region: Sky
+                  locations:
+                    Chandelier: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Break
+                      the Chandelier
+                    Crystal inside Lumpy Pumpkin: Night
+                    Break the Chandelier: 'True'
+                    Start Hot Soup Delivery: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy\
+                      \ Pumpkin Building\\Break the Chandelier & \\Bottle"
+                    Complete Hot Soup Delivery: \Skyloft\Upper Skyloft\Sparring Hall\Delivered
+                      Hot Soup
+                    Play the Harp with Kina: "\\Sky\\South East\\Lumpy Pumpkin\\Pumpkin\
+                      \ Carrying & Goddess's Harp & Night"
+                    Harp Minigame: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Play
+                      the Harp with Kina
+                    Pick up Levias' Soup: Spiral Charge
+                  name: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+        South West:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits:
+            \Sky\South East: 'True'
+            \Sky\Around Skyloft: 'True'
+            \Sky\South West\Lanayru Pillar: 'True'
+            \Sky\South West\Volcanic Island: 'True'
+            \Sky\South West\Orielle's Island: 'True'
+            \Sky\South West\Fun Fun Island: 'True'
+            \Sky\South West\Triple Island: 'True'
+          hint_region: Sky
+          locations:
+            Chest in Breakable Boulder near Fun Fun Island: Spiral Charge
+          name: \Sky\South West
+          sub_areas:
+            Lanayru Pillar:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                First Time Dive: Amber Tablet
+                Lanayru Mine Entry Statue Dive: "Amber Tablet & \\Lanayru\\Mine\\\
+                  Entry\\Unlock Statue"
+                Desert Entrance Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\Entry\\\
+                  Unlock Statue"
+                West Desert Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\West Part\\\
+                  Unlock Statue"
+                Desert Gorge Statue Dive: "Amber Tablet & \\Lanayru\\Temple of Time\\\
+                  South East\\Unlock Statue"
+                Temple of Time Statue Dive: "Amber Tablet & \\Lanayru\\Temple of Time\\\
+                  Inside\\Unlock Statue"
+                North Desert Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\North\
+                  \ Part\\Unlock Statue"
+                Stone Cache Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\East\\\
+                  Unlock Statue"
+                Ancient Harbour Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru Sand\
+                  \ Sea\\Ancient Harbour\\Unlock Statue"
+                Skipper's Retreat Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru\
+                  \ Sand Sea\\Skipper's Retreat\\Unlock Statue"
+                Shipyard Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru Sand Sea\\\
+                  Shipyard\\Unlock Statue"
+                Pirate Stronghold Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru\
+                  \ Sand Sea\\Pirate Stronghold\\Unlock Statue"
+                Lanayru Gorge Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru Sand\
+                  \ Sea\\Gorge\\Unlock Statue"
+                \Sky\South West: 'True'
+              hint_region: Sky
+              locations: {}
+              name: \Sky\South West\Lanayru Pillar
+              sub_areas: {}
+              toplevel_alias: null
+            Volcanic Island:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\South West: Day
+              hint_region: Sky
+              locations:
+                Goddess Chest outside Volcanic Island: \Lanayru\Desert\Sand Oasis\Goddess
+                  Cube in Sand Oasis
+                Goddess Chest inside Volcanic Island: "\\Faron\\Faron Woods\\Clawshot\
+                  \ Target Branch\\Goddess Cube on East Great Tree with Clawshots\
+                  \ Target & (Clawshots | Sky - Volcanic Island Dive Trick)"
+                Gossip Stone on Volcanic Island: 'True'
+              name: \Sky\South West\Volcanic Island
+              sub_areas: {}
+              toplevel_alias: null
+            Orielle's Island:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\South West: Day
+              hint_region: Sky
+              locations:
+                Talk to Orielle: 'True'
+                Save Orielle: \Bottle
+                Orielle's Crystals: \Sky\South West\Orielle's Island\Save Orielle
+              name: \Sky\South West\Orielle's Island
+              sub_areas: {}
+              toplevel_alias: null
+            Fun Fun Island:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\South West: Day
+              hint_region: Sky
+              locations:
+                Start Dodoh's Quest: 'True'
+                Dodoh's Crystals: \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve
+                  Party Wheel
+                Fun Fun Island Minigame -- 500 Rupees: \Sky\South West\Fun Fun Island\Fun
+                  Fun Island Minigame
+                Goddess Chest under Fun Fun Island: \Faron\Lake Floria\Waterfall\Goddess
+                  Cube in Floria Waterfall
+                Fun Fun Island Minigame: \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve
+                  Party Wheel
+              name: \Sky\South West\Fun Fun Island
+              sub_areas: {}
+              toplevel_alias: null
+            Triple Island:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\South West: Day
+              hint_region: Sky
+              locations:
+                Southwest Triple Island Upper Goddess Chest: \Eldin\Volcano\Entry\Goddess
+                  Cube at Eldin Entrance
+                Southwest Triple Island Lower Goddess Chest: \Lanayru\Desert\Near
+                  Caged Robot\Goddess Cube near Caged Robot
+                Southwest Triple Island Cage Goddess Chest: "\\Lanayru\\Lanayru Sand\
+                  \ Sea\\Skipper's Retreat\\Past Rock\\Goddess Cube in Skipper's Retreat\
+                  \ & Clawshots"
+              name: \Sky\South West\Triple Island
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Around Skyloft:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Skyloft: null
+            Entrance from Thunderhead: null
+          exits:
+            \Sky\North East: 'True'
+            \Sky\South West: 'True'
+            \Sky\South East: 'True'
+            Exit to Thunderhead: "Open Thunderhead option | Ballad of the Goddess"
+            Exit to Skyloft: 'True'
+          hint_region: Sky
+          locations: {}
+          name: \Sky\Around Skyloft
+          sub_areas: {}
+          toplevel_alias: null
+        Thunderhead:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: 'True'
+            \Sky\Thunderhead\Isle of Songs: 'True'
+            \Sky\Thunderhead\East Island: 'True'
+            \Sky\Thunderhead\Mogma Mitts Island: 'True'
+            \Sky\Thunderhead\Bug Heaven: 'True'
+          hint_region: Thunderhead
+          locations:
+            Song from Levias: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy Pumpkin Building\\\
+              Pick up Levias' Soup & Spiral Charge & Scrapper & \\Sword"
+          name: \Sky\Thunderhead
+          sub_areas:
+            Isle of Songs:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Inside: null
+              exits:
+                \Sky\Thunderhead: Day
+                Exit to Inside: \Sky\Thunderhead\Isle of Songs\Puzzle Solved
+              hint_region: Thunderhead
+              locations:
+                Goddess Chest outside Isle of Songs: \Eldin\Mogma Turf\Pre Vent\Goddess
+                  Cube in Mogma Turf
+                Goddess Chest on top of Isle of Songs: \Eldin\Volcano Summit\Outside
+                  Fire Sanctuary\Goddess Cube near Fire Sanctuary Entrance
+                Puzzle Solved: 'True'
+              name: \Sky\Thunderhead\Isle of Songs
+              sub_areas:
+                Inside:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Entrance: null
+                  exits:
+                    Exit: 'True'
+                  hint_region: Thunderhead
+                  locations:
+                    Strike Crest with Goddess Sword: \Goddess Sword
+                    Strike Crest with Longsword: \Goddess Longsword
+                    Strike Crest with White Sword: \Goddess White Sword
+                  name: \Sky\Thunderhead\Isle of Songs\Inside
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            East Island:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\Thunderhead: Day
+              hint_region: Thunderhead
+              locations:
+                East Island Goddess Chest: \Faron\Faron Woods\Rope Branch\Goddess
+                  Cube on East Great Tree with Rope
+                East Island Chest: "\\Digging Mitts | Thunderhead - East Island Dive\
+                  \ Trick"
+              name: \Sky\Thunderhead\East Island
+              sub_areas: {}
+              toplevel_alias: null
+            Mogma Mitts Island:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\Thunderhead: Day
+              hint_region: Thunderhead
+              locations:
+                First Goddess Chest on Mogma Mitts Island: "\\Eldin\\Volcano Summit\\\
+                  Goddess Cube inside Volcano Summit & \\Mogma Mitts"
+                Second Goddess Chest on Mogma Mitts Island: "\\Lanayru\\Lanayru Sand\
+                  \ Sea\\Gorge\\Beyond Bridge\\Goddess Cube in Lanayru Gorge & \\\
+                  Mogma Mitts"
+              name: \Sky\Thunderhead\Mogma Mitts Island
+              sub_areas: {}
+              toplevel_alias: null
+            Bug Heaven:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Sky\Thunderhead: Day
+              hint_region: Thunderhead
+              locations:
+                Bug Heaven -- 10 Bugs in 3 Minutes: \Bug Net
+                Bug Heaven Goddess Chest: \Eldin\Volcano Summit\Waterfall\Goddess
+                  Cube in Summit Waterfall
+                Gossip Stone near Bug Heaven: 'True'
+              name: \Sky\Thunderhead\Bug Heaven
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+      toplevel_alias: null
+    Skyloft:
+      abstract: false
+      allowed_time_of_day: 3
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: null
+      locations: {}
+      name: \Skyloft
+      sub_areas:
+        Upper Skyloft:
+          abstract: false
+          allowed_time_of_day: 3
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Sparring Hall Right Door Entrance: null
+            Goddess Statue Entrance: null
+            Knight Academy Upper Left Door Entrance: null
+            Knight Academy Lower Left Door Entrance: null
+            Sparring Hall Left Door Entrance: null
+            Knight Academy Lower Right Door Entrance: null
+            Knight Academy Upper Right Door Entrance: null
+          exits:
+            Knight Academy Upper Right Door Exit: 'True'
+            Knight Academy Upper Left Door Exit: 'True'
+            Knight Academy Lower Right Door Exit: Day
+            Knight Academy Lower Left Door Exit: Day
+            Knight Academy Chimney Entrance: Clawshots
+            Sparring Hall Right Door Exit: 'True'
+            Sparring Hall Left Door Exit: 'True'
+            Goddess Statue Exit: 'True'
+            \Skyloft\Central Skyloft: 'True'
+          hint_region: Upper Skyloft
+          locations:
+            Owlan's Gift: Day
+            Chest near Goddess Statue: 'True'
+            Pumpkin Archery -- 600 Points: "\\Bow & Day"
+          name: \Skyloft\Upper Skyloft
+          sub_areas:
+            Knight Academy:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Lower Left Door Entrance: null
+                Upper Left Door Entrance: null
+                Upper Right Door Entrance: null
+                Lower Right Door Entrance: null
+              exits:
+                Upper Right Door Exit: 'True'
+                Upper Left Door Exit: 'True'
+                Lower Right Door Exit: Day
+                Lower Left Door Exit: Day
+                \Skyloft\Upper Skyloft\Knight Academy\Link's Room: 'True'
+                \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room: \Skyloft\Upper
+                  Skyloft\Knight Academy\Zelda's Room\Unlocked Zelda's Room
+              hint_region: Upper Skyloft
+              locations:
+                Fledge's Gift: 'True'
+                Crystal in Knight Academy Plant: Night
+                Start Owlan's Quest: \Faron\Faron Woods\All Kikwis Saved
+                Owlan's Crystals: "\\Faron\\Faron Woods\\Behind the Crawlspace and\
+                  \ Rope\\Retrieve Oolo & Day"
+                Knock on Toilet Door: "Goddess's Harp & Night"
+                Item from Cawlin: "\\Skyloft\\Upper Skyloft\\Knight Academy\\Knock\
+                  \ on Toilet Door & Day"
+                Ghost/Pipit's Crystals: "Cawlin's Letter & Day"
+                Fledge's Crystals: "\\Skyloft\\Central Skyloft\\Bazaar\\Endurance\
+                  \ Potion & Night"
+              name: \Skyloft\Upper Skyloft\Knight Academy
+              sub_areas:
+                Link's Room:
+                  abstract: false
+                  allowed_time_of_day: 3
+                  can_save: false
+                  can_sleep: true
+                  entrances: !!set
+                    Start Entrance: null
+                  exits:
+                    \Skyloft\Upper Skyloft\Knight Academy: 'True'
+                  hint_region: Upper Skyloft
+                  locations:
+                    Crystal in Link's Room: Night
+                  name: \Skyloft\Upper Skyloft\Knight Academy\Link's Room
+                  sub_areas: {}
+                  toplevel_alias: null
+                Zelda's Room:
+                  abstract: false
+                  allowed_time_of_day: 3
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Chimney: null
+                  exits:
+                    \Skyloft\Upper Skyloft\Knight Academy: 'True'
+                  hint_region: Upper Skyloft
+                  locations:
+                    Unlocked Zelda's Room: 'True'
+                    Crystal in Zelda's Room: Night
+                    In Zelda's Closet: 'True'
+                  name: \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Sparring Hall:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Right Door Entrance: null
+                Left Door Entrance: null
+              exits:
+                Right Door Exit: 'True'
+                Left Door Exit: 'True'
+              hint_region: Upper Skyloft
+              locations:
+                Crystal in Sparring Hall: "\\Beetle & Night"
+                Sparring Hall Chest: 'True'
+                Delivered Hot Soup: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Start
+                  Hot Soup Delivery
+              name: \Skyloft\Upper Skyloft\Sparring Hall
+              sub_areas: {}
+              toplevel_alias: null
+            Goddess Statue:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Upper Skyloft
+              locations:
+                First Goddess Sword Item in Goddess Statue: 'True'
+                Second Goddess Sword Item in Goddess Statue: 'True'
+              name: \Skyloft\Upper Skyloft\Goddess Statue
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Central Skyloft:
+          abstract: false
+          allowed_time_of_day: 3
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Waterfall Cave Upper Entrance: null
+            Entrance from Beedle's Shop: null
+            Bazaar West Entrance: null
+            Wryna's House Entrance: null
+            Peatrice's House Entrance: null
+            Orielle and Parrow's House Entrance: null
+            Bazaar South Entrance: null
+            Trial Gate Entrance: null
+            Piper's House Entrance: null
+            Entrance from Sky: null
+            Bazaar North Entrance: null
+          exits:
+            Exit to Beedle's Shop: "Day & (\\Distance Activator | Beedle's Shop With\
+              \ Bombs Trick & Bomb Bag)"
+            Bazaar North Exit: Day
+            Bazaar West Exit: Day
+            Bazaar South Exit: Day
+            Trial Gate Exit: \Skyloft\Central Skyloft\Open Trial Gate
+            Orielle and Parrow's House Exit: 'True'
+            Peatrice's House Exit: 'True'
+            Wryna's House Exit: 'True'
+            Piper's House Exit: 'True'
+            Exit to Sky: Day
+            \Skyloft\Upper Skyloft: 'True'
+            \Skyloft\Skyloft Village: 'True'
+            \Skyloft\Central Skyloft\Near Temple Entrance: "Day & Clawshots"
+            \Skyloft\Central Skyloft\Waterfall Island: Clawshots
+            Waterfall Cave Upper Exit: \Skyloft\Central Skyloft\Open Cave Entrance
+          hint_region: Central Skyloft
+          locations:
+            Crystal between Wooden Planks: Night
+            Crystal on West Cliff: Night
+            Crystal on Light Tower: Night
+            West Cliff Goddess Chest: \Faron\Faron Woods\West Branch\Goddess Cube
+              on West Great Tree near Exit
+            Parrow's Gift: "\\Sky\\South West\\Orielle's Island\\Talk to Orielle &\
+              \ Day"
+            Parrow's Crystals: "\\Sky\\South West\\Orielle's Island\\Save Orielle\
+              \ & Day"
+            Shed Chest: Water Dragon's Scale
+            Shed Goddess Chest: "Water Dragon's Scale & \\Eldin\\Volcano\\Sand Slide\\\
+              Goddess Cube on Sand Slide"
+            \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest: "Baby Rattle from\
+              \ Beedle's Shop Trick & Day & \\Distance Activator & Gust Bellows &\
+              \ (\\Beetle | Whip)"
+            Open Trial Gate: "Goddess's Harp & \\Song of the Hero"
+            \Can Collect Water: 'True'
+            Waterfall Cave Crystals from above: \Beetle
+            Crystal on Waterfall Island from the ground: \Quick Beetle
+            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: "Night\
+              \ & \\Skyloft\\Central Skyloft\\Waterfall Cave Crystals from above"
+            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: "Night\
+              \ & \\Skyloft\\Central Skyloft\\Waterfall Cave Crystals from above"
+            Crystal on Waterfall Island: "Night & \\Skyloft\\Central Skyloft\\Crystal\
+              \ on Waterfall Island from the ground"
+            Open Cave Entrance: "\\Sword | Bomb Bag"
+          name: \Skyloft\Central Skyloft
+          sub_areas:
+            Bird Nest:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyloft\Central Skyloft: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Item in Bird Nest: Gust Bellows
+              name: \Skyloft\Central Skyloft\Bird Nest
+              sub_areas: {}
+              toplevel_alias: null
+            Bazaar:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                North Entrance: null
+                South Entrance: null
+                West Entrance: null
+              exits:
+                North Exit: 'True'
+                West Exit: 'True'
+                South Exit: 'True'
+                \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades: Gondo Upgrades On
+                  option
+              hint_region: Central Skyloft
+              locations:
+                Potion Lady's Gift: 'True'
+                Repair Gondo's Junk: \Ancient Flower Farming
+                Bazaar Goddess Chest: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Goddess
+                  Cube in Ancient Harbour
+                Endurance Potion: "\\Bottle & \\Lanayru\\Raise Lanayru Mining Facility"
+                Talk to Peatrice: 'True'
+                Item Check Access: 'True'
+              name: \Skyloft\Central Skyloft\Bazaar
+              sub_areas:
+                Gondo's Upgrades:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyloft\Central Skyloft\Bazaar: 'True'
+                  hint_region: Central Skyloft
+                  locations:
+                    Upgrade to Quick Beetle: "\\Hook Beetle & \\Faron\\Faron Woods\\\
+                      Deep Woods\\Entry\\Hornet Larvae Farming & \\Ancient Flower\
+                      \ Farming & \\Sky\\North East\\Bamboo Island\\Inside\\Clean\
+                      \ Cut Minigame"
+                    Upgrade to Tough Beetle: "\\Quick Beetle & \\Faron\\Faron Woods\\\
+                      Amber Relic Farming & \\Ancient Flower Farming & \\Sky\\North\
+                      \ East\\Bamboo Island\\Inside\\Clean Cut Minigame"
+                  name: \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Orielle and Parrow's House:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Crystal in Orielle and Parrow's House: 'True'
+                Parrow's Gift: "\\Sky\\South West\\Orielle's Island\\Talk to Orielle\
+                  \ & Night"
+                Parrow's Crystals: "\\Sky\\South West\\Orielle's Island\\Save Orielle\
+                  \ & Night"
+              name: \Skyloft\Central Skyloft\Orielle and Parrow's House
+              sub_areas: {}
+              toplevel_alias: null
+            Peatrice's House:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Peater/Peatrice's Crystals: "\\Skyloft\\Central Skyloft\\Bazaar\\\
+                  Talk to Peatrice & Night"
+              name: \Skyloft\Central Skyloft\Peatrice's House
+              sub_areas: {}
+              toplevel_alias: null
+            Wryna's House:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Wryna's Crystals: 'True'
+              name: \Skyloft\Central Skyloft\Wryna's House
+              sub_areas: {}
+              toplevel_alias: null
+            Piper's House:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Central Skyloft
+              locations: {}
+              name: \Skyloft\Central Skyloft\Piper's House
+              sub_areas: {}
+              toplevel_alias: null
+            Near Temple Entrance:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance from Sky Keep: null
+              exits:
+                Exit to Sky Keep: Stone of Trials
+                \Skyloft\Central Skyloft: Clawshots
+              hint_region: Central Skyloft
+              locations: {}
+              name: \Skyloft\Central Skyloft\Near Temple Entrance
+              sub_areas: {}
+              toplevel_alias: null
+            Waterfall Island:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyloft\Central Skyloft: 'True'
+                \Skyloft\Skyloft Village: 'True'
+                \Skyloft\Central Skyloft\Bird Nest: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Crystal on Waterfall Island: Night
+                Waterfall Goddess Chest: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside
+                  the Shark Head\Goddess Cube in Pirate Stronghold
+                Floating Island Goddess Chest: \Faron\Lake Floria\Below Rock\Emerged
+                  Area\Goddess Cube in Lake Floria
+                Gossip Stone on Waterfall Island: 'True'
+              name: \Skyloft\Central Skyloft\Waterfall Island
+              sub_areas: {}
+              toplevel_alias: null
+            Waterfall Cave:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Lower Entrance: null
+                Upper Entrance: null
+              exits:
+                Upper Exit: 'True'
+                Lower Exit: 'True'
+              hint_region: Central Skyloft
+              locations:
+                Waterfall Cave First Chest: 'True'
+                Waterfall Cave Second Chest: 'True'
+                Rupee Waterfall Cave Crawlspace: 'True'
+              name: \Skyloft\Central Skyloft\Waterfall Cave
+              sub_areas: {}
+              toplevel_alias: null
+            Past Waterfall Cave:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Waterfall Cave Lower Entrance: null
+              exits:
+                Waterfall Cave Lower Exit: 'True'
+                \Skyloft\Central Skyloft\Exit to Sky: Day
+              hint_region: Central Skyloft
+              locations:
+                Crystal after Waterfall Cave: Night
+                Crystal in Loftwing Prison: Night
+              name: \Skyloft\Central Skyloft\Past Waterfall Cave
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Skyloft Silent Realm:
+          abstract: false
+          allowed_time_of_day: 3
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: 'True'
+          hint_region: Skyloft Silent Realm
+          locations:
+            Trial Reward: 'True'
+            Relic 1: 'True'
+            Relic 2: 'True'
+            Relic 3: 'True'
+            Relic 4: 'True'
+            Relic 5: 'True'
+            Relic 6: 'True'
+            Relic 7: 'True'
+            Relic 8: 'True'
+            Relic 9: 'True'
+            Relic 10: 'True'
+          name: \Skyloft\Skyloft Silent Realm
+          sub_areas: {}
+          toplevel_alias: null
+        Skyloft Village:
+          abstract: false
+          allowed_time_of_day: 3
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Gondo's House Entrance: null
+            Rupin's House Entrance: null
+            Bertie's House Entrance: null
+            Mallara's House Entrance: null
+            Sparrot's House Entrance: null
+            Batreaux's House Entrance: null
+          exits:
+            \Skyloft\Central Skyloft: 'True'
+            \Skyloft\Central Skyloft\Past Waterfall Cave: "Waterfall Cave Jump Trick\
+              \ & Day"
+            Bertie's House Exit: 'True'
+            Sparrot's House Exit: 'True'
+            Mallara's House Exit: 'True'
+            Gondo's House Exit: 'True'
+            Rupin's House Exit: 'True'
+            Batreaux's House Exit: "\\Skyloft\\Skyloft Village\\Opened Shed | Gravestone\
+              \ Jump Trick"
+            \Skyloft\Central Skyloft\Exit to Sky: Day
+          hint_region: Skyloft Village
+          locations:
+            Crystal near Pumpkin Patch: Night
+            Opened Shed: Night
+          name: \Skyloft\Skyloft Village
+          sub_areas:
+            Bertie's House:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Skyloft Village
+              locations:
+                Bertie's Crystals: "Baby Rattle & Night"
+              name: \Skyloft\Skyloft Village\Bertie's House
+              sub_areas: {}
+              toplevel_alias: null
+            Sparrot's House:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Skyloft Village
+              locations:
+                Start Sparrot's Quest: 'True'
+                Sparrot's Crystals: \Eldin\Volcano\Near Temple Entrance\Retrieve Crystal
+                  Ball
+              name: \Skyloft\Skyloft Village\Sparrot's House
+              sub_areas: {}
+              toplevel_alias: null
+            Mallara's House:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Skyloft Village
+              locations:
+                Mallara's Crystals: Gust Bellows
+              name: \Skyloft\Skyloft Village\Mallara's House
+              sub_areas: {}
+              toplevel_alias: null
+            Gondo's House:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Skyloft Village
+              locations: {}
+              name: \Skyloft\Skyloft Village\Gondo's House
+              sub_areas: {}
+              toplevel_alias: null
+            Rupin's House:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: true
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Skyloft Village
+              locations: {}
+              name: \Skyloft\Skyloft Village\Rupin's House
+              sub_areas: {}
+              toplevel_alias: null
+            Batreaux's House:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Entrance: null
+              exits:
+                Exit: 'True'
+              hint_region: Batreaux's House
+              locations:
+                5 Crystals: \5 Gratitude Crystals
+                10 Crystals: \10 Gratitude Crystals
+                30 Crystals: \30 Gratitude Crystals
+                30 Crystals Chest: \30 Gratitude Crystals
+                40 Crystals: \40 Gratitude Crystals
+                50 Crystals: \50 Gratitude Crystals
+                70 Crystals: \70 Gratitude Crystals
+                70 Crystals Second Reward: \70 Gratitude Crystals
+                80 Crystals: \80 Gratitude Crystals
+              name: \Skyloft\Skyloft Village\Batreaux's House
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: null
+        Beedle's Shop:
+          abstract: false
+          allowed_time_of_day: 3
+          can_save: false
+          can_sleep: true
+          entrances: !!set
+            Night Entrance: null
+            Day Entrance: null
+          exits:
+            Night Exit: Night
+            Day Exit: Day
+            \Skyloft\Beedle's Shop\Stall: Day
+          hint_region: Beedle's Shop
+          locations: {}
+          name: \Skyloft\Beedle's Shop
+          sub_areas:
+            Stall:
+              abstract: false
+              allowed_time_of_day: 3
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyloft\Beedle's Shop: 'True'
+              hint_region: Beedle's Shop
+              locations:
+                300 Rupee Item: "\\Can Afford 300 Rupees & (\\Pouch | Randomized Beedle\
+                  \ option)"
+                600 Rupee Item: \Can Afford 600 Rupees
+                1200 Rupee Item: \Can Afford 1200 Rupees
+                800 Rupee Item: \Can Afford 800 Rupees
+                1600 Rupee Item: \Can Afford 1600 Rupees
+                First 100 Rupee Item: \Can Afford 100 Rupees
+                Second 100 Rupee Item: \Can Afford 100 Rupees
+                Third 100 Rupee Item: "\\Can Afford 100 Rupees & \\Can Medium Rupee\
+                  \ Farm"
+                50 Rupee Item: \Can Afford 50 Rupees
+                1000 Rupee Item: \Can Afford 1000 Rupees
+              name: \Skyloft\Beedle's Shop\Stall
+              sub_areas: {}
+              toplevel_alias: null
+          toplevel_alias: Beedle
+      toplevel_alias: null
+    Skyview:
+      abstract: true
+      allowed_time_of_day: 1
+      can_save: false
+      can_sleep: false
+      entrances: !!set {}
+      exits: {}
+      hint_region: Skyview
+      locations:
+        Skyview 2: Water Dragon's Scale
+        Can Hit High Skyview Switches: "\\Distance Activator | Bomb Bag & Bomb Throws\
+          \ Trick"
+        Can Cut Tree: "\\Sword | Bomb Bag"
+      name: \Skyview
+      sub_areas:
+        Main:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set {}
+          exits: {}
+          hint_region: Skyview
+          locations: {}
+          name: \Skyview\Main
+          sub_areas:
+            Entry:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set
+                Main Entrance: null
+              exits:
+                Main Exit: 'True'
+                \Skyview\Main\First Room: \Skyview\Main\Entry\Cut Tree
+              hint_region: Skyview
+              locations:
+                Cut Tree: \Skyview\Can Cut Tree
+              name: \Skyview\Main\Entry
+              sub_areas: {}
+              toplevel_alias: null
+            First Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyview\Main\Entry: \Skyview\Main\Entry\Cut Tree
+                \Skyview\Main\One Eye Room: \Skyview\Main\First Room\Switch to One
+                  Eye Room
+                \Skyview\Main\First Hub: \Skyview\Main\First Room\Destroy Barricade
+              hint_region: Skyview
+              locations:
+                \Skyview\Main\Entry\Cut Tree: \Skyview\Can Cut Tree
+                Destroy Barricade: "\\Skyview\\Skyview 2 | Bomb Bag"
+                Switch to One Eye Room: \Skyview\Can Hit High Skyview Switches
+                Goddess Wall Trigger: "Ballad of the Goddess & Goddess's Harp"
+              name: \Skyview\Main\First Room
+              sub_areas: {}
+              toplevel_alias: null
+            One Eye Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyview\Main\First Room: \Skyview\Main\First Room\Switch to One Eye
+                  Room
+                \Skyview\Main\First Hub: \Skyview\Main\One Eye Room\Unlock Door to
+                  First Hub
+              hint_region: Skyview
+              locations:
+                Unlock Door to First Hub: \Sword
+              name: \Skyview\Main\One Eye Room
+              sub_areas: {}
+              toplevel_alias: null
+            First Hub:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyview\Main\One Eye Room: \Skyview\Main\One Eye Room\Unlock Door
+                  to First Hub
+                \Skyview\Main\First Room: \Skyview\Main\First Room\Destroy Barricade
+                \Skyview\Main\First Hub\Left Room: \Skyview\Main\First Hub\Switch
+                  to Left Room
+                \Skyview\Main\First Hub\Right Room\Lower Area: \Skyview\Main\First
+                  Hub\Switch to Right Room
+                \Skyview\Main\First Hub\Right Room\Upper Area: "\\Skyview\\Main\\\
+                  First Hub\\Left Room\\Raise Water & \\Skyview\\Main\\First Hub\\\
+                  Right Room\\After Crawlspace\\Raise Water | Clawshots"
+                \Skyview\Main\Second Hub: "\\Skyview\\Main\\First Hub\\One Water Raise\
+                  \ & Skyview Small Key"
+              hint_region: Skyview
+              locations:
+                \Skyview\Main\First Room\Destroy Barricade: 'True'
+                Switch to Left Room: "\\Can Hit Switch | \\Skyview\\Main\\First Hub\\\
+                  One Water Raise & Water Dragon's Scale"
+                Switch to Right Room: \Skyview\Can Hit High Skyview Switches
+                One Water Raise: "\\Skyview\\Main\\First Hub\\Left Room\\Raise Water\
+                  \ | \\Skyview\\Main\\First Hub\\Right Room\\After Crawlspace\\Raise\
+                  \ Water"
+              name: \Skyview\Main\First Hub
+              sub_areas:
+                Left Room:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\First Hub: 'True'
+                  hint_region: Skyview
+                  locations:
+                    Hit Vines: "\\Skyview\\Can Hit High Skyview Switches | \\Goddess\
+                      \ Sword | Whip"
+                    Spider Roll: Skyview - Spider Roll Trick
+                    Raise Water: "\\Skyview\\Main\\First Hub\\Left Room\\Hit Vines\
+                      \ & \\Can Hit Switch | \\Skyview\\Main\\First Hub\\Left Room\\\
+                      Spider Roll & \\Skyview\\Can Hit High Skyview Switches"
+                    Chest on Tree Branch: "\\Skyview\\Main\\First Hub\\Left Room\\\
+                      Hit Vines | \\Skyview\\Main\\First Hub\\Left Room\\Spider Roll"
+                  name: \Skyview\Main\First Hub\Left Room
+                  sub_areas: {}
+                  toplevel_alias: null
+                Right Room:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits: {}
+                  hint_region: Skyview
+                  locations: {}
+                  name: \Skyview\Main\First Hub\Right Room
+                  sub_areas:
+                    Lower Area:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Skyview\Main\First Hub: 'True'
+                        \Skyview\Main\First Hub\Right Room\After Crawlspace: 'True'
+                        \Skyview\Main\First Hub\Right Room\After Crawlspace\With Water: Water
+                          Dragon's Scale
+                      hint_region: Skyview
+                      locations: {}
+                      name: \Skyview\Main\First Hub\Right Room\Lower Area
+                      sub_areas: {}
+                      toplevel_alias: null
+                    After Crawlspace:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
+                      hint_region: Skyview
+                      locations:
+                        Raise Water: \Skyview\Can Hit High Skyview Switches
+                        Digging Spot in Crawlspace: 'False'
+                      name: \Skyview\Main\First Hub\Right Room\After Crawlspace
+                      sub_areas:
+                        With Water:
+                          abstract: false
+                          allowed_time_of_day: 1
+                          can_save: false
+                          can_sleep: false
+                          entrances: !!set {}
+                          exits:
+                            \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
+                          hint_region: Skyview
+                          locations:
+                            \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace: \Digging
+                              Mitts
+                          name: \Skyview\Main\First Hub\Right Room\After Crawlspace\With
+                            Water
+                          sub_areas: {}
+                          toplevel_alias: null
+                      toplevel_alias: null
+                    Upper Area:
+                      abstract: false
+                      allowed_time_of_day: 1
+                      can_save: false
+                      can_sleep: false
+                      entrances: !!set {}
+                      exits:
+                        \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
+                        \Skyview\Main\First Hub: 'True'
+                      hint_region: Skyview
+                      locations:
+                        Chest behind Two Eyes: \Sword
+                      name: \Skyview\Main\First Hub\Right Room\Upper Area
+                      sub_areas: {}
+                      toplevel_alias: null
+                  toplevel_alias: null
+              toplevel_alias: null
+            Second Hub:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits:
+                \Skyview\Main\First Hub: Skyview Small Key x 2
+                \Skyview\Main\Second Hub\Miniboss Room: \Skyview\Main\Second Hub\Switch
+                  to Miniboss Room
+                \Skyview\Main\Second Hub\Left Rooms: \Skyview\Main\Second Hub\Switch
+                  to Left Room
+                \Skyview\Main\Second Hub\Staldra Room: Skyview Small Key x 2
+                \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Before
+                  Rope\Unlock Shortcut to Second Hub
+              hint_region: Skyview
+              locations:
+                Rupee in Southeast Tunnel: \Beetle
+                Rupee in Southwest Tunnel: \Beetle
+                Rupee in East Tunnel: \Beetle
+                Switch to Miniboss Room: \Distance Activator
+                Switch for Bars: "\\Beetle | \\Slingshot & Skyview Slingshot Shot\
+                  \ Trick"
+                Switch to Left Room: \Beetle
+                Item behind Bars: "\\Skyview\\Main\\Second Hub\\Switch for Bars |\
+                  \ Whip"
+              name: \Skyview\Main\Second Hub
+              sub_areas:
+                Miniboss Room:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Second Hub: 'True'
+                  hint_region: Skyview
+                  locations:
+                    Chest after Stalfos Fight: "\\Sword | \\Skyview\\Skyview 2"
+                  name: \Skyview\Main\Second Hub\Miniboss Room
+                  sub_areas: {}
+                  toplevel_alias: null
+                Left Rooms:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Second Hub: "\\Sword & \\Projectile Item"
+                  hint_region: Skyview
+                  locations:
+                    Chest behind Three Eyes: "\\Beetle & \\Sword"
+                  name: \Skyview\Main\Second Hub\Left Rooms
+                  sub_areas: {}
+                  toplevel_alias: null
+                Staldra Room:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Second Hub: Skyview Small Key
+                    \Skyview\Main\Last Room\Near East Entrance: \Skyview\Main\Second
+                      Hub\Staldra Room\Can Defeat Staldra
+                  hint_region: Skyview
+                  locations:
+                    Can Defeat Staldra: "\\Sword | Bomb Bag"
+                  name: \Skyview\Main\Second Hub\Staldra Room
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+            Last Room:
+              abstract: false
+              allowed_time_of_day: 1
+              can_save: false
+              can_sleep: false
+              entrances: !!set {}
+              exits: {}
+              hint_region: Skyview
+              locations: {}
+              name: \Skyview\Main\Last Room
+              sub_areas:
+                Near East Entrance:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Second Hub\Staldra Room: 'True'
+                    \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Near
+                      East Entrance\Deal with Hanging Skulltula
+                  hint_region: Skyview
+                  locations:
+                    Deal with Hanging Skulltula: "Bomb Bag | \\Goddess Sword | \\\
+                      Beetle | \\Bow | \\Skyview\\Skyview 2"
+                  name: \Skyview\Main\Last Room\Near East Entrance
+                  sub_areas: {}
+                  toplevel_alias: null
+                Before Rope:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Last Room\Near East Entrance: \Skyview\Main\Last
+                      Room\Near East Entrance\Deal with Hanging Skulltula
+                    \Skyview\Main\Second Hub: \Skyview\Main\Last Room\Before Rope\Unlock
+                      Shortcut to Second Hub
+                    \Skyview\Main\Last Room\After Rope: \Skyview\Main\Last Room\Before
+                      Rope\Deal with Archers
+                  hint_region: Skyview
+                  locations:
+                    \Skyview\Main\Last Room\Near East Entrance\Deal with Hanging Skulltula: "Bomb\
+                      \ Bag | \\Goddess Sword | \\Beetle | \\Bow | \\Skyview\\Skyview\
+                      \ 2"
+                    Unlock Shortcut to Second Hub: \Skyview\Can Hit High Skyview Switches
+                    Deal with Archers: "\\Long Range Skyward Strike | \\Hook Beetle\
+                      \ | \\Bow"
+                  name: \Skyview\Main\Last Room\Before Rope
+                  sub_areas: {}
+                  toplevel_alias: null
+                After Rope:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set
+                    Boss Door Entrance: null
+                  exits:
+                    \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Before
+                      Rope\Deal with Archers
+                    \Skyview\Main\Last Room\Near Boss Key Chest: \Skyview\Main\Last
+                      Room\After Rope\Hit Vines
+                    Boss Door Exit: Skyview Boss Key
+                  hint_region: Skyview
+                  locations:
+                    Chest near Boss Door: 'True'
+                    Hit Vines: "\\Long Range Skyward Strike | \\Distance Activator"
+                    \Skyview\Main\Last Room\Before Rope\Deal with Archers: "\\Can\
+                      \ Defeat Bokoblins | \\Hook Beetle"
+                  name: \Skyview\Main\Last Room\After Rope
+                  sub_areas: {}
+                  toplevel_alias: null
+                Near Boss Key Chest:
+                  abstract: false
+                  allowed_time_of_day: 1
+                  can_save: false
+                  can_sleep: false
+                  entrances: !!set {}
+                  exits:
+                    \Skyview\Main\Last Room\Before Rope: 'True'
+                    \Skyview\Main\Last Room\After Rope: \Skyview\Main\Last Room\After
+                      Rope\Hit Vines
+                  hint_region: Skyview
+                  locations:
+                    Boss Key Chest: 'True'
+                  name: \Skyview\Main\Last Room\Near Boss Key Chest
+                  sub_areas: {}
+                  toplevel_alias: null
+              toplevel_alias: null
+          toplevel_alias: null
+        Boss Room:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance from Dungeon: null
+            Entrance from Spring: null
+          exits:
+            Exit to Dungeon: \Skyview\Boss Room\Beat Ghirahim
+            Exit to Spring: \Skyview\Boss Room\Beat Ghirahim
+          hint_region: Skyview
+          locations:
+            Beat Ghirahim: \Sword
+            Heart Container: \Skyview\Boss Room\Beat Ghirahim
+          name: \Skyview\Boss Room
+          sub_areas: {}
+          toplevel_alias: null
+        Spring:
+          abstract: false
+          allowed_time_of_day: 1
+          can_save: false
+          can_sleep: false
+          entrances: !!set
+            Entrance: null
+          exits:
+            Exit: 'True'
+          hint_region: Skyview
+          locations:
+            Rupee on Spring Pillar: \Beetle
+            Strike Crest: \Goddess Sword
+            Goddess Cube in Skyview Spring: \Goddess Sword
+            Sacred Water: "\\Bottle & \\Skyview\\Skyview 2"
+          name: \Skyview\Spring
+          sub_areas: {}
+          toplevel_alias: Skyview Spring
+      toplevel_alias: Skyview Temple
+  toplevel_alias: null
+checks:
+  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Gift: Upper Skyloft - Fledge's Gift
+  \Skyloft\Upper Skyloft\Owlan's Gift: Upper Skyloft - Owlan's Gift
+  \Skyloft\Upper Skyloft\Sparring Hall\Sparring Hall Chest: Upper Skyloft - Sparring
+    Hall Chest
+  \Skyloft\Upper Skyloft\Chest near Goddess Statue: Upper Skyloft - Chest near Goddess
+    Statue
+  \Skyloft\Upper Skyloft\Goddess Statue\First Goddess Sword Item in Goddess Statue: Upper
+    Skyloft - First Goddess Sword Item in Goddess Statue
+  \Skyloft\Upper Skyloft\Goddess Statue\Second Goddess Sword Item in Goddess Statue: Upper
+    Skyloft - Second Goddess Sword Item in Goddess Statue
+  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\In Zelda's Closet: Upper Skyloft
+    - In Zelda's Closet
+  \Skyloft\Upper Skyloft\Knight Academy\Owlan's Crystals: Upper Skyloft - Owlan's
+    Crystals
+  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Crystals: Upper Skyloft - Fledge's
+    Crystals
+  \Skyloft\Upper Skyloft\Knight Academy\Item from Cawlin: Upper Skyloft - Item from
+    Cawlin
+  \Skyloft\Upper Skyloft\Knight Academy\Ghost/Pipit's Crystals: Upper Skyloft - Ghost/Pipit's
+    Crystals
+  \Skyloft\Upper Skyloft\Pumpkin Archery -- 600 Points: Upper Skyloft - Pumpkin Archery
+    -- 600 Points
+  \Skyloft\Central Skyloft\Bazaar\Potion Lady's Gift: Central Skyloft - Potion Lady's
+    Gift
+  \Skyloft\Central Skyloft\Bazaar\Repair Gondo's Junk: Central Skyloft - Repair Gondo's
+    Junk
+  \Skyloft\Central Skyloft\Wryna's House\Wryna's Crystals: Central Skyloft - Wryna's
+    Crystals
+  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave First Chest: Central Skyloft
+    - Waterfall Cave First Chest
+  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave Second Chest: Central Skyloft
+    - Waterfall Cave Second Chest
+  \Skyloft\Central Skyloft\Waterfall Cave\Rupee Waterfall Cave Crawlspace: Central
+    Skyloft - Rupee Waterfall Cave Crawlspace
+  \Skyloft\Central Skyloft\Parrow's Gift: Central Skyloft - Parrow's Gift
+  \Skyloft\Central Skyloft\Parrow's Crystals: Central Skyloft - Parrow's Crystals
+  \Skyloft\Central Skyloft\Peatrice's House\Peater/Peatrice's Crystals: Central Skyloft
+    - Peater/Peatrice's Crystals
+  \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest: Central Skyloft - Item in
+    Bird Nest
+  \Skyloft\Central Skyloft\Shed Chest: Central Skyloft - Shed Chest
+  \Skyloft\Central Skyloft\West Cliff Goddess Chest: Central Skyloft - West Cliff
+    Goddess Chest
+  \Skyloft\Central Skyloft\Bazaar\Bazaar Goddess Chest: Central Skyloft - Bazaar Goddess
+    Chest
+  \Skyloft\Central Skyloft\Shed Goddess Chest: Central Skyloft - Shed Goddess Chest
+  \Skyloft\Central Skyloft\Waterfall Island\Floating Island Goddess Chest: Central
+    Skyloft - Floating Island Goddess Chest
+  \Skyloft\Central Skyloft\Waterfall Island\Waterfall Goddess Chest: Central Skyloft
+    - Waterfall Goddess Chest
+  \Skyloft\Skyloft Village\Mallara's House\Mallara's Crystals: Skyloft Village - Mallara's
+    Crystals
+  \Skyloft\Skyloft Village\Bertie's House\Bertie's Crystals: Skyloft Village - Bertie's
+    Crystals
+  \Skyloft\Skyloft Village\Sparrot's House\Sparrot's Crystals: Skyloft Village - Sparrot's
+    Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\5 Crystals: Batreaux's House - 5 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\10 Crystals: Batreaux's House - 10 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals: Batreaux's House - 30 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals Chest: Batreaux's House -
+    30 Crystals Chest
+  \Skyloft\Skyloft Village\Batreaux's House\40 Crystals: Batreaux's House - 40 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\50 Crystals: Batreaux's House - 50 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals: Batreaux's House - 70 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals Second Reward: Batreaux's
+    House - 70 Crystals Second Reward
+  \Skyloft\Skyloft Village\Batreaux's House\80 Crystals: Batreaux's House - 80 Crystals
+  \Skyloft\Beedle's Shop\Stall\300 Rupee Item: Beedle's Shop - 300 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\600 Rupee Item: Beedle's Shop - 600 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\1200 Rupee Item: Beedle's Shop - 1200 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\800 Rupee Item: Beedle's Shop - 800 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\1600 Rupee Item: Beedle's Shop - 1600 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\First 100 Rupee Item: Beedle's Shop - First 100 Rupee
+    Item
+  \Skyloft\Beedle's Shop\Stall\Second 100 Rupee Item: Beedle's Shop - Second 100 Rupee
+    Item
+  \Skyloft\Beedle's Shop\Stall\Third 100 Rupee Item: Beedle's Shop - Third 100 Rupee
+    Item
+  \Skyloft\Beedle's Shop\Stall\50 Rupee Item: Beedle's Shop - 50 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\1000 Rupee Item: Beedle's Shop - 1000 Rupee Item
+  \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Crystal in Link's Room: Upper
+    Skyloft - Crystal in Link's Room
+  \Skyloft\Upper Skyloft\Knight Academy\Crystal in Knight Academy Plant: Upper Skyloft
+    - Crystal in Knight Academy Plant
+  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Crystal in Zelda's Room: Upper
+    Skyloft - Crystal in Zelda's Room
+  \Skyloft\Upper Skyloft\Sparring Hall\Crystal in Sparring Hall: Upper Skyloft - Crystal
+    in Sparring Hall
+  \Skyloft\Central Skyloft\Orielle and Parrow's House\Crystal in Orielle and Parrow's House: Central
+    Skyloft - Crystal in Orielle and Parrow's House
+  \Skyloft\Central Skyloft\Crystal on West Cliff: Central Skyloft - Crystal on West
+    Cliff
+  \Skyloft\Central Skyloft\Crystal between Wooden Planks: Central Skyloft - Crystal
+    between Wooden Planks
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: Central
+    Skyloft - Crystal after Waterfall Cave
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: Central
+    Skyloft - Crystal in Loftwing Prison
+  \Skyloft\Central Skyloft\Crystal on Waterfall Island: Central Skyloft - Crystal
+    on Waterfall Island
+  \Skyloft\Central Skyloft\Crystal on Light Tower: Central Skyloft - Crystal on Light
+    Tower
+  \Skyloft\Skyloft Village\Crystal near Pumpkin Patch: Skyloft Village - Crystal near
+    Pumpkin Patch
+  \Sky\South East\Lumpy Pumpkin\Crystal outside Lumpy Pumpkin: Sky - Crystal outside
+    Lumpy Pumpkin
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Crystal inside Lumpy Pumpkin: Sky
+    - Crystal inside Lumpy Pumpkin
+  \Sky\North East\Beedle's Island\Crystal on Beedle's Ship: Sky - Crystal on Beedle's
+    Ship
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Chandelier: Sky - Lumpy Pumpkin
+    - Chandelier
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Harp Minigame: Sky - Lumpy
+    Pumpkin - Harp Minigame
+  \Sky\South East\Lumpy Pumpkin\Kina's Crystals: Sky - Kina's Crystals
+  \Sky\South West\Orielle's Island\Orielle's Crystals: Sky - Orielle's Crystals
+  \Sky\North East\Beedle's Island\Beedle's Crystals: Sky - Beedle's Crystals
+  \Sky\South West\Fun Fun Island\Dodoh's Crystals: Sky - Dodoh's Crystals
+  \Sky\South West\Fun Fun Island\Fun Fun Island Minigame -- 500 Rupees: Sky - Fun
+    Fun Island Minigame -- 500 Rupees
+  \Sky\South West\Chest in Breakable Boulder near Fun Fun Island: Sky - Chest in Breakable
+    Boulder near Fun Fun Island
+  \Sky\South East\Chest in Breakable Boulder near Lumpy Pumpkin: Sky - Chest in Breakable
+    Boulder near Lumpy Pumpkin
+  \Sky\North East\Bamboo Island\Bamboo Island Goddess Chest: Sky - Bamboo Island Goddess
+    Chest
+  \Sky\North East\Goddess Chest on Island next to Bamboo Island: Sky - Goddess Chest
+    on Island next to Bamboo Island
+  \Sky\North East\Goddess Chest in Cave on Island next to Bamboo Island: Sky - Goddess
+    Chest in Cave on Island next to Bamboo Island
+  \Sky\North East\Beedle's Island\Top\Beedle's Island Goddess Chest: Sky - Beedle's
+    Island Goddess Chest
+  \Sky\North East\Beedle's Island\Cage\Beedle's Island Cage Goddess Chest: Sky - Beedle's
+    Island Cage Goddess Chest
+  \Sky\North East\Northeast Island Goddess Chest behind Bombable Rocks: Sky - Northeast
+    Island Goddess Chest behind Bombable Rocks
+  \Sky\North East\Northeast Island Cage Goddess Chest: Sky - Northeast Island Cage
+    Goddess Chest
+  \Sky\South East\Lumpy Pumpkin\Goddess Chest on the Roof: Sky - Lumpy Pumpkin - Goddess
+    Chest on the Roof
+  \Sky\South East\Lumpy Pumpkin\Outside Goddess Chest: Sky - Lumpy Pumpkin - Outside
+    Goddess Chest
+  \Sky\South East\Goddess Chest on Island Closest to Faron Pillar: Sky - Goddess Chest
+    on Island Closest to Faron Pillar
+  \Sky\South West\Volcanic Island\Goddess Chest outside Volcanic Island: Sky - Goddess
+    Chest outside Volcanic Island
+  \Sky\South West\Volcanic Island\Goddess Chest inside Volcanic Island: Sky - Goddess
+    Chest inside Volcanic Island
+  \Sky\South West\Fun Fun Island\Goddess Chest under Fun Fun Island: Sky - Goddess
+    Chest under Fun Fun Island
+  \Sky\South West\Triple Island\Southwest Triple Island Upper Goddess Chest: Sky -
+    Southwest Triple Island Upper Goddess Chest
+  \Sky\South West\Triple Island\Southwest Triple Island Lower Goddess Chest: Sky -
+    Southwest Triple Island Lower Goddess Chest
+  \Sky\South West\Triple Island\Southwest Triple Island Cage Goddess Chest: Sky -
+    Southwest Triple Island Cage Goddess Chest
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Goddess Sword: Thunderhead
+    - Isle of Songs - Strike Crest with Goddess Sword
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Longsword: Thunderhead -
+    Isle of Songs - Strike Crest with Longsword
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with White Sword: Thunderhead
+    - Isle of Songs - Strike Crest with White Sword
+  \Sky\Thunderhead\Song from Levias: Thunderhead - Song from Levias
+  \Sky\Thunderhead\Bug Heaven\Bug Heaven -- 10 Bugs in 3 Minutes: Thunderhead - Bug
+    Heaven -- 10 Bugs in 3 Minutes
+  \Sky\Thunderhead\East Island\East Island Chest: Thunderhead - East Island Chest
+  \Sky\Thunderhead\East Island\East Island Goddess Chest: Thunderhead - East Island
+    Goddess Chest
+  \Sky\Thunderhead\Isle of Songs\Goddess Chest on top of Isle of Songs: Thunderhead
+    - Goddess Chest on top of Isle of Songs
+  \Sky\Thunderhead\Isle of Songs\Goddess Chest outside Isle of Songs: Thunderhead
+    - Goddess Chest outside Isle of Songs
+  \Sky\Thunderhead\Mogma Mitts Island\First Goddess Chest on Mogma Mitts Island: Thunderhead
+    - First Goddess Chest on Mogma Mitts Island
+  \Sky\Thunderhead\Mogma Mitts Island\Second Goddess Chest on Mogma Mitts Island: Thunderhead
+    - Second Goddess Chest on Mogma Mitts Island
+  \Sky\Thunderhead\Bug Heaven\Bug Heaven Goddess Chest: Thunderhead - Bug Heaven Goddess
+    Chest
+  \Faron\Sealed Grounds\Sealed Temple\Chest inside Sealed Temple: Sealed Grounds -
+    Chest inside Sealed Temple
+  \Faron\Sealed Grounds\Sealed Temple\Song from Impa: Sealed Grounds - Song from Impa
+  \Faron\Sealed Grounds\Behind the Temple\Gorko's Goddess Wall Reward: Sealed Grounds
+    - Gorko's Goddess Wall Reward
+  \Faron\Sealed Grounds\Hylia's Temple\Zelda's Blessing: Sealed Grounds - Zelda's
+    Blessing
+  \Faron\Faron Woods\Item behind Lower Bombable Rock: Faron Woods - Item behind Lower
+    Bombable Rock
+  \Faron\Faron Woods\Item on Tree: Faron Woods - Item on Tree
+  \Faron\Faron Woods\Kikwi Elder's Reward: Faron Woods - Kikwi Elder's Reward
+  \Faron\Faron Woods\Rupee on Hollow Tree Root: Faron Woods - Rupee on Hollow Tree
+    Root
+  \Faron\Faron Woods\Rupee on Hollow Tree Branch: Faron Woods - Rupee on Hollow Tree
+    Branch
+  \Faron\Faron Woods\Rupee on Platform near Floria Door: Faron Woods - Rupee on Platform
+    near Floria Door
+  \Faron\Faron Woods\Deep Woods\Deep Woods Chest: Faron Woods - Deep Woods Chest
+  \Faron\Faron Woods\Chest behind Upper Bombable Rock: Faron Woods - Chest behind
+    Upper Bombable Rock
+  \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest\Chest inside Great Tree: Faron
+    Woods - Chest inside Great Tree
+  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree North Branch: Faron Woods
+    - Rupee on Great Tree North Branch
+  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree West Branch: Faron Woods -
+    Rupee on Great Tree West Branch
+  \Faron\Lake Floria\Above Rock\Rupee under Central Boulder: Lake Floria - Rupee under
+    Central Boulder
+  \Faron\Lake Floria\Above Rock\Rupee behind Southwest Boulder: Lake Floria - Rupee
+    behind Southwest Boulder
+  \Faron\Lake Floria\Above Rock\Left Rupee behind Northwest Boulder: Lake Floria -
+    Left Rupee behind Northwest Boulder
+  \Faron\Lake Floria\Above Rock\Right Rupee behind Northwest Boulder: Lake Floria
+    - Right Rupee behind Northwest Boulder
+  \Faron\Lake Floria\Below Rock\Emerged Area\Lake Floria Chest: Lake Floria - Lake
+    Floria Chest
+  \Faron\Lake Floria\Farore's Lair\Dragon Lair South Chest: Lake Floria - Dragon Lair
+    South Chest
+  \Faron\Lake Floria\Farore's Lair\Dragon Lair East Chest: Lake Floria - Dragon Lair
+    East Chest
+  \Faron\Lake Floria\Waterfall\Rupee on High Ledge outside Ancient Cistern Entrance: Lake
+    Floria - Rupee on High Ledge outside Ancient Cistern Entrance
+  \Faron\Flooded Faron Woods\Yellow Tadtone under Lilypad: Flooded Faron Woods - Yellow
+    Tadtone under Lilypad
+  \Faron\Flooded Faron Woods\8 Light Blue Tadtones near Viewing Platform: Flooded
+    Faron Woods - 8 Light Blue Tadtones near Viewing Platform
+  \Faron\Flooded Faron Woods\4 Purple Tadtones under Viewing Platform: Flooded Faron
+    Woods - 4 Purple Tadtones under Viewing Platform
+  \Faron\Flooded Faron Woods\Red Moving Tadtone near Viewing Platform: Flooded Faron
+    Woods - Red Moving Tadtone near Viewing Platform
+  \Faron\Flooded Faron Woods\Light Blue Tadtone under Great Tree Root: Flooded Faron
+    Woods - Light Blue Tadtone under Great Tree Root
+  \Faron\Flooded Faron Woods\8 Yellow Tadtones near Kikwi Elder: Flooded Faron Woods
+    - 8 Yellow Tadtones near Kikwi Elder
+  \Faron\Flooded Faron Woods\4 Light Blue Moving Tadtones under Kikwi Elder: Flooded
+    Faron Woods - 4 Light Blue Moving Tadtones under Kikwi Elder
+  \Faron\Flooded Faron Woods\4 Red Moving Tadtones North West of Great Tree: Flooded
+    Faron Woods - 4 Red Moving Tadtones North West of Great Tree
+  \Faron\Flooded Faron Woods\Green Tadtone behind Upper Bombable Rock: Flooded Faron
+    Woods - Green Tadtone behind Upper Bombable Rock
+  \Faron\Flooded Faron Woods\2 Dark Blue Tadtones in Grass West of Great Tree: Flooded
+    Faron Woods - 2 Dark Blue Tadtones in Grass West of Great Tree
+  \Faron\Flooded Faron Woods\8 Green Tadtones in West Tunnel: Flooded Faron Woods
+    - 8 Green Tadtones in West Tunnel
+  \Faron\Flooded Faron Woods\2 Red Tadtones in Grass near Lower Bombable Rock: Flooded
+    Faron Woods - 2 Red Tadtones in Grass near Lower Bombable Rock
+  \Faron\Flooded Faron Woods\16 Dark Blue Tadtones in the South West: Flooded Faron
+    Woods - 16 Dark Blue Tadtones in the South West
+  \Faron\Flooded Faron Woods\4 Purple Moving Tadtones near Floria Gate: Flooded Faron
+    Woods - 4 Purple Moving Tadtones near Floria Gate
+  \Faron\Flooded Faron Woods\Dark Blue Moving Tadtone inside Small Hollow Tree: Flooded
+    Faron Woods - Dark Blue Moving Tadtone inside Small Hollow Tree
+  \Faron\Flooded Faron Woods\4 Yellow Tadtones under Small Hollow Tree: Flooded Faron
+    Woods - 4 Yellow Tadtones under Small Hollow Tree
+  \Faron\Flooded Faron Woods\8 Purple Tadtones in Clearing after Small Hollow Tree: Flooded
+    Faron Woods - 8 Purple Tadtones in Clearing after Small Hollow Tree
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Water Dragon's Reward: Flooded Faron
+    Woods - Water Dragon's Reward
+  \Eldin\Volcano\Entry\Rupee on Ledge before First Room: Eldin Volcano - Rupee on
+    Ledge before First Room
+  \Eldin\Volcano\First Room\Chest behind Bombable Wall in First Room: Eldin Volcano
+    - Chest behind Bombable Wall in First Room
+  \Eldin\Volcano\First Room\Rupee behind Bombable Wall in First Room: Eldin Volcano
+    - Rupee behind Bombable Wall in First Room
+  \Eldin\Volcano\First Room\Rupee in Crawlspace in First Room: Eldin Volcano - Rupee
+    in Crawlspace in First Room
+  \Eldin\Volcano\East\Chest after Crawlspace: Eldin Volcano - Chest after Crawlspace
+  \Eldin\Volcano\East\Southeast Rupee above Mogma Turf Entrance: Eldin Volcano - Southeast
+    Rupee above Mogma Turf Entrance
+  \Eldin\Volcano\East\North Rupee above Mogma Turf Entrance: Eldin Volcano - North
+    Rupee above Mogma Turf Entrance
+  \Eldin\Volcano\East\Chest behind Bombable Wall near Cliff: Eldin Volcano - Chest
+    behind Bombable Wall near Cliff
+  \Eldin\Volcano\East\Item on Cliff: Eldin Volcano - Item on Cliff
+  \Eldin\Volcano\Ascent\Chest behind Bombable Wall near Volcano Ascent: Eldin Volcano
+    - Chest behind Bombable Wall near Volcano Ascent
+  \Eldin\Volcano\Near Thrill Digger Cave\Left Rupee behind Bombable Wall on First Slope: Eldin
+    Volcano - Left Rupee behind Bombable Wall on First Slope
+  \Eldin\Volcano\Near Thrill Digger Cave\Right Rupee behind Bombable Wall on First Slope: Eldin
+    Volcano - Right Rupee behind Bombable Wall on First Slope
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot in front of Earth Temple: Eldin
+    Volcano - Digging Spot in front of Earth Temple
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot below Tower: Eldin Volcano - Digging
+    Spot below Tower
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot behind Boulder on Sandy Slope: Eldin
+    Volcano - Digging Spot behind Boulder on Sandy Slope
+  \Eldin\Volcano\Sand Slide\Digging Spot after Vents: Eldin Volcano - Digging Spot
+    after Vents
+  \Eldin\Volcano\Past Slide\Digging Spot after Draining Lava: Eldin Volcano - Digging
+    Spot after Draining Lava
+  \Eldin\Mogma Turf\Pre Vent\Free Fall Chest: Mogma Turf - Free Fall Chest
+  \Eldin\Mogma Turf\Pre Vent\Chest behind Bombable Wall at Entrance: Mogma Turf -
+    Chest behind Bombable Wall at Entrance
+  \Eldin\Mogma Turf\Pre Vent\Defeat Bokoblins: Mogma Turf - Defeat Bokoblins
+  \Eldin\Mogma Turf\Sand Slide Platform\Sand Slide Chest: Mogma Turf - Sand Slide
+    Chest
+  \Eldin\Mogma Turf\Past Vent\Chest behind Bombable Wall in Fire Maze: Mogma Turf
+    - Chest behind Bombable Wall in Fire Maze
+  \Eldin\Volcano Summit\Waterfall\Higher Area\Chest behind Bombable Wall in Waterfall Area: Volcano
+    Summit - Chest behind Bombable Wall in Waterfall Area
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Item behind Digging: Volcano
+    Summit - Item behind Digging
+  \Eldin\Bokoblin Base\Prison\Plats' Gift: Bokoblin Base - Plats' Gift
+  \Eldin\Bokoblin Base\Volcano East\Chest near Bone Bridge: Bokoblin Base - Chest
+    near Bone Bridge
+  \Eldin\Bokoblin Base\Volcano East\Chest on Cliff: Bokoblin Base - Chest on Cliff
+  \Eldin\Bokoblin Base\Before Drawbridge\Chest near Drawbridge: Bokoblin Base - Chest
+    near Drawbridge
+  \Eldin\Bokoblin Base\Outside Earth Temple\Chest East of Earth Temple Entrance: Bokoblin
+    Base - Chest East of Earth Temple Entrance
+  \Eldin\Bokoblin Base\Outside Earth Temple\Chest West of Earth Temple Entrance: Bokoblin
+    Base - Chest West of Earth Temple Entrance
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\First Chest in Volcano Summit: Bokoblin
+    Base - First Chest in Volcano Summit
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\Raised Chest in Volcano Summit: Bokoblin
+    Base - Raised Chest in Volcano Summit
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\Chest in Volcano Summit Alcove: Bokoblin
+    Base - Chest in Volcano Summit Alcove
+  \Eldin\Bokoblin Base\Fire Dragon's Lair\Fire Dragon's Reward: Bokoblin Base - Fire
+    Dragon's Reward
+  \Lanayru\Mine\Entry\Higher Area\Chest behind First Landing: Lanayru Mine - Chest
+    behind First Landing
+  \Lanayru\Mine\Entry\Chest near First Timeshift Stone: Lanayru Mine - Chest near
+    First Timeshift Stone
+  \Lanayru\Mine\Statues Area\Chest behind Statue: Lanayru Mine - Chest behind Statue
+  \Lanayru\Mine\End\Chest at the End of Mine: Lanayru Mine - Chest at the End of Mine
+  \Lanayru\Desert\Entry\High Ledge after Vines\Chest near Party Wheel: Lanayru Desert
+    - Chest near Party Wheel
+  \Lanayru\Desert\Near Caged Robot\Chest near Caged Robot: Lanayru Desert - Chest
+    near Caged Robot
+  \Lanayru\Desert\Near Caged Robot\Rescue Caged Robot: Lanayru Desert - Rescue Caged
+    Robot
+  \Lanayru\Desert\East\Chest on Platform near Fire Node: Lanayru Desert - Chest on
+    Platform near Fire Node
+  \Lanayru\Desert\North Part\Chest on Platform near Lightning Node: Lanayru Desert
+    - Chest on Platform near Lightning Node
+  \Lanayru\Desert\Top of West Wall\Chest near Sand Oasis: Lanayru Desert - Chest near
+    Sand Oasis
+  \Lanayru\Desert\Top of LMF\Chest on top of Lanayru Mining Facility: Lanayru Desert
+    - Chest on top of Lanayru Mining Facility
+  \Lanayru\Desert\North Part\Secret Passageway\Secret Passageway Chest: Lanayru Desert
+    - Secret Passageway Chest
+  \Lanayru\Desert\East\Fire Node\Present after Sand\Shortcut Chest: Lanayru Desert
+    - Fire Node - Shortcut Chest
+  \Lanayru\Desert\East\Fire Node\Past\First Small Chest: Lanayru Desert - Fire Node
+    - First Small Chest
+  \Lanayru\Desert\East\Fire Node\Past\Second Small Chest: Lanayru Desert - Fire Node
+    - Second Small Chest
+  \Lanayru\Desert\East\Fire Node\Past after Grate\Left Ending Chest: Lanayru Desert
+    - Fire Node - Left Ending Chest
+  \Lanayru\Desert\East\Fire Node\Past after Grate\Right Ending Chest: Lanayru Desert
+    - Fire Node - Right Ending Chest
+  \Lanayru\Desert\North Part\Lightning Node\Past\First Chest: Lanayru Desert - Lightning
+    Node - First Chest
+  \Lanayru\Desert\North Part\Lightning Node\Past\Second Chest: Lanayru Desert - Lightning
+    Node - Second Chest
+  \Lanayru\Desert\North Part\Lightning Node\Present from afar\Raised Chest near Generator: Lanayru
+    Desert - Lightning Node - Raised Chest near Generator
+  \Lanayru\Caves\Chest: Lanayru Caves - Chest
+  \Lanayru\Caves\Golo's Gift: Lanayru Caves - Golo's Gift
+  \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward: Lanayru Gorge - Thunder
+    Dragon's Reward
+  \Lanayru\Lanayru Sand Sea\Gorge\Item on Pillar: Lanayru Gorge - Item on Pillar
+  \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Digging Spot: Lanayru Gorge - Digging
+    Spot
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Rupee on First Pillar: Lanayru
+    Sand Sea - Ancient Harbour - Rupee on First Pillar
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Left Rupee on Entrance Crown: Lanayru
+    Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Right Rupee on Entrance Crown: Lanayru
+    Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Chest after Moblin: Lanayru
+    Sand Sea - Skipper's Retreat - Chest after Moblin
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Chest on top of Cacti Pillar: Lanayru
+    Sand Sea - Skipper's Retreat - Chest on top of Cacti Pillar
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Chest in Shack: Lanayru Sand Sea
+    - Skipper's Retreat - Chest in Shack
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform\Skydive Chest: Lanayru
+    Sand Sea - Skipper's Retreat - Skydive Chest
+  \Lanayru\Lanayru Sand Sea\Shipyard\Rickety Coaster -- Heart Stopping Track in 1'05: Lanayru
+    Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar: Lanayru Sand
+    Sea - Pirate Stronghold - Rupee on East Sea Pillar
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar: Lanayru Sand
+    Sea - Pirate Stronghold - Rupee on West Sea Pillar
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose: Lanayru
+    Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar or Nose
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Chest: Lanayru Sand Sea
+    - Pirate Stronghold - First Chest
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Chest: Lanayru Sand Sea
+    - Pirate Stronghold - Second Chest
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Third Chest: Lanayru Sand Sea
+    - Pirate Stronghold - Third Chest
+  \Skyview\Main\First Hub\Left Room\Chest on Tree Branch: Skyview - Chest on Tree
+    Branch
+  \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace: Skyview
+    - Digging Spot in Crawlspace
+  \Skyview\Main\First Hub\Right Room\Upper Area\Chest behind Two Eyes: Skyview - Chest
+    behind Two Eyes
+  \Skyview\Main\Second Hub\Miniboss Room\Chest after Stalfos Fight: Skyview - Chest
+    after Stalfos Fight
+  \Skyview\Main\Second Hub\Item behind Bars: Skyview - Item behind Bars
+  \Skyview\Main\Second Hub\Rupee in Southeast Tunnel: Skyview - Rupee in Southeast
+    Tunnel
+  \Skyview\Main\Second Hub\Rupee in Southwest Tunnel: Skyview - Rupee in Southwest
+    Tunnel
+  \Skyview\Main\Second Hub\Rupee in East Tunnel: Skyview - Rupee in East Tunnel
+  \Skyview\Main\Second Hub\Left Rooms\Chest behind Three Eyes: Skyview - Chest behind
+    Three Eyes
+  \Skyview\Main\Last Room\After Rope\Chest near Boss Door: Skyview - Chest near Boss
+    Door
+  \Skyview\Main\Last Room\Near Boss Key Chest\Boss Key Chest: Skyview - Boss Key Chest
+  \Skyview\Boss Room\Heart Container: Skyview - Heart Container
+  \Skyview\Spring\Rupee on Spring Pillar: Skyview - Rupee on Spring Pillar
+  \Skyview\Spring\Strike Crest: Skyview - Strike Crest
+  \Earth Temple\Main\First Room\Vent Chest: Earth Temple - Vent Chest
+  \Earth Temple\Main\First Room\Rupee above Drawbridge: Earth Temple - Rupee above
+    Drawbridge
+  \Earth Temple\Main\Hub Room\Chest behind Bombable Rock: Earth Temple - Chest behind
+    Bombable Rock
+  \Earth Temple\Main\Hub Room\Chest Left of Main Room Bridge: Earth Temple - Chest
+    Left of Main Room Bridge
+  \Earth Temple\Main\West Room\Chest in West Room: Earth Temple - Chest in West Room
+  \Earth Temple\Main\East Room\Chest after Double Lizalfos Fight: Earth Temple - Chest
+    after Double Lizalfos Fight
+  \Earth Temple\Main\Hub Room\Ledd's Gift: Earth Temple - Ledd's Gift
+  \Earth Temple\Main\Hub Room\Rupee in Lava Tunnel: Earth Temple - Rupee in Lava Tunnel
+  \Earth Temple\Main\Hub Room\Past Lava Section\Chest Guarded by Lizalfos: Earth Temple
+    - Chest Guarded by Lizalfos
+  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Key Chest: Earth Temple
+    - Boss Key Chest
+  \Earth Temple\Boss Room\Slope\Heart Container: Earth Temple - Heart Container
+  \Earth Temple\Spring\Strike Crest: Earth Temple - Strike Crest
+  \Lanayru Mining Facility\Main\First Room\Chest behind Bars: Lanayru Mining Facility
+    - Chest behind Bars
+  \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes\First Chest in Hub Room: Lanayru
+    Mining Facility - First Chest in Hub Room
+  \Lanayru Mining Facility\Main\First West Room\Chest in First West Room: Lanayru
+    Mining Facility - Chest in First West Room
+  \Lanayru Mining Facility\Main\Armos Fight Room\Chest after Armos Fight: Lanayru
+    Mining Facility - Chest after Armos Fight
+  \Lanayru Mining Facility\Main\Key Locked Room\Chest in Key Locked Room: Lanayru
+    Mining Facility - Chest in Key Locked Room
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Raised Chest in Hop across Boxes Room: Lanayru
+    Mining Facility - Raised Chest in Hop across Boxes Room
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Lower Chest in Hop across Boxes Room: Lanayru
+    Mining Facility - Lower Chest in Hop across Boxes Room
+  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Chest behind First Crawlspace: Lanayru
+    Mining Facility - Chest behind First Crawlspace
+  \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Chest in Spike Maze: Lanayru
+    Mining Facility - Chest in Spike Maze
+  \Lanayru Mining Facility\Main\Boss Key Room\Boss Key Chest: Lanayru Mining Facility
+    - Boss Key Chest
+  \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Shortcut Chest in Main Hub: Lanayru
+    Mining Facility - Shortcut Chest in Main Hub
+  \Lanayru Mining Facility\Boss Room\After Sand Drain\Heart Container: Lanayru Mining
+    Facility - Heart Container
+  \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit Hall of Ancient Robots: Lanayru
+    Mining Facility - Exit Hall of Ancient Robots
+  \Ancient Cistern\Main\Main Room\Rupee in West Hand: Ancient Cistern - Rupee in West
+    Hand
+  \Ancient Cistern\Main\Main Room\Rupee in East Hand: Ancient Cistern - Rupee in East
+    Hand
+  \Ancient Cistern\Main\East Part\Second Room\First Rupee in East Part in Short Tunnel: Ancient
+    Cistern - First Rupee in East Part in Short Tunnel
+  \Ancient Cistern\Main\East Part\Second Room\Second Rupee in East Part in Short Tunnel: Ancient
+    Cistern - Second Rupee in East Part in Short Tunnel
+  \Ancient Cistern\Main\East Part\Second Room\Third Rupee in East Part in Short Tunnel: Ancient
+    Cistern - Third Rupee in East Part in Short Tunnel
+  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Cubby: Ancient
+    Cistern - Rupee in East Part in Cubby
+  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Main Tunnel: Ancient
+    Cistern - Rupee in East Part in Main Tunnel
+  \Ancient Cistern\Main\East Part\Chest Ledge\Chest in East Part: Ancient Cistern
+    - Chest in East Part
+  \Ancient Cistern\Main\Main Room\After Whip Hooks\Chest after Whip Hooks: Ancient
+    Cistern - Chest after Whip Hooks
+  \Ancient Cistern\Main\Main Room\Vines Area\Chest near Vines: Ancient Cistern - Chest
+    near Vines
+  \Ancient Cistern\Main\Main Room\Behind the Waterfall\Chest behind the Waterfall: Ancient
+    Cistern - Chest behind the Waterfall
+  \Ancient Cistern\Main\Basement Gutters\Past Skulltula\Bokoblin: Ancient Cistern
+    - Bokoblin
+  \Ancient Cistern\Main\Main Room\After Gutters\Rupee under Lilypad: Ancient Cistern
+    - Rupee under Lilypad
+  \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest\Chest in Key Locked Room: Ancient
+    Cistern - Chest in Key Locked Room
+  \Ancient Cistern\Main\Basement\Under the Statue\Boss Key Chest: Ancient Cistern
+    - Boss Key Chest
+  \Ancient Cistern\Boss Room\Heart Container: Ancient Cistern - Heart Container
+  \Ancient Cistern\Flame Room\Farore's Flame: Ancient Cistern - Farore's Flame
+  \Sandship\Main\Deck\Stern\Chest at the Stern: Sandship - Chest at the Stern
+  \Sandship\Main\Before Ship's Bow\Chest before 4-Door Corridor: Sandship - Chest
+    before 4-Door Corridor
+  \Sandship\Main\Before Boss Door\Chest behind Combination Lock: Sandship - Chest
+    behind Combination Lock
+  \Sandship\Main\Treasure Room\Treasure Room First Chest: Sandship - Treasure Room
+    First Chest
+  \Sandship\Main\Treasure Room\Treasure Room Second Chest: Sandship - Treasure Room
+    Second Chest
+  \Sandship\Main\Treasure Room\Treasure Room Third Chest: Sandship - Treasure Room
+    Third Chest
+  \Sandship\Main\Treasure Room\Treasure Room Fourth Chest: Sandship - Treasure Room
+    Fourth Chest
+  \Sandship\Main\Treasure Room\Treasure Room Fifth Chest: Sandship - Treasure Room
+    Fifth Chest
+  \Sandship\Main\Brig Prison\Robot in Brig's Reward: Sandship - Robot in Brig's Reward
+  \Sandship\Main\Ship's Bow\Chest after Scervo Fight: Sandship - Chest after Scervo
+    Fight
+  \Sandship\Main\Deck\Captain's Cabin\Boss Key Chest: Sandship - Boss Key Chest
+  \Sandship\Boss Room\Heart Container: Sandship - Heart Container
+  \Sandship\Boss Room\Nayru's Flame: Sandship - Nayru's Flame
+  \Fire Sanctuary\Main\First Room\Past Water Plant\Chest in First Room: Fire Sanctuary
+    - Chest in First Room
+  \Fire Sanctuary\Main\Second Room\Chest in Second Room: Fire Sanctuary - Chest in
+    Second Room
+  \Fire Sanctuary\Main\Second Room\Balcony\Chest on Balcony: Fire Sanctuary - Chest
+    on Balcony
+  \Fire Sanctuary\Main\First Trapped Mogma Room\Chest near First Trapped Mogma: Fire
+    Sanctuary - Chest near First Trapped Mogma
+  \Fire Sanctuary\Main\Water Fruit Room\First Chest in Water Fruit Room: Fire Sanctuary
+    - First Chest in Water Fruit Room
+  \Fire Sanctuary\Main\Water Fruit Room\Second Chest in Water Fruit Room: Fire Sanctuary
+    - Second Chest in Water Fruit Room
+  \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area\Rescue First Trapped Mogma: Fire
+    Sanctuary - Rescue First Trapped Mogma
+  \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Second Trapped Mogma: Fire
+    Sanctuary - Rescue Second Trapped Mogma
+  \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall\Chest after Bombable Wall: Fire
+    Sanctuary - Chest after Bombable Wall
+  \Fire Sanctuary\Main\West of Boss Door\Plats' Chest: Fire Sanctuary - Plats' Chest
+  \Fire Sanctuary\Main\Staircase Room\Chest in Staircase Room: Fire Sanctuary - Chest
+    in Staircase Room
+  \Fire Sanctuary\Main\Boss Key Room\Boss Key Chest: Fire Sanctuary - Boss Key Chest
+  \Fire Sanctuary\Boss Room\Heart Container: Fire Sanctuary - Heart Container
+  \Fire Sanctuary\Flame Room\Din's Flame: Fire Sanctuary - Din's Flame
+  \Sky Keep\Main\First Room\First Chest: Sky Keep - First Chest
+  \Sky Keep\Main\Mini Boss Room\Near Chest\Chest after Dreadfuse: Sky Keep - Chest
+    after Dreadfuse
+  \Sky Keep\Main\Fire Sanctuary Room\First Platform\Rupee in Fire Sanctuary Room in Alcove: Sky
+    Keep - Rupee in Fire Sanctuary Room in Alcove
+  \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Sacred Power of Din: Sky Keep -
+    Sacred Power of Din
+  \Sky Keep\Main\Sandship Room\Triforce Area\Sacred Power of Nayru: Sky Keep - Sacred
+    Power of Nayru
+  \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Sacred Power of Farore: Sky Keep
+    - Sacred Power of Farore
+  \Skyloft\Skyloft Silent Realm\Trial Reward: Skyloft Silent Realm - Trial Reward
+  \Skyloft\Skyloft Silent Realm\Relic 1: Skyloft Silent Realm - Relic 1
+  \Skyloft\Skyloft Silent Realm\Relic 2: Skyloft Silent Realm - Relic 2
+  \Skyloft\Skyloft Silent Realm\Relic 3: Skyloft Silent Realm - Relic 3
+  \Skyloft\Skyloft Silent Realm\Relic 4: Skyloft Silent Realm - Relic 4
+  \Skyloft\Skyloft Silent Realm\Relic 5: Skyloft Silent Realm - Relic 5
+  \Skyloft\Skyloft Silent Realm\Relic 6: Skyloft Silent Realm - Relic 6
+  \Skyloft\Skyloft Silent Realm\Relic 7: Skyloft Silent Realm - Relic 7
+  \Skyloft\Skyloft Silent Realm\Relic 8: Skyloft Silent Realm - Relic 8
+  \Skyloft\Skyloft Silent Realm\Relic 9: Skyloft Silent Realm - Relic 9
+  \Skyloft\Skyloft Silent Realm\Relic 10: Skyloft Silent Realm - Relic 10
+  \Faron\Faron Silent Realm\Trial Reward: Faron Silent Realm - Trial Reward
+  \Faron\Faron Silent Realm\Relic 1: Faron Silent Realm - Relic 1
+  \Faron\Faron Silent Realm\Relic 2: Faron Silent Realm - Relic 2
+  \Faron\Faron Silent Realm\Relic 3: Faron Silent Realm - Relic 3
+  \Faron\Faron Silent Realm\Relic 4: Faron Silent Realm - Relic 4
+  \Faron\Faron Silent Realm\Relic 5: Faron Silent Realm - Relic 5
+  \Faron\Faron Silent Realm\Relic 6: Faron Silent Realm - Relic 6
+  \Faron\Faron Silent Realm\Relic 7: Faron Silent Realm - Relic 7
+  \Faron\Faron Silent Realm\Relic 8: Faron Silent Realm - Relic 8
+  \Faron\Faron Silent Realm\Relic 9: Faron Silent Realm - Relic 9
+  \Faron\Faron Silent Realm\Relic 10: Faron Silent Realm - Relic 10
+  \Lanayru\Lanayru Silent Realm\Trial Reward: Lanayru Silent Realm - Trial Reward
+  \Lanayru\Lanayru Silent Realm\Relic 1: Lanayru Silent Realm - Relic 1
+  \Lanayru\Lanayru Silent Realm\Relic 2: Lanayru Silent Realm - Relic 2
+  \Lanayru\Lanayru Silent Realm\Relic 3: Lanayru Silent Realm - Relic 3
+  \Lanayru\Lanayru Silent Realm\Relic 4: Lanayru Silent Realm - Relic 4
+  \Lanayru\Lanayru Silent Realm\Relic 5: Lanayru Silent Realm - Relic 5
+  \Lanayru\Lanayru Silent Realm\Relic 6: Lanayru Silent Realm - Relic 6
+  \Lanayru\Lanayru Silent Realm\Relic 7: Lanayru Silent Realm - Relic 7
+  \Lanayru\Lanayru Silent Realm\Relic 8: Lanayru Silent Realm - Relic 8
+  \Lanayru\Lanayru Silent Realm\Relic 9: Lanayru Silent Realm - Relic 9
+  \Lanayru\Lanayru Silent Realm\Relic 10: Lanayru Silent Realm - Relic 10
+  \Eldin\Eldin Silent Realm\Trial Reward: Eldin Silent Realm - Trial Reward
+  \Eldin\Eldin Silent Realm\Relic 1: Eldin Silent Realm - Relic 1
+  \Eldin\Eldin Silent Realm\Relic 2: Eldin Silent Realm - Relic 2
+  \Eldin\Eldin Silent Realm\Relic 3: Eldin Silent Realm - Relic 3
+  \Eldin\Eldin Silent Realm\Relic 4: Eldin Silent Realm - Relic 4
+  \Eldin\Eldin Silent Realm\Relic 5: Eldin Silent Realm - Relic 5
+  \Eldin\Eldin Silent Realm\Relic 6: Eldin Silent Realm - Relic 6
+  \Eldin\Eldin Silent Realm\Relic 7: Eldin Silent Realm - Relic 7
+  \Eldin\Eldin Silent Realm\Relic 8: Eldin Silent Realm - Relic 8
+  \Eldin\Eldin Silent Realm\Relic 9: Eldin Silent Realm - Relic 9
+  \Eldin\Eldin Silent Realm\Relic 10: Eldin Silent Realm - Relic 10
+gossip_stones:
+  \Skyloft\Central Skyloft\Waterfall Island\Gossip Stone on Waterfall Island: Central
+    Skyloft - Gossip Stone on Waterfall Island
+  \Sky\South East\Lumpy Pumpkin\Gossip Stone on Lumpy Pumpkin: Sky - Gossip Stone
+    on Lumpy Pumpkin
+  \Sky\South West\Volcanic Island\Gossip Stone on Volcanic Island: Sky - Gossip Stone
+    on Volcanic Island
+  \Sky\North East\Bamboo Island\Inside\Gossip Stone on Bamboo Island: Sky - Gossip
+    Stone on Bamboo Island
+  \Sky\Thunderhead\Bug Heaven\Gossip Stone near Bug Heaven: Thunderhead - Gossip Stone
+    near Bug Heaven
+  \Faron\Sealed Grounds\Behind the Temple\Gossip Stone behind the Temple: Sealed Grounds
+    - Gossip Stone behind the Temple
+  \Faron\Faron Woods\Deep Woods\Gossip Stone in Deep Woods: Faron Woods - Gossip Stone
+    in Deep Woods
+  \Faron\Lake Floria\Waterfall\Gossip Stone outside Ancient Cistern: Lake Floria -
+    Gossip Stone outside Ancient Cistern
+  \Eldin\Volcano\Near Temple Entrance\Gossip Stone next to Earth Temple: Eldin Volcano
+    - Gossip Stone next to Earth Temple
+  \Eldin\Volcano\Thrill Digger Cave\Gossip Stone in Thrill Digger Cave: Eldin Volcano
+    - Gossip Stone in Thrill Digger Cave
+  \Eldin\Volcano\Lower Platform Cave\Gossip Stone in Lower Platform Cave: Eldin Volcano
+    - Gossip Stone in Lower Platform Cave
+  \Eldin\Volcano\Upper Platform Cave\Gossip Stone in Upper Platform Cave: Eldin Volcano
+    - Gossip Stone in Upper Platform Cave
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Gossip Stone near Second Thirsty Frog: Volcano
+    Summit - Gossip Stone near Second Thirsty Frog
+  \Eldin\Volcano Summit\Waterfall\Higher Area\Gossip Stone in Waterfall Area: Volcano
+    Summit - Gossip Stone in Waterfall Area
+  \Lanayru\Temple of Time\Front\Gossip Stone in Temple of Time Area: Temple of Time
+    - Gossip Stone in Temple of Time Area
+  \Lanayru\Lanayru Sand Sea\Shipyard\Gossip Stone in Shipyard: Lanayru Sand Sea -
+    Gossip Stone in Shipyard
+  \Lanayru\Caves\Gossip Stone in Center: Lanayru Caves - Gossip Stone in Center
+  \Lanayru\Caves\Past Crawlspace\Gossip Stone towards Lanayru Gorge: Lanayru Caves
+    - Gossip Stone towards Lanayru Gorge
+exits:
+  \Start:
+    type: exit
+    vanilla: Skyloft - Knight Academy - Start Entrance
+    stage: F001r
+    room: 1
+    index: 2
+    req_index: 1802
+    short_name: Start
+  \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Exit:
+    type: exit
+    vanilla: Skyloft - Knight Academy Lower Right Door Entrance
+    stage: F001r
+    room: 0
+    index: 0
+    req_index: 1803
+    short_name: Skyloft - Knight Academy - Lower Left Door Exit
+  \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Exit:
+    type: exit
+    vanilla: Skyloft - Knight Academy Lower Left Door Entrance
+    stage: F001r
+    room: 0
+    index: 1
+    req_index: 1804
+    short_name: Skyloft - Knight Academy - Lower Right Door Exit
+  \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Exit:
+    type: exit
+    vanilla: Skyloft - Knight Academy Upper Left Door Entrance
+    stage: F001r
+    room: 0
+    index: 2
+    req_index: 1805
+    short_name: Skyloft - Knight Academy - Upper Right Door Exit
+  \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Exit:
+    type: exit
+    vanilla: Skyloft - Knight Academy Upper Right Door Entrance
+    stage: F001r
+    room: 0
+    index: 3
+    req_index: 1806
+    short_name: Skyloft - Knight Academy - Upper Left Door Exit
+  \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Exit:
+    type: exit
+    vanilla: Skyloft - Knight Academy - Lower Left Door Entrance
+    stage: F000
+    room: 0
+    index: 3
+    req_index: 1807
+    short_name: Skyloft - Knight Academy Lower Right Door Exit
+  \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Exit:
+    type: exit
+    vanilla: Skyloft - Knight Academy - Lower Right Door Entrance
+    stage: F000
+    room: 0
+    index: 4
+    req_index: 1808
+    short_name: Skyloft - Knight Academy Lower Left Door Exit
+  \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Exit:
+    type: exit
+    vanilla: Skyloft - Knight Academy - Upper Right Door Entrance
+    stage: F000
+    room: 0
+    index: 23
+    req_index: 1809
+    short_name: Skyloft - Knight Academy Upper Left Door Exit
+  \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Exit:
+    type: exit
+    vanilla: Skyloft - Knight Academy - Upper Left Door Entrance
+    stage: F000
+    room: 0
+    index: 24
+    req_index: 1810
+    short_name: Skyloft - Knight Academy Upper Right Door Exit
+  \Skyloft\Upper Skyloft\Knight Academy Chimney Entrance:
+    type: exit
+    vanilla: Skyloft - Knight Academy - Chimney
+    stage: F000
+    room: 0
+    index: 57
+    req_index: 1811
+    short_name: Skyloft - Knight Academy Chimney Entrance
+  \Skyloft\Upper Skyloft\Sparring Hall\Right Door Exit:
+    type: exit
+    vanilla: Skyloft - Sparring Hall Left Door Entrance
+    stage: F009r
+    room: 0
+    index: 0
+    req_index: 1812
+    short_name: Sparring Hall - Right Door Exit
+  \Skyloft\Upper Skyloft\Sparring Hall\Left Door Exit:
+    type: exit
+    vanilla: Skyloft - Sparring Hall Right Door Entrance
+    stage: F009r
+    room: 0
+    index: 1
+    req_index: 1813
+    short_name: Sparring Hall - Left Door Exit
+  \Skyloft\Upper Skyloft\Sparring Hall Left Door Exit:
+    type: exit
+    vanilla: Sparring Hall - Right Door Entrance
+    stage: F000
+    room: 0
+    index: 20
+    req_index: 1814
+    short_name: Skyloft - Sparring Hall Left Door Exit
+  \Skyloft\Upper Skyloft\Sparring Hall Right Door Exit:
+    type: exit
+    vanilla: Sparring Hall - Left Door Entrance
+    stage: F000
+    room: 0
+    index: 27
+    req_index: 1815
+    short_name: Skyloft - Sparring Hall Right Door Exit
+  \Skyloft\Upper Skyloft\Goddess Statue\Exit:
+    type: exit
+    vanilla: Goddess Statue Entrance
+    stage: F008r
+    room: 0
+    index: 0
+    req_index: 1816
+    short_name: Goddess Statue - Exit
+  \Skyloft\Upper Skyloft\Goddess Statue Exit:
+    type: exit
+    vanilla: Goddess Statue - Entrance
+    stage: F000
+    room: 0
+    index: 5
+    req_index: 1817
+    short_name: Goddess Statue Exit
+  \Skyloft\Central Skyloft\Waterfall Cave\Upper Exit:
+    type: exit
+    vanilla: Waterfall Cave Upper Entrance
+    stage: D000
+    room: 0
+    index: 0
+    req_index: 1818
+    short_name: Waterfall Cave - Upper Exit
+  \Skyloft\Central Skyloft\Waterfall Cave\Lower Exit:
+    type: exit
+    vanilla: Waterfall Cave Lower Entrance
+    stage: D000
+    room: 0
+    index: 1
+    req_index: 1819
+    short_name: Waterfall Cave - Lower Exit
+  \Skyloft\Central Skyloft\Waterfall Cave Upper Exit:
+    type: exit
+    vanilla: Waterfall Cave - Upper Entrance
+    stage: F000
+    room: 0
+    index: 6
+    req_index: 1820
+    short_name: Waterfall Cave Upper Exit
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Exit:
+    type: exit
+    vanilla: Waterfall Cave - Lower Entrance
+    stage: F000
+    room: 0
+    index: 7
+    req_index: 1821
+    short_name: Waterfall Cave Lower Exit
+  \Skyloft\Central Skyloft\Bazaar\North Exit:
+    type: exit
+    vanilla: Bazaar North Entrance
+    stage: F004r
+    room: 0
+    index: 0
+    req_index: 1822
+    short_name: Bazaar - North Exit
+  \Skyloft\Central Skyloft\Bazaar\South Exit:
+    type: exit
+    vanilla: Bazaar South Entrance
+    stage: F004r
+    room: 0
+    index: 1
+    req_index: 1823
+    short_name: Bazaar - South Exit
+  \Skyloft\Central Skyloft\Bazaar\West Exit:
+    type: exit
+    vanilla: Bazaar West Entrance
+    stage: F004r
+    room: 0
+    index: 2
+    req_index: 1824
+    short_name: Bazaar - West Exit
+  \Skyloft\Central Skyloft\Bazaar North Exit:
+    type: exit
+    vanilla: Bazaar - North Entrance
+    stage: F000
+    room: 0
+    index: 1
+    req_index: 1825
+    short_name: Bazaar North Exit
+  \Skyloft\Central Skyloft\Bazaar South Exit:
+    type: exit
+    vanilla: Bazaar - South Entrance
+    stage: F000
+    room: 0
+    index: 2
+    req_index: 1826
+    short_name: Bazaar South Exit
+  \Skyloft\Central Skyloft\Bazaar West Exit:
+    type: exit
+    vanilla: Bazaar - West Entrance
+    stage: F000
+    room: 0
+    index: 19
+    req_index: 1827
+    short_name: Bazaar West Exit
+  \Skyloft\Beedle's Shop\Day Exit:
+    type: exit
+    vanilla: Skyloft - Entrance from Beedle's Shop
+    stage: F002r
+    room: 0
+    index: 0
+    req_index: 1828
+    short_name: Beedle's Shop - Day Exit
+  \Skyloft\Beedle's Shop\Night Exit:
+    type: exit
+    vanilla: Sky - Beedle's Island - Beedle's Ship Entrance
+    allowed-time-of-day: NightOnly
+    stage: F002r
+    room: 0
+    index: 2
+    req_index: 1829
+    short_name: Beedle's Shop - Night Exit
+  \Skyloft\Central Skyloft\Exit to Beedle's Shop:
+    type: exit
+    vanilla: Beedle's Shop - Day Entrance
+    stage: F000
+    room: 0
+    index: 26
+    req_index: 1830
+    short_name: Skyloft - Exit to Beedle's Shop
+  \Skyloft\Skyloft Silent Realm\Exit:
+    type: exit
+    vanilla: Skyloft - Trial Gate Entrance
+    req_index: 1831
+    short_name: Skyloft Silent Realm - Exit
+  \Skyloft\Central Skyloft\Trial Gate Exit:
+    type: exit
+    vanilla: Skyloft Silent Realm - Entrance
+    req_index: 1832
+    short_name: Skyloft - Trial Gate Exit
+  \Skyloft\Central Skyloft\Near Temple Entrance\Exit to Sky Keep:
+    type: exit
+    vanilla: Sky Keep - First Room - Bottom Entrance
+    stage: F000
+    room: 0
+    index: 48
+    req_index: 1833
+    short_name: Skyloft - Exit to Sky Keep
+  \Skyloft\Central Skyloft\Orielle and Parrow's House\Exit:
+    type: exit
+    vanilla: Orielle and Parrow's House Entrance
+    stage: F005r
+    room: 0
+    index: 0
+    req_index: 1834
+    short_name: Orielle and Parrow's House - Exit
+  \Skyloft\Central Skyloft\Orielle and Parrow's House Exit:
+    type: exit
+    vanilla: Orielle and Parrow's House - Entrance
+    stage: F000
+    room: 0
+    index: 31
+    req_index: 1835
+    short_name: Orielle and Parrow's House Exit
+  \Skyloft\Central Skyloft\Peatrice's House\Exit:
+    type: exit
+    vanilla: Peatrice's House Entrance
+    stage: F018r
+    room: 0
+    index: 0
+    req_index: 1836
+    short_name: Peatrice's House - Exit
+  \Skyloft\Central Skyloft\Peatrice's House Exit:
+    type: exit
+    vanilla: Peatrice's House - Entrance
+    stage: F000
+    room: 0
+    index: 38
+    req_index: 1837
+    short_name: Peatrice's House Exit
+  \Skyloft\Central Skyloft\Wryna's House\Exit:
+    type: exit
+    vanilla: Wryna's House Entrance
+    stage: F006r
+    room: 0
+    index: 0
+    req_index: 1838
+    short_name: Wryna's House - Exit
+  \Skyloft\Central Skyloft\Wryna's House Exit:
+    type: exit
+    vanilla: Wryna's House - Entrance
+    stage: F000
+    room: 0
+    index: 10
+    req_index: 1839
+    short_name: Wryna's House Exit
+  \Skyloft\Skyloft Village\Bertie's House\Exit:
+    type: exit
+    vanilla: Bertie's House Entrance
+    stage: F014r
+    room: 0
+    index: 0
+    req_index: 1840
+    short_name: Bertie's House - Exit
+  \Skyloft\Skyloft Village\Bertie's House Exit:
+    type: exit
+    vanilla: Bertie's House - Entrance
+    stage: F000
+    room: 0
+    index: 34
+    req_index: 1841
+    short_name: Bertie's House Exit
+  \Skyloft\Skyloft Village\Sparrot's House\Exit:
+    type: exit
+    vanilla: Sparrot's House Entrance
+    stage: F013r
+    room: 0
+    index: 0
+    req_index: 1842
+    short_name: Sparrot's House - Exit
+  \Skyloft\Skyloft Village\Sparrot's House Exit:
+    type: exit
+    vanilla: Sparrot's House - Entrance
+    stage: F000
+    room: 0
+    index: 33
+    req_index: 1843
+    short_name: Sparrot's House Exit
+  \Skyloft\Skyloft Village\Mallara's House Exit:
+    type: exit
+    vanilla: Mallara's House - Entrance
+    stage: F000
+    room: 0
+    index: 36
+    req_index: 1844
+    short_name: Skyloft - Mallara's House Exit
+  \Skyloft\Skyloft Village\Mallara's House\Exit:
+    type: exit
+    vanilla: Mallara's House Entrance
+    stage: F016r
+    room: 0
+    index: 0
+    req_index: 1845
+    short_name: Mallara's House - Exit
+  \Skyloft\Skyloft Village\Batreaux's House\Exit:
+    type: exit
+    vanilla: Batreaux's House Entrance
+    stage: F012r
+    room: 0
+    index: 0
+    req_index: 1846
+    short_name: Batreaux's House - Exit
+  \Skyloft\Skyloft Village\Batreaux's House Exit:
+    type: exit
+    vanilla: Batreaux's House - Entrance
+    stage: F000
+    room: 0
+    index: 30
+    req_index: 1847
+    short_name: Batreaux's House Exit
+  \Skyloft\Skyloft Village\Gondo's House\Exit:
+    type: exit
+    vanilla: Gondo's House Entrance
+    stage: F015r
+    room: 0
+    index: 0
+    req_index: 1848
+    short_name: Gondo's House - Exit
+  \Skyloft\Skyloft Village\Gondo's House Exit:
+    type: exit
+    vanilla: Gondo's House - Entrance
+    stage: F000
+    room: 0
+    index: 35
+    req_index: 1849
+    short_name: Gondo's House Exit
+  \Skyloft\Skyloft Village\Rupin's House\Exit:
+    type: exit
+    vanilla: Rupin's House Entrance
+    stage: F017r
+    room: 0
+    index: 1
+    req_index: 1850
+    short_name: Rupin's House - Exit
+  \Skyloft\Skyloft Village\Rupin's House Exit:
+    type: exit
+    vanilla: Rupin's House - Entrance
+    stage: F000
+    room: 0
+    index: 37
+    req_index: 1851
+    short_name: Rupin's House Exit
+  \Skyloft\Central Skyloft\Piper's House\Exit:
+    type: exit
+    vanilla: Piper's House Entrance
+    stage: F007r
+    room: 0
+    index: 0
+    req_index: 1852
+    short_name: Piper's House - Exit
+  \Skyloft\Central Skyloft\Piper's House Exit:
+    type: exit
+    vanilla: Piper's House - Entrance
+    stage: F000
+    room: 0
+    index: 32
+    req_index: 1853
+    short_name: Piper's House Exit
+  \Skyloft\Central Skyloft\Exit to Sky:
+    type: exit
+    vanilla: Sky - Entrance from Skyloft
+    req_index: 1854
+    short_name: Skyloft - Exit to Sky
+  \Sky\Around Skyloft\Exit to Skyloft:
+    type: exit
+    vanilla: Skyloft - Entrance from Sky
+    req_index: 1855
+    short_name: Sky - Exit to Skyloft
+  \Sky\North East\Bamboo Island\Inside\Exit:
+    type: exit
+    vanilla: Bamboo Island - Entrance from Inside
+    stage: F019r
+    room: 0
+    index: 2
+    req_index: 1856
+    short_name: Bamboo Island - Inside - Exit
+  \Sky\North East\Bamboo Island\Exit to Inside:
+    type: exit
+    vanilla: Bamboo Island - Inside - Entrance
+    stage: F020
+    room: 0
+    index: 13
+    req_index: 1857
+    short_name: Bamboo Island - Exit to Inside
+  \Sky\North East\Beedle's Island\Beedle's Ship Exit:
+    type: exit
+    vanilla: Beedle's Shop - Night Entrance
+    allowed-time-of-day: NightOnly
+    stage: F020
+    room: 0
+    index: 14
+    req_index: 1858
+    short_name: Sky - Beedle's Island - Beedle's Ship Exit
+  \Sky\North East\Eldin Pillar\First Time Dive:
+    type: exit
+    vanilla: Eldin Volcano - First Time Entrance
+    stage: F020
+    room: 0
+    index: 1
+    req_index: 1859
+    short_name: Sky - Eldin Pillar - First Time Dive
+  \Sky\North East\Eldin Pillar\Temple Entrance Statue Dive:
+    type: exit
+    vanilla: Eldin Volcano - Temple Entrance Statue Entrance
+    stage: F020
+    room: 0
+    index: 29
+    req_index: 1860
+    short_name: Sky - Eldin Pillar - Temple Entrance Statue Dive
+  \Sky\North East\Eldin Pillar\Inside the Volcano Statue Dive:
+    type: exit
+    vanilla: Outside Fire Sanctuary - Statue Entrance
+    stage: F020
+    room: 0
+    index: 30
+    req_index: 1861
+    short_name: Sky - Eldin Pillar - Inside the Volcano Statue Dive
+  \Sky\North East\Eldin Pillar\Volcano Entrance Statue Dive:
+    type: exit
+    vanilla: Eldin Volcano - Volcano Entrance Statue Entrance
+    stage: F020
+    room: 0
+    index: 50
+    req_index: 1862
+    short_name: Sky - Eldin Pillar - Volcano Entrance Statue Dive
+  \Sky\North East\Eldin Pillar\Volcano East Statue Dive:
+    type: exit
+    vanilla: Eldin Volcano - Volcano East Statue Entrance
+    stage: F020
+    room: 0
+    index: 51
+    req_index: 1863
+    short_name: Sky - Eldin Pillar - Volcano East Statue Dive
+  \Sky\North East\Eldin Pillar\Volcano Ascent Statue Dive:
+    type: exit
+    vanilla: Eldin Volcano - Volcano Ascent Statue Entrance
+    stage: F020
+    room: 0
+    index: 52
+    req_index: 1864
+    short_name: Sky - Eldin Pillar - Volcano Ascent Statue Dive
+  \Sky\North East\Eldin Pillar\Fire Sanctuary Statue Dive:
+    type: exit
+    vanilla: Fire Sanctuary - Statue Entrance
+    stage: F020
+    room: 0
+    index: 55
+    req_index: 1865
+    short_name: Sky - Eldin Pillar - Fire Sanctuary Statue Dive
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Exit:
+    type: exit
+    vanilla: Lumpy Pumpkin - Main Left Door Entrance
+    stage: F011r
+    room: 0
+    index: 0
+    req_index: 1866
+    short_name: Lumpy Pumpkin Building - Main Right Door Exit
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Exit:
+    type: exit
+    vanilla: Lumpy Pumpkin - Main Right Door Entrance
+    stage: F011r
+    room: 0
+    index: 1
+    req_index: 1867
+    short_name: Lumpy Pumpkin Building - Main Left Door Exit
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Exit:
+    type: exit
+    vanilla: Lumpy Pumpkin - Back Door Entrance
+    stage: F011r
+    room: 0
+    index: 2
+    req_index: 1868
+    short_name: Lumpy Pumpkin Building - Back Door Exit
+  \Sky\South East\Lumpy Pumpkin\Main Right Door Exit:
+    type: exit
+    vanilla: Lumpy Pumpkin Building - Main Left Door Entrance
+    stage: F020
+    room: 0
+    index: 18
+    req_index: 1869
+    short_name: Lumpy Pumpkin - Main Right Door Exit
+  \Sky\South East\Lumpy Pumpkin\Main Left Door Exit:
+    type: exit
+    vanilla: Lumpy Pumpkin Building - Main Right Door Entrance
+    stage: F020
+    room: 0
+    index: 19
+    req_index: 1870
+    short_name: Lumpy Pumpkin - Main Left Door Exit
+  \Sky\South East\Lumpy Pumpkin\Back Door Exit:
+    type: exit
+    vanilla: Lumpy Pumpkin Building - Back Door Entrance
+    stage: F020
+    room: 0
+    index: 20
+    req_index: 1871
+    short_name: Lumpy Pumpkin - Back Door Exit
+  \Sky\South East\Faron Pillar\First Time Dive:
+    type: exit
+    vanilla: Sealed Grounds Spiral - Statue Entrance
+    stage: F020
+    room: 0
+    index: 0
+    req_index: 1872
+    short_name: Sky - Faron Pillar - First Time Dive
+  \Sky\South East\Faron Pillar\Sealed Grounds Statue Dive:
+    type: exit
+    vanilla: Sealed Grounds Spiral - Statue Entrance
+    stage: F020
+    room: 0
+    index: 68
+    req_index: 1873
+    short_name: Sky - Faron Pillar - Sealed Grounds Statue Dive
+  \Sky\South East\Faron Pillar\Forest Temple Statue Dive:
+    type: exit
+    vanilla: Deep Woods - Forest Temple Statue Entrance
+    stage: F020
+    room: 0
+    index: 27
+    req_index: 1874
+    short_name: Sky - Faron Pillar - Forest Temple Statue Dive
+  \Sky\South East\Faron Pillar\Behind the Temple Statue Dive:
+    type: exit
+    vanilla: Behind the Temple - Statue Entrance
+    stage: F020
+    room: 0
+    index: 40
+    req_index: 1875
+    short_name: Sky - Faron Pillar - Behind the Temple Statue Dive
+  \Sky\South East\Faron Pillar\Faron Woods Entry Statue Dive:
+    type: exit
+    vanilla: Faron Woods - Faron Woods Entry Statue Entrance
+    stage: F020
+    room: 0
+    index: 41
+    req_index: 1876
+    short_name: Sky - Faron Pillar - Faron Woods Entry Statue Dive
+  \Sky\South East\Faron Pillar\In the Woods Statue Dive:
+    type: exit
+    vanilla: Faron Woods - In the Woods Statue Entrance
+    stage: F020
+    room: 0
+    index: 42
+    req_index: 1877
+    short_name: Sky - Faron Pillar - In the Woods Statue Dive
+  \Sky\South East\Faron Pillar\Viewing Platform Statue Dive:
+    type: exit
+    vanilla: Faron Woods - Viewing Platform Statue Entrance
+    stage: F020
+    room: 0
+    index: 43
+    req_index: 1878
+    short_name: Sky - Faron Pillar - Viewing Platform Statue Dive
+  \Sky\South East\Faron Pillar\The Great Tree Statue Dive:
+    type: exit
+    vanilla: Great Tree - The Great Tree Statue Entrance
+    stage: F020
+    room: 0
+    index: 44
+    req_index: 1879
+    short_name: Sky - Faron Pillar - The Great Tree Statue Dive
+  \Sky\South East\Faron Pillar\Deep Woods Statue Dive:
+    type: exit
+    vanilla: Deep Woods - Deep Woods Statue Entrance
+    stage: F020
+    room: 0
+    index: 46
+    req_index: 1880
+    short_name: Sky - Faron Pillar - Deep Woods Statue Dive
+  \Sky\South East\Faron Pillar\Lake Floria Statue Dive:
+    type: exit
+    vanilla: Lake Floria - Below Rock - Statue Entrance
+    stage: F020
+    room: 0
+    index: 47
+    req_index: 1881
+    short_name: Sky - Faron Pillar - Lake Floria Statue Dive
+  \Sky\South East\Faron Pillar\Floria Waterfall Statue Dive:
+    type: exit
+    vanilla: Floria Waterfall - Statue Entrance
+    stage: F020
+    room: 0
+    index: 48
+    req_index: 1882
+    short_name: Sky - Faron Pillar - Floria Waterfall Statue Dive
+  \Sky\South West\Lanayru Pillar\First Time Dive:
+    type: exit
+    vanilla: Lanayru Mine - First Time Entrance
+    stage: F020
+    room: 0
+    index: 2
+    req_index: 1883
+    short_name: Sky - Lanayru Pillar - First Time Dive
+  \Sky\South West\Lanayru Pillar\Lanayru Mine Entry Statue Dive:
+    type: exit
+    vanilla: Lanayru Mine - Statue Entrance
+    stage: F020
+    room: 0
+    index: 56
+    req_index: 1884
+    short_name: Sky - Lanayru Pillar - Lanayru Mine Entry Statue Dive
+  \Sky\South West\Lanayru Pillar\Desert Entrance Statue Dive:
+    type: exit
+    vanilla: Lanayru Desert - Desert Entrance Statue Entrance
+    stage: F020
+    room: 0
+    index: 57
+    req_index: 1885
+    short_name: Sky - Lanayru Pillar - Desert Entrance Statue Dive
+  \Sky\South West\Lanayru Pillar\West Desert Statue Dive:
+    type: exit
+    vanilla: Lanayru Desert - West Desert Statue Entrance
+    stage: F020
+    room: 0
+    index: 58
+    req_index: 1886
+    short_name: Sky - Lanayru Pillar - West Desert Statue Dive
+  \Sky\South West\Lanayru Pillar\North Desert Statue Dive:
+    type: exit
+    vanilla: Lanayru Desert - North Desert Statue Entrance
+    stage: F020
+    room: 0
+    index: 59
+    req_index: 1887
+    short_name: Sky - Lanayru Pillar - North Desert Statue Dive
+  \Sky\South West\Lanayru Pillar\Stone Cache Statue Dive:
+    type: exit
+    vanilla: Lanayru Desert - Stone Cache Statue Entrance
+    stage: F020
+    room: 0
+    index: 60
+    req_index: 1888
+    short_name: Sky - Lanayru Pillar - Stone Cache Statue Dive
+  \Sky\South West\Lanayru Pillar\Desert Gorge Statue Dive:
+    type: exit
+    vanilla: Temple of Time - Desert Gorge Statue Entrance
+    stage: F020
+    room: 0
+    index: 61
+    req_index: 1889
+    short_name: Sky - Lanayru Pillar - Desert Gorge Statue Dive
+  \Sky\South West\Lanayru Pillar\Temple of Time Statue Dive:
+    type: exit
+    vanilla: Temple of Time - Temple of Time Statue Entrance
+    stage: F020
+    room: 0
+    index: 62
+    req_index: 1890
+    short_name: Sky - Lanayru Pillar - Temple of Time Statue Dive
+  \Sky\South West\Lanayru Pillar\Ancient Harbour Statue Dive:
+    type: exit
+    vanilla: Lanayru Sand Sea Docks - Statue Entrance
+    stage: F020
+    room: 0
+    index: 63
+    req_index: 1891
+    short_name: Sky - Lanayru Pillar - Ancient Harbour Statue Dive
+  \Sky\South West\Lanayru Pillar\Skipper's Retreat Statue Dive:
+    type: exit
+    vanilla: Skipper's Retreat - Statue Entrance
+    stage: F020
+    room: 0
+    index: 64
+    req_index: 1892
+    short_name: Sky - Lanayru Pillar - Skipper's Retreat Statue Dive
+  \Sky\South West\Lanayru Pillar\Shipyard Statue Dive:
+    type: exit
+    vanilla: Shipyard - Statue Entrance
+    stage: F020
+    room: 0
+    index: 65
+    req_index: 1893
+    short_name: Sky - Lanayru Pillar - Shipyard Statue Dive
+  \Sky\South West\Lanayru Pillar\Pirate Stronghold Statue Dive:
+    type: exit
+    vanilla: Pirate Stronghold - Statue Entrance
+    stage: F020
+    room: 0
+    index: 66
+    req_index: 1894
+    short_name: Sky - Lanayru Pillar - Pirate Stronghold Statue Dive
+  \Sky\South West\Lanayru Pillar\Lanayru Gorge Statue Dive:
+    type: exit
+    vanilla: Lanayru Gorge - Statue Entrance
+    req_index: 1895
+    short_name: Sky - Lanayru Pillar - Lanayru Gorge Statue Dive
+  \Sky\Around Skyloft\Exit to Thunderhead:
+    type: exit
+    vanilla: Thunderhead - Entrance
+    stage: F020
+    room: 0
+    index: 25
+    req_index: 1896
+    short_name: Sky - Exit to Thunderhead
+  \Sky\Thunderhead\Exit:
+    type: exit
+    vanilla: Sky - Entrance from Thunderhead
+    stage: F023
+    room: 0
+    index: 1
+    req_index: 1897
+    short_name: Thunderhead - Exit
+  \Sky\Thunderhead\Isle of Songs\Inside\Exit:
+    type: exit
+    vanilla: Isle of Songs - Entrance from Inside
+    stage: F010r
+    room: 0
+    index: 0
+    req_index: 1898
+    short_name: Isle of Songs - Exit
+  \Sky\Thunderhead\Isle of Songs\Exit to Inside:
+    type: exit
+    vanilla: Isle of Songs - Entrance
+    stage: F023
+    room: 0
+    index: 2
+    req_index: 1899
+    short_name: Isle of Songs - Exit to Inside
+  \Faron\Sealed Grounds\Spiral\Upper Part\Statue Exit:
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+    stage: F401
+    room: 1
+    index: 19
+    req_index: 1900
+    short_name: Sealed Grounds Spiral - Statue Exit
+  \Faron\Sealed Grounds\Spiral\Door Exit:
+    type: exit
+    vanilla: Sealed Temple - Main Entrance
+    stage: F401
+    room: 1
+    index: 0
+    req_index: 1901
+    short_name: Sealed Grounds Spiral - Door Exit
+  \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Exit to Behind the Temple:
+    type: exit
+    vanilla: Behind the Temple - Shortcut Entrance from Spiral
+    stage: F401
+    room: 1
+    index: 1
+    req_index: 1902
+    short_name: Sealed Grounds Spiral - Shortcut Exit to Behind the Temple
+  \Faron\Sealed Grounds\Sealed Temple\Main Exit:
+    type: exit
+    vanilla: Sealed Grounds Spiral - Door Entrance
+    stage: F402
+    room: 2
+    index: 0
+    req_index: 1903
+    short_name: Sealed Temple - Main Exit
+  \Faron\Sealed Grounds\Sealed Temple\Side Exit:
+    type: exit
+    vanilla: Behind the Temple - Door Entrance
+    stage: F402
+    room: 2
+    index: 1
+    req_index: 1904
+    short_name: Sealed Temple - Side Exit
+  \Faron\Sealed Grounds\Sealed Temple\Gate of Time Exit:
+    type: exit
+    vanilla: Hylia's Temple - Gate of Time Entrance
+    stage: F402
+    room: 2
+    index: 5
+    req_index: 1905
+    short_name: Sealed Temple - Gate of Time Exit
+  \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Exit:
+    type: exit
+    vanilla: Sealed Temple - Gate of Time Entrance
+    stage: F404
+    room: 2
+    index: 1
+    req_index: 1906
+    short_name: Hylia's Temple - Gate of Time Exit
+  \Faron\Sealed Grounds\Behind the Temple\Statue Exit:
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+    stage: F400
+    room: 0
+    index: 5
+    req_index: 1907
+    short_name: Behind the Temple - Statue Exit
+  \Faron\Sealed Grounds\Behind the Temple\Shortcut Exit to Spiral:
+    type: exit
+    vanilla: Sealed Grounds Spiral - Shortcut Entrance from Behind the Temple
+    stage: F400
+    room: 0
+    index: 0
+    req_index: 1908
+    short_name: Behind the Temple - Shortcut Exit to Spiral
+  \Faron\Sealed Grounds\Behind the Temple\Door Exit:
+    type: exit
+    vanilla: Sealed Temple - Side Entrance
+    stage: F400
+    room: 0
+    index: 1
+    req_index: 1909
+    short_name: Behind the Temple - Door Exit
+  \Faron\Sealed Grounds\Behind the Temple\Exit to Faron Woods:
+    type: exit
+    vanilla: Faron Woods - Entrance from Behind the Temple
+    stage: F400
+    room: 0
+    index: 2
+    req_index: 1910
+    short_name: Behind the Temple - Exit to Faron Woods
+  \Faron\Faron Woods\Shared Statue Exit:
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+    stage: F100
+    room: 0
+    index: 10
+    req_index: 1911
+    short_name: Faron Woods - Shared Statue Exit
+  \Faron\Faron Woods\Entry\Exit to Behind the Temple:
+    type: exit
+    vanilla: Behind the Temple - Entrance from Faron Woods
+    stage: F100
+    room: 0
+    index: 0
+    req_index: 1912
+    short_name: Faron Woods - Exit to Behind the Temple
+  \Faron\Faron Woods\Ledge To Deep Woods\Exit to Deep Woods:
+    type: exit
+    vanilla: Deep Woods - Entrance from Faron Woods
+    stage: F100
+    room: 0
+    index: 1
+    req_index: 1913
+    short_name: Faron Woods - Exit to Deep Woods
+  \Faron\Faron Woods\Lake Floria Dive:
+    type: exit
+    vanilla: Lake Floria - Dive from Faron Woods
+    stage: F100
+    room: 0
+    index: 9
+    req_index: 1914
+    short_name: Faron Woods - Lake Floria Dive
+  \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Exit to Floria Waterfall:
+    type: exit
+    vanilla: Floria Waterfall - Entrance from Faron Woods
+    stage: F100
+    room: 0
+    index: 11
+    req_index: 1915
+    short_name: Faron Woods - Shortcut Exit to Floria Waterfall
+  \Faron\Faron Woods\Trial Gate Exit:
+    type: exit
+    vanilla: Faron Silent Realm - Entrance
+    req_index: 1916
+    short_name: Faron Woods - Trial Gate Exit
+  \Faron\Faron Silent Realm\Exit:
+    type: exit
+    vanilla: Faron Woods - Trial Gate Entrance
+    req_index: 1917
+    short_name: Faron Silent Realm - Exit
+  \Faron\Faron Woods\Great Tree\Platforms\Lower Exit to Great Tree:
+    type: exit
+    vanilla: Great Tree - Lower Entrance from Platforms
+    stage: F100
+    room: 0
+    index: 3
+    req_index: 1918
+    short_name: Great Tree - Platforms - Lower Exit to Great Tree
+  \Faron\Faron Woods\Great Tree\Platforms\Upper Exit to Great Tree:
+    type: exit
+    vanilla: Great Tree - Upper Entrance from Platforms
+    stage: F100
+    room: 0
+    index: 4
+    req_index: 1919
+    short_name: Great Tree - Platforms - Upper Exit to Great Tree
+  \Faron\Faron Woods\Great Tree\Top\Top Exit to Great Tree:
+    type: exit
+    vanilla: Great Tree - Entrance from Top
+    stage: F100
+    room: 0
+    index: 5
+    req_index: 1920
+    short_name: Great Tree - Top Exit to Great Tree
+  \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Exit:
+    type: exit
+    vanilla: Great Tree - Underwater Tunnel Entrance
+    stage: F100
+    room: 0
+    index: 6
+    req_index: 1921
+    short_name: Great Tree - Underwater Hole Exit
+  \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Exit to Platforms:
+    type: exit
+    vanilla: Great Tree - Platforms - Lower Entrance from Great Tree
+    stage: F100_1
+    room: 0
+    index: 1
+    req_index: 1922
+    short_name: Great Tree - Lower Exit to Platforms
+  \Faron\Faron Woods\Great Tree\Upper Area\Upper Exit to Platforms:
+    type: exit
+    vanilla: Great Tree - Platforms - Upper Entrance from Great Tree
+    stage: F100_1
+    room: 0
+    index: 2
+    req_index: 1923
+    short_name: Great Tree - Upper Exit to Platforms
+  \Faron\Faron Woods\Great Tree\Upper Area\Exit to Top:
+    type: exit
+    vanilla: Great Tree - Top Entrance from Great Tree
+    stage: F100_1
+    room: 0
+    index: 3
+    req_index: 1924
+    short_name: Great Tree - Exit to Top
+  \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Exit:
+    type: exit
+    vanilla: Great Tree - Underwater Hole Entrance
+    stage: F100_1
+    room: 0
+    index: 4
+    req_index: 1925
+    short_name: Great Tree - Underwater Tunnel Exit
+  \Faron\Faron Woods\Great Tree\Upper Area\Exit to Flooded Great Tree:
+    type: exit
+    vanilla: Flooded Great Tree - Entrance
+    req_index: 1926
+    short_name: Great Tree - Exit to Flooded Great Tree
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Exit:
+    type: exit
+    vanilla: Entrance from Flooded Great Tree
+    req_index: 1927
+    short_name: Flooded Great Tree - Exit
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Upper Flooded Faron Woods:
+    type: exit
+    vanilla: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
+    req_index: 1928
+    short_name: Flooded Great Tree - Exit to Upper Flooded Faron Woods
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Lower Flooded Faron Woods:
+    type: exit
+    vanilla: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
+    req_index: 1929
+    short_name: Flooded Great Tree - Exit to Lower Flooded Faron Woods
+  \Faron\Flooded Faron Woods\Exit to Upper Flooded Great Tree:
+    type: exit
+    vanilla: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
+    req_index: 1930
+    short_name: Flooded Faron Woods - Exit to Upper Flooded Great Tree
+  \Faron\Flooded Faron Woods\Exit to Lower Flooded Great Tree:
+    type: exit
+    vanilla: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
+    req_index: 1931
+    short_name: Flooded Faron Woods - Exit to Lower Flooded Great Tree
+  \Faron\Faron Woods\Deep Woods\Shared Statue Exit:
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+    stage: F101
+    room: 0
+    index: 2
+    req_index: 1932
+    short_name: Deep Woods - Shared Statue Exit
+  \Faron\Faron Woods\Deep Woods\Entry\Exit to Faron Woods:
+    type: exit
+    vanilla: Faron Woods - Entrance from Deep Woods
+    stage: F101
+    room: 0
+    index: 0
+    req_index: 1933
+    short_name: Deep Woods - Exit to Faron Woods
+  \Faron\Faron Woods\Deep Woods\Exit to Skyview Temple:
+    type: exit
+    vanilla: Skyview Temple - Main Entrance
+    stage: F101
+    room: 0
+    index: 1
+    req_index: 1934
+    short_name: Deep Woods - Exit to Skyview Temple
+  \Faron\Lake Floria\Below Rock\Emerged Area\Statue Exit:
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+    stage: F102
+    room: 3
+    index: 0
+    req_index: 1935
+    short_name: Lake Floria - Below Rock - Statue Exit
+  \Faron\Lake Floria\Below Rock\Exit to Farore's Lair:
+    type: exit
+    vanilla: Farore's Lair - Entrance from Lake Floria
+    stage: F102
+    room: 4
+    index: 0
+    req_index: 1936
+    short_name: Lake Floria - Exit to Farore's Lair
+  \Faron\Lake Floria\Farore's Lair\Exit to Lake Floria:
+    type: exit
+    vanilla: Lake Floria - Entrance from Farore's Lair
+    stage: F102_2
+    room: 0
+    index: 0
+    req_index: 1937
+    short_name: Farore's Lair - Exit to Lake Floria
+  \Faron\Lake Floria\Farore's Lair\Exit to Waterfall:
+    type: exit
+    vanilla: Floria Waterfall - Entrance from Farore's Lair
+    stage: F102_2
+    room: 0
+    index: 1
+    req_index: 1938
+    short_name: Farore's Lair - Exit to Waterfall
+  \Faron\Lake Floria\Waterfall\Statue Exit:
+    type: exit
+    vanilla: Sky - Faron Pillar - Entrance
+    stage: F102_1
+    room: 0
+    index: 3
+    req_index: 1939
+    short_name: Floria Waterfall - Statue Exit
+  \Faron\Lake Floria\Waterfall\Exit to Farore's Lair:
+    type: exit
+    vanilla: Farore's Lair - Entrance from Waterfall
+    stage: F102_1
+    room: 0
+    index: 0
+    req_index: 1940
+    short_name: Floria Waterfall - Exit to Farore's Lair
+  \Faron\Lake Floria\Waterfall\Exit to Ancient Cistern:
+    type: exit
+    vanilla: Ancient Cistern - Main Entrance
+    stage: F102_1
+    room: 0
+    index: 1
+    req_index: 1941
+    short_name: Floria Waterfall - Exit to Ancient Cistern
+  \Faron\Lake Floria\Waterfall\Exit to Faron Woods:
+    type: exit
+    vanilla: Faron Woods - Shortcut Entrance from Floria Waterfall
+    stage: F102_1
+    room: 0
+    index: 2
+    req_index: 1942
+    short_name: Floria Waterfall - Exit to Faron Woods
+  \Skyview\Main\Entry\Main Exit:
+    type: exit
+    vanilla: Deep Woods - Entrance from Skyview Temple
+    req_index: 1943
+    short_name: Skyview Temple - Main Exit
+  \Skyview\Main\Last Room\After Rope\Boss Door Exit:
+    type: exit
+    vanilla: Skyview Temple - Boss Room - Entrance from Dungeon
+    req_index: 1944
+    short_name: Skyview Temple - Boss Door Exit
+  \Skyview\Boss Room\Exit to Dungeon:
+    type: exit
+    vanilla: Skyview Temple - Boss Door Entrance
+    req_index: 1945
+    short_name: Skyview Temple - Boss Room - Exit to Dungeon
+  \Skyview\Boss Room\Exit to Spring:
+    type: exit
+    vanilla: Skyview Temple - Spring - Entrance
+    req_index: 1946
+    short_name: Skyview Temple - Boss Room - Exit to Spring
+  \Skyview\Spring\Exit:
+    type: exit
+    vanilla: Skyview Temple - Boss Room - Entrance from Spring
+    req_index: 1947
+    short_name: Skyview Temple - Spring - Exit
+  \Ancient Cistern\Main\Main Room\Main Exit:
+    type: exit
+    vanilla: Floria Waterfall - Entrance from Ancient Cistern
+    req_index: 1948
+    short_name: Ancient Cistern - Main Exit
+  \Ancient Cistern\Main\Inside Statue\Boss Door Exit:
+    type: exit
+    vanilla: Ancient Cistern - Boss Room - Entrance from Dungeon
+    req_index: 1949
+    short_name: Ancient Cistern - Boss Door Exit
+  \Ancient Cistern\Boss Room\Exit to Dungeon:
+    type: exit
+    vanilla: Ancient Cistern - Boss Door Entrance
+    req_index: 1950
+    short_name: Ancient Cistern - Boss Room - Exit to Dungeon
+  \Ancient Cistern\Boss Room\Exit to Flame Room:
+    type: exit
+    vanilla: Ancient Cistern - Flame Room - Entrance
+    req_index: 1951
+    short_name: Ancient Cistern - Boss Room - Exit to Flame Room
+  \Ancient Cistern\Flame Room\Exit:
+    type: exit
+    vanilla: Ancient Cistern - Boss Room - Entrance from Flame Room
+    req_index: 1952
+    short_name: Ancient Cistern - Flame Room - Exit
+  \Eldin\Volcano\Entry\Volcano Entrance Statue Exit:
+    type: exit
+    vanilla: Sky - Eldin Pillar - Entrance
+    stage: F200
+    room: 0
+    index: 0
+    req_index: 1953
+    short_name: Eldin Volcano - Volcano Entrance Statue Exit
+  \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit:
+    type: exit
+    vanilla: Sky - Eldin Pillar - Entrance
+    stage: F200
+    room: 2
+    index: 2
+    req_index: 1954
+    short_name: Eldin Volcano - Volcano East / Volcano Ascent Statue Exit
+  \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Exit:
+    type: exit
+    vanilla: Sky - Eldin Pillar - Entrance
+    stage: F200
+    room: 4
+    index: 2
+    req_index: 1955
+    short_name: Eldin Volcano - Temple Entrance Statue Exit
+  \Eldin\Volcano\East\Dive to Mogma Turf:
+    type: exit
+    vanilla: Mogma Turf - Entrance
+    stage: F200
+    room: 2
+    index: 1
+    req_index: 1956
+    short_name: Eldin Volcano - Dive to Mogma Turf
+  \Eldin\Volcano\Near Temple Entrance\Exit to Earth Temple:
+    type: exit
+    vanilla: Earth Temple - Main Entrance
+    stage: F200
+    room: 4
+    index: 0
+    req_index: 1957
+    short_name: Eldin Volcano - Exit to Earth Temple
+  \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Exit:
+    type: exit
+    vanilla: Thrill Digger Cave - Entrance
+    stage: F200
+    room: 4
+    index: 1
+    req_index: 1958
+    short_name: Eldin Volcano - Thrill Digger Cave Exit
+  \Eldin\Volcano\Hot Cave\Exit to Summit:
+    type: exit
+    vanilla: Volcano Summit - Entrance from Eldin Volcano
+    stage: F200
+    room: 5
+    index: 1
+    req_index: 1959
+    short_name: Eldin Volcano - Exit to Summit
+  \Eldin\Volcano\Ascent\Trial Gate Exit:
+    type: exit
+    vanilla: Eldin Silent Realm - Entrance
+    req_index: 1960
+    short_name: Eldin Volcano - Trial Gate Exit
+  \Eldin\Volcano\Past Slide\Vent Exit near Ascent:
+    type: exit
+    vanilla: Eldin Volcano - Vent Entrance near Hot Cave
+    req_index: 1961
+    short_name: Eldin Volcano - Vent Exit near Ascent
+  \Eldin\Volcano\East\Exit to Bokoblin Base:
+    type: exit
+    vanilla: Bokoblin Base - Entrance
+    req_index: 1962
+    short_name: Eldin Volcano - Exit to Bokoblin Base
+  \Eldin\Bokoblin Base\Prison\Exit:
+    type: exit
+    vanilla: Entrance from Bokoblin Base
+    req_index: 1963
+    short_name: Bokoblin Base - Exit
+  \Eldin\Mogma Turf\Pre Vent\First Vent:
+    type: exit
+    vanilla: Eldin Volcano - First Vent from Mogma Turf
+    stage: F210
+    room: 0
+    index: 0
+    req_index: 1964
+    short_name: Mogma Turf - First Vent
+  \Eldin\Mogma Turf\Past Vent\Second Vent:
+    type: exit
+    vanilla: Eldin Volcano - Second Vent from Mogma Turf
+    stage: F210
+    room: 0
+    index: 1
+    req_index: 1965
+    short_name: Mogma Turf - Second Vent
+  \Eldin\Volcano\Thrill Digger Cave\Exit:
+    type: exit
+    vanilla: Eldin Volcano - Thrill Digger Cave Entrance
+    stage: F211
+    room: 0
+    index: 0
+    req_index: 1966
+    short_name: Thrill Digger Cave - Exit
+  \Eldin\Eldin Silent Realm\Exit:
+    type: exit
+    vanilla: Eldin Volcano - Trial Gate Entrance
+    req_index: 1967
+    short_name: Eldin Silent Realm - Exit
+  \Eldin\Volcano Summit\Exit to Eldin Volcano:
+    type: exit
+    vanilla: Eldin Volcano - Entrance from Summit
+    stage: F201_1
+    room: 0
+    index: 0
+    req_index: 1968
+    short_name: Volcano Summit - Exit to Eldin Volcano
+  \Eldin\Volcano Summit\Exit to Waterfall:
+    type: exit
+    vanilla: Volcano Summit - Waterfall - Entrance
+    stage: F201_1
+    room: 0
+    index: 1
+    req_index: 1969
+    short_name: Volcano Summit - Exit to Waterfall
+  \Eldin\Volcano Summit\Exit to Outside Fire Sanctuary:
+    type: exit
+    vanilla: Outside Fire Sanctuary - Entrance from Summit
+    stage: F201_1
+    room: 0
+    index: 2
+    req_index: 1970
+    short_name: Volcano Summit - Exit to Outside Fire Sanctuary
+  \Eldin\Volcano Summit\Waterfall\Exit:
+    type: exit
+    vanilla: Volcano Summit - Entrance from Waterfall
+    stage: F201_4
+    room: 0
+    index: 0
+    req_index: 1971
+    short_name: Volcano Summit - Waterfall - Exit
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Exit:
+    type: exit
+    vanilla: Sky - Eldin Pillar - Entrance
+    stage: F201_3
+    room: 0
+    index: 2
+    req_index: 1972
+    short_name: Outside Fire Sanctuary - Statue Exit
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Exit to Summit:
+    type: exit
+    vanilla: Volcano Summit - Entrance from Outside Fire Sanctuary
+    stage: F201_3
+    room: 0
+    index: 0
+    req_index: 1973
+    short_name: Outside Fire Sanctuary - Exit to Summit
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Exit to Fire Sanctuary:
+    type: exit
+    vanilla: Fire Sanctuary - Main Entrance
+    stage: F201_3
+    room: 0
+    index: 1
+    req_index: 1974
+    short_name: Outside Fire Sanctuary - Exit to Fire Sanctuary
+  \Earth Temple\Main\First Room\Main Exit:
+    type: exit
+    vanilla: Eldin Volcano - Entrance from Earth Temple
+    req_index: 1975
+    short_name: Earth Temple - Main Exit
+  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Exit:
+    type: exit
+    vanilla: Earth Temple - Boss Room - Entrance from Dungeon
+    req_index: 1976
+    short_name: Earth Temple - Boss Door Exit
+  \Earth Temple\Boss Room\Entry\Exit to Dungeon:
+    type: exit
+    vanilla: Earth Temple - Boss Door Entrance
+    req_index: 1977
+    short_name: Earth Temple - Boss Room - Exit to Dungeon
+  \Earth Temple\Boss Room\Slope\Exit to Spring:
+    type: exit
+    vanilla: Earth Temple - Spring - Entrance
+    req_index: 1978
+    short_name: Earth Temple - Boss Room - Exit to Spring
+  \Earth Temple\Spring\Exit:
+    type: exit
+    vanilla: Earth Temple - Boss Room - Entrance from Spring
+    req_index: 1979
+    short_name: Earth Temple - Spring - Exit
+  \Fire Sanctuary\Main\Front of Boss Door\Statue Exit:
+    type: exit
+    vanilla: Sky - Eldin Pillar - Entrance
+    stage: D201
+    room: 10
+    index: 3
+    req_index: 1980
+    short_name: Fire Sanctuary - Statue Exit
+  \Fire Sanctuary\Main\First Room\Main Exit:
+    type: exit
+    vanilla: Outside Fire Sanctuary - Entrance from Fire Sanctuary
+    req_index: 1981
+    short_name: Fire Sanctuary - Main Exit
+  \Fire Sanctuary\Main\First Room\Past Water Plant\Exit to Second Room:
+    type: exit
+    vanilla: Fire Sanctuary - Second Room - Entrance from First Room
+    req_index: 1982
+    short_name: Fire Sanctuary - First Room - Exit to Second Room
+  \Fire Sanctuary\Main\Second Room\Outside Section\Exit to First Room:
+    type: exit
+    vanilla: Fire Sanctuary - First Room - Entrance from Second Room
+    req_index: 1983
+    short_name: Fire Sanctuary - Second Room - Exit to First Room
+  \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Exit to West of Boss Door:
+    type: exit
+    vanilla: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight Room
+    req_index: 1984
+    short_name: Fire Sanctuary - Magmanos Fight Room - Exit to West of Boss Door
+  \Fire Sanctuary\Main\West of Boss Door\Entry\Exit to Magmanos Fight Room:
+    type: exit
+    vanilla: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss Door
+    req_index: 1985
+    short_name: Fire Sanctuary - West of Boss Door - Exit to Magmanos Fight Room
+  \Fire Sanctuary\Main\Front of Boss Door\Boss Door Exit:
+    type: exit
+    vanilla: Fire Sanctuary - Boss Room - Entrance from Dungeon
+    req_index: 1986
+    short_name: Fire Sanctuary - Boss Door Exit
+  \Fire Sanctuary\Boss Room\Exit to Dungeon:
+    type: exit
+    vanilla: Fire Sanctuary - Boss Door Entrance
+    req_index: 1987
+    short_name: Fire Sanctuary - Boss Room - Exit to Dungeon
+  \Fire Sanctuary\Boss Room\Exit to Flame Room:
+    type: exit
+    vanilla: Fire Sanctuary - Flame Room - Entrance
+    req_index: 1988
+    short_name: Fire Sanctuary - Boss Room - Exit to Flame Room
+  \Fire Sanctuary\Flame Room\Exit:
+    type: exit
+    vanilla: Fire Sanctuary - Boss Room - Entrance from Flame Room
+    req_index: 1989
+    short_name: Fire Sanctuary - Flame Room - Exit
+  \Lanayru\Mine\Entry\Statue Exit:
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+    stage: F300_1
+    room: 0
+    index: 0
+    req_index: 1990
+    short_name: Lanayru Mine - Statue Exit
+  \Lanayru\Mine\Entry\Caves Entrance\Exit to Caves:
+    type: exit
+    vanilla: Lanayru Caves - Entrance from Mine
+    stage: F300_1
+    room: 0
+    index: 1
+    req_index: 1991
+    short_name: Lanayru Mine - Exit to Caves
+  \Lanayru\Mine\End\In Minecart\Exit to Desert:
+    type: exit
+    vanilla: Lanayru Desert - Entrance from Mine
+    stage: F300_1
+    room: 2
+    index: 0
+    req_index: 1992
+    short_name: Lanayru Mine - Exit to Desert
+  \Lanayru\Desert\Shared Statue Exit:
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+    stage: F300
+    room: 0
+    index: 6
+    req_index: 1993
+    short_name: Lanayru Desert - Shared Statue Exit
+  \Lanayru\Desert\North Part\Lightning Node Exit:
+    type: exit
+    vanilla: Lightning Node - Entrance
+    stage: F300
+    room: 0
+    index: 0
+    req_index: 1994
+    short_name: Lanayru Desert - Lightning Node Exit
+  \Lanayru\Desert\Entry\Exit to Mine:
+    type: exit
+    vanilla: Lanayru Mine - Entrance from Desert
+    stage: F300
+    room: 0
+    index: 1
+    req_index: 1995
+    short_name: Lanayru Desert - Exit to Mine
+  \Lanayru\Desert\East\Fire Node Exit:
+    type: exit
+    vanilla: Fire Node - Entrance
+    stage: F300
+    room: 0
+    index: 2
+    req_index: 1996
+    short_name: Lanayru Desert - Fire Node Exit
+  \Lanayru\Desert\Near South Exit to Temple of Time\South Exit to Temple of Time:
+    type: exit
+    vanilla: Temple of Time - South Entrance from Desert
+    stage: F300
+    room: 0
+    index: 3
+    req_index: 1997
+    short_name: Lanayru Desert - South Exit to Temple of Time
+  \Lanayru\Desert\North Part\North Exit to Temple of Time:
+    type: exit
+    vanilla: Temple of Time - North Entrance from Desert
+    stage: F300
+    room: 0
+    index: 4
+    req_index: 1998
+    short_name: Lanayru Desert - North Exit to Temple of Time
+  \Lanayru\Desert\Top of LMF\Exit to Lanayru Mining Facility:
+    type: exit
+    vanilla: Lanayru Mining Facility - Main Entrance
+    stage: F300
+    room: 0
+    index: 5
+    req_index: 1999
+    short_name: Lanayru Desert - Exit to Lanayru Mining Facility
+  \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Exit to Caves:
+    type: exit
+    vanilla: Lanayru Caves - Entrance from Desert
+    stage: F300
+    room: 0
+    index: 8
+    req_index: 2000
+    short_name: Lanayru Desert - Exit to Caves
+  \Lanayru\Desert\North Part\Trial Gate Exit:
+    type: exit
+    vanilla: Lanayru Silent Realm - Entrance
+    req_index: 2001
+    short_name: Lanayru Desert - Trial Gate Exit
+  \Lanayru\Lanayru Silent Realm\Exit:
+    type: exit
+    vanilla: Lanayru Desert - Trial Gate Entrance
+    req_index: 2002
+    short_name: Lanayru Silent Realm - Exit
+  \Lanayru\Desert\North Part\Lightning Node\Present\Exit:
+    type: exit
+    vanilla: Lanayru Desert - Lightning Node Entrance
+    stage: F300_2
+    room: 0
+    index: 0
+    req_index: 2003
+    short_name: Lightning Node - Exit
+  \Lanayru\Desert\East\Fire Node\Present\Exit:
+    type: exit
+    vanilla: Lanayru Desert - Fire Node Entrance
+    stage: F300_3
+    room: 0
+    index: 0
+    req_index: 2004
+    short_name: Fire Node - Exit
+  \Lanayru\Temple of Time\Shared Statue Exit:
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+    stage: F300_4
+    room: 0
+    index: 2
+    req_index: 2005
+    short_name: Temple of Time - Shared Statue Exit
+  \Lanayru\Temple of Time\South East\South Exit to Desert:
+    type: exit
+    vanilla: Lanayru Desert - South Entrance from Temple of Time
+    stage: F300_4
+    room: 0
+    index: 0
+    req_index: 2006
+    short_name: Temple of Time - South Exit to Desert
+  \Lanayru\Temple of Time\North East\North Exit to Desert:
+    type: exit
+    vanilla: Lanayru Desert - North Entrance from Temple of Time
+    stage: F300_4
+    room: 0
+    index: 1
+    req_index: 2007
+    short_name: Temple of Time - North Exit to Desert
+  \Lanayru\Temple of Time\Inside\Exit to Lanayru Mining Facility:
+    type: exit
+    subtype: vanilla
+    stage: F300_4
+    room: 0
+    index: 4
+    req_index: 2008
+    short_name: Temple of Time - Exit to Lanayru Mining Facility
+  \Lanayru\Caves\Exit to Mine:
+    type: exit
+    vanilla: Lanayru Mine - Entrance from Caves
+    stage: F303
+    room: 0
+    index: 0
+    req_index: 2009
+    short_name: Lanayru Caves - Exit to Mine
+  \Lanayru\Caves\Exit to Desert:
+    type: exit
+    vanilla: Lanayru Desert - Entrance from Caves
+    stage: F303
+    room: 0
+    index: 1
+    req_index: 2010
+    short_name: Lanayru Caves - Exit to Desert
+  \Lanayru\Caves\Past Door to Lanayru Sand Sea\Exit to Lanayru Sand Sea:
+    type: exit
+    vanilla: Lanayru Sand Sea Docks - Entrance from Caves
+    stage: F303
+    room: 0
+    index: 2
+    req_index: 2011
+    short_name: Lanayru Caves - Exit to Lanayru Sand Sea
+  \Lanayru\Caves\Past Crawlspace\Exit to Gorge:
+    type: exit
+    vanilla: Lanayru Gorge - Entrance
+    req_index: 2012
+    short_name: Lanayru Caves - Exit to Gorge
+  \Lanayru\Lanayru Sand Sea\Gorge\Exit:
+    type: exit
+    vanilla: Lanayru Caves - Entrance from Gorge
+    req_index: 2013
+    short_name: Lanayru Gorge - Exit
+  \Lanayru\Lanayru Sand Sea\Gorge\Statue Exit:
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+    req_index: 2014
+    short_name: Lanayru Gorge - Statue Exit
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Exit:
+    type: exit
+    vanilla: Lanayru Sand Sea Docks - Dock Entrance
+    stage: F301_1
+    room: 0
+    index: 0
+    req_index: 2015
+    short_name: Lanayru Sand Sea - Ancient Harbour Dock Exit
+  \Lanayru\Lanayru Sand Sea\Sandship Dock Exit:
+    type: exit
+    vanilla: Sandship - Main Entrance
+    stage: F301_1
+    room: 0
+    index: 1
+    req_index: 2016
+    short_name: Lanayru Sand Sea - Sandship Dock Exit
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Exit:
+    type: exit
+    vanilla: Skipper's Retreat - Dock Entrance
+    stage: F301_1
+    room: 0
+    index: 2
+    req_index: 2017
+    short_name: Lanayru Sand Sea - Skipper's Retreat Dock Exit
+  \Lanayru\Lanayru Sand Sea\Shipyard Dock Exit:
+    type: exit
+    vanilla: Shipyard - Dock Entrance
+    stage: F301_1
+    room: 0
+    index: 3
+    req_index: 2018
+    short_name: Lanayru Sand Sea - Shipyard Dock Exit
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Exit:
+    type: exit
+    vanilla: Pirate Stronghold - Dock Entrance
+    stage: F301_1
+    room: 0
+    index: 4
+    req_index: 2019
+    short_name: Lanayru Sand Sea - Pirate Stronghold Dock Exit
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Exit:
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+    stage: F301
+    room: 0
+    index: 3
+    req_index: 2020
+    short_name: Lanayru Sand Sea Docks - Statue Exit
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Exit to Sandship:
+    type: exit
+    vanilla: Sandship - Main Entrance
+    stage: F301
+    room: 0
+    index: 0
+    req_index: 2021
+    short_name: Lanayru Sand Sea Docks - Exit to Sandship
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Exit to Caves:
+    type: exit
+    vanilla: Lanayru Caves - Entrance from Lanayru Sand Sea
+    stage: F301
+    room: 0
+    index: 1
+    req_index: 2022
+    short_name: Lanayru Sand Sea Docks - Exit to Caves
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Exit:
+    type: exit
+    vanilla: Lanayru Sand Sea - Ancient Harbour Dock Entrance
+    stage: F301
+    room: 0
+    index: 2
+    req_index: 2023
+    short_name: Lanayru Sand Sea Docks - Dock Exit
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Exit:
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+    stage: F301_3
+    room: 0
+    index: 1
+    req_index: 2024
+    short_name: Skipper's Retreat - Statue Exit
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Exit:
+    type: exit
+    vanilla: Lanayru Sand Sea - Skipper's Retreat Dock Entrance
+    stage: F301_3
+    room: 0
+    index: 2
+    req_index: 2025
+    short_name: Skipper's Retreat - Dock Exit
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Exit:
+    type: exit
+    vanilla: Skipper's Retreat - Shack - Entrance
+    stage: F301_3
+    room: 0
+    index: 3
+    req_index: 2026
+    short_name: Skipper's Retreat - Shack Exit
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Exit:
+    type: exit
+    vanilla: Skipper's Retreat - Shack Entrance
+    stage: F301_5
+    room: 0
+    index: 0
+    req_index: 2027
+    short_name: Skipper's Retreat - Shack - Exit
+  \Lanayru\Lanayru Sand Sea\Shipyard\Statue Exit:
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+    stage: F301_4
+    room: 0
+    index: 1
+    req_index: 2028
+    short_name: Shipyard - Statue Exit
+  \Lanayru\Lanayru Sand Sea\Shipyard\Dock Exit:
+    type: exit
+    vanilla: Lanayru Sand Sea - Shipyard Dock Entrance
+    stage: F301_4
+    room: 0
+    index: 2
+    req_index: 2029
+    short_name: Shipyard - Dock Exit
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Exit:
+    type: exit
+    vanilla: Shipyard - Construction Bay - Upper Entrance
+    stage: F301_4
+    room: 0
+    index: 3
+    req_index: 2030
+    short_name: Shipyard - Construction Bay Upper Exit
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Exit:
+    type: exit
+    vanilla: Shipyard - Construction Bay - Lower Entrance
+    stage: F301_4
+    room: 0
+    index: 4
+    req_index: 2031
+    short_name: Shipyard - Construction Bay Lower Exit
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Exit:
+    type: exit
+    vanilla: Shipyard - Construction Bay Lower Entrance
+    stage: F301_7
+    room: 0
+    index: 0
+    req_index: 2032
+    short_name: Shipyard - Construction Bay - Lower Exit
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Exit:
+    type: exit
+    vanilla: Shipyard - Construction Bay Upper Entrance
+    stage: F301_7
+    room: 0
+    index: 1
+    req_index: 2033
+    short_name: Shipyard - Construction Bay - Upper Exit
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Exit:
+    type: exit
+    vanilla: Sky - Lanayru Pillar - Entrance
+    stage: F301_6
+    room: 0
+    index: 3
+    req_index: 2034
+    short_name: Pirate Stronghold - Statue Exit
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Exit:
+    type: exit
+    vanilla: Lanayru Sand Sea - Pirate Stronghold Dock Entrance
+    stage: F301_6
+    room: 0
+    index: 0
+    req_index: 2035
+    short_name: Pirate Stronghold - Dock Exit
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Exit:
+    type: exit
+    vanilla: Pirate Stronghold - Inside - First Door Entrance
+    stage: F301_6
+    room: 0
+    index: 1
+    req_index: 2036
+    short_name: Pirate Stronghold - Side Exit
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Exit:
+    type: exit
+    vanilla: Pirate Stronghold - Inside - Second Door Entrance
+    stage: F301_6
+    room: 0
+    index: 2
+    req_index: 2037
+    short_name: Pirate Stronghold - Top Exit
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Exit:
+    type: exit
+    vanilla: Pirate Stronghold - Side Entrance
+    stage: F301_2
+    room: 1
+    index: 0
+    req_index: 2038
+    short_name: Pirate Stronghold - Inside - First Door Exit
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Exit:
+    type: exit
+    vanilla: Pirate Stronghold - Top Entrance
+    stage: F301_2
+    room: 1
+    index: 2
+    req_index: 2039
+    short_name: Pirate Stronghold - Inside - Second Door Exit
+  \Lanayru Mining Facility\Main\First Room\Main Exit:
+    type: exit
+    vanilla: Lanayru Desert - Entrance from Lanayru Mining Facility
+    req_index: 2040
+    short_name: Lanayru Mining Facility - Main Exit
+  \Lanayru Mining Facility\Main\First Hub\Exit to Big Hub:
+    type: exit
+    vanilla: Lanayru Mining Facility - Big Hub - Entrance from First Hub
+    req_index: 2041
+    short_name: Lanayru Mining Facility - First Hub - Exit to Big Hub
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Exit to Big Hub:
+    type: exit
+    vanilla: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes Room
+    req_index: 2042
+    short_name: Lanayru Mining Facility - Hop Across Boxes Room - Exit to Big Hub
+  \Lanayru Mining Facility\Main\Armos Fight Room\Exit to Big Hub:
+    type: exit
+    vanilla: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
+    req_index: 2043
+    short_name: Lanayru Mining Facility - Armos Fight Room - Exit to Big Hub
+  \Lanayru Mining Facility\Main\Big Hub\Entry\Exit to First Hub:
+    type: exit
+    vanilla: Lanayru Mining Facility - First Hub - Entrance from Big Hub
+    req_index: 2044
+    short_name: Lanayru Mining Facility - Big Hub - Exit to First Hub
+  \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Exit to Hop Across Boxes Room:
+    type: exit
+    vanilla: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big Hub
+    req_index: 2045
+    short_name: Lanayru Mining Facility - Big Hub - Exit to Hop Across Boxes Room
+  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Exit to Armos Fight Room:
+    type: exit
+    vanilla: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
+    req_index: 2046
+    short_name: Lanayru Mining Facility - Big Hub - Exit to Armos Fight Room
+  \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Exit:
+    type: exit
+    vanilla: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
+    req_index: 2047
+    short_name: Lanayru Mining Facility - Boss Door Exit
+  \Lanayru Mining Facility\Boss Room\Exit to Dungeon:
+    type: exit
+    vanilla: Lanayru Mining Facility - Boss Door Entrance
+    req_index: 2048
+    short_name: Lanayru Mining Facility - Boss Room - Exit to Dungeon
+  \Lanayru Mining Facility\Boss Room\After Sand Drain\Exit to Hall of Ancient Robots:
+    type: exit
+    vanilla: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
+      Room
+    req_index: 2049
+    short_name: Lanayru Mining Facility - Boss Room - Exit to Hall of Ancient Robots
+  \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Exit to Boss Room:
+    type: exit
+    vanilla: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient Robots
+    req_index: 2050
+    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Boss Room
+  \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit to Temple of Time:
+    type: exit
+    subtype: vanilla
+    vanilla: Temple of Time - Entrance from Lanayru Mining Facility
+    stage: F300_5
+    room: 0
+    index: 1
+    req_index: 2051
+    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Temple
+      of Time
+  \Sandship\Main\Deck\Main Exit:
+    type: exit
+    vanilla: Lanayru Sand Sea - Sandship Dock Entrance
+    req_index: 2052
+    short_name: Sandship - Main Exit
+  \Sandship\Main\Before Boss Door\Boss Door one-way Exit:
+    type: exit
+    vanilla: Sandship - Boss Room - Entrance
+    req_index: 2053
+    short_name: Sandship - Boss Door one-way Exit
+  \Sky Keep\Main\First Room\Bottom Exit:
+    type: exit
+    vanilla: Skyloft - Entrance from Sky Keep
+    req_index: 2054
+    short_name: Sky Keep - First Room - Bottom Exit
+entrances:
+  \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Start Entrance:
+    type: entrance
+    province: The Sky
+    allowed-time-of-day: DayOnly
+    statue-name: Link's Room
+    stage: F001r
+    room: 1
+    layer: 0
+    entrance: 5
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2055
+    short_name: Skyloft - Knight Academy - Start Entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Chimney:
+    type: entrance
+    province: The Sky
+    stage: F001r
+    room: 6
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2056
+    short_name: Skyloft - Knight Academy - Chimney
+  \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F001r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2058
+    short_name: Skyloft - Knight Academy - Lower Right Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F001r
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2060
+    short_name: Skyloft - Knight Academy - Lower Left Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F001r
+    room: 0
+    layer: 0
+    entrance: 3
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2062
+    short_name: Skyloft - Knight Academy - Upper Right Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F001r
+    room: 0
+    layer: 0
+    entrance: 4
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2064
+    short_name: Skyloft - Knight Academy - Upper Left Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 4
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2066
+    short_name: Skyloft - Knight Academy Lower Right Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 5
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2068
+    short_name: Skyloft - Knight Academy Lower Left Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 23
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2070
+    short_name: Skyloft - Knight Academy Upper Left Door Entrance
+  \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 24
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2072
+    short_name: Skyloft - Knight Academy Upper Right Door Entrance
+  \Skyloft\Upper Skyloft\Sparring Hall\Right Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F009r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2074
+    short_name: Sparring Hall - Right Door Entrance
+  \Skyloft\Upper Skyloft\Sparring Hall\Left Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F009r
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2076
+    short_name: Sparring Hall - Left Door Entrance
+  \Skyloft\Upper Skyloft\Sparring Hall Left Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 21
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2078
+    short_name: Skyloft - Sparring Hall Left Door Entrance
+  \Skyloft\Upper Skyloft\Sparring Hall Right Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 26
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2080
+    short_name: Skyloft - Sparring Hall Right Door Entrance
+  \Skyloft\Upper Skyloft\Goddess Statue\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F008r
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2082
+    short_name: Goddess Statue - Entrance
+  \Skyloft\Upper Skyloft\Goddess Statue Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 6
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2084
+    short_name: Goddess Statue Entrance
+  \Skyloft\Central Skyloft\Waterfall Cave\Upper Entrance:
+    type: entrance
+    province: The Sky
+    stage: D000
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2086
+    short_name: Waterfall Cave - Upper Entrance
+  \Skyloft\Central Skyloft\Waterfall Cave\Lower Entrance:
+    type: entrance
+    province: The Sky
+    stage: D000
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2088
+    short_name: Waterfall Cave - Lower Entrance
+  \Skyloft\Central Skyloft\Waterfall Cave Upper Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 7
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2090
+    short_name: Waterfall Cave Upper Entrance
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 8
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2092
+    short_name: Waterfall Cave Lower Entrance
+  \Skyloft\Central Skyloft\Bazaar\North Entrance:
+    type: entrance
+    province: The Sky
+    stage: F004r
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2094
+    short_name: Bazaar - North Entrance
+  \Skyloft\Central Skyloft\Bazaar\South Entrance:
+    type: entrance
+    province: The Sky
+    stage: F004r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2095
+    short_name: Bazaar - South Entrance
+  \Skyloft\Central Skyloft\Bazaar\West Entrance:
+    type: entrance
+    province: The Sky
+    stage: F004r
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2096
+    short_name: Bazaar - West Entrance
+  \Skyloft\Central Skyloft\Bazaar North Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2097
+    short_name: Bazaar North Entrance
+  \Skyloft\Central Skyloft\Bazaar South Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 3
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2099
+    short_name: Bazaar South Entrance
+  \Skyloft\Central Skyloft\Bazaar West Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 20
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2101
+    short_name: Bazaar West Entrance
+  \Skyloft\Beedle's Shop\Day Entrance:
+    type: entrance
+    province: The Sky
+    stage: F002r
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2103
+    short_name: Beedle's Shop - Day Entrance
+  \Skyloft\Beedle's Shop\Night Entrance:
+    type: entrance
+    province: The Sky
+    allowed-time-of-day: NightOnly
+    stage: F002r
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 1
+    allowed_time_of_day: 2
+    req_index: 2105
+    short_name: Beedle's Shop - Night Entrance
+  \Skyloft\Central Skyloft\Entrance from Beedle's Shop:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2106
+    short_name: Skyloft - Entrance from Beedle's Shop
+  \Skyloft\Skyloft Silent Realm\Entrance:
+    type: entrance
+    province: The Sky
+    can-start-at: false
+    tod: 0
+    allowed_time_of_day: 3
+    req_index: 2108
+    short_name: Skyloft Silent Realm - Entrance
+  \Skyloft\Central Skyloft\Trial Gate Entrance:
+    type: entrance
+    province: The Sky
+    can-start-at: false
+    tod: 0
+    allowed_time_of_day: 3
+    req_index: 2110
+    short_name: Skyloft - Trial Gate Entrance
+  \Skyloft\Central Skyloft\Near Temple Entrance\Entrance from Sky Keep:
+    type: entrance
+    province: The Sky
+    can-start-at: false
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 53
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2112
+    short_name: Skyloft - Entrance from Sky Keep
+  \Skyloft\Central Skyloft\Orielle and Parrow's House\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F005r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2113
+    short_name: Orielle and Parrow's House - Entrance
+  \Skyloft\Central Skyloft\Orielle and Parrow's House Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 30
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2115
+    short_name: Orielle and Parrow's House Entrance
+  \Skyloft\Central Skyloft\Peatrice's House\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F018r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2117
+    short_name: Peatrice's House - Entrance
+  \Skyloft\Central Skyloft\Peatrice's House Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 38
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2119
+    short_name: Peatrice's House Entrance
+  \Skyloft\Central Skyloft\Wryna's House\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F006r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2121
+    short_name: Wryna's House - Entrance
+  \Skyloft\Central Skyloft\Wryna's House Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 31
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2123
+    short_name: Wryna's House Entrance
+  \Skyloft\Skyloft Village\Bertie's House\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F014r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2125
+    short_name: Bertie's House - Entrance
+  \Skyloft\Skyloft Village\Bertie's House Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 34
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2127
+    short_name: Bertie's House Entrance
+  \Skyloft\Skyloft Village\Sparrot's House\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F013r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2129
+    short_name: Sparrot's House - Entrance
+  \Skyloft\Skyloft Village\Sparrot's House Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 33
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2131
+    short_name: Sparrot's House Entrance
+  \Skyloft\Skyloft Village\Mallara's House Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 36
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2133
+    short_name: Skyloft - Mallara's House Entrance
+  \Skyloft\Skyloft Village\Mallara's House\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F016r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2135
+    short_name: Mallara's House - Entrance
+  \Skyloft\Skyloft Village\Batreaux's House\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F012r
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2137
+    short_name: Batreaux's House - Entrance
+  \Skyloft\Skyloft Village\Batreaux's House Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 29
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2139
+    short_name: Batreaux's House Entrance
+  \Skyloft\Skyloft Village\Gondo's House\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F015r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2141
+    short_name: Gondo's House - Entrance
+  \Skyloft\Skyloft Village\Gondo's House Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 35
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2143
+    short_name: Gondo's House Entrance
+  \Skyloft\Skyloft Village\Rupin's House\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F017r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2145
+    short_name: Rupin's House - Entrance
+  \Skyloft\Skyloft Village\Rupin's House Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 37
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2147
+    short_name: Rupin's House Entrance
+  \Skyloft\Central Skyloft\Piper's House\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F007r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2149
+    short_name: Piper's House - Entrance
+  \Skyloft\Central Skyloft\Piper's House Entrance:
+    type: entrance
+    province: The Sky
+    stage: F000
+    room: 0
+    layer: 0
+    entrance: 32
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2151
+    short_name: Piper's House Entrance
+  \Skyloft\Central Skyloft\Entrance from Sky:
+    type: entrance
+    province: The Sky
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2153
+    short_name: Skyloft - Entrance from Sky
+  \Sky\Around Skyloft\Entrance from Skyloft:
+    type: entrance
+    province: The Sky
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2155
+    short_name: Sky - Entrance from Skyloft
+  \Sky\North East\Bamboo Island\Inside\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F019r
+    room: 0
+    layer: 1
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2156
+    short_name: Bamboo Island - Inside - Entrance
+  \Sky\North East\Bamboo Island\Entrance from Inside:
+    type: entrance
+    province: The Sky
+    stage: F020
+    room: 0
+    layer: 0
+    entrance: 11
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2157
+    short_name: Bamboo Island - Entrance from Inside
+  \Sky\North East\Beedle's Island\Beedle's Ship Entrance:
+    type: entrance
+    province: The Sky
+    allowed-time-of-day: NightOnly
+    stage: F020
+    room: 0
+    layer: 4
+    entrance: 0
+    tod: 1
+    allowed_time_of_day: 2
+    req_index: 2158
+    short_name: Sky - Beedle's Island - Beedle's Ship Entrance
+  \Sky\North East\Eldin Pillar\Entrance:
+    type: entrance
+    province: The Sky
+    statue-name: Volcano Entry
+    stage: F020
+    room: 0
+    layer: 0
+    entrance: 13
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2159
+    short_name: Sky - Eldin Pillar - Entrance
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F011r
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2160
+    short_name: Lumpy Pumpkin Building - Main Right Door Entrance
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F011r
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2162
+    short_name: Lumpy Pumpkin Building - Main Left Door Entrance
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F011r
+    room: 0
+    layer: 0
+    entrance: 3
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2164
+    short_name: Lumpy Pumpkin Building - Back Door Entrance
+  \Sky\South East\Lumpy Pumpkin\Main Left Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F020
+    room: 0
+    layer: 0
+    entrance: 22
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2166
+    short_name: Lumpy Pumpkin - Main Left Door Entrance
+  \Sky\South East\Lumpy Pumpkin\Main Right Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F020
+    room: 0
+    layer: 0
+    entrance: 23
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2168
+    short_name: Lumpy Pumpkin - Main Right Door Entrance
+  \Sky\South East\Lumpy Pumpkin\Back Door Entrance:
+    type: entrance
+    province: The Sky
+    stage: F020
+    room: 0
+    layer: 0
+    entrance: 24
+    tod: 2
+    allowed_time_of_day: 3
+    req_index: 2170
+    short_name: Lumpy Pumpkin - Back Door Entrance
+  \Sky\South East\Faron Pillar\Entrance:
+    type: entrance
+    province: The Sky
+    statue-name: Sealed Grounds
+    stage: F020
+    room: 0
+    layer: 0
+    entrance: 12
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2172
+    short_name: Sky - Faron Pillar - Entrance
+  \Sky\South West\Lanayru Pillar\Entrance:
+    type: entrance
+    province: The Sky
+    stage: F020
+    room: 0
+    layer: 0
+    entrance: 14
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2173
+    short_name: Sky - Lanayru Pillar - Entrance
+  \Sky\Around Skyloft\Entrance from Thunderhead:
+    type: entrance
+    province: The Sky
+    can-start-at: false
+    stage: F020
+    room: 0
+    layer: 0
+    entrance: 28
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2174
+    short_name: Sky - Entrance from Thunderhead
+  \Sky\Thunderhead\Entrance:
+    type: entrance
+    province: The Sky
+    can-start-at: false
+    stage: F023
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2175
+    short_name: Thunderhead - Entrance
+  \Sky\Thunderhead\Isle of Songs\Inside\Entrance:
+    type: entrance
+    province: The Sky
+    can-start-at: false
+    stage: F010r
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2176
+    short_name: Isle of Songs - Entrance
+  \Sky\Thunderhead\Isle of Songs\Entrance from Inside:
+    type: entrance
+    province: The Sky
+    can-start-at: false
+    stage: F023
+    room: 0
+    layer: 0
+    entrance: 4
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2177
+    short_name: Isle of Songs - Entrance from Inside
+  \Faron\Sealed Grounds\Spiral\Upper Part\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Faron Province
+    statue-name: Sealed Grounds
+    stage: F401
+    room: 1
+    layer: 0
+    entrance: 8
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2178
+    short_name: Sealed Grounds Spiral - Statue Entrance
+  \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Entrance from Behind the Temple:
+    type: entrance
+    province: Faron Province
+    stage: F401
+    room: 1
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2179
+    short_name: Sealed Grounds Spiral - Shortcut Entrance from Behind the Temple
+  \Faron\Sealed Grounds\Spiral\Door Entrance:
+    type: entrance
+    province: Faron Province
+    stage: F401
+    room: 1
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2180
+    short_name: Sealed Grounds Spiral - Door Entrance
+  \Faron\Sealed Grounds\Sealed Temple\Main Entrance:
+    type: entrance
+    province: Faron Province
+    stage: F402
+    room: 2
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2181
+    short_name: Sealed Temple - Main Entrance
+  \Faron\Sealed Grounds\Sealed Temple\Side Entrance:
+    type: entrance
+    province: Faron Province
+    stage: F402
+    room: 2
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2182
+    short_name: Sealed Temple - Side Entrance
+  \Faron\Sealed Grounds\Sealed Temple\Gate of Time Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: F402
+    room: 2
+    layer: 0
+    entrance: 11
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2183
+    short_name: Sealed Temple - Gate of Time Entrance
+  \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: F404
+    room: 2
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2184
+    short_name: Hylia's Temple - Gate of Time Entrance
+  \Faron\Sealed Grounds\Behind the Temple\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Faron Province
+    statue-name: Behind the Temple
+    stage: F400
+    room: 0
+    layer: 0
+    entrance: 10
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2185
+    short_name: Behind the Temple - Statue Entrance
+  \Faron\Sealed Grounds\Behind the Temple\Door Entrance:
+    type: entrance
+    province: Faron Province
+    stage: F400
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2186
+    short_name: Behind the Temple - Door Entrance
+  \Faron\Sealed Grounds\Behind the Temple\Shortcut Entrance from Spiral:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: F400
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2187
+    short_name: Behind the Temple - Shortcut Entrance from Spiral
+  \Faron\Sealed Grounds\Behind the Temple\Entrance from Faron Woods:
+    type: entrance
+    province: Faron Province
+    stage: F400
+    room: 0
+    layer: 0
+    entrance: 3
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2188
+    short_name: Behind the Temple - Entrance from Faron Woods
+  \Faron\Faron Woods\Entry\Faron Woods Entry Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Faron Province
+    statue-name: Faron Woods Entry
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 50
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2189
+    short_name: Faron Woods - Faron Woods Entry Statue Entrance
+  \Faron\Faron Woods\In the Woods Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Faron Province
+    statue-name: In the Woods
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 51
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2190
+    short_name: Faron Woods - In the Woods Statue Entrance
+  \Faron\Faron Woods\Viewing Platform Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Faron Province
+    statue-name: Viewing Platform
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 52
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2191
+    short_name: Faron Woods - Viewing Platform Statue Entrance
+  \Faron\Faron Woods\Great Tree\Top\The Great Tree Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Faron Province
+    statue-name: Great Tree Top
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 53
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2192
+    short_name: Great Tree - The Great Tree Statue Entrance
+  \Faron\Faron Woods\Entry\Entrance from Behind the Temple:
+    type: entrance
+    province: Faron Province
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2193
+    short_name: Faron Woods - Entrance from Behind the Temple
+  \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Entrance from Floria Waterfall:
+    type: entrance
+    province: Faron Province
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 17
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2194
+    short_name: Faron Woods - Shortcut Entrance from Floria Waterfall
+  \Faron\Faron Woods\Ledge To Deep Woods\Entrance from Deep Woods:
+    type: entrance
+    province: Faron Province
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 45
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2195
+    short_name: Faron Woods - Entrance from Deep Woods
+  \Faron\Faron Woods\Trial Gate Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2196
+    short_name: Faron Woods - Trial Gate Entrance
+  \Faron\Faron Silent Realm\Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2197
+    short_name: Faron Silent Realm - Entrance
+  \Faron\Faron Woods\Great Tree\Platforms\Lower Entrance from Great Tree:
+    type: entrance
+    province: Faron Province
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 4
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2198
+    short_name: Great Tree - Platforms - Lower Entrance from Great Tree
+  \Faron\Faron Woods\Great Tree\Platforms\Upper Entrance from Great Tree:
+    type: entrance
+    province: Faron Province
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 5
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2199
+    short_name: Great Tree - Platforms - Upper Entrance from Great Tree
+  \Faron\Faron Woods\Great Tree\Top\Top Entrance from Great Tree:
+    type: entrance
+    province: Faron Province
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 6
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2200
+    short_name: Great Tree - Top Entrance from Great Tree
+  \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: F100
+    room: 0
+    layer: 0
+    entrance: 7
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2201
+    short_name: Great Tree - Underwater Hole Entrance
+  \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Entrance from Platforms:
+    type: entrance
+    province: Faron Province
+    stage: F100_1
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2202
+    short_name: Great Tree - Lower Entrance from Platforms
+  \Faron\Faron Woods\Great Tree\Upper Area\Upper Entrance from Platforms:
+    type: entrance
+    province: Faron Province
+    stage: F100_1
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2203
+    short_name: Great Tree - Upper Entrance from Platforms
+  \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Top:
+    type: entrance
+    province: Faron Province
+    stage: F100_1
+    room: 0
+    layer: 0
+    entrance: 3
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2204
+    short_name: Great Tree - Entrance from Top
+  \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: F100_1
+    room: 0
+    layer: 0
+    entrance: 4
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2205
+    short_name: Great Tree - Underwater Tunnel Entrance
+  \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Flooded Great Tree:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2206
+    short_name: Great Tree - Entrance from Flooded Great Tree
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance:
+    type: entrance
+    allowed_time_of_day: 1
+    req_index: 2207
+    short_name: Flooded Great Tree - Entrance
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Upper Flooded Faron Woods:
+    type: entrance
+    allowed_time_of_day: 1
+    req_index: 2208
+    short_name: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Lower Flooded Faron Woods:
+    type: entrance
+    allowed_time_of_day: 1
+    req_index: 2209
+    short_name: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
+  \Faron\Flooded Faron Woods\Entrance from Upper Flooded Great Tree:
+    type: entrance
+    allowed_time_of_day: 1
+    req_index: 2210
+    short_name: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
+  \Faron\Flooded Faron Woods\Entrance from Lower Flooded Great Tree:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2211
+    short_name: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
+  \Faron\Faron Woods\Deep Woods\Forest Temple Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Faron Province
+    statue-name: Forest Temple
+    stage: F101
+    room: 0
+    layer: 0
+    entrance: 13
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2212
+    short_name: Deep Woods - Forest Temple Statue Entrance
+  \Faron\Faron Woods\Deep Woods\Deep Woods Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Faron Province
+    statue-name: Deep Woods
+    stage: F101
+    room: 0
+    layer: 0
+    entrance: 14
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2213
+    short_name: Deep Woods - Deep Woods Statue Entrance
+  \Faron\Faron Woods\Deep Woods\Entry\Entrance from Faron Woods:
+    type: entrance
+    province: Faron Province
+    stage: F101
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2214
+    short_name: Deep Woods - Entrance from Faron Woods
+  \Faron\Faron Woods\Deep Woods\Entrance from Skyview Temple:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: F101
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2215
+    short_name: Deep Woods - Entrance from Skyview Temple
+  \Faron\Lake Floria\Below Rock\Emerged Area\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Faron Province
+    statue-name: Lake Floria
+    stage: F102
+    room: 3
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2216
+    short_name: Lake Floria - Below Rock - Statue Entrance
+  \Faron\Lake Floria\Above Rock\Dive from Faron Woods:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: F102
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2217
+    short_name: Lake Floria - Dive from Faron Woods
+  \Faron\Lake Floria\Below Rock\Entrance from Farore's Lair:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: F102
+    room: 4
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2218
+    short_name: Lake Floria - Entrance from Farore's Lair
+  \Faron\Lake Floria\Farore's Lair\Entrance from Lake Floria:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: F102_2
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2219
+    short_name: Farore's Lair - Entrance from Lake Floria
+  \Faron\Lake Floria\Farore's Lair\Entrance from Waterfall:
+    type: entrance
+    province: Faron Province
+    stage: F102_2
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2220
+    short_name: Farore's Lair - Entrance from Waterfall
+  \Faron\Lake Floria\Waterfall\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Faron Province
+    statue-name: Floria Waterfall
+    stage: F102_1
+    room: 0
+    layer: 0
+    entrance: 5
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2221
+    short_name: Floria Waterfall - Statue Entrance
+  \Faron\Lake Floria\Waterfall\Entrance from Farore's Lair:
+    type: entrance
+    province: Faron Province
+    stage: F102_1
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2222
+    short_name: Floria Waterfall - Entrance from Farore's Lair
+  \Faron\Lake Floria\Waterfall\Entrance from Ancient Cistern:
+    type: entrance
+    province: Faron Province
+    statue-name: Floria Waterfall
+    stage: F102_1
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2223
+    short_name: Floria Waterfall - Entrance from Ancient Cistern
+  \Faron\Lake Floria\Waterfall\Entrance from Faron Woods:
+    type: entrance
+    province: Faron Province
+    stage: F102_1
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2224
+    short_name: Floria Waterfall - Entrance from Faron Woods
+  \Skyview\Main\Entry\Main Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: D100
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2225
+    short_name: Skyview Temple - Main Entrance
+  \Skyview\Main\Last Room\After Rope\Boss Door Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2226
+    short_name: Skyview Temple - Boss Door Entrance
+  \Skyview\Boss Room\Entrance from Dungeon:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2227
+    short_name: Skyview Temple - Boss Room - Entrance from Dungeon
+  \Skyview\Boss Room\Entrance from Spring:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2228
+    short_name: Skyview Temple - Boss Room - Entrance from Spring
+  \Skyview\Spring\Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2229
+    short_name: Skyview Temple - Spring - Entrance
+  \Ancient Cistern\Main\Main Room\Main Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    stage: D101
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2230
+    short_name: Ancient Cistern - Main Entrance
+  \Ancient Cistern\Main\Inside Statue\Boss Door Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2231
+    short_name: Ancient Cistern - Boss Door Entrance
+  \Ancient Cistern\Boss Room\Entrance from Dungeon:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2232
+    short_name: Ancient Cistern - Boss Room - Entrance from Dungeon
+  \Ancient Cistern\Boss Room\Entrance from Flame Room:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2233
+    short_name: Ancient Cistern - Boss Room - Entrance from Flame Room
+  \Ancient Cistern\Flame Room\Entrance:
+    type: entrance
+    province: Faron Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2234
+    short_name: Ancient Cistern - Flame Room - Entrance
+  \Eldin\Volcano\Entry\First Time Entrance:
+    type: entrance
+    province: Eldin Province
+    stage: F200
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2235
+    short_name: Eldin Volcano - First Time Entrance
+  \Eldin\Volcano\Entry\Volcano Entrance Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Eldin Province
+    statue-name: Volcano Entry
+    stage: F200
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2236
+    short_name: Eldin Volcano - Volcano Entrance Statue Entrance
+  \Eldin\Volcano\East\Volcano East Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Eldin Province
+    statue-name: Volcano East
+    stage: F200
+    room: 2
+    layer: 0
+    entrance: 6
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2237
+    short_name: Eldin Volcano - Volcano East Statue Entrance
+  \Eldin\Volcano\Ascent\Volcano Ascent Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Eldin Province
+    statue-name: Volcano Ascent
+    stage: F200
+    room: 2
+    layer: 0
+    entrance: 7
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2238
+    short_name: Eldin Volcano - Volcano Ascent Statue Entrance
+  \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Eldin Province
+    statue-name: Temple Entrance
+    stage: F200
+    room: 4
+    layer: 0
+    entrance: 7
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2239
+    short_name: Eldin Volcano - Temple Entrance Statue Entrance
+  \Eldin\Volcano\East\First Vent from Mogma Turf:
+    type: entrance
+    province: Eldin Province
+    stage: F200
+    room: 2
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2240
+    short_name: Eldin Volcano - First Vent from Mogma Turf
+  \Eldin\Volcano\Past Mogma Turf\Second Vent from Mogma Turf:
+    type: entrance
+    province: Eldin Province
+    stage: F200
+    room: 2
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2241
+    short_name: Eldin Volcano - Second Vent from Mogma Turf
+  \Eldin\Volcano\Near Temple Entrance\Entrance from Earth Temple:
+    type: entrance
+    province: Eldin Province
+    stage: F200
+    room: 4
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2242
+    short_name: Eldin Volcano - Entrance from Earth Temple
+  \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Entrance:
+    type: entrance
+    province: Eldin Province
+    stage: F200
+    room: 4
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2243
+    short_name: Eldin Volcano - Thrill Digger Cave Entrance
+  \Eldin\Volcano\Hot Cave\Entrance from Summit:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    stage: F200
+    room: 5
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2244
+    short_name: Eldin Volcano - Entrance from Summit
+  \Eldin\Volcano\Ascent\Trial Gate Entrance:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2245
+    short_name: Eldin Volcano - Trial Gate Entrance
+  \Eldin\Volcano\Hot Cave\Vent Entrance near Hot Cave:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2246
+    short_name: Eldin Volcano - Vent Entrance near Hot Cave
+  \Eldin\Volcano\East\Entrance from Bokoblin Base:
+    type: entrance
+    province: Eldin Province
+    stage: F200
+    room: 1
+    layer: 1
+    entrance: 5
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2247
+    short_name: Eldin Volcano - Entrance from Bokoblin Base
+  \Eldin\Bokoblin Base\Prison\Entrance:
+    type: entrance
+    province: Eldin Province
+    stage: F202
+    room: 1
+    layer: 1
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2248
+    short_name: Bokoblin Base - Entrance
+  \Eldin\Mogma Turf\Pre Vent\Entrance:
+    type: entrance
+    province: Eldin Province
+    stage: F210
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2249
+    short_name: Mogma Turf - Entrance
+  \Eldin\Volcano\Thrill Digger Cave\Entrance:
+    type: entrance
+    province: Eldin Province
+    stage: F211
+    room: 0
+    layer: 1
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2250
+    short_name: Thrill Digger Cave - Entrance
+  \Eldin\Eldin Silent Realm\Entrance:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2251
+    short_name: Eldin Silent Realm - Entrance
+  \Eldin\Volcano Summit\Entrance from Outside Fire Sanctuary:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    stage: F201_1
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2252
+    short_name: Volcano Summit - Entrance from Outside Fire Sanctuary
+  \Eldin\Volcano Summit\Entrance from Waterfall:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    stage: F201_1
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2253
+    short_name: Volcano Summit - Entrance from Waterfall
+  \Eldin\Volcano Summit\Entrance from Eldin Volcano:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    stage: F201_1
+    room: 0
+    layer: 0
+    entrance: 4
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2254
+    short_name: Volcano Summit - Entrance from Eldin Volcano
+  \Eldin\Volcano Summit\Waterfall\Entrance:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    stage: F201_4
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2255
+    short_name: Volcano Summit - Waterfall - Entrance
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Eldin Province
+    statue-name: Inside the Volcano
+    stage: F201_3
+    room: 0
+    layer: 0
+    entrance: 3
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2256
+    short_name: Outside Fire Sanctuary - Statue Entrance
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Entrance from Summit:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    stage: F201_3
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2257
+    short_name: Outside Fire Sanctuary - Entrance from Summit
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Entrance from Fire Sanctuary:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    stage: F201_3
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2258
+    short_name: Outside Fire Sanctuary - Entrance from Fire Sanctuary
+  \Earth Temple\Main\First Room\Main Entrance:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    stage: D200
+    room: 1
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2259
+    short_name: Earth Temple - Main Entrance
+  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Entrance:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2260
+    short_name: Earth Temple - Boss Door Entrance
+  \Earth Temple\Boss Room\Entry\Entrance from Dungeon:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2261
+    short_name: Earth Temple - Boss Room - Entrance from Dungeon
+  \Earth Temple\Boss Room\Slope\Entrance from Spring:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2262
+    short_name: Earth Temple - Boss Room - Entrance from Spring
+  \Earth Temple\Spring\Entrance:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2263
+    short_name: Earth Temple - Spring - Entrance
+  \Fire Sanctuary\Main\Front of Boss Door\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Eldin Province
+    can-start-at: false
+    statue-name: Inside the Fire Sanctuary
+    stage: D201
+    room: 10
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2264
+    short_name: Fire Sanctuary - Statue Entrance
+  \Fire Sanctuary\Main\First Room\Main Entrance:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    stage: D201
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2265
+    short_name: Fire Sanctuary - Main Entrance
+  \Fire Sanctuary\Main\First Room\Past Water Plant\Entrance from Second Room:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2266
+    short_name: Fire Sanctuary - First Room - Entrance from Second Room
+  \Fire Sanctuary\Main\Second Room\Outside Section\Entrance from First Room:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2267
+    short_name: Fire Sanctuary - Second Room - Entrance from First Room
+  \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Entrance from West of Boss Door:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2268
+    short_name: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss
+      Door
+  \Fire Sanctuary\Main\West of Boss Door\Entry\Entrance from Magmanos Fight Room:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2269
+    short_name: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight
+      Room
+  \Fire Sanctuary\Main\Front of Boss Door\Boss Door Entrance:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2270
+    short_name: Fire Sanctuary - Boss Door Entrance
+  \Fire Sanctuary\Boss Room\Entrance from Dungeon:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2271
+    short_name: Fire Sanctuary - Boss Room - Entrance from Dungeon
+  \Fire Sanctuary\Boss Room\Entrance from Flame Room:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2272
+    short_name: Fire Sanctuary - Boss Room - Entrance from Flame Room
+  \Fire Sanctuary\Flame Room\Entrance:
+    type: entrance
+    province: Eldin Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2273
+    short_name: Fire Sanctuary - Flame Room - Entrance
+  \Lanayru\Mine\Entry\First Time Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F300_1
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2274
+    short_name: Lanayru Mine - First Time Entrance
+  \Lanayru\Mine\Entry\Caves Entrance\Entrance from Caves:
+    type: entrance
+    province: Lanayru Province
+    stage: F300_1
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2275
+    short_name: Lanayru Mine - Entrance from Caves
+  \Lanayru\Mine\Entry\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: Lanayru Mine Entry
+    stage: F300_1
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2276
+    short_name: Lanayru Mine - Statue Entrance
+  \Lanayru\Mine\End\In Minecart\Entrance from Desert:
+    type: entrance
+    province: Lanayru Province
+    stage: F300_1
+    room: 2
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2277
+    short_name: Lanayru Mine - Entrance from Desert
+  \Lanayru\Desert\Entry\Desert Entrance Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: Desert Entrance
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 15
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2278
+    short_name: Lanayru Desert - Desert Entrance Statue Entrance
+  \Lanayru\Desert\West Part\West Desert Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: West Desert
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 16
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2279
+    short_name: Lanayru Desert - West Desert Statue Entrance
+  \Lanayru\Desert\North Part\North Desert Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: North Desert
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 17
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2280
+    short_name: Lanayru Desert - North Desert Statue Entrance
+  \Lanayru\Desert\East\Stone Cache Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: Stone Cache
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 18
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2281
+    short_name: Lanayru Desert - Stone Cache Statue Entrance
+  \Lanayru\Desert\Near South Exit to Temple of Time\South Entrance from Temple of Time:
+    type: entrance
+    province: Lanayru Province
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2282
+    short_name: Lanayru Desert - South Entrance from Temple of Time
+  \Lanayru\Desert\North Part\North Entrance from Temple of Time:
+    type: entrance
+    province: Lanayru Province
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2283
+    short_name: Lanayru Desert - North Entrance from Temple of Time
+  \Lanayru\Desert\Entry\Entrance from Mine:
+    type: entrance
+    province: Lanayru Province
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2284
+    short_name: Lanayru Desert - Entrance from Mine
+  \Lanayru\Desert\East\Fire Node Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 3
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2285
+    short_name: Lanayru Desert - Fire Node Entrance
+  \Lanayru\Desert\Top of LMF\Entrance from Lanayru Mining Facility:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 5
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2286
+    short_name: Lanayru Desert - Entrance from Lanayru Mining Facility
+  \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Entrance from Caves:
+    type: entrance
+    province: Lanayru Province
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 6
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2287
+    short_name: Lanayru Desert - Entrance from Caves
+  \Lanayru\Desert\North Part\Lightning Node Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F300
+    room: 0
+    layer: 0
+    entrance: 7
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2288
+    short_name: Lanayru Desert - Lightning Node Entrance
+  \Lanayru\Desert\North Part\Trial Gate Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2289
+    short_name: Lanayru Desert - Trial Gate Entrance
+  \Lanayru\Lanayru Silent Realm\Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2290
+    short_name: Lanayru Silent Realm - Entrance
+  \Lanayru\Desert\North Part\Lightning Node\Present\Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F300_2
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2291
+    short_name: Lightning Node - Entrance
+  \Lanayru\Desert\East\Fire Node\Present\Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F300_3
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2292
+    short_name: Fire Node - Entrance
+  \Lanayru\Temple of Time\South East\Desert Gorge Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: Desert Gorge
+    stage: F300_4
+    room: 0
+    layer: 0
+    entrance: 16
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2293
+    short_name: Temple of Time - Desert Gorge Statue Entrance
+  \Lanayru\Temple of Time\Inside\Temple of Time Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: Temple of Time
+    stage: F300_4
+    room: 0
+    layer: 0
+    entrance: 17
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2294
+    short_name: Temple of Time - Temple of Time Statue Entrance
+  \Lanayru\Temple of Time\South East\South Entrance from Desert:
+    type: entrance
+    province: Lanayru Province
+    stage: F300_4
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2295
+    short_name: Temple of Time - South Entrance from Desert
+  \Lanayru\Temple of Time\North East\North Entrance from Desert:
+    type: entrance
+    province: Lanayru Province
+    stage: F300_4
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2296
+    short_name: Temple of Time - North Entrance from Desert
+  \Lanayru\Temple of Time\Inside\Entrance from Lanayru Mining Facility:
+    type: entrance
+    subtype: vanilla
+    province: Lanayru Province
+    can-start-at: false
+    stage: F300_4
+    room: 0
+    layer: 2
+    entrance: 5
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2297
+    short_name: Temple of Time - Entrance from Lanayru Mining Facility
+  \Lanayru\Caves\Entrance from Mine:
+    type: entrance
+    province: Lanayru Province
+    stage: F303
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2298
+    short_name: Lanayru Caves - Entrance from Mine
+  \Lanayru\Caves\Entrance from Desert:
+    type: entrance
+    province: Lanayru Province
+    stage: F303
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2299
+    short_name: Lanayru Caves - Entrance from Desert
+  \Lanayru\Caves\Past Door to Lanayru Sand Sea\Entrance from Lanayru Sand Sea:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: F303
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2300
+    short_name: Lanayru Caves - Entrance from Lanayru Sand Sea
+  \Lanayru\Caves\Past Crawlspace\Entrance from Gorge:
+    type: entrance
+    province: Lanayru Province
+    stage: F303
+    room: 0
+    layer: 0
+    entrance: 3
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2301
+    short_name: Lanayru Caves - Entrance from Gorge
+  \Lanayru\Lanayru Sand Sea\Gorge\Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F302
+    room: 0
+    layer: 2
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2302
+    short_name: Lanayru Gorge - Entrance
+  \Lanayru\Lanayru Sand Sea\Gorge\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: Lanayru Gorge
+    stage: F302
+    room: 0
+    layer: 0
+    entrance: 12
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2303
+    short_name: Lanayru Gorge - Statue Entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_1
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2304
+    short_name: Lanayru Sand Sea - Ancient Harbour Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_1
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2305
+    short_name: Lanayru Sand Sea - Skipper's Retreat Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard Dock Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_1
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2306
+    short_name: Lanayru Sand Sea - Shipyard Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_1
+    room: 0
+    layer: 0
+    entrance: 3
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2307
+    short_name: Lanayru Sand Sea - Pirate Stronghold Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Sandship Dock Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: F301_1
+    room: 0
+    layer: 0
+    entrance: 4
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2308
+    short_name: Lanayru Sand Sea - Sandship Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: Ancient Harbour
+    stage: F301
+    room: 0
+    layer: 0
+    entrance: 10
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2309
+    short_name: Lanayru Sand Sea Docks - Statue Entrance
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Entrance from Caves:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: F301
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2310
+    short_name: Lanayru Sand Sea Docks - Entrance from Caves
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2311
+    short_name: Lanayru Sand Sea Docks - Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: Skipper's Retreat
+    stage: F301_3
+    room: 0
+    layer: 0
+    entrance: 10
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2312
+    short_name: Skipper's Retreat - Statue Entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_3
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2313
+    short_name: Skipper's Retreat - Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_3
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2314
+    short_name: Skipper's Retreat - Shack Entrance
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_5
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2315
+    short_name: Skipper's Retreat - Shack - Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: Lanayru Shipyard
+    stage: F301_4
+    room: 0
+    layer: 0
+    entrance: 10
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2316
+    short_name: Shipyard - Statue Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Dock Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_4
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2317
+    short_name: Shipyard - Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: F301_4
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2318
+    short_name: Shipyard - Construction Bay Lower Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: F301_4
+    room: 0
+    layer: 0
+    entrance: 4
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2319
+    short_name: Shipyard - Construction Bay Upper Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: F301_7
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2320
+    short_name: Shipyard - Construction Bay - Upper Entrance
+  \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: F301_7
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2321
+    short_name: Shipyard - Construction Bay - Lower Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Entrance:
+    type: entrance
+    subtype: bird-statue-entrance
+    province: Lanayru Province
+    statue-name: Pirate Stronghold
+    stage: F301_6
+    room: 0
+    layer: 0
+    entrance: 10
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2322
+    short_name: Pirate Stronghold - Statue Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_6
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2323
+    short_name: Pirate Stronghold - Dock Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_6
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2324
+    short_name: Pirate Stronghold - Side Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: F301_6
+    room: 0
+    layer: 0
+    entrance: 2
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2325
+    short_name: Pirate Stronghold - Top Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Entrance:
+    type: entrance
+    province: Lanayru Province
+    stage: F301_2
+    room: 1
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2326
+    short_name: Pirate Stronghold - Inside - First Door Entrance
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: F301_2
+    room: 1
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2327
+    short_name: Pirate Stronghold - Inside - Second Door Entrance
+  \Lanayru Mining Facility\Main\First Room\Main Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: D300
+    room: 0
+    layer: 0
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2328
+    short_name: Lanayru Mining Facility - Main Entrance
+  \Lanayru Mining Facility\Main\First Hub\Entrance from Big Hub:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2329
+    short_name: Lanayru Mining Facility - First Hub - Entrance from Big Hub
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Entrance from Big Hub:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2330
+    short_name: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big
+      Hub
+  \Lanayru Mining Facility\Main\Armos Fight Room\Entrance from Big Hub:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2331
+    short_name: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
+  \Lanayru Mining Facility\Main\Big Hub\Entry\Entrance from First Hub:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2332
+    short_name: Lanayru Mining Facility - Big Hub - Entrance from First Hub
+  \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Entrance from Hop Across Boxes Room:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2333
+    short_name: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes
+      Room
+  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Entrance from Armos Fight Room:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2334
+    short_name: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
+  \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2335
+    short_name: Lanayru Mining Facility - Boss Door Entrance
+  \Lanayru Mining Facility\Boss Room\Entrance from Dungeon:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2336
+    short_name: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
+  \Lanayru Mining Facility\Boss Room\After Sand Drain\Entrance from Hall of Ancient Robots:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2337
+    short_name: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient
+      Robots
+  \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Entrance from Boss Room:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2338
+    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
+      Room
+  \Lanayru Mining Facility\Hall of Ancient Robots\End\Entrance from Temple of Time:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    subtype: vanilla
+    stage: F300_5
+    room: 0
+    layer: 0
+    entrance: 1
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2339
+    short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Temple
+      of Time
+  \Sandship\Main\Deck\Main Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    stage: D301
+    room: 0
+    layer: 1
+    entrance: 0
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2340
+    short_name: Sandship - Main Entrance
+  \Sandship\Boss Room\Entrance:
+    type: entrance
+    province: Lanayru Province
+    can-start-at: false
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2341
+    short_name: Sandship - Boss Room - Entrance
+  \Sky Keep\Main\First Room\Bottom Entrance:
+    type: entrance
+    province: The Sky
+    can-start-at: false
+    stage: D003_7
+    room: 0
+    layer: 0
+    entrance: 4
+    tod: 2
+    allowed_time_of_day: 1
+    req_index: 2342
+    short_name: Sky Keep - First Room - Bottom Entrance

--- a/dump.yaml
+++ b/dump.yaml
@@ -14358,3 +14358,11 @@ linked_entrances:
       exit_from_outside: \Skyloft\Central Skyloft\Near Temple Entrance\Exit to Sky
         Keep
       exit_from_inside: \Sky Keep\Main\First Room\Bottom Exit
+  dungeon_completion_requirements:
+    Skyview: \Skyview\Spring\Strike Crest
+    Earth Temple: \Earth Temple\Spring\Strike Crest
+    Lanayru Mining Facility: \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit
+      Hall of Ancient Robots
+    Ancient Cistern: \Ancient Cistern\Flame Room\Farore's Flame
+    Sandship: \Sandship\Boss Room\Nayru's Flame
+    Fire Sanctuary: \Fire Sanctuary\Flame Room\Din's Flame

--- a/dump.yaml
+++ b/dump.yaml
@@ -2881,8 +2881,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Entrance from Flame Room
           - Entrance from Dungeon
+          - Entrance from Flame Room
           exits:
             Exit to Dungeon: \Ancient Cistern\Boss Room\Beat Koloktos
             Exit to Flame Room: \Ancient Cistern\Boss Room\Beat Koloktos
@@ -3171,8 +3171,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - First Time Entrance
               - Volcano Entrance Statue Entrance
+              - First Time Entrance
               exits:
                 Volcano Entrance Statue Exit: \Eldin\Volcano\Entry\Unlock Statue
                 \Eldin\Volcano\Ascent: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
@@ -3266,8 +3266,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Trial Gate Entrance
               - Volcano Ascent Statue Entrance
+              - Trial Gate Entrance
               exits:
                 \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\Ascent\Unlock
                   Statue
@@ -3380,8 +3380,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Summit
               - Vent Entrance near Hot Cave
+              - Entrance from Summit
               exits:
                 Exit to Summit: Fireshield Earrings
                 \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Temple Entrance\Blow
@@ -3912,9 +3912,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Main Entrance
               - Side Entrance
               - Gate of Time Entrance
+              - Main Entrance
               exits:
                 Main Exit: 'True'
                 Side Exit: 'True'
@@ -3980,8 +3980,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - In the Woods Statue Entrance
           - Viewing Platform Statue Entrance
+          - In the Woods Statue Entrance
           - Trial Gate Entrance
           exits:
             \Faron\Faron Woods\Entry: 'True'
@@ -4274,9 +4274,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Deep Woods Statue Entrance
               - Entrance from Skyview Temple
               - Forest Temple Statue Entrance
+              - Deep Woods Statue Entrance
               exits:
                 Shared Statue Exit: 'True'
                 \Faron\Faron Woods\Deep Woods\Entry: 'True'
@@ -4379,9 +4379,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
+              - Entrance
               - Entrance from Lower Flooded Faron Woods
               - Entrance from Upper Flooded Faron Woods
-              - Entrance
               exits:
                 Exit: 'True'
                 Exit to Upper Flooded Faron Woods: 'True'
@@ -4466,8 +4466,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Waterfall
               - Entrance from Lake Floria
+              - Entrance from Waterfall
               exits:
                 Exit to Waterfall: 'True'
                 Exit to Lake Floria: Water Dragon's Scale
@@ -4485,10 +4485,10 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Farore's Lair
               - Statue Entrance
-              - Entrance from Ancient Cistern
               - Entrance from Faron Woods
+              - Entrance from Ancient Cistern
+              - Entrance from Farore's Lair
               exits:
                 Statue Exit: \Faron\Lake Floria\Waterfall\Unlock Statue
                 Exit to Farore's Lair: 'True'
@@ -5078,8 +5078,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Entrance from Flame Room
           - Entrance from Dungeon
+          - Entrance from Flame Room
           exits:
             Exit to Dungeon: \Fire Sanctuary\Boss Room\Beat Ghirahim
             Exit to Flame Room: \Fire Sanctuary\Boss Room\Beat Ghirahim
@@ -5899,9 +5899,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Lightning Node Entrance
-              - North Entrance from Temple of Time
               - Trial Gate Entrance
+              - North Entrance from Temple of Time
+              - Lightning Node Entrance
               - North Desert Statue Entrance
               exits:
                 North Exit to Temple of Time: 'True'
@@ -6023,8 +6023,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Stone Cache Statue Entrance
               - Fire Node Entrance
+              - Stone Cache Statue Entrance
               exits:
                 \Lanayru\Desert\North Part: 'True'
                 \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
@@ -6162,8 +6162,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - South Entrance from Desert
               - Desert Gorge Statue Entrance
+              - South Entrance from Desert
               exits:
                 South Exit to Desert: 'True'
                 \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\South
@@ -6208,8 +6208,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Lanayru Mining Facility
               - Temple of Time Statue Entrance
+              - Entrance from Lanayru Mining Facility
               exits:
                 \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\Inside\Unlock
                   Statue
@@ -6246,9 +6246,9 @@ areas:
               exits:
                 \Lanayru\Temple of Time\South East: \Distance Activator
                 North Exit to Desert: 'True'
-                \Ancient Flower Farming: \Distance Activator
               hint_region: null
-              locations: {}
+              locations:
+                \Ancient Flower Farming: \Distance Activator
               name: \Lanayru\Temple of Time\North East
               sub_areas: {}
               toplevel_alias: null
@@ -6337,11 +6337,11 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Sandship Dock Entrance
           - Pirate Stronghold Dock Entrance
           - Ancient Harbour Dock Entrance
-          - Shipyard Dock Entrance
+          - Sandship Dock Entrance
           - Skipper's Retreat Dock Entrance
+          - Shipyard Dock Entrance
           exits:
             Ancient Harbour Dock Exit: 'True'
             Sandship Dock Exit: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
@@ -6489,8 +6489,8 @@ areas:
               can_sleep: false
               entrances:
               - Statue Entrance
-              - Dock Entrance
               - Construction Bay Lower Entrance
+              - Dock Entrance
               - Construction Bay Upper Entrance
               exits:
                 Statue Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
@@ -6577,8 +6577,8 @@ areas:
                   can_save: false
                   can_sleep: false
                   entrances:
-                  - Second Door Entrance
                   - First Door Entrance
+                  - Second Door Entrance
                   exits:
                     First Door Exit: 'True'
                     Second Door Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
@@ -7703,8 +7703,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Entrance from Skyloft
           - Entrance from Thunderhead
+          - Entrance from Skyloft
           exits:
             \Sky\North East: 'True'
             \Sky\South West: 'True'
@@ -7844,12 +7844,12 @@ areas:
           can_sleep: false
           entrances:
           - Knight Academy Upper Right Door Entrance
+          - Knight Academy Lower Left Door Entrance
+          - Sparring Hall Left Door Entrance
+          - Knight Academy Upper Left Door Entrance
+          - Sparring Hall Right Door Entrance
           - Goddess Statue Entrance
           - Knight Academy Lower Right Door Entrance
-          - Sparring Hall Left Door Entrance
-          - Sparring Hall Right Door Entrance
-          - Knight Academy Upper Left Door Entrance
-          - Knight Academy Lower Left Door Entrance
           exits:
             Knight Academy Upper Right Door Exit: 'True'
             Knight Academy Upper Left Door Exit: 'True'
@@ -7873,10 +7873,10 @@ areas:
               can_save: false
               can_sleep: true
               entrances:
-              - Upper Right Door Entrance
               - Lower Right Door Entrance
-              - Upper Left Door Entrance
               - Lower Left Door Entrance
+              - Upper Right Door Entrance
+              - Upper Left Door Entrance
               exits:
                 Upper Right Door Exit: 'True'
                 Upper Left Door Exit: 'True'
@@ -7939,8 +7939,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Right Door Entrance
               - Left Door Entrance
+              - Right Door Entrance
               exits:
                 Right Door Exit: 'True'
                 Left Door Exit: 'True'
@@ -7976,17 +7976,17 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Waterfall Cave Upper Entrance
-          - Bazaar South Entrance
-          - Bazaar North Entrance
-          - Peatrice's House Entrance
+          - Bazaar West Entrance
           - Entrance from Sky
           - Trial Gate Entrance
-          - Piper's House Entrance
-          - Entrance from Beedle's Shop
+          - Waterfall Cave Upper Entrance
+          - Bazaar North Entrance
           - Wryna's House Entrance
+          - Peatrice's House Entrance
           - Orielle and Parrow's House Entrance
-          - Bazaar West Entrance
+          - Entrance from Beedle's Shop
+          - Bazaar South Entrance
+          - Piper's House Entrance
           exits:
             Exit to Beedle's Shop: "Day & (\\Distance Activator | Beedle's Shop With\
               \ Bombs Trick & Bomb Bag)"
@@ -8263,12 +8263,12 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Batreaux's House Entrance
-          - Rupin's House Entrance
-          - Sparrot's House Entrance
-          - Bertie's House Entrance
           - Gondo's House Entrance
+          - Sparrot's House Entrance
           - Mallara's House Entrance
+          - Rupin's House Entrance
+          - Bertie's House Entrance
+          - Batreaux's House Entrance
           exits:
             \Skyloft\Central Skyloft: 'True'
             \Skyloft\Central Skyloft\Past Waterfall Cave: "Waterfall Cave Jump Trick\

--- a/dump.yaml
+++ b/dump.yaml
@@ -3267,8 +3267,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Volcano Ascent Statue Entrance
               - Trial Gate Entrance
+              - Volcano Ascent Statue Entrance
               exits:
                 \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\Ascent\Unlock
                   Statue
@@ -3381,8 +3381,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Summit
               - Vent Entrance near Hot Cave
+              - Entrance from Summit
               exits:
                 Exit to Summit: Fireshield Earrings
                 \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Temple Entrance\Blow
@@ -3542,9 +3542,9 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
+          - Entrance from Waterfall
           - Entrance from Eldin Volcano
           - Entrance from Outside Fire Sanctuary
-          - Entrance from Waterfall
           exits:
             Exit to Eldin Volcano: Fireshield Earrings
             Exit to Waterfall: Fireshield Earrings
@@ -3593,8 +3593,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Statue Entrance
               - Entrance from Fire Sanctuary
+              - Statue Entrance
               exits:
                 Statue Exit: \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
                 \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: \Eldin\Volcano
@@ -3914,8 +3914,8 @@ areas:
               can_sleep: false
               entrances:
               - Side Entrance
-              - Gate of Time Entrance
               - Main Entrance
+              - Gate of Time Entrance
               exits:
                 Main Exit: 'True'
                 Side Exit: 'True'
@@ -3956,10 +3956,10 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Statue Entrance
               - Entrance from Faron Woods
-              - Shortcut Entrance from Spiral
+              - Statue Entrance
               - Door Entrance
+              - Shortcut Entrance from Spiral
               exits:
                 Statue Exit: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
                 Door Exit: 'True'
@@ -3981,9 +3981,9 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Trial Gate Entrance
           - Viewing Platform Statue Entrance
           - In the Woods Statue Entrance
+          - Trial Gate Entrance
           exits:
             \Faron\Faron Woods\Entry: 'True'
             Shared Statue Exit: "\\Faron\\Faron Woods\\Unlock In the Woods Statue\
@@ -4381,8 +4381,8 @@ areas:
               can_sleep: false
               entrances:
               - Entrance from Lower Flooded Faron Woods
-              - Entrance
               - Entrance from Upper Flooded Faron Woods
+              - Entrance
               exits:
                 Exit: 'True'
                 Exit to Upper Flooded Faron Woods: 'True'
@@ -4486,9 +4486,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Statue Entrance
               - Entrance from Farore's Lair
               - Entrance from Ancient Cistern
+              - Statue Entrance
               - Entrance from Faron Woods
               exits:
                 Statue Exit: \Faron\Lake Floria\Waterfall\Unlock Statue
@@ -4980,8 +4980,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Boss Door Entrance
               - Statue Entrance
+              - Boss Door Entrance
               exits:
                 Statue Exit: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
                 Boss Door Exit: Fire Sanctuary Boss Key
@@ -5601,8 +5601,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - First Time Entrance
               - Statue Entrance
+              - First Time Entrance
               exits:
                 Statue Exit: \Lanayru\Mine\Entry\Unlock Statue
                 \Lanayru\Mine\Statues Area: \Lanayru\Mine\Entry\Timeshift Stone
@@ -5719,8 +5719,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Mine
               - Desert Entrance Statue Entrance
+              - Entrance from Mine
               exits:
                 Exit to Mine: \Lanayru\Desert\Entry\Timeshift Stone
                 \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\Entry\Unlock Statue
@@ -5901,9 +5901,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Lightning Node Entrance
-              - Trial Gate Entrance
               - North Entrance from Temple of Time
+              - Trial Gate Entrance
+              - Lightning Node Entrance
               - North Desert Statue Entrance
               exits:
                 North Exit to Temple of Time: 'True'
@@ -6164,8 +6164,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - South Entrance from Desert
               - Desert Gorge Statue Entrance
+              - South Entrance from Desert
               exits:
                 South Exit to Desert: 'True'
                 \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\South
@@ -6339,11 +6339,11 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Ancient Harbour Dock Entrance
           - Pirate Stronghold Dock Entrance
           - Sandship Dock Entrance
           - Shipyard Dock Entrance
           - Skipper's Retreat Dock Entrance
+          - Ancient Harbour Dock Entrance
           exits:
             Ancient Harbour Dock Exit: 'True'
             Sandship Dock Exit: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
@@ -6361,8 +6361,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Dock Entrance
               - Statue Entrance
+              - Dock Entrance
               exits:
                 Dock Exit: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Ship Timeshift
                   Stone
@@ -6490,10 +6490,10 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Construction Bay Lower Entrance
-              - Statue Entrance
-              - Dock Entrance
               - Construction Bay Upper Entrance
+              - Statue Entrance
+              - Construction Bay Lower Entrance
+              - Dock Entrance
               exits:
                 Statue Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
                 Dock Exit: 'True'
@@ -6514,8 +6514,8 @@ areas:
                   can_save: false
                   can_sleep: false
                   entrances:
-                  - Lower Entrance
                   - Upper Entrance
+                  - Lower Entrance
                   exits:
                     Upper Exit: 'True'
                     Lower Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
@@ -6534,8 +6534,8 @@ areas:
               can_sleep: false
               entrances:
               - Statue Entrance
-              - Dock Entrance
               - Side Entrance
+              - Dock Entrance
               exits:
                 Statue Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
                 Dock Exit: 'True'
@@ -6579,8 +6579,8 @@ areas:
                   can_save: false
                   can_sleep: false
                   entrances:
-                  - First Door Entrance
                   - Second Door Entrance
+                  - First Door Entrance
                   exits:
                     First Door Exit: 'True'
                     Second Door Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
@@ -7507,9 +7507,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Back Door Entrance
-              - Main Right Door Entrance
               - Main Left Door Entrance
+              - Main Right Door Entrance
+              - Back Door Entrance
               exits:
                 \Sky\South East: Day
                 Main Right Door Exit: 'True'
@@ -7536,9 +7536,9 @@ areas:
                   can_save: false
                   can_sleep: true
                   entrances:
-                  - Back Door Entrance
-                  - Main Right Door Entrance
                   - Main Left Door Entrance
+                  - Main Right Door Entrance
+                  - Back Door Entrance
                   exits:
                     Main Right Door Exit: 'True'
                     Main Left Door Exit: 'True'
@@ -7846,12 +7846,12 @@ areas:
           can_sleep: false
           entrances:
           - Sparring Hall Right Door Entrance
-          - Knight Academy Lower Left Door Entrance
-          - Sparring Hall Left Door Entrance
           - Knight Academy Lower Right Door Entrance
-          - Knight Academy Upper Left Door Entrance
           - Goddess Statue Entrance
+          - Knight Academy Lower Left Door Entrance
           - Knight Academy Upper Right Door Entrance
+          - Knight Academy Upper Left Door Entrance
+          - Sparring Hall Left Door Entrance
           exits:
             Knight Academy Upper Right Door Exit: 'True'
             Knight Academy Upper Left Door Exit: 'True'
@@ -7875,10 +7875,10 @@ areas:
               can_save: false
               can_sleep: true
               entrances:
+              - Lower Right Door Entrance
+              - Upper Right Door Entrance
               - Upper Left Door Entrance
               - Lower Left Door Entrance
-              - Upper Right Door Entrance
-              - Lower Right Door Entrance
               exits:
                 Upper Right Door Exit: 'True'
                 Upper Left Door Exit: 'True'
@@ -7941,8 +7941,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Left Door Entrance
               - Right Door Entrance
+              - Left Door Entrance
               exits:
                 Right Door Exit: 'True'
                 Left Door Exit: 'True'
@@ -7978,17 +7978,17 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Piper's House Entrance
-          - Orielle and Parrow's House Entrance
-          - Trial Gate Entrance
           - Bazaar West Entrance
-          - Peatrice's House Entrance
-          - Wryna's House Entrance
-          - Entrance from Sky
-          - Entrance from Beedle's Shop
+          - Orielle and Parrow's House Entrance
           - Bazaar North Entrance
-          - Waterfall Cave Upper Entrance
           - Bazaar South Entrance
+          - Waterfall Cave Upper Entrance
+          - Peatrice's House Entrance
+          - Entrance from Sky
+          - Trial Gate Entrance
+          - Piper's House Entrance
+          - Entrance from Beedle's Shop
+          - Wryna's House Entrance
           exits:
             Exit to Beedle's Shop: "Day & (\\Distance Activator | (Beedle's Shop With\
               \ Bombs Trick & Bomb Bag))"
@@ -8056,9 +8056,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - South Entrance
               - North Entrance
               - West Entrance
+              - South Entrance
               exits:
                 North Exit: 'True'
                 West Exit: 'True'
@@ -8203,8 +8203,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Lower Entrance
               - Upper Entrance
+              - Lower Entrance
               exits:
                 Upper Exit: 'True'
                 Lower Exit: 'True'
@@ -8265,12 +8265,12 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Mallara's House Entrance
-          - Batreaux's House Entrance
-          - Gondo's House Entrance
-          - Bertie's House Entrance
-          - Rupin's House Entrance
           - Sparrot's House Entrance
+          - Gondo's House Entrance
+          - Mallara's House Entrance
+          - Bertie's House Entrance
+          - Batreaux's House Entrance
+          - Rupin's House Entrance
           exits:
             \Skyloft\Central Skyloft: 'True'
             \Skyloft\Central Skyloft\Past Waterfall Cave: "Waterfall Cave Jump Trick\
@@ -8394,8 +8394,8 @@ areas:
           can_save: false
           can_sleep: true
           entrances:
-          - Day Entrance
           - Night Entrance
+          - Day Entrance
           exits:
             Night Exit: Night
             Day Exit: Day
@@ -8807,8 +8807,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Entrance from Dungeon
           - Entrance from Spring
+          - Entrance from Dungeon
           exits:
             Exit to Dungeon: \Skyview\Boss Room\Beat Ghirahim
             Exit to Spring: \Skyview\Boss Room\Beat Ghirahim
@@ -8840,595 +8840,1058 @@ areas:
       toplevel_alias: Skyview Temple
   toplevel_alias: null
 checks:
-  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Gift: Upper Skyloft - Fledge's Gift
-  \Skyloft\Upper Skyloft\Owlan's Gift: Upper Skyloft - Owlan's Gift
-  \Skyloft\Upper Skyloft\Sparring Hall\Sparring Hall Chest: Upper Skyloft - Sparring
-    Hall Chest
-  \Skyloft\Upper Skyloft\Chest near Goddess Statue: Upper Skyloft - Chest near Goddess
-    Statue
-  \Skyloft\Upper Skyloft\Goddess Statue\First Goddess Sword Item in Goddess Statue: Upper
-    Skyloft - First Goddess Sword Item in Goddess Statue
-  \Skyloft\Upper Skyloft\Goddess Statue\Second Goddess Sword Item in Goddess Statue: Upper
-    Skyloft - Second Goddess Sword Item in Goddess Statue
-  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\In Zelda's Closet: Upper Skyloft
-    - In Zelda's Closet
-  \Skyloft\Upper Skyloft\Knight Academy\Owlan's Crystals: Upper Skyloft - Owlan's
-    Crystals
-  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Crystals: Upper Skyloft - Fledge's
-    Crystals
-  \Skyloft\Upper Skyloft\Knight Academy\Item from Cawlin: Upper Skyloft - Item from
-    Cawlin
-  \Skyloft\Upper Skyloft\Knight Academy\Ghost/Pipit's Crystals: Upper Skyloft - Ghost/Pipit's
-    Crystals
-  \Skyloft\Upper Skyloft\Pumpkin Archery -- 600 Points: Upper Skyloft - Pumpkin Archery
-    -- 600 Points
-  \Skyloft\Central Skyloft\Bazaar\Potion Lady's Gift: Central Skyloft - Potion Lady's
-    Gift
-  \Skyloft\Central Skyloft\Bazaar\Repair Gondo's Junk: Central Skyloft - Repair Gondo's
-    Junk
-  \Skyloft\Central Skyloft\Wryna's House\Wryna's Crystals: Central Skyloft - Wryna's
-    Crystals
-  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave First Chest: Central Skyloft
-    - Waterfall Cave First Chest
-  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave Second Chest: Central Skyloft
-    - Waterfall Cave Second Chest
-  \Skyloft\Central Skyloft\Waterfall Cave\Rupee Waterfall Cave Crawlspace: Central
-    Skyloft - Rupee Waterfall Cave Crawlspace
-  \Skyloft\Central Skyloft\Parrow's Gift: Central Skyloft - Parrow's Gift
-  \Skyloft\Central Skyloft\Parrow's Crystals: Central Skyloft - Parrow's Crystals
-  \Skyloft\Central Skyloft\Peatrice's House\Peater/Peatrice's Crystals: Central Skyloft
-    - Peater/Peatrice's Crystals
-  \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest: Central Skyloft - Item in
-    Bird Nest
-  \Skyloft\Central Skyloft\Shed Chest: Central Skyloft - Shed Chest
-  \Skyloft\Central Skyloft\West Cliff Goddess Chest: Central Skyloft - West Cliff
-    Goddess Chest
-  \Skyloft\Central Skyloft\Bazaar\Bazaar Goddess Chest: Central Skyloft - Bazaar Goddess
-    Chest
-  \Skyloft\Central Skyloft\Shed Goddess Chest: Central Skyloft - Shed Goddess Chest
-  \Skyloft\Central Skyloft\Waterfall Island\Floating Island Goddess Chest: Central
-    Skyloft - Floating Island Goddess Chest
-  \Skyloft\Central Skyloft\Waterfall Island\Waterfall Goddess Chest: Central Skyloft
-    - Waterfall Goddess Chest
-  \Skyloft\Skyloft Village\Mallara's House\Mallara's Crystals: Skyloft Village - Mallara's
-    Crystals
-  \Skyloft\Skyloft Village\Bertie's House\Bertie's Crystals: Skyloft Village - Bertie's
-    Crystals
-  \Skyloft\Skyloft Village\Sparrot's House\Sparrot's Crystals: Skyloft Village - Sparrot's
-    Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\5 Crystals: Batreaux's House - 5 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\10 Crystals: Batreaux's House - 10 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals: Batreaux's House - 30 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals Chest: Batreaux's House -
-    30 Crystals Chest
-  \Skyloft\Skyloft Village\Batreaux's House\40 Crystals: Batreaux's House - 40 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\50 Crystals: Batreaux's House - 50 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals: Batreaux's House - 70 Crystals
-  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals Second Reward: Batreaux's
-    House - 70 Crystals Second Reward
-  \Skyloft\Skyloft Village\Batreaux's House\80 Crystals: Batreaux's House - 80 Crystals
-  \Skyloft\Beedle's Shop\Stall\300 Rupee Item: Beedle's Shop - 300 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\600 Rupee Item: Beedle's Shop - 600 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\1200 Rupee Item: Beedle's Shop - 1200 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\800 Rupee Item: Beedle's Shop - 800 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\1600 Rupee Item: Beedle's Shop - 1600 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\First 100 Rupee Item: Beedle's Shop - First 100 Rupee
-    Item
-  \Skyloft\Beedle's Shop\Stall\Second 100 Rupee Item: Beedle's Shop - Second 100 Rupee
-    Item
-  \Skyloft\Beedle's Shop\Stall\Third 100 Rupee Item: Beedle's Shop - Third 100 Rupee
-    Item
-  \Skyloft\Beedle's Shop\Stall\50 Rupee Item: Beedle's Shop - 50 Rupee Item
-  \Skyloft\Beedle's Shop\Stall\1000 Rupee Item: Beedle's Shop - 1000 Rupee Item
-  \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Crystal in Link's Room: Upper
-    Skyloft - Crystal in Link's Room
-  \Skyloft\Upper Skyloft\Knight Academy\Crystal in Knight Academy Plant: Upper Skyloft
-    - Crystal in Knight Academy Plant
-  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Crystal in Zelda's Room: Upper
-    Skyloft - Crystal in Zelda's Room
-  \Skyloft\Upper Skyloft\Sparring Hall\Crystal in Sparring Hall: Upper Skyloft - Crystal
-    in Sparring Hall
-  \Skyloft\Central Skyloft\Orielle and Parrow's House\Crystal in Orielle and Parrow's House: Central
-    Skyloft - Crystal in Orielle and Parrow's House
-  \Skyloft\Central Skyloft\Crystal on West Cliff: Central Skyloft - Crystal on West
-    Cliff
-  \Skyloft\Central Skyloft\Crystal between Wooden Planks: Central Skyloft - Crystal
-    between Wooden Planks
-  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: Central
-    Skyloft - Crystal after Waterfall Cave
-  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: Central
-    Skyloft - Crystal in Loftwing Prison
-  \Skyloft\Central Skyloft\Crystal on Waterfall Island: Central Skyloft - Crystal
-    on Waterfall Island
-  \Skyloft\Central Skyloft\Crystal on Light Tower: Central Skyloft - Crystal on Light
-    Tower
-  \Skyloft\Skyloft Village\Crystal near Pumpkin Patch: Skyloft Village - Crystal near
-    Pumpkin Patch
-  \Sky\South East\Lumpy Pumpkin\Crystal outside Lumpy Pumpkin: Sky - Crystal outside
-    Lumpy Pumpkin
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Crystal inside Lumpy Pumpkin: Sky
-    - Crystal inside Lumpy Pumpkin
-  \Sky\North East\Beedle's Island\Crystal on Beedle's Ship: Sky - Crystal on Beedle's
-    Ship
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Chandelier: Sky - Lumpy Pumpkin
-    - Chandelier
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Harp Minigame: Sky - Lumpy
-    Pumpkin - Harp Minigame
-  \Sky\South East\Lumpy Pumpkin\Kina's Crystals: Sky - Kina's Crystals
-  \Sky\South West\Orielle's Island\Orielle's Crystals: Sky - Orielle's Crystals
-  \Sky\North East\Beedle's Island\Beedle's Crystals: Sky - Beedle's Crystals
-  \Sky\South West\Fun Fun Island\Dodoh's Crystals: Sky - Dodoh's Crystals
-  \Sky\South West\Fun Fun Island\Fun Fun Island Minigame -- 500 Rupees: Sky - Fun
-    Fun Island Minigame -- 500 Rupees
-  \Sky\South West\Chest in Breakable Boulder near Fun Fun Island: Sky - Chest in Breakable
-    Boulder near Fun Fun Island
-  \Sky\South East\Chest in Breakable Boulder near Lumpy Pumpkin: Sky - Chest in Breakable
-    Boulder near Lumpy Pumpkin
-  \Sky\North East\Bamboo Island\Bamboo Island Goddess Chest: Sky - Bamboo Island Goddess
-    Chest
-  \Sky\North East\Goddess Chest on Island next to Bamboo Island: Sky - Goddess Chest
-    on Island next to Bamboo Island
-  \Sky\North East\Goddess Chest in Cave on Island next to Bamboo Island: Sky - Goddess
-    Chest in Cave on Island next to Bamboo Island
-  \Sky\North East\Beedle's Island\Top\Beedle's Island Goddess Chest: Sky - Beedle's
-    Island Goddess Chest
-  \Sky\North East\Beedle's Island\Cage\Beedle's Island Cage Goddess Chest: Sky - Beedle's
-    Island Cage Goddess Chest
-  \Sky\North East\Northeast Island Goddess Chest behind Bombable Rocks: Sky - Northeast
-    Island Goddess Chest behind Bombable Rocks
-  \Sky\North East\Northeast Island Cage Goddess Chest: Sky - Northeast Island Cage
-    Goddess Chest
-  \Sky\South East\Lumpy Pumpkin\Goddess Chest on the Roof: Sky - Lumpy Pumpkin - Goddess
-    Chest on the Roof
-  \Sky\South East\Lumpy Pumpkin\Outside Goddess Chest: Sky - Lumpy Pumpkin - Outside
-    Goddess Chest
-  \Sky\South East\Goddess Chest on Island Closest to Faron Pillar: Sky - Goddess Chest
-    on Island Closest to Faron Pillar
-  \Sky\South West\Volcanic Island\Goddess Chest outside Volcanic Island: Sky - Goddess
-    Chest outside Volcanic Island
-  \Sky\South West\Volcanic Island\Goddess Chest inside Volcanic Island: Sky - Goddess
-    Chest inside Volcanic Island
-  \Sky\South West\Fun Fun Island\Goddess Chest under Fun Fun Island: Sky - Goddess
-    Chest under Fun Fun Island
-  \Sky\South West\Triple Island\Southwest Triple Island Upper Goddess Chest: Sky -
-    Southwest Triple Island Upper Goddess Chest
-  \Sky\South West\Triple Island\Southwest Triple Island Lower Goddess Chest: Sky -
-    Southwest Triple Island Lower Goddess Chest
-  \Sky\South West\Triple Island\Southwest Triple Island Cage Goddess Chest: Sky -
-    Southwest Triple Island Cage Goddess Chest
-  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Goddess Sword: Thunderhead
-    - Isle of Songs - Strike Crest with Goddess Sword
-  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Longsword: Thunderhead -
-    Isle of Songs - Strike Crest with Longsword
-  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with White Sword: Thunderhead
-    - Isle of Songs - Strike Crest with White Sword
-  \Sky\Thunderhead\Song from Levias: Thunderhead - Song from Levias
-  \Sky\Thunderhead\Bug Heaven\Bug Heaven -- 10 Bugs in 3 Minutes: Thunderhead - Bug
-    Heaven -- 10 Bugs in 3 Minutes
-  \Sky\Thunderhead\East Island\East Island Chest: Thunderhead - East Island Chest
-  \Sky\Thunderhead\East Island\East Island Goddess Chest: Thunderhead - East Island
-    Goddess Chest
-  \Sky\Thunderhead\Isle of Songs\Goddess Chest on top of Isle of Songs: Thunderhead
-    - Goddess Chest on top of Isle of Songs
-  \Sky\Thunderhead\Isle of Songs\Goddess Chest outside Isle of Songs: Thunderhead
-    - Goddess Chest outside Isle of Songs
-  \Sky\Thunderhead\Mogma Mitts Island\First Goddess Chest on Mogma Mitts Island: Thunderhead
-    - First Goddess Chest on Mogma Mitts Island
-  \Sky\Thunderhead\Mogma Mitts Island\Second Goddess Chest on Mogma Mitts Island: Thunderhead
-    - Second Goddess Chest on Mogma Mitts Island
-  \Sky\Thunderhead\Bug Heaven\Bug Heaven Goddess Chest: Thunderhead - Bug Heaven Goddess
-    Chest
-  \Faron\Sealed Grounds\Sealed Temple\Chest inside Sealed Temple: Sealed Grounds -
-    Chest inside Sealed Temple
-  \Faron\Sealed Grounds\Sealed Temple\Song from Impa: Sealed Grounds - Song from Impa
-  \Faron\Sealed Grounds\Behind the Temple\Gorko's Goddess Wall Reward: Sealed Grounds
-    - Gorko's Goddess Wall Reward
-  \Faron\Sealed Grounds\Hylia's Temple\Zelda's Blessing: Sealed Grounds - Zelda's
-    Blessing
-  \Faron\Faron Woods\Item behind Lower Bombable Rock: Faron Woods - Item behind Lower
-    Bombable Rock
-  \Faron\Faron Woods\Item on Tree: Faron Woods - Item on Tree
-  \Faron\Faron Woods\Kikwi Elder's Reward: Faron Woods - Kikwi Elder's Reward
-  \Faron\Faron Woods\Rupee on Hollow Tree Root: Faron Woods - Rupee on Hollow Tree
-    Root
-  \Faron\Faron Woods\Rupee on Hollow Tree Branch: Faron Woods - Rupee on Hollow Tree
-    Branch
-  \Faron\Faron Woods\Rupee on Platform near Floria Door: Faron Woods - Rupee on Platform
-    near Floria Door
-  \Faron\Faron Woods\Deep Woods\Deep Woods Chest: Faron Woods - Deep Woods Chest
-  \Faron\Faron Woods\Chest behind Upper Bombable Rock: Faron Woods - Chest behind
-    Upper Bombable Rock
-  \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest\Chest inside Great Tree: Faron
-    Woods - Chest inside Great Tree
-  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree North Branch: Faron Woods
-    - Rupee on Great Tree North Branch
-  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree West Branch: Faron Woods -
-    Rupee on Great Tree West Branch
-  \Faron\Lake Floria\Above Rock\Rupee under Central Boulder: Lake Floria - Rupee under
-    Central Boulder
-  \Faron\Lake Floria\Above Rock\Rupee behind Southwest Boulder: Lake Floria - Rupee
-    behind Southwest Boulder
-  \Faron\Lake Floria\Above Rock\Left Rupee behind Northwest Boulder: Lake Floria -
-    Left Rupee behind Northwest Boulder
-  \Faron\Lake Floria\Above Rock\Right Rupee behind Northwest Boulder: Lake Floria
-    - Right Rupee behind Northwest Boulder
-  \Faron\Lake Floria\Below Rock\Emerged Area\Lake Floria Chest: Lake Floria - Lake
-    Floria Chest
-  \Faron\Lake Floria\Farore's Lair\Dragon Lair South Chest: Lake Floria - Dragon Lair
-    South Chest
-  \Faron\Lake Floria\Farore's Lair\Dragon Lair East Chest: Lake Floria - Dragon Lair
-    East Chest
-  \Faron\Lake Floria\Waterfall\Rupee on High Ledge outside Ancient Cistern Entrance: Lake
-    Floria - Rupee on High Ledge outside Ancient Cistern Entrance
-  \Faron\Flooded Faron Woods\Yellow Tadtone under Lilypad: Flooded Faron Woods - Yellow
-    Tadtone under Lilypad
-  \Faron\Flooded Faron Woods\8 Light Blue Tadtones near Viewing Platform: Flooded
-    Faron Woods - 8 Light Blue Tadtones near Viewing Platform
-  \Faron\Flooded Faron Woods\4 Purple Tadtones under Viewing Platform: Flooded Faron
-    Woods - 4 Purple Tadtones under Viewing Platform
-  \Faron\Flooded Faron Woods\Red Moving Tadtone near Viewing Platform: Flooded Faron
-    Woods - Red Moving Tadtone near Viewing Platform
-  \Faron\Flooded Faron Woods\Light Blue Tadtone under Great Tree Root: Flooded Faron
-    Woods - Light Blue Tadtone under Great Tree Root
-  \Faron\Flooded Faron Woods\8 Yellow Tadtones near Kikwi Elder: Flooded Faron Woods
-    - 8 Yellow Tadtones near Kikwi Elder
-  \Faron\Flooded Faron Woods\4 Light Blue Moving Tadtones under Kikwi Elder: Flooded
-    Faron Woods - 4 Light Blue Moving Tadtones under Kikwi Elder
-  \Faron\Flooded Faron Woods\4 Red Moving Tadtones North West of Great Tree: Flooded
-    Faron Woods - 4 Red Moving Tadtones North West of Great Tree
-  \Faron\Flooded Faron Woods\Green Tadtone behind Upper Bombable Rock: Flooded Faron
-    Woods - Green Tadtone behind Upper Bombable Rock
-  \Faron\Flooded Faron Woods\2 Dark Blue Tadtones in Grass West of Great Tree: Flooded
-    Faron Woods - 2 Dark Blue Tadtones in Grass West of Great Tree
-  \Faron\Flooded Faron Woods\8 Green Tadtones in West Tunnel: Flooded Faron Woods
-    - 8 Green Tadtones in West Tunnel
-  \Faron\Flooded Faron Woods\2 Red Tadtones in Grass near Lower Bombable Rock: Flooded
-    Faron Woods - 2 Red Tadtones in Grass near Lower Bombable Rock
-  \Faron\Flooded Faron Woods\16 Dark Blue Tadtones in the South West: Flooded Faron
-    Woods - 16 Dark Blue Tadtones in the South West
-  \Faron\Flooded Faron Woods\4 Purple Moving Tadtones near Floria Gate: Flooded Faron
-    Woods - 4 Purple Moving Tadtones near Floria Gate
-  \Faron\Flooded Faron Woods\Dark Blue Moving Tadtone inside Small Hollow Tree: Flooded
-    Faron Woods - Dark Blue Moving Tadtone inside Small Hollow Tree
-  \Faron\Flooded Faron Woods\4 Yellow Tadtones under Small Hollow Tree: Flooded Faron
-    Woods - 4 Yellow Tadtones under Small Hollow Tree
-  \Faron\Flooded Faron Woods\8 Purple Tadtones in Clearing after Small Hollow Tree: Flooded
-    Faron Woods - 8 Purple Tadtones in Clearing after Small Hollow Tree
-  \Faron\Flooded Faron Woods\Flooded Great Tree\Water Dragon's Reward: Flooded Faron
-    Woods - Water Dragon's Reward
-  \Eldin\Volcano\Entry\Rupee on Ledge before First Room: Eldin Volcano - Rupee on
-    Ledge before First Room
-  \Eldin\Volcano\First Room\Chest behind Bombable Wall in First Room: Eldin Volcano
-    - Chest behind Bombable Wall in First Room
-  \Eldin\Volcano\First Room\Rupee behind Bombable Wall in First Room: Eldin Volcano
-    - Rupee behind Bombable Wall in First Room
-  \Eldin\Volcano\First Room\Rupee in Crawlspace in First Room: Eldin Volcano - Rupee
-    in Crawlspace in First Room
-  \Eldin\Volcano\East\Chest after Crawlspace: Eldin Volcano - Chest after Crawlspace
-  \Eldin\Volcano\East\Southeast Rupee above Mogma Turf Entrance: Eldin Volcano - Southeast
-    Rupee above Mogma Turf Entrance
-  \Eldin\Volcano\East\North Rupee above Mogma Turf Entrance: Eldin Volcano - North
-    Rupee above Mogma Turf Entrance
-  \Eldin\Volcano\East\Chest behind Bombable Wall near Cliff: Eldin Volcano - Chest
-    behind Bombable Wall near Cliff
-  \Eldin\Volcano\East\Item on Cliff: Eldin Volcano - Item on Cliff
-  \Eldin\Volcano\Ascent\Chest behind Bombable Wall near Volcano Ascent: Eldin Volcano
-    - Chest behind Bombable Wall near Volcano Ascent
-  \Eldin\Volcano\Near Thrill Digger Cave\Left Rupee behind Bombable Wall on First Slope: Eldin
-    Volcano - Left Rupee behind Bombable Wall on First Slope
-  \Eldin\Volcano\Near Thrill Digger Cave\Right Rupee behind Bombable Wall on First Slope: Eldin
-    Volcano - Right Rupee behind Bombable Wall on First Slope
-  \Eldin\Volcano\Near Temple Entrance\Digging Spot in front of Earth Temple: Eldin
-    Volcano - Digging Spot in front of Earth Temple
-  \Eldin\Volcano\Near Temple Entrance\Digging Spot below Tower: Eldin Volcano - Digging
-    Spot below Tower
-  \Eldin\Volcano\Near Temple Entrance\Digging Spot behind Boulder on Sandy Slope: Eldin
-    Volcano - Digging Spot behind Boulder on Sandy Slope
-  \Eldin\Volcano\Sand Slide\Digging Spot after Vents: Eldin Volcano - Digging Spot
-    after Vents
-  \Eldin\Volcano\Past Slide\Digging Spot after Draining Lava: Eldin Volcano - Digging
-    Spot after Draining Lava
-  \Eldin\Mogma Turf\Pre Vent\Free Fall Chest: Mogma Turf - Free Fall Chest
-  \Eldin\Mogma Turf\Pre Vent\Chest behind Bombable Wall at Entrance: Mogma Turf -
-    Chest behind Bombable Wall at Entrance
-  \Eldin\Mogma Turf\Pre Vent\Defeat Bokoblins: Mogma Turf - Defeat Bokoblins
-  \Eldin\Mogma Turf\Sand Slide Platform\Sand Slide Chest: Mogma Turf - Sand Slide
-    Chest
-  \Eldin\Mogma Turf\Past Vent\Chest behind Bombable Wall in Fire Maze: Mogma Turf
-    - Chest behind Bombable Wall in Fire Maze
-  \Eldin\Volcano Summit\Waterfall\Higher Area\Chest behind Bombable Wall in Waterfall Area: Volcano
-    Summit - Chest behind Bombable Wall in Waterfall Area
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Item behind Digging: Volcano
-    Summit - Item behind Digging
-  \Eldin\Bokoblin Base\Prison\Plats' Gift: Bokoblin Base - Plats' Gift
-  \Eldin\Bokoblin Base\Volcano East\Chest near Bone Bridge: Bokoblin Base - Chest
-    near Bone Bridge
-  \Eldin\Bokoblin Base\Volcano East\Chest on Cliff: Bokoblin Base - Chest on Cliff
-  \Eldin\Bokoblin Base\Before Drawbridge\Chest near Drawbridge: Bokoblin Base - Chest
-    near Drawbridge
-  \Eldin\Bokoblin Base\Outside Earth Temple\Chest East of Earth Temple Entrance: Bokoblin
-    Base - Chest East of Earth Temple Entrance
-  \Eldin\Bokoblin Base\Outside Earth Temple\Chest West of Earth Temple Entrance: Bokoblin
-    Base - Chest West of Earth Temple Entrance
-  \Eldin\Bokoblin Base\Bokoblin Base Summit\First Chest in Volcano Summit: Bokoblin
-    Base - First Chest in Volcano Summit
-  \Eldin\Bokoblin Base\Bokoblin Base Summit\Raised Chest in Volcano Summit: Bokoblin
-    Base - Raised Chest in Volcano Summit
-  \Eldin\Bokoblin Base\Bokoblin Base Summit\Chest in Volcano Summit Alcove: Bokoblin
-    Base - Chest in Volcano Summit Alcove
-  \Eldin\Bokoblin Base\Fire Dragon's Lair\Fire Dragon's Reward: Bokoblin Base - Fire
-    Dragon's Reward
-  \Lanayru\Mine\Entry\Higher Area\Chest behind First Landing: Lanayru Mine - Chest
-    behind First Landing
-  \Lanayru\Mine\Entry\Chest near First Timeshift Stone: Lanayru Mine - Chest near
-    First Timeshift Stone
-  \Lanayru\Mine\Statues Area\Chest behind Statue: Lanayru Mine - Chest behind Statue
-  \Lanayru\Mine\End\Chest at the End of Mine: Lanayru Mine - Chest at the End of Mine
-  \Lanayru\Desert\Entry\High Ledge after Vines\Chest near Party Wheel: Lanayru Desert
-    - Chest near Party Wheel
-  \Lanayru\Desert\Near Caged Robot\Chest near Caged Robot: Lanayru Desert - Chest
-    near Caged Robot
-  \Lanayru\Desert\Near Caged Robot\Rescue Caged Robot: Lanayru Desert - Rescue Caged
-    Robot
-  \Lanayru\Desert\East\Chest on Platform near Fire Node: Lanayru Desert - Chest on
-    Platform near Fire Node
-  \Lanayru\Desert\North Part\Chest on Platform near Lightning Node: Lanayru Desert
-    - Chest on Platform near Lightning Node
-  \Lanayru\Desert\Top of West Wall\Chest near Sand Oasis: Lanayru Desert - Chest near
-    Sand Oasis
-  \Lanayru\Desert\Top of LMF\Chest on top of Lanayru Mining Facility: Lanayru Desert
-    - Chest on top of Lanayru Mining Facility
-  \Lanayru\Desert\North Part\Secret Passageway\Secret Passageway Chest: Lanayru Desert
-    - Secret Passageway Chest
-  \Lanayru\Desert\East\Fire Node\Present after Sand\Shortcut Chest: Lanayru Desert
-    - Fire Node - Shortcut Chest
-  \Lanayru\Desert\East\Fire Node\Past\First Small Chest: Lanayru Desert - Fire Node
-    - First Small Chest
-  \Lanayru\Desert\East\Fire Node\Past\Second Small Chest: Lanayru Desert - Fire Node
-    - Second Small Chest
-  \Lanayru\Desert\East\Fire Node\Past after Grate\Left Ending Chest: Lanayru Desert
-    - Fire Node - Left Ending Chest
-  \Lanayru\Desert\East\Fire Node\Past after Grate\Right Ending Chest: Lanayru Desert
-    - Fire Node - Right Ending Chest
-  \Lanayru\Desert\North Part\Lightning Node\Past\First Chest: Lanayru Desert - Lightning
-    Node - First Chest
-  \Lanayru\Desert\North Part\Lightning Node\Past\Second Chest: Lanayru Desert - Lightning
-    Node - Second Chest
-  \Lanayru\Desert\North Part\Lightning Node\Present from afar\Raised Chest near Generator: Lanayru
-    Desert - Lightning Node - Raised Chest near Generator
-  \Lanayru\Caves\Chest: Lanayru Caves - Chest
-  \Lanayru\Caves\Golo's Gift: Lanayru Caves - Golo's Gift
-  \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward: Lanayru Gorge - Thunder
-    Dragon's Reward
-  \Lanayru\Lanayru Sand Sea\Gorge\Item on Pillar: Lanayru Gorge - Item on Pillar
-  \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Digging Spot: Lanayru Gorge - Digging
-    Spot
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Rupee on First Pillar: Lanayru
-    Sand Sea - Ancient Harbour - Rupee on First Pillar
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Left Rupee on Entrance Crown: Lanayru
-    Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Right Rupee on Entrance Crown: Lanayru
-    Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Chest after Moblin: Lanayru
-    Sand Sea - Skipper's Retreat - Chest after Moblin
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Chest on top of Cacti Pillar: Lanayru
-    Sand Sea - Skipper's Retreat - Chest on top of Cacti Pillar
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Chest in Shack: Lanayru Sand Sea
-    - Skipper's Retreat - Chest in Shack
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform\Skydive Chest: Lanayru
-    Sand Sea - Skipper's Retreat - Skydive Chest
-  \Lanayru\Lanayru Sand Sea\Shipyard\Rickety Coaster -- Heart Stopping Track in 1'05: Lanayru
-    Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar: Lanayru Sand
-    Sea - Pirate Stronghold - Rupee on East Sea Pillar
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar: Lanayru Sand
-    Sea - Pirate Stronghold - Rupee on West Sea Pillar
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose: Lanayru
-    Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar or Nose
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Chest: Lanayru Sand Sea
-    - Pirate Stronghold - First Chest
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Chest: Lanayru Sand Sea
-    - Pirate Stronghold - Second Chest
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Third Chest: Lanayru Sand Sea
-    - Pirate Stronghold - Third Chest
-  \Skyview\Main\First Hub\Left Room\Chest on Tree Branch: Skyview - Chest on Tree
-    Branch
-  \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace: Skyview
-    - Digging Spot in Crawlspace
-  \Skyview\Main\First Hub\Right Room\Upper Area\Chest behind Two Eyes: Skyview - Chest
-    behind Two Eyes
-  \Skyview\Main\Second Hub\Miniboss Room\Chest after Stalfos Fight: Skyview - Chest
-    after Stalfos Fight
-  \Skyview\Main\Second Hub\Item behind Bars: Skyview - Item behind Bars
-  \Skyview\Main\Second Hub\Rupee in Southeast Tunnel: Skyview - Rupee in Southeast
-    Tunnel
-  \Skyview\Main\Second Hub\Rupee in Southwest Tunnel: Skyview - Rupee in Southwest
-    Tunnel
-  \Skyview\Main\Second Hub\Rupee in East Tunnel: Skyview - Rupee in East Tunnel
-  \Skyview\Main\Second Hub\Left Rooms\Chest behind Three Eyes: Skyview - Chest behind
-    Three Eyes
-  \Skyview\Main\Last Room\After Rope\Chest near Boss Door: Skyview - Chest near Boss
-    Door
-  \Skyview\Main\Last Room\Near Boss Key Chest\Boss Key Chest: Skyview - Boss Key Chest
-  \Skyview\Boss Room\Heart Container: Skyview - Heart Container
-  \Skyview\Spring\Rupee on Spring Pillar: Skyview - Rupee on Spring Pillar
-  \Skyview\Spring\Strike Crest: Skyview - Strike Crest
-  \Earth Temple\Main\First Room\Vent Chest: Earth Temple - Vent Chest
-  \Earth Temple\Main\First Room\Rupee above Drawbridge: Earth Temple - Rupee above
-    Drawbridge
-  \Earth Temple\Main\Hub Room\Chest behind Bombable Rock: Earth Temple - Chest behind
-    Bombable Rock
-  \Earth Temple\Main\Hub Room\Chest Left of Main Room Bridge: Earth Temple - Chest
-    Left of Main Room Bridge
-  \Earth Temple\Main\West Room\Chest in West Room: Earth Temple - Chest in West Room
-  \Earth Temple\Main\East Room\Chest after Double Lizalfos Fight: Earth Temple - Chest
-    after Double Lizalfos Fight
-  \Earth Temple\Main\Hub Room\Ledd's Gift: Earth Temple - Ledd's Gift
-  \Earth Temple\Main\Hub Room\Rupee in Lava Tunnel: Earth Temple - Rupee in Lava Tunnel
-  \Earth Temple\Main\Hub Room\Past Lava Section\Chest Guarded by Lizalfos: Earth Temple
-    - Chest Guarded by Lizalfos
-  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Key Chest: Earth Temple
-    - Boss Key Chest
-  \Earth Temple\Boss Room\Slope\Heart Container: Earth Temple - Heart Container
-  \Earth Temple\Spring\Strike Crest: Earth Temple - Strike Crest
-  \Lanayru Mining Facility\Main\First Room\Chest behind Bars: Lanayru Mining Facility
-    - Chest behind Bars
-  \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes\First Chest in Hub Room: Lanayru
-    Mining Facility - First Chest in Hub Room
-  \Lanayru Mining Facility\Main\First West Room\Chest in First West Room: Lanayru
-    Mining Facility - Chest in First West Room
-  \Lanayru Mining Facility\Main\Armos Fight Room\Chest after Armos Fight: Lanayru
-    Mining Facility - Chest after Armos Fight
-  \Lanayru Mining Facility\Main\Key Locked Room\Chest in Key Locked Room: Lanayru
-    Mining Facility - Chest in Key Locked Room
-  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Raised Chest in Hop across Boxes Room: Lanayru
-    Mining Facility - Raised Chest in Hop across Boxes Room
-  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Lower Chest in Hop across Boxes Room: Lanayru
-    Mining Facility - Lower Chest in Hop across Boxes Room
-  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Chest behind First Crawlspace: Lanayru
-    Mining Facility - Chest behind First Crawlspace
-  \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Chest in Spike Maze: Lanayru
-    Mining Facility - Chest in Spike Maze
-  \Lanayru Mining Facility\Main\Boss Key Room\Boss Key Chest: Lanayru Mining Facility
-    - Boss Key Chest
-  \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Shortcut Chest in Main Hub: Lanayru
-    Mining Facility - Shortcut Chest in Main Hub
-  \Lanayru Mining Facility\Boss Room\After Sand Drain\Heart Container: Lanayru Mining
-    Facility - Heart Container
-  \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit Hall of Ancient Robots: Lanayru
-    Mining Facility - Exit Hall of Ancient Robots
-  \Ancient Cistern\Main\Main Room\Rupee in West Hand: Ancient Cistern - Rupee in West
-    Hand
-  \Ancient Cistern\Main\Main Room\Rupee in East Hand: Ancient Cistern - Rupee in East
-    Hand
-  \Ancient Cistern\Main\East Part\Second Room\First Rupee in East Part in Short Tunnel: Ancient
-    Cistern - First Rupee in East Part in Short Tunnel
-  \Ancient Cistern\Main\East Part\Second Room\Second Rupee in East Part in Short Tunnel: Ancient
-    Cistern - Second Rupee in East Part in Short Tunnel
-  \Ancient Cistern\Main\East Part\Second Room\Third Rupee in East Part in Short Tunnel: Ancient
-    Cistern - Third Rupee in East Part in Short Tunnel
-  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Cubby: Ancient
-    Cistern - Rupee in East Part in Cubby
-  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Main Tunnel: Ancient
-    Cistern - Rupee in East Part in Main Tunnel
-  \Ancient Cistern\Main\East Part\Chest Ledge\Chest in East Part: Ancient Cistern
-    - Chest in East Part
-  \Ancient Cistern\Main\Main Room\After Whip Hooks\Chest after Whip Hooks: Ancient
-    Cistern - Chest after Whip Hooks
-  \Ancient Cistern\Main\Main Room\Vines Area\Chest near Vines: Ancient Cistern - Chest
-    near Vines
-  \Ancient Cistern\Main\Main Room\Behind the Waterfall\Chest behind the Waterfall: Ancient
-    Cistern - Chest behind the Waterfall
-  \Ancient Cistern\Main\Basement Gutters\Past Skulltula\Bokoblin: Ancient Cistern
-    - Bokoblin
-  \Ancient Cistern\Main\Main Room\After Gutters\Rupee under Lilypad: Ancient Cistern
-    - Rupee under Lilypad
-  \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest\Chest in Key Locked Room: Ancient
-    Cistern - Chest in Key Locked Room
-  \Ancient Cistern\Main\Basement\Under the Statue\Boss Key Chest: Ancient Cistern
-    - Boss Key Chest
-  \Ancient Cistern\Boss Room\Heart Container: Ancient Cistern - Heart Container
-  \Ancient Cistern\Flame Room\Farore's Flame: Ancient Cistern - Farore's Flame
-  \Sandship\Main\Deck\Stern\Chest at the Stern: Sandship - Chest at the Stern
-  \Sandship\Main\Before Ship's Bow\Chest before 4-Door Corridor: Sandship - Chest
-    before 4-Door Corridor
-  \Sandship\Main\Before Boss Door\Chest behind Combination Lock: Sandship - Chest
-    behind Combination Lock
-  \Sandship\Main\Treasure Room\Treasure Room First Chest: Sandship - Treasure Room
-    First Chest
-  \Sandship\Main\Treasure Room\Treasure Room Second Chest: Sandship - Treasure Room
-    Second Chest
-  \Sandship\Main\Treasure Room\Treasure Room Third Chest: Sandship - Treasure Room
-    Third Chest
-  \Sandship\Main\Treasure Room\Treasure Room Fourth Chest: Sandship - Treasure Room
-    Fourth Chest
-  \Sandship\Main\Treasure Room\Treasure Room Fifth Chest: Sandship - Treasure Room
-    Fifth Chest
-  \Sandship\Main\Brig Prison\Robot in Brig's Reward: Sandship - Robot in Brig's Reward
-  \Sandship\Main\Ship's Bow\Chest after Scervo Fight: Sandship - Chest after Scervo
-    Fight
-  \Sandship\Main\Deck\Captain's Cabin\Boss Key Chest: Sandship - Boss Key Chest
-  \Sandship\Boss Room\Heart Container: Sandship - Heart Container
-  \Sandship\Boss Room\Nayru's Flame: Sandship - Nayru's Flame
-  \Fire Sanctuary\Main\First Room\Past Water Plant\Chest in First Room: Fire Sanctuary
-    - Chest in First Room
-  \Fire Sanctuary\Main\Second Room\Chest in Second Room: Fire Sanctuary - Chest in
-    Second Room
-  \Fire Sanctuary\Main\Second Room\Balcony\Chest on Balcony: Fire Sanctuary - Chest
-    on Balcony
-  \Fire Sanctuary\Main\First Trapped Mogma Room\Chest near First Trapped Mogma: Fire
-    Sanctuary - Chest near First Trapped Mogma
-  \Fire Sanctuary\Main\Water Fruit Room\First Chest in Water Fruit Room: Fire Sanctuary
-    - First Chest in Water Fruit Room
-  \Fire Sanctuary\Main\Water Fruit Room\Second Chest in Water Fruit Room: Fire Sanctuary
-    - Second Chest in Water Fruit Room
-  \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area\Rescue First Trapped Mogma: Fire
-    Sanctuary - Rescue First Trapped Mogma
-  \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Second Trapped Mogma: Fire
-    Sanctuary - Rescue Second Trapped Mogma
-  \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall\Chest after Bombable Wall: Fire
-    Sanctuary - Chest after Bombable Wall
-  \Fire Sanctuary\Main\West of Boss Door\Plats' Chest: Fire Sanctuary - Plats' Chest
-  \Fire Sanctuary\Main\Staircase Room\Chest in Staircase Room: Fire Sanctuary - Chest
-    in Staircase Room
-  \Fire Sanctuary\Main\Boss Key Room\Boss Key Chest: Fire Sanctuary - Boss Key Chest
-  \Fire Sanctuary\Boss Room\Heart Container: Fire Sanctuary - Heart Container
-  \Fire Sanctuary\Flame Room\Din's Flame: Fire Sanctuary - Din's Flame
-  \Sky Keep\Main\First Room\First Chest: Sky Keep - First Chest
-  \Sky Keep\Main\Mini Boss Room\Near Chest\Chest after Dreadfuse: Sky Keep - Chest
-    after Dreadfuse
-  \Sky Keep\Main\Fire Sanctuary Room\First Platform\Rupee in Fire Sanctuary Room in Alcove: Sky
-    Keep - Rupee in Fire Sanctuary Room in Alcove
-  \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Sacred Power of Din: Sky Keep -
-    Sacred Power of Din
-  \Sky Keep\Main\Sandship Room\Triforce Area\Sacred Power of Nayru: Sky Keep - Sacred
-    Power of Nayru
-  \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Sacred Power of Farore: Sky Keep
-    - Sacred Power of Farore
-  \Skyloft\Skyloft Silent Realm\Trial Reward: Skyloft Silent Realm - Trial Reward
-  \Skyloft\Skyloft Silent Realm\Relic 1: Skyloft Silent Realm - Relic 1
-  \Skyloft\Skyloft Silent Realm\Relic 2: Skyloft Silent Realm - Relic 2
-  \Skyloft\Skyloft Silent Realm\Relic 3: Skyloft Silent Realm - Relic 3
-  \Skyloft\Skyloft Silent Realm\Relic 4: Skyloft Silent Realm - Relic 4
-  \Skyloft\Skyloft Silent Realm\Relic 5: Skyloft Silent Realm - Relic 5
-  \Skyloft\Skyloft Silent Realm\Relic 6: Skyloft Silent Realm - Relic 6
-  \Skyloft\Skyloft Silent Realm\Relic 7: Skyloft Silent Realm - Relic 7
-  \Skyloft\Skyloft Silent Realm\Relic 8: Skyloft Silent Realm - Relic 8
-  \Skyloft\Skyloft Silent Realm\Relic 9: Skyloft Silent Realm - Relic 9
-  \Skyloft\Skyloft Silent Realm\Relic 10: Skyloft Silent Realm - Relic 10
-  \Faron\Faron Silent Realm\Trial Reward: Faron Silent Realm - Trial Reward
-  \Faron\Faron Silent Realm\Relic 1: Faron Silent Realm - Relic 1
-  \Faron\Faron Silent Realm\Relic 2: Faron Silent Realm - Relic 2
-  \Faron\Faron Silent Realm\Relic 3: Faron Silent Realm - Relic 3
-  \Faron\Faron Silent Realm\Relic 4: Faron Silent Realm - Relic 4
-  \Faron\Faron Silent Realm\Relic 5: Faron Silent Realm - Relic 5
-  \Faron\Faron Silent Realm\Relic 6: Faron Silent Realm - Relic 6
-  \Faron\Faron Silent Realm\Relic 7: Faron Silent Realm - Relic 7
-  \Faron\Faron Silent Realm\Relic 8: Faron Silent Realm - Relic 8
-  \Faron\Faron Silent Realm\Relic 9: Faron Silent Realm - Relic 9
-  \Faron\Faron Silent Realm\Relic 10: Faron Silent Realm - Relic 10
-  \Lanayru\Lanayru Silent Realm\Trial Reward: Lanayru Silent Realm - Trial Reward
-  \Lanayru\Lanayru Silent Realm\Relic 1: Lanayru Silent Realm - Relic 1
-  \Lanayru\Lanayru Silent Realm\Relic 2: Lanayru Silent Realm - Relic 2
-  \Lanayru\Lanayru Silent Realm\Relic 3: Lanayru Silent Realm - Relic 3
-  \Lanayru\Lanayru Silent Realm\Relic 4: Lanayru Silent Realm - Relic 4
-  \Lanayru\Lanayru Silent Realm\Relic 5: Lanayru Silent Realm - Relic 5
-  \Lanayru\Lanayru Silent Realm\Relic 6: Lanayru Silent Realm - Relic 6
-  \Lanayru\Lanayru Silent Realm\Relic 7: Lanayru Silent Realm - Relic 7
-  \Lanayru\Lanayru Silent Realm\Relic 8: Lanayru Silent Realm - Relic 8
-  \Lanayru\Lanayru Silent Realm\Relic 9: Lanayru Silent Realm - Relic 9
-  \Lanayru\Lanayru Silent Realm\Relic 10: Lanayru Silent Realm - Relic 10
-  \Eldin\Eldin Silent Realm\Trial Reward: Eldin Silent Realm - Trial Reward
-  \Eldin\Eldin Silent Realm\Relic 1: Eldin Silent Realm - Relic 1
-  \Eldin\Eldin Silent Realm\Relic 2: Eldin Silent Realm - Relic 2
-  \Eldin\Eldin Silent Realm\Relic 3: Eldin Silent Realm - Relic 3
-  \Eldin\Eldin Silent Realm\Relic 4: Eldin Silent Realm - Relic 4
-  \Eldin\Eldin Silent Realm\Relic 5: Eldin Silent Realm - Relic 5
-  \Eldin\Eldin Silent Realm\Relic 6: Eldin Silent Realm - Relic 6
-  \Eldin\Eldin Silent Realm\Relic 7: Eldin Silent Realm - Relic 7
-  \Eldin\Eldin Silent Realm\Relic 8: Eldin Silent Realm - Relic 8
-  \Eldin\Eldin Silent Realm\Relic 9: Eldin Silent Realm - Relic 9
-  \Eldin\Eldin Silent Realm\Relic 10: Eldin Silent Realm - Relic 10
+  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Gift:
+    type: null
+    short_name: Upper Skyloft - Fledge's Gift
+  \Skyloft\Upper Skyloft\Owlan's Gift:
+    type: null
+    short_name: Upper Skyloft - Owlan's Gift
+  \Skyloft\Upper Skyloft\Sparring Hall\Sparring Hall Chest:
+    type: null
+    short_name: Upper Skyloft - Sparring Hall Chest
+  \Skyloft\Upper Skyloft\Chest near Goddess Statue:
+    type: null
+    short_name: Upper Skyloft - Chest near Goddess Statue
+  \Skyloft\Upper Skyloft\Goddess Statue\First Goddess Sword Item in Goddess Statue:
+    type: null
+    short_name: Upper Skyloft - First Goddess Sword Item in Goddess Statue
+  \Skyloft\Upper Skyloft\Goddess Statue\Second Goddess Sword Item in Goddess Statue:
+    type: null
+    short_name: Upper Skyloft - Second Goddess Sword Item in Goddess Statue
+  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\In Zelda's Closet:
+    type: null
+    short_name: Upper Skyloft - In Zelda's Closet
+  \Skyloft\Upper Skyloft\Knight Academy\Owlan's Crystals:
+    type: Scrapper Deliveries, Gratitude Crystal Sidequests, Combat
+    short_name: Upper Skyloft - Owlan's Crystals
+  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Crystals:
+    type: Gratitude Crystal Sidequests
+    short_name: Upper Skyloft - Fledge's Crystals
+  \Skyloft\Upper Skyloft\Knight Academy\Item from Cawlin:
+    type: null
+    short_name: Upper Skyloft - Item from Cawlin
+  \Skyloft\Upper Skyloft\Knight Academy\Ghost/Pipit's Crystals:
+    type: Gratitude Crystal Sidequests
+    short_name: Upper Skyloft - Ghost/Pipit's Crystals
+  \Skyloft\Upper Skyloft\Pumpkin Archery -- 600 Points:
+    type: Minigames
+    short_name: Upper Skyloft - Pumpkin Archery -- 600 Points
+  \Skyloft\Central Skyloft\Bazaar\Potion Lady's Gift:
+    type: null
+    short_name: Central Skyloft - Potion Lady's Gift
+  \Skyloft\Central Skyloft\Bazaar\Repair Gondo's Junk:
+    type: null
+    short_name: Central Skyloft - Repair Gondo's Junk
+  \Skyloft\Central Skyloft\Wryna's House\Wryna's Crystals:
+    type: Gratitude Crystal Sidequests
+    short_name: Central Skyloft - Wryna's Crystals
+  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave First Chest:
+    type: null
+    short_name: Central Skyloft - Waterfall Cave First Chest
+  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave Second Chest:
+    type: null
+    short_name: Central Skyloft - Waterfall Cave Second Chest
+  \Skyloft\Central Skyloft\Waterfall Cave\Rupee Waterfall Cave Crawlspace:
+    type: Rupees (No Quick Beetle)
+    short_name: Central Skyloft - Rupee Waterfall Cave Crawlspace
+  \Skyloft\Central Skyloft\Parrow's Gift:
+    type: null
+    short_name: Central Skyloft - Parrow's Gift
+  \Skyloft\Central Skyloft\Parrow's Crystals:
+    type: Gratitude Crystal Sidequests
+    short_name: Central Skyloft - Parrow's Crystals
+  \Skyloft\Central Skyloft\Peatrice's House\Peater/Peatrice's Crystals:
+    type: Gratitude Crystal Sidequests
+    short_name: Central Skyloft - Peater/Peatrice's Crystals
+  \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest:
+    type: null
+    short_name: Central Skyloft - Item in Bird Nest
+  \Skyloft\Central Skyloft\Shed Chest:
+    type: null
+    short_name: Central Skyloft - Shed Chest
+  \Skyloft\Central Skyloft\West Cliff Goddess Chest:
+    type: goddess, Faron Woods Goddess Chests
+    short_name: Central Skyloft - West Cliff Goddess Chest
+  \Skyloft\Central Skyloft\Bazaar\Bazaar Goddess Chest:
+    type: goddess, Sand Sea Goddess Chests
+    short_name: Central Skyloft - Bazaar Goddess Chest
+  \Skyloft\Central Skyloft\Shed Goddess Chest:
+    type: goddess, Eldin Volcano Goddess Chests
+    short_name: Central Skyloft - Shed Goddess Chest
+  \Skyloft\Central Skyloft\Waterfall Island\Floating Island Goddess Chest:
+    type: goddess, Lake Floria Goddess Chests
+    short_name: Central Skyloft - Floating Island Goddess Chest
+  \Skyloft\Central Skyloft\Waterfall Island\Waterfall Goddess Chest:
+    type: goddess, Sand Sea Goddess Chests
+    short_name: Central Skyloft - Waterfall Goddess Chest
+  \Skyloft\Skyloft Village\Mallara's House\Mallara's Crystals:
+    type: Gratitude Crystal Sidequests
+    short_name: Skyloft Village - Mallara's Crystals
+  \Skyloft\Skyloft Village\Bertie's House\Bertie's Crystals:
+    type: Gratitude Crystal Sidequests
+    short_name: Skyloft Village - Bertie's Crystals
+  \Skyloft\Skyloft Village\Sparrot's House\Sparrot's Crystals:
+    type: Scrapper Deliveries, Gratitude Crystal Sidequests
+    short_name: Skyloft Village - Sparrot's Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\5 Crystals:
+    type: Batreaux's Rewards
+    short_name: Batreaux's House - 5 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\10 Crystals:
+    type: Batreaux's Rewards
+    short_name: Batreaux's House - 10 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals:
+    type: Batreaux's Rewards
+    short_name: Batreaux's House - 30 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals Chest:
+    type: Batreaux's Rewards
+    short_name: Batreaux's House - 30 Crystals Chest
+  \Skyloft\Skyloft Village\Batreaux's House\40 Crystals:
+    type: Batreaux's Rewards
+    short_name: Batreaux's House - 40 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\50 Crystals:
+    type: Batreaux's Rewards
+    short_name: Batreaux's House - 50 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals:
+    type: Batreaux's Rewards
+    short_name: Batreaux's House - 70 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals Second Reward:
+    type: Batreaux's Rewards
+    short_name: Batreaux's House - 70 Crystals Second Reward
+  \Skyloft\Skyloft Village\Batreaux's House\80 Crystals:
+    type: Batreaux's Rewards
+    short_name: Batreaux's House - 80 Crystals
+  \Skyloft\Beedle's Shop\Stall\300 Rupee Item:
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
+    short_name: Beedle's Shop - 300 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\600 Rupee Item:
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
+    short_name: Beedle's Shop - 600 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\1200 Rupee Item:
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
+    short_name: Beedle's Shop - 1200 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\800 Rupee Item:
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
+    short_name: Beedle's Shop - 800 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\1600 Rupee Item:
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
+    short_name: Beedle's Shop - 1600 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\First 100 Rupee Item:
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
+    short_name: Beedle's Shop - First 100 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\Second 100 Rupee Item:
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
+    short_name: Beedle's Shop - Second 100 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\Third 100 Rupee Item:
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
+    short_name: Beedle's Shop - Third 100 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\50 Rupee Item:
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
+    short_name: Beedle's Shop - 50 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\1000 Rupee Item:
+    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
+    short_name: Beedle's Shop - 1000 Rupee Item
+  \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Crystal in Link's Room:
+    type: Loose Crystals
+    short_name: Upper Skyloft - Crystal in Link's Room
+  \Skyloft\Upper Skyloft\Knight Academy\Crystal in Knight Academy Plant:
+    type: Loose Crystals
+    short_name: Upper Skyloft - Crystal in Knight Academy Plant
+  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Crystal in Zelda's Room:
+    type: Loose Crystals
+    short_name: Upper Skyloft - Crystal in Zelda's Room
+  \Skyloft\Upper Skyloft\Sparring Hall\Crystal in Sparring Hall:
+    type: Loose Crystals
+    short_name: Upper Skyloft - Crystal in Sparring Hall
+  \Skyloft\Central Skyloft\Orielle and Parrow's House\Crystal in Orielle and Parrow's House:
+    type: Loose Crystals
+    short_name: Central Skyloft - Crystal in Orielle and Parrow's House
+  \Skyloft\Central Skyloft\Crystal on West Cliff:
+    type: Loose Crystals
+    short_name: Central Skyloft - Crystal on West Cliff
+  \Skyloft\Central Skyloft\Crystal between Wooden Planks:
+    type: Loose Crystals
+    short_name: Central Skyloft - Crystal between Wooden Planks
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave:
+    type: Loose Crystals
+    short_name: Central Skyloft - Crystal after Waterfall Cave
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison:
+    type: Loose Crystals
+    short_name: Central Skyloft - Crystal in Loftwing Prison
+  \Skyloft\Central Skyloft\Crystal on Waterfall Island:
+    type: Loose Crystals
+    short_name: Central Skyloft - Crystal on Waterfall Island
+  \Skyloft\Central Skyloft\Crystal on Light Tower:
+    type: Loose Crystals
+    short_name: Central Skyloft - Crystal on Light Tower
+  \Skyloft\Skyloft Village\Crystal near Pumpkin Patch:
+    type: Loose Crystals
+    short_name: Skyloft Village - Crystal near Pumpkin Patch
+  \Sky\South East\Lumpy Pumpkin\Crystal outside Lumpy Pumpkin:
+    type: Loose Crystals
+    short_name: Sky - Crystal outside Lumpy Pumpkin
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Crystal inside Lumpy Pumpkin:
+    type: Loose Crystals
+    short_name: Sky - Crystal inside Lumpy Pumpkin
+  \Sky\North East\Beedle's Island\Crystal on Beedle's Ship:
+    type: Loose Crystals
+    short_name: Sky - Crystal on Beedle's Ship
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Chandelier:
+    type: null
+    short_name: Sky - Lumpy Pumpkin - Chandelier
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Harp Minigame:
+    type: Minigames
+    short_name: Sky - Lumpy Pumpkin - Harp Minigame
+  \Sky\South East\Lumpy Pumpkin\Kina's Crystals:
+    type: Scrapper Deliveries, Gratitude Crystal Sidequests
+    short_name: Sky - Kina's Crystals
+  \Sky\South West\Orielle's Island\Orielle's Crystals:
+    type: Gratitude Crystal Sidequests
+    short_name: Sky - Orielle's Crystals
+  \Sky\North East\Beedle's Island\Beedle's Crystals:
+    type: Gratitude Crystal Sidequests
+    short_name: Sky - Beedle's Crystals
+  \Sky\South West\Fun Fun Island\Dodoh's Crystals:
+    type: Scrapper Deliveries
+    short_name: Sky - Dodoh's Crystals
+  \Sky\South West\Fun Fun Island\Fun Fun Island Minigame -- 500 Rupees:
+    type: Minigames, Scrapper Deliveries
+    short_name: Sky - Fun Fun Island Minigame -- 500 Rupees
+  \Sky\South West\Chest in Breakable Boulder near Fun Fun Island:
+    type: null
+    short_name: Sky - Chest in Breakable Boulder near Fun Fun Island
+  \Sky\South East\Chest in Breakable Boulder near Lumpy Pumpkin:
+    type: null
+    short_name: Sky - Chest in Breakable Boulder near Lumpy Pumpkin
+  \Sky\North East\Bamboo Island\Bamboo Island Goddess Chest:
+    type: goddess, Eldin Volcano Goddess Chests
+    short_name: Sky - Bamboo Island Goddess Chest
+  \Sky\North East\Goddess Chest on Island next to Bamboo Island:
+    type: goddess, Eldin Volcano Goddess Chests
+    short_name: Sky - Goddess Chest on Island next to Bamboo Island
+  \Sky\North East\Goddess Chest in Cave on Island next to Bamboo Island:
+    type: goddess, Lanayru Desert Goddess Chests
+    short_name: Sky - Goddess Chest in Cave on Island next to Bamboo Island
+  \Sky\North East\Beedle's Island\Top\Beedle's Island Goddess Chest:
+    type: goddess, Lanayru Desert Goddess Chests, Combat
+    short_name: Sky - Beedle's Island Goddess Chest
+  \Sky\North East\Beedle's Island\Cage\Beedle's Island Cage Goddess Chest:
+    type: goddess, Faron Woods Goddess Chests
+    short_name: Sky - Beedle's Island Cage Goddess Chest
+  \Sky\North East\Northeast Island Goddess Chest behind Bombable Rocks:
+    type: goddess, Lanayru Desert Goddess Chests
+    short_name: Sky - Northeast Island Goddess Chest behind Bombable Rocks
+  \Sky\North East\Northeast Island Cage Goddess Chest:
+    type: goddess, Eldin Volcano Goddess Chests
+    short_name: Sky - Northeast Island Cage Goddess Chest
+  \Sky\South East\Lumpy Pumpkin\Goddess Chest on the Roof:
+    type: goddess, Faron Woods Goddess Chests
+    short_name: Sky - Lumpy Pumpkin - Goddess Chest on the Roof
+  \Sky\South East\Lumpy Pumpkin\Outside Goddess Chest:
+    type: goddess, Faron Woods Goddess Chests
+    short_name: Sky - Lumpy Pumpkin - Outside Goddess Chest
+  \Sky\South East\Goddess Chest on Island Closest to Faron Pillar:
+    type: goddess, Faron Woods Goddess Chests
+    short_name: Sky - Goddess Chest on Island Closest to Faron Pillar
+  \Sky\South West\Volcanic Island\Goddess Chest outside Volcanic Island:
+    type: goddess, Lanayru Desert Goddess Chests
+    short_name: Sky - Goddess Chest outside Volcanic Island
+  \Sky\South West\Volcanic Island\Goddess Chest inside Volcanic Island:
+    type: goddess, Faron Woods Goddess Chests
+    short_name: Sky - Goddess Chest inside Volcanic Island
+  \Sky\South West\Fun Fun Island\Goddess Chest under Fun Fun Island:
+    type: goddess, Lake Floria Goddess Chests
+    short_name: Sky - Goddess Chest under Fun Fun Island
+  \Sky\South West\Triple Island\Southwest Triple Island Upper Goddess Chest:
+    type: goddess, Eldin Volcano Goddess Chests
+    short_name: Sky - Southwest Triple Island Upper Goddess Chest
+  \Sky\South West\Triple Island\Southwest Triple Island Lower Goddess Chest:
+    type: goddess, Lanayru Desert Goddess Chests
+    short_name: Sky - Southwest Triple Island Lower Goddess Chest
+  \Sky\South West\Triple Island\Southwest Triple Island Cage Goddess Chest:
+    type: goddess, Sand Sea Goddess Chests
+    short_name: Sky - Southwest Triple Island Cage Goddess Chest
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Goddess Sword:
+    type: null
+    short_name: Thunderhead - Isle of Songs - Strike Crest with Goddess Sword
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Longsword:
+    type: null
+    short_name: Thunderhead - Isle of Songs - Strike Crest with Longsword
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with White Sword:
+    type: null
+    short_name: Thunderhead - Isle of Songs - Strike Crest with White Sword
+  \Sky\Thunderhead\Song from Levias:
+    type: Scrapper Deliveries, Combat
+    short_name: Thunderhead - Song from Levias
+  \Sky\Thunderhead\Bug Heaven\Bug Heaven -- 10 Bugs in 3 Minutes:
+    type: Minigames
+    short_name: Thunderhead - Bug Heaven -- 10 Bugs in 3 Minutes
+  \Sky\Thunderhead\East Island\East Island Chest:
+    type: null
+    short_name: Thunderhead - East Island Chest
+  \Sky\Thunderhead\East Island\East Island Goddess Chest:
+    type: goddess, Faron Woods Goddess Chests
+    short_name: Thunderhead - East Island Goddess Chest
+  \Sky\Thunderhead\Isle of Songs\Goddess Chest on top of Isle of Songs:
+    type: goddess, Volcano Summit Goddess Chests
+    short_name: Thunderhead - Goddess Chest on top of Isle of Songs
+  \Sky\Thunderhead\Isle of Songs\Goddess Chest outside Isle of Songs:
+    type: goddess, Eldin Volcano Goddess Chests
+    short_name: Thunderhead - Goddess Chest outside Isle of Songs
+  \Sky\Thunderhead\Mogma Mitts Island\First Goddess Chest on Mogma Mitts Island:
+    type: goddess, Volcano Summit Goddess Chests
+    short_name: Thunderhead - First Goddess Chest on Mogma Mitts Island
+  \Sky\Thunderhead\Mogma Mitts Island\Second Goddess Chest on Mogma Mitts Island:
+    type: goddess, Sand Sea Goddess Chests
+    short_name: Thunderhead - Second Goddess Chest on Mogma Mitts Island
+  \Sky\Thunderhead\Bug Heaven\Bug Heaven Goddess Chest:
+    type: goddess, Volcano Summit Goddess Chests
+    short_name: Thunderhead - Bug Heaven Goddess Chest
+  \Faron\Sealed Grounds\Sealed Temple\Chest inside Sealed Temple:
+    type: null
+    short_name: Sealed Grounds - Chest inside Sealed Temple
+  \Faron\Sealed Grounds\Sealed Temple\Song from Impa:
+    type: null
+    short_name: Sealed Grounds - Song from Impa
+  \Faron\Sealed Grounds\Behind the Temple\Gorko's Goddess Wall Reward:
+    type: null
+    short_name: Sealed Grounds - Gorko's Goddess Wall Reward
+  \Faron\Sealed Grounds\Hylia's Temple\Zelda's Blessing:
+    type: null
+    short_name: Sealed Grounds - Zelda's Blessing
+  \Faron\Faron Woods\Item behind Lower Bombable Rock:
+    type: null
+    short_name: Faron Woods - Item behind Lower Bombable Rock
+  \Faron\Faron Woods\Item on Tree:
+    type: null
+    short_name: Faron Woods - Item on Tree
+  \Faron\Faron Woods\Kikwi Elder's Reward:
+    type: Combat
+    short_name: Faron Woods - Kikwi Elder's Reward
+  \Faron\Faron Woods\Rupee on Hollow Tree Root:
+    type: Rupees (No Quick Beetle)
+    short_name: Faron Woods - Rupee on Hollow Tree Root
+  \Faron\Faron Woods\Rupee on Hollow Tree Branch:
+    type: Rupees (No Quick Beetle)
+    short_name: Faron Woods - Rupee on Hollow Tree Branch
+  \Faron\Faron Woods\Rupee on Platform near Floria Door:
+    type: Rupees (No Quick Beetle)
+    short_name: Faron Woods - Rupee on Platform near Floria Door
+  \Faron\Faron Woods\Deep Woods\Deep Woods Chest:
+    type: null
+    short_name: Faron Woods - Deep Woods Chest
+  \Faron\Faron Woods\Chest behind Upper Bombable Rock:
+    type: null
+    short_name: Faron Woods - Chest behind Upper Bombable Rock
+  \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest\Chest inside Great Tree:
+    type: null
+    short_name: Faron Woods - Chest inside Great Tree
+  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree North Branch:
+    type: Rupees (No Quick Beetle)
+    short_name: Faron Woods - Rupee on Great Tree North Branch
+  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree West Branch:
+    type: Rupees (No Quick Beetle)
+    short_name: Faron Woods - Rupee on Great Tree West Branch
+  \Faron\Lake Floria\Above Rock\Rupee under Central Boulder:
+    type: Rupees (No Quick Beetle)
+    short_name: Lake Floria - Rupee under Central Boulder
+  \Faron\Lake Floria\Above Rock\Rupee behind Southwest Boulder:
+    type: Rupees (No Quick Beetle)
+    short_name: Lake Floria - Rupee behind Southwest Boulder
+  \Faron\Lake Floria\Above Rock\Left Rupee behind Northwest Boulder:
+    type: Rupees (No Quick Beetle)
+    short_name: Lake Floria - Left Rupee behind Northwest Boulder
+  \Faron\Lake Floria\Above Rock\Right Rupee behind Northwest Boulder:
+    type: Rupees (No Quick Beetle)
+    short_name: Lake Floria - Right Rupee behind Northwest Boulder
+  \Faron\Lake Floria\Below Rock\Emerged Area\Lake Floria Chest:
+    type: null
+    short_name: Lake Floria - Lake Floria Chest
+  \Faron\Lake Floria\Farore's Lair\Dragon Lair South Chest:
+    type: null
+    short_name: Lake Floria - Dragon Lair South Chest
+  \Faron\Lake Floria\Farore's Lair\Dragon Lair East Chest:
+    type: null
+    short_name: Lake Floria - Dragon Lair East Chest
+  \Faron\Lake Floria\Waterfall\Rupee on High Ledge outside Ancient Cistern Entrance:
+    type: Rupees (No Quick Beetle)
+    short_name: Lake Floria - Rupee on High Ledge outside Ancient Cistern Entrance
+  \Faron\Flooded Faron Woods\Yellow Tadtone under Lilypad:
+    type: Tadtones
+    short_name: Flooded Faron Woods - Yellow Tadtone under Lilypad
+  \Faron\Flooded Faron Woods\8 Light Blue Tadtones near Viewing Platform:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 8 Light Blue Tadtones near Viewing Platform
+  \Faron\Flooded Faron Woods\4 Purple Tadtones under Viewing Platform:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 4 Purple Tadtones under Viewing Platform
+  \Faron\Flooded Faron Woods\Red Moving Tadtone near Viewing Platform:
+    type: Tadtones
+    short_name: Flooded Faron Woods - Red Moving Tadtone near Viewing Platform
+  \Faron\Flooded Faron Woods\Light Blue Tadtone under Great Tree Root:
+    type: Tadtones
+    short_name: Flooded Faron Woods - Light Blue Tadtone under Great Tree Root
+  \Faron\Flooded Faron Woods\8 Yellow Tadtones near Kikwi Elder:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 8 Yellow Tadtones near Kikwi Elder
+  \Faron\Flooded Faron Woods\4 Light Blue Moving Tadtones under Kikwi Elder:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 4 Light Blue Moving Tadtones under Kikwi Elder
+  \Faron\Flooded Faron Woods\4 Red Moving Tadtones North West of Great Tree:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 4 Red Moving Tadtones North West of Great Tree
+  \Faron\Flooded Faron Woods\Green Tadtone behind Upper Bombable Rock:
+    type: Tadtones
+    short_name: Flooded Faron Woods - Green Tadtone behind Upper Bombable Rock
+  \Faron\Flooded Faron Woods\2 Dark Blue Tadtones in Grass West of Great Tree:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 2 Dark Blue Tadtones in Grass West of Great
+      Tree
+  \Faron\Flooded Faron Woods\8 Green Tadtones in West Tunnel:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 8 Green Tadtones in West Tunnel
+  \Faron\Flooded Faron Woods\2 Red Tadtones in Grass near Lower Bombable Rock:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 2 Red Tadtones in Grass near Lower Bombable
+      Rock
+  \Faron\Flooded Faron Woods\16 Dark Blue Tadtones in the South West:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 16 Dark Blue Tadtones in the South West
+  \Faron\Flooded Faron Woods\4 Purple Moving Tadtones near Floria Gate:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 4 Purple Moving Tadtones near Floria Gate
+  \Faron\Flooded Faron Woods\Dark Blue Moving Tadtone inside Small Hollow Tree:
+    type: Tadtones
+    short_name: Flooded Faron Woods - Dark Blue Moving Tadtone inside Small Hollow
+      Tree
+  \Faron\Flooded Faron Woods\4 Yellow Tadtones under Small Hollow Tree:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 4 Yellow Tadtones under Small Hollow Tree
+  \Faron\Flooded Faron Woods\8 Purple Tadtones in Clearing after Small Hollow Tree:
+    type: Tadtones
+    short_name: Flooded Faron Woods - 8 Purple Tadtones in Clearing after Small Hollow
+      Tree
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Water Dragon's Reward:
+    type: Tadtones
+    short_name: Flooded Faron Woods - Water Dragon's Reward
+  \Eldin\Volcano\Entry\Rupee on Ledge before First Room:
+    type: Rupees (No Quick Beetle)
+    short_name: Eldin Volcano - Rupee on Ledge before First Room
+  \Eldin\Volcano\First Room\Chest behind Bombable Wall in First Room:
+    type: null
+    short_name: Eldin Volcano - Chest behind Bombable Wall in First Room
+  \Eldin\Volcano\First Room\Rupee behind Bombable Wall in First Room:
+    type: Rupees (No Quick Beetle)
+    short_name: Eldin Volcano - Rupee behind Bombable Wall in First Room
+  \Eldin\Volcano\First Room\Rupee in Crawlspace in First Room:
+    type: Rupees (No Quick Beetle)
+    short_name: Eldin Volcano - Rupee in Crawlspace in First Room
+  \Eldin\Volcano\East\Chest after Crawlspace:
+    type: null
+    short_name: Eldin Volcano - Chest after Crawlspace
+  \Eldin\Volcano\East\Southeast Rupee above Mogma Turf Entrance:
+    type: Rupees (No Quick Beetle)
+    short_name: Eldin Volcano - Southeast Rupee above Mogma Turf Entrance
+  \Eldin\Volcano\East\North Rupee above Mogma Turf Entrance:
+    type: Rupees (No Quick Beetle)
+    short_name: Eldin Volcano - North Rupee above Mogma Turf Entrance
+  \Eldin\Volcano\East\Chest behind Bombable Wall near Cliff:
+    type: null
+    short_name: Eldin Volcano - Chest behind Bombable Wall near Cliff
+  \Eldin\Volcano\East\Item on Cliff:
+    type: null
+    short_name: Eldin Volcano - Item on Cliff
+  \Eldin\Volcano\Ascent\Chest behind Bombable Wall near Volcano Ascent:
+    type: null
+    short_name: Eldin Volcano - Chest behind Bombable Wall near Volcano Ascent
+  \Eldin\Volcano\Near Thrill Digger Cave\Left Rupee behind Bombable Wall on First Slope:
+    type: Rupees (No Quick Beetle)
+    short_name: Eldin Volcano - Left Rupee behind Bombable Wall on First Slope
+  \Eldin\Volcano\Near Thrill Digger Cave\Right Rupee behind Bombable Wall on First Slope:
+    type: Rupees (No Quick Beetle)
+    short_name: Eldin Volcano - Right Rupee behind Bombable Wall on First Slope
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot in front of Earth Temple:
+    type: null
+    short_name: Eldin Volcano - Digging Spot in front of Earth Temple
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot below Tower:
+    type: null
+    short_name: Eldin Volcano - Digging Spot below Tower
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot behind Boulder on Sandy Slope:
+    type: null
+    short_name: Eldin Volcano - Digging Spot behind Boulder on Sandy Slope
+  \Eldin\Volcano\Sand Slide\Digging Spot after Vents:
+    type: null
+    short_name: Eldin Volcano - Digging Spot after Vents
+  \Eldin\Volcano\Past Slide\Digging Spot after Draining Lava:
+    type: null
+    short_name: Eldin Volcano - Digging Spot after Draining Lava
+  \Eldin\Mogma Turf\Pre Vent\Free Fall Chest:
+    type: null
+    short_name: Mogma Turf - Free Fall Chest
+  \Eldin\Mogma Turf\Pre Vent\Chest behind Bombable Wall at Entrance:
+    type: null
+    short_name: Mogma Turf - Chest behind Bombable Wall at Entrance
+  \Eldin\Mogma Turf\Pre Vent\Defeat Bokoblins:
+    type: Combat
+    short_name: Mogma Turf - Defeat Bokoblins
+  \Eldin\Mogma Turf\Sand Slide Platform\Sand Slide Chest:
+    type: null
+    short_name: Mogma Turf - Sand Slide Chest
+  \Eldin\Mogma Turf\Past Vent\Chest behind Bombable Wall in Fire Maze:
+    type: null
+    short_name: Mogma Turf - Chest behind Bombable Wall in Fire Maze
+  \Eldin\Volcano Summit\Waterfall\Higher Area\Chest behind Bombable Wall in Waterfall Area:
+    type: null
+    short_name: Volcano Summit - Chest behind Bombable Wall in Waterfall Area
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Item behind Digging:
+    type: null
+    short_name: Volcano Summit - Item behind Digging
+  \Eldin\Bokoblin Base\Prison\Plats' Gift:
+    type: null
+    short_name: Bokoblin Base - Plats' Gift
+  \Eldin\Bokoblin Base\Volcano East\Chest near Bone Bridge:
+    type: null
+    short_name: Bokoblin Base - Chest near Bone Bridge
+  \Eldin\Bokoblin Base\Volcano East\Chest on Cliff:
+    type: null
+    short_name: Bokoblin Base - Chest on Cliff
+  \Eldin\Bokoblin Base\Before Drawbridge\Chest near Drawbridge:
+    type: null
+    short_name: Bokoblin Base - Chest near Drawbridge
+  \Eldin\Bokoblin Base\Outside Earth Temple\Chest East of Earth Temple Entrance:
+    type: null
+    short_name: Bokoblin Base - Chest East of Earth Temple Entrance
+  \Eldin\Bokoblin Base\Outside Earth Temple\Chest West of Earth Temple Entrance:
+    type: null
+    short_name: Bokoblin Base - Chest West of Earth Temple Entrance
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\First Chest in Volcano Summit:
+    type: null
+    short_name: Bokoblin Base - First Chest in Volcano Summit
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\Raised Chest in Volcano Summit:
+    type: null
+    short_name: Bokoblin Base - Raised Chest in Volcano Summit
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\Chest in Volcano Summit Alcove:
+    type: null
+    short_name: Bokoblin Base - Chest in Volcano Summit Alcove
+  \Eldin\Bokoblin Base\Fire Dragon's Lair\Fire Dragon's Reward:
+    type: null
+    short_name: Bokoblin Base - Fire Dragon's Reward
+  \Lanayru\Mine\Entry\Higher Area\Chest behind First Landing:
+    type: null
+    short_name: Lanayru Mine - Chest behind First Landing
+  \Lanayru\Mine\Entry\Chest near First Timeshift Stone:
+    type: null
+    short_name: Lanayru Mine - Chest near First Timeshift Stone
+  \Lanayru\Mine\Statues Area\Chest behind Statue:
+    type: null
+    short_name: Lanayru Mine - Chest behind Statue
+  \Lanayru\Mine\End\Chest at the End of Mine:
+    type: null
+    short_name: Lanayru Mine - Chest at the End of Mine
+  \Lanayru\Desert\Entry\High Ledge after Vines\Chest near Party Wheel:
+    type: null
+    short_name: Lanayru Desert - Chest near Party Wheel
+  \Lanayru\Desert\Near Caged Robot\Chest near Caged Robot:
+    type: null
+    short_name: Lanayru Desert - Chest near Caged Robot
+  \Lanayru\Desert\Near Caged Robot\Rescue Caged Robot:
+    type: Combat
+    short_name: Lanayru Desert - Rescue Caged Robot
+  \Lanayru\Desert\East\Chest on Platform near Fire Node:
+    type: null
+    short_name: Lanayru Desert - Chest on Platform near Fire Node
+  \Lanayru\Desert\North Part\Chest on Platform near Lightning Node:
+    type: lanayru, miscellaneous
+    short_name: Lanayru Desert - Chest on Platform near Lightning Node
+  \Lanayru\Desert\Top of West Wall\Chest near Sand Oasis:
+    type: null
+    short_name: Lanayru Desert - Chest near Sand Oasis
+  \Lanayru\Desert\Top of LMF\Chest on top of Lanayru Mining Facility:
+    type: null
+    short_name: Lanayru Desert - Chest on top of Lanayru Mining Facility
+  \Lanayru\Desert\North Part\Secret Passageway\Secret Passageway Chest:
+    type: null
+    short_name: Lanayru Desert - Secret Passageway Chest
+  \Lanayru\Desert\East\Fire Node\Present after Sand\Shortcut Chest:
+    type: null
+    short_name: Lanayru Desert - Fire Node - Shortcut Chest
+  \Lanayru\Desert\East\Fire Node\Past\First Small Chest:
+    type: null
+    short_name: Lanayru Desert - Fire Node - First Small Chest
+  \Lanayru\Desert\East\Fire Node\Past\Second Small Chest:
+    type: null
+    short_name: Lanayru Desert - Fire Node - Second Small Chest
+  \Lanayru\Desert\East\Fire Node\Past after Grate\Left Ending Chest:
+    type: null
+    short_name: Lanayru Desert - Fire Node - Left Ending Chest
+  \Lanayru\Desert\East\Fire Node\Past after Grate\Right Ending Chest:
+    type: null
+    short_name: Lanayru Desert - Fire Node - Right Ending Chest
+  \Lanayru\Desert\North Part\Lightning Node\Past\First Chest:
+    type: null
+    short_name: Lanayru Desert - Lightning Node - First Chest
+  \Lanayru\Desert\North Part\Lightning Node\Past\Second Chest:
+    type: null
+    short_name: Lanayru Desert - Lightning Node - Second Chest
+  \Lanayru\Desert\North Part\Lightning Node\Present from afar\Raised Chest near Generator:
+    type: null
+    short_name: Lanayru Desert - Lightning Node - Raised Chest near Generator
+  \Lanayru\Caves\Chest:
+    type: null
+    short_name: Lanayru Caves - Chest
+  \Lanayru\Caves\Golo's Gift:
+    type: null
+    short_name: Lanayru Caves - Golo's Gift
+  \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward:
+    type: null
+    short_name: Lanayru Gorge - Thunder Dragon's Reward
+  \Lanayru\Lanayru Sand Sea\Gorge\Item on Pillar:
+    type: null
+    short_name: Lanayru Gorge - Item on Pillar
+  \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Digging Spot:
+    type: null
+    short_name: Lanayru Gorge - Digging Spot
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Rupee on First Pillar:
+    type: Rupees (No Quick Beetle)
+    short_name: Lanayru Sand Sea - Ancient Harbour - Rupee on First Pillar
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Left Rupee on Entrance Crown:
+    type: Rupees (Quick Beetle)
+    short_name: Lanayru Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Right Rupee on Entrance Crown:
+    type: Rupees (Quick Beetle)
+    short_name: Lanayru Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Chest after Moblin:
+    type: null
+    short_name: Lanayru Sand Sea - Skipper's Retreat - Chest after Moblin
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Chest on top of Cacti Pillar:
+    type: null
+    short_name: Lanayru Sand Sea - Skipper's Retreat - Chest on top of Cacti Pillar
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Chest in Shack:
+    type: null
+    short_name: Lanayru Sand Sea - Skipper's Retreat - Chest in Shack
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform\Skydive Chest:
+    type: null
+    short_name: Lanayru Sand Sea - Skipper's Retreat - Skydive Chest
+  \Lanayru\Lanayru Sand Sea\Shipyard\Rickety Coaster -- Heart Stopping Track in 1'05:
+    type: Minigames, Combat
+    short_name: Lanayru Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar:
+    type: Rupees (Quick Beetle)
+    short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on East Sea Pillar
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar:
+    type: Rupees (Quick Beetle)
+    short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on West Sea Pillar
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose:
+    type: Rupees (No Quick Beetle)
+    short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar
+      or Nose
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Chest:
+    type: null
+    short_name: Lanayru Sand Sea - Pirate Stronghold - First Chest
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Chest:
+    type: null
+    short_name: Lanayru Sand Sea - Pirate Stronghold - Second Chest
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Third Chest:
+    type: null
+    short_name: Lanayru Sand Sea - Pirate Stronghold - Third Chest
+  \Skyview\Main\First Hub\Left Room\Chest on Tree Branch:
+    type: null
+    short_name: Skyview - Chest on Tree Branch
+  \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace:
+    type: null
+    short_name: Skyview - Digging Spot in Crawlspace
+  \Skyview\Main\First Hub\Right Room\Upper Area\Chest behind Two Eyes:
+    type: null
+    short_name: Skyview - Chest behind Two Eyes
+  \Skyview\Main\Second Hub\Miniboss Room\Chest after Stalfos Fight:
+    type: null
+    short_name: Skyview - Chest after Stalfos Fight
+  \Skyview\Main\Second Hub\Item behind Bars:
+    type: null
+    short_name: Skyview - Item behind Bars
+  \Skyview\Main\Second Hub\Rupee in Southeast Tunnel:
+    type: Rupees (No Quick Beetle)
+    short_name: Skyview - Rupee in Southeast Tunnel
+  \Skyview\Main\Second Hub\Rupee in Southwest Tunnel:
+    type: Rupees (No Quick Beetle)
+    short_name: Skyview - Rupee in Southwest Tunnel
+  \Skyview\Main\Second Hub\Rupee in East Tunnel:
+    type: Rupees (No Quick Beetle)
+    short_name: Skyview - Rupee in East Tunnel
+  \Skyview\Main\Second Hub\Left Rooms\Chest behind Three Eyes:
+    type: null
+    short_name: Skyview - Chest behind Three Eyes
+  \Skyview\Main\Last Room\After Rope\Chest near Boss Door:
+    type: null
+    short_name: Skyview - Chest near Boss Door
+  \Skyview\Main\Last Room\Near Boss Key Chest\Boss Key Chest:
+    type: null
+    short_name: Skyview - Boss Key Chest
+  \Skyview\Boss Room\Heart Container:
+    type: null
+    short_name: Skyview - Heart Container
+  \Skyview\Spring\Rupee on Spring Pillar:
+    type: Rupees (No Quick Beetle)
+    short_name: Skyview - Rupee on Spring Pillar
+  \Skyview\Spring\Strike Crest:
+    type: null
+    short_name: Skyview - Strike Crest
+  \Earth Temple\Main\First Room\Vent Chest:
+    type: null
+    short_name: Earth Temple - Vent Chest
+  \Earth Temple\Main\First Room\Rupee above Drawbridge:
+    type: Rupees (No Quick Beetle)
+    short_name: Earth Temple - Rupee above Drawbridge
+  \Earth Temple\Main\Hub Room\Chest behind Bombable Rock:
+    type: null
+    short_name: Earth Temple - Chest behind Bombable Rock
+  \Earth Temple\Main\Hub Room\Chest Left of Main Room Bridge:
+    type: null
+    short_name: Earth Temple - Chest Left of Main Room Bridge
+  \Earth Temple\Main\West Room\Chest in West Room:
+    type: null
+    short_name: Earth Temple - Chest in West Room
+  \Earth Temple\Main\East Room\Chest after Double Lizalfos Fight:
+    type: null
+    short_name: Earth Temple - Chest after Double Lizalfos Fight
+  \Earth Temple\Main\Hub Room\Ledd's Gift:
+    type: null
+    short_name: Earth Temple - Ledd's Gift
+  \Earth Temple\Main\Hub Room\Rupee in Lava Tunnel:
+    type: Rupees (No Quick Beetle)
+    short_name: Earth Temple - Rupee in Lava Tunnel
+  \Earth Temple\Main\Hub Room\Past Lava Section\Chest Guarded by Lizalfos:
+    type: null
+    short_name: Earth Temple - Chest Guarded by Lizalfos
+  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Key Chest:
+    type: null
+    short_name: Earth Temple - Boss Key Chest
+  \Earth Temple\Boss Room\Slope\Heart Container:
+    type: null
+    short_name: Earth Temple - Heart Container
+  \Earth Temple\Spring\Strike Crest:
+    type: null
+    short_name: Earth Temple - Strike Crest
+  \Lanayru Mining Facility\Main\First Room\Chest behind Bars:
+    type: null
+    short_name: Lanayru Mining Facility - Chest behind Bars
+  \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes\First Chest in Hub Room:
+    type: null
+    short_name: Lanayru Mining Facility - First Chest in Hub Room
+  \Lanayru Mining Facility\Main\First West Room\Chest in First West Room:
+    type: null
+    short_name: Lanayru Mining Facility - Chest in First West Room
+  \Lanayru Mining Facility\Main\Armos Fight Room\Chest after Armos Fight:
+    type: null
+    short_name: Lanayru Mining Facility - Chest after Armos Fight
+  \Lanayru Mining Facility\Main\Key Locked Room\Chest in Key Locked Room:
+    type: null
+    short_name: Lanayru Mining Facility - Chest in Key Locked Room
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Raised Chest in Hop across Boxes Room:
+    type: null
+    short_name: Lanayru Mining Facility - Raised Chest in Hop across Boxes Room
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Lower Chest in Hop across Boxes Room:
+    type: null
+    short_name: Lanayru Mining Facility - Lower Chest in Hop across Boxes Room
+  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Chest behind First Crawlspace:
+    type: null
+    short_name: Lanayru Mining Facility - Chest behind First Crawlspace
+  \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Chest in Spike Maze:
+    type: null
+    short_name: Lanayru Mining Facility - Chest in Spike Maze
+  \Lanayru Mining Facility\Main\Boss Key Room\Boss Key Chest:
+    type: null
+    short_name: Lanayru Mining Facility - Boss Key Chest
+  \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Shortcut Chest in Main Hub:
+    type: null
+    short_name: Lanayru Mining Facility - Shortcut Chest in Main Hub
+  \Lanayru Mining Facility\Boss Room\After Sand Drain\Heart Container:
+    type: null
+    short_name: Lanayru Mining Facility - Heart Container
+  \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit Hall of Ancient Robots:
+    type: null
+    short_name: Lanayru Mining Facility - Exit Hall of Ancient Robots
+  \Ancient Cistern\Main\Main Room\Rupee in West Hand:
+    type: Rupees (No Quick Beetle)
+    short_name: Ancient Cistern - Rupee in West Hand
+  \Ancient Cistern\Main\Main Room\Rupee in East Hand:
+    type: Rupees (No Quick Beetle)
+    short_name: Ancient Cistern - Rupee in East Hand
+  \Ancient Cistern\Main\East Part\Second Room\First Rupee in East Part in Short Tunnel:
+    type: Rupees (No Quick Beetle)
+    short_name: Ancient Cistern - First Rupee in East Part in Short Tunnel
+  \Ancient Cistern\Main\East Part\Second Room\Second Rupee in East Part in Short Tunnel:
+    type: Rupees (No Quick Beetle)
+    short_name: Ancient Cistern - Second Rupee in East Part in Short Tunnel
+  \Ancient Cistern\Main\East Part\Second Room\Third Rupee in East Part in Short Tunnel:
+    type: Rupees (No Quick Beetle)
+    short_name: Ancient Cistern - Third Rupee in East Part in Short Tunnel
+  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Cubby:
+    type: Rupees (No Quick Beetle)
+    short_name: Ancient Cistern - Rupee in East Part in Cubby
+  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Main Tunnel:
+    type: Rupees (No Quick Beetle)
+    short_name: Ancient Cistern - Rupee in East Part in Main Tunnel
+  \Ancient Cistern\Main\East Part\Chest Ledge\Chest in East Part:
+    type: null
+    short_name: Ancient Cistern - Chest in East Part
+  \Ancient Cistern\Main\Main Room\After Whip Hooks\Chest after Whip Hooks:
+    type: null
+    short_name: Ancient Cistern - Chest after Whip Hooks
+  \Ancient Cistern\Main\Main Room\Vines Area\Chest near Vines:
+    type: null
+    short_name: Ancient Cistern - Chest near Vines
+  \Ancient Cistern\Main\Main Room\Behind the Waterfall\Chest behind the Waterfall:
+    type: null
+    short_name: Ancient Cistern - Chest behind the Waterfall
+  \Ancient Cistern\Main\Basement Gutters\Past Skulltula\Bokoblin:
+    type: null
+    short_name: Ancient Cistern - Bokoblin
+  \Ancient Cistern\Main\Main Room\After Gutters\Rupee under Lilypad:
+    type: Rupees (No Quick Beetle)
+    short_name: Ancient Cistern - Rupee under Lilypad
+  \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest\Chest in Key Locked Room:
+    type: null
+    short_name: Ancient Cistern - Chest in Key Locked Room
+  \Ancient Cistern\Main\Basement\Under the Statue\Boss Key Chest:
+    type: null
+    short_name: Ancient Cistern - Boss Key Chest
+  \Ancient Cistern\Boss Room\Heart Container:
+    type: null
+    short_name: Ancient Cistern - Heart Container
+  \Ancient Cistern\Flame Room\Farore's Flame:
+    type: null
+    short_name: Ancient Cistern - Farore's Flame
+  \Sandship\Main\Deck\Stern\Chest at the Stern:
+    type: null
+    short_name: Sandship - Chest at the Stern
+  \Sandship\Main\Before Ship's Bow\Chest before 4-Door Corridor:
+    type: null
+    short_name: Sandship - Chest before 4-Door Corridor
+  \Sandship\Main\Before Boss Door\Chest behind Combination Lock:
+    type: null
+    short_name: Sandship - Chest behind Combination Lock
+  \Sandship\Main\Treasure Room\Treasure Room First Chest:
+    type: null
+    short_name: Sandship - Treasure Room First Chest
+  \Sandship\Main\Treasure Room\Treasure Room Second Chest:
+    type: null
+    short_name: Sandship - Treasure Room Second Chest
+  \Sandship\Main\Treasure Room\Treasure Room Third Chest:
+    type: null
+    short_name: Sandship - Treasure Room Third Chest
+  \Sandship\Main\Treasure Room\Treasure Room Fourth Chest:
+    type: null
+    short_name: Sandship - Treasure Room Fourth Chest
+  \Sandship\Main\Treasure Room\Treasure Room Fifth Chest:
+    type: null
+    short_name: Sandship - Treasure Room Fifth Chest
+  \Sandship\Main\Brig Prison\Robot in Brig's Reward:
+    type: null
+    short_name: Sandship - Robot in Brig's Reward
+  \Sandship\Main\Ship's Bow\Chest after Scervo Fight:
+    type: null
+    short_name: Sandship - Chest after Scervo Fight
+  \Sandship\Main\Deck\Captain's Cabin\Boss Key Chest:
+    type: null
+    short_name: Sandship - Boss Key Chest
+  \Sandship\Boss Room\Heart Container:
+    type: null
+    short_name: Sandship - Heart Container
+  \Sandship\Boss Room\Nayru's Flame:
+    type: null
+    short_name: Sandship - Nayru's Flame
+  \Fire Sanctuary\Main\First Room\Past Water Plant\Chest in First Room:
+    type: null
+    short_name: Fire Sanctuary - Chest in First Room
+  \Fire Sanctuary\Main\Second Room\Chest in Second Room:
+    type: null
+    short_name: Fire Sanctuary - Chest in Second Room
+  \Fire Sanctuary\Main\Second Room\Balcony\Chest on Balcony:
+    type: null
+    short_name: Fire Sanctuary - Chest on Balcony
+  \Fire Sanctuary\Main\First Trapped Mogma Room\Chest near First Trapped Mogma:
+    type: null
+    short_name: Fire Sanctuary - Chest near First Trapped Mogma
+  \Fire Sanctuary\Main\Water Fruit Room\First Chest in Water Fruit Room:
+    type: null
+    short_name: Fire Sanctuary - First Chest in Water Fruit Room
+  \Fire Sanctuary\Main\Water Fruit Room\Second Chest in Water Fruit Room:
+    type: null
+    short_name: Fire Sanctuary - Second Chest in Water Fruit Room
+  \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area\Rescue First Trapped Mogma:
+    type: null
+    short_name: Fire Sanctuary - Rescue First Trapped Mogma
+  \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Second Trapped Mogma:
+    type: null
+    short_name: Fire Sanctuary - Rescue Second Trapped Mogma
+  \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall\Chest after Bombable Wall:
+    type: null
+    short_name: Fire Sanctuary - Chest after Bombable Wall
+  \Fire Sanctuary\Main\West of Boss Door\Plats' Chest:
+    type: null
+    short_name: Fire Sanctuary - Plats' Chest
+  \Fire Sanctuary\Main\Staircase Room\Chest in Staircase Room:
+    type: null
+    short_name: Fire Sanctuary - Chest in Staircase Room
+  \Fire Sanctuary\Main\Boss Key Room\Boss Key Chest:
+    type: null
+    short_name: Fire Sanctuary - Boss Key Chest
+  \Fire Sanctuary\Boss Room\Heart Container:
+    type: null
+    short_name: Fire Sanctuary - Heart Container
+  \Fire Sanctuary\Flame Room\Din's Flame:
+    type: null
+    short_name: Fire Sanctuary - Din's Flame
+  \Sky Keep\Main\First Room\First Chest:
+    type: null
+    short_name: Sky Keep - First Chest
+  \Sky Keep\Main\Mini Boss Room\Near Chest\Chest after Dreadfuse:
+    type: null
+    short_name: Sky Keep - Chest after Dreadfuse
+  \Sky Keep\Main\Fire Sanctuary Room\First Platform\Rupee in Fire Sanctuary Room in Alcove:
+    type: Rupees (No Quick Beetle)
+    short_name: Sky Keep - Rupee in Fire Sanctuary Room in Alcove
+  \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Sacred Power of Din:
+    type: null
+    short_name: Sky Keep - Sacred Power of Din
+  \Sky Keep\Main\Sandship Room\Triforce Area\Sacred Power of Nayru:
+    type: null
+    short_name: Sky Keep - Sacred Power of Nayru
+  \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Sacred Power of Farore:
+    type: null
+    short_name: Sky Keep - Sacred Power of Farore
+  \Skyloft\Skyloft Silent Realm\Trial Reward:
+    type: null
+    short_name: Skyloft Silent Realm - Trial Reward
+  \Skyloft\Skyloft Silent Realm\Relic 1:
+    type: skyloft, silent realm
+    short_name: Skyloft Silent Realm - Relic 1
+  \Skyloft\Skyloft Silent Realm\Relic 2:
+    type: skyloft, silent realm
+    short_name: Skyloft Silent Realm - Relic 2
+  \Skyloft\Skyloft Silent Realm\Relic 3:
+    type: skyloft, silent realm
+    short_name: Skyloft Silent Realm - Relic 3
+  \Skyloft\Skyloft Silent Realm\Relic 4:
+    type: skyloft, silent realm
+    short_name: Skyloft Silent Realm - Relic 4
+  \Skyloft\Skyloft Silent Realm\Relic 5:
+    type: skyloft, silent realm
+    short_name: Skyloft Silent Realm - Relic 5
+  \Skyloft\Skyloft Silent Realm\Relic 6:
+    type: skyloft, silent realm
+    short_name: Skyloft Silent Realm - Relic 6
+  \Skyloft\Skyloft Silent Realm\Relic 7:
+    type: skyloft, silent realm
+    short_name: Skyloft Silent Realm - Relic 7
+  \Skyloft\Skyloft Silent Realm\Relic 8:
+    type: skyloft, silent realm
+    short_name: Skyloft Silent Realm - Relic 8
+  \Skyloft\Skyloft Silent Realm\Relic 9:
+    type: skyloft, silent realm
+    short_name: Skyloft Silent Realm - Relic 9
+  \Skyloft\Skyloft Silent Realm\Relic 10:
+    type: skyloft, silent realm
+    short_name: Skyloft Silent Realm - Relic 10
+  \Faron\Faron Silent Realm\Trial Reward:
+    type: null
+    short_name: Faron Silent Realm - Trial Reward
+  \Faron\Faron Silent Realm\Relic 1:
+    type: faron, silent realm
+    short_name: Faron Silent Realm - Relic 1
+  \Faron\Faron Silent Realm\Relic 2:
+    type: faron, silent realm
+    short_name: Faron Silent Realm - Relic 2
+  \Faron\Faron Silent Realm\Relic 3:
+    type: faron, silent realm
+    short_name: Faron Silent Realm - Relic 3
+  \Faron\Faron Silent Realm\Relic 4:
+    type: faron, silent realm
+    short_name: Faron Silent Realm - Relic 4
+  \Faron\Faron Silent Realm\Relic 5:
+    type: faron, silent realm
+    short_name: Faron Silent Realm - Relic 5
+  \Faron\Faron Silent Realm\Relic 6:
+    type: faron, silent realm
+    short_name: Faron Silent Realm - Relic 6
+  \Faron\Faron Silent Realm\Relic 7:
+    type: faron, silent realm
+    short_name: Faron Silent Realm - Relic 7
+  \Faron\Faron Silent Realm\Relic 8:
+    type: faron, silent realm
+    short_name: Faron Silent Realm - Relic 8
+  \Faron\Faron Silent Realm\Relic 9:
+    type: faron, silent realm
+    short_name: Faron Silent Realm - Relic 9
+  \Faron\Faron Silent Realm\Relic 10:
+    type: faron, silent realm
+    short_name: Faron Silent Realm - Relic 10
+  \Lanayru\Lanayru Silent Realm\Trial Reward:
+    type: null
+    short_name: Lanayru Silent Realm - Trial Reward
+  \Lanayru\Lanayru Silent Realm\Relic 1:
+    type: lanayru, silent realm
+    short_name: Lanayru Silent Realm - Relic 1
+  \Lanayru\Lanayru Silent Realm\Relic 2:
+    type: lanayru, silent realm
+    short_name: Lanayru Silent Realm - Relic 2
+  \Lanayru\Lanayru Silent Realm\Relic 3:
+    type: lanayru, silent realm
+    short_name: Lanayru Silent Realm - Relic 3
+  \Lanayru\Lanayru Silent Realm\Relic 4:
+    type: lanayru, silent realm
+    short_name: Lanayru Silent Realm - Relic 4
+  \Lanayru\Lanayru Silent Realm\Relic 5:
+    type: lanayru, silent realm
+    short_name: Lanayru Silent Realm - Relic 5
+  \Lanayru\Lanayru Silent Realm\Relic 6:
+    type: lanayru, silent realm
+    short_name: Lanayru Silent Realm - Relic 6
+  \Lanayru\Lanayru Silent Realm\Relic 7:
+    type: lanayru, silent realm
+    short_name: Lanayru Silent Realm - Relic 7
+  \Lanayru\Lanayru Silent Realm\Relic 8:
+    type: lanayru, silent realm
+    short_name: Lanayru Silent Realm - Relic 8
+  \Lanayru\Lanayru Silent Realm\Relic 9:
+    type: lanayru, silent realm
+    short_name: Lanayru Silent Realm - Relic 9
+  \Lanayru\Lanayru Silent Realm\Relic 10:
+    type: lanayru, silent realm
+    short_name: Lanayru Silent Realm - Relic 10
+  \Eldin\Eldin Silent Realm\Trial Reward:
+    type: null
+    short_name: Eldin Silent Realm - Trial Reward
+  \Eldin\Eldin Silent Realm\Relic 1:
+    type: eldin, silent realm
+    short_name: Eldin Silent Realm - Relic 1
+  \Eldin\Eldin Silent Realm\Relic 2:
+    type: eldin, silent realm
+    short_name: Eldin Silent Realm - Relic 2
+  \Eldin\Eldin Silent Realm\Relic 3:
+    type: eldin, silent realm
+    short_name: Eldin Silent Realm - Relic 3
+  \Eldin\Eldin Silent Realm\Relic 4:
+    type: eldin, silent realm
+    short_name: Eldin Silent Realm - Relic 4
+  \Eldin\Eldin Silent Realm\Relic 5:
+    type: eldin, silent realm
+    short_name: Eldin Silent Realm - Relic 5
+  \Eldin\Eldin Silent Realm\Relic 6:
+    type: eldin, silent realm
+    short_name: Eldin Silent Realm - Relic 6
+  \Eldin\Eldin Silent Realm\Relic 7:
+    type: eldin, silent realm
+    short_name: Eldin Silent Realm - Relic 7
+  \Eldin\Eldin Silent Realm\Relic 8:
+    type: eldin, silent realm
+    short_name: Eldin Silent Realm - Relic 8
+  \Eldin\Eldin Silent Realm\Relic 9:
+    type: eldin, silent realm
+    short_name: Eldin Silent Realm - Relic 9
+  \Eldin\Eldin Silent Realm\Relic 10:
+    type: eldin, silent realm
+    short_name: Eldin Silent Realm - Relic 10
 gossip_stones:
   \Skyloft\Central Skyloft\Waterfall Island\Gossip Stone on Waterfall Island: Central
     Skyloft - Gossip Stone on Waterfall Island

--- a/dump.yaml
+++ b/dump.yaml
@@ -1347,7 +1347,6 @@ items:
 - \Skyloft\Central Skyloft\Open Trial Gate
 - \Skyloft\Central Skyloft\Waterfall Cave Crystals from above
 - \Skyloft\Central Skyloft\Crystal on Waterfall Island from the ground
-- \Skyloft\Central Skyloft\Crystal on Waterfall Island
 - \Skyloft\Central Skyloft\Open Cave Entrance
 - \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest
 - \Skyloft\Central Skyloft\Bazaar\Potion Lady's Gift
@@ -8031,8 +8030,9 @@ areas:
               \ & \\Skyloft\\Central Skyloft\\Waterfall Cave Crystals from above"
             \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: "Night\
               \ & \\Skyloft\\Central Skyloft\\Waterfall Cave Crystals from above"
-            Crystal on Waterfall Island: "Night & \\Skyloft\\Central Skyloft\\Crystal\
-              \ on Waterfall Island from the ground"
+            \Skyloft\Central Skyloft\Waterfall Island\Crystal on Waterfall Island: "Night\
+              \ & \\Skyloft\\Central Skyloft\\Crystal on Waterfall Island from the\
+              \ ground"
             Open Cave Entrance: "\\Sword | Bomb Bag"
           name: \Skyloft\Central Skyloft
           sub_areas:
@@ -9017,7 +9017,7 @@ checks:
   \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison:
     type: Loose Crystals
     short_name: Central Skyloft - Crystal in Loftwing Prison
-  \Skyloft\Central Skyloft\Crystal on Waterfall Island:
+  \Skyloft\Central Skyloft\Waterfall Island\Crystal on Waterfall Island:
     type: Loose Crystals
     short_name: Central Skyloft - Crystal on Waterfall Island
   \Skyloft\Central Skyloft\Crystal on Light Tower:
@@ -9935,7 +9935,7 @@ exits:
     stage: F001r
     room: 1
     index: 2
-    req_index: 1802
+    req_index: 1801
     short_name: Start
   \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Exit:
     type: exit
@@ -9943,7 +9943,7 @@ exits:
     stage: F001r
     room: 0
     index: 0
-    req_index: 1803
+    req_index: 1802
     short_name: Skyloft - Knight Academy - Lower Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Exit:
     type: exit
@@ -9951,7 +9951,7 @@ exits:
     stage: F001r
     room: 0
     index: 1
-    req_index: 1804
+    req_index: 1803
     short_name: Skyloft - Knight Academy - Lower Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Exit:
     type: exit
@@ -9959,7 +9959,7 @@ exits:
     stage: F001r
     room: 0
     index: 2
-    req_index: 1805
+    req_index: 1804
     short_name: Skyloft - Knight Academy - Upper Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Exit:
     type: exit
@@ -9967,7 +9967,7 @@ exits:
     stage: F001r
     room: 0
     index: 3
-    req_index: 1806
+    req_index: 1805
     short_name: Skyloft - Knight Academy - Upper Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Exit:
     type: exit
@@ -9975,7 +9975,7 @@ exits:
     stage: F000
     room: 0
     index: 3
-    req_index: 1807
+    req_index: 1806
     short_name: Skyloft - Knight Academy Lower Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Exit:
     type: exit
@@ -9983,7 +9983,7 @@ exits:
     stage: F000
     room: 0
     index: 4
-    req_index: 1808
+    req_index: 1807
     short_name: Skyloft - Knight Academy Lower Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Exit:
     type: exit
@@ -9991,7 +9991,7 @@ exits:
     stage: F000
     room: 0
     index: 23
-    req_index: 1809
+    req_index: 1808
     short_name: Skyloft - Knight Academy Upper Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Exit:
     type: exit
@@ -9999,7 +9999,7 @@ exits:
     stage: F000
     room: 0
     index: 24
-    req_index: 1810
+    req_index: 1809
     short_name: Skyloft - Knight Academy Upper Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Chimney Entrance:
     type: exit
@@ -10007,7 +10007,7 @@ exits:
     stage: F000
     room: 0
     index: 57
-    req_index: 1811
+    req_index: 1810
     short_name: Skyloft - Knight Academy Chimney Entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Right Door Exit:
     type: exit
@@ -10015,7 +10015,7 @@ exits:
     stage: F009r
     room: 0
     index: 0
-    req_index: 1812
+    req_index: 1811
     short_name: Sparring Hall - Right Door Exit
   \Skyloft\Upper Skyloft\Sparring Hall\Left Door Exit:
     type: exit
@@ -10023,7 +10023,7 @@ exits:
     stage: F009r
     room: 0
     index: 1
-    req_index: 1813
+    req_index: 1812
     short_name: Sparring Hall - Left Door Exit
   \Skyloft\Upper Skyloft\Sparring Hall Left Door Exit:
     type: exit
@@ -10031,7 +10031,7 @@ exits:
     stage: F000
     room: 0
     index: 20
-    req_index: 1814
+    req_index: 1813
     short_name: Skyloft - Sparring Hall Left Door Exit
   \Skyloft\Upper Skyloft\Sparring Hall Right Door Exit:
     type: exit
@@ -10039,7 +10039,7 @@ exits:
     stage: F000
     room: 0
     index: 27
-    req_index: 1815
+    req_index: 1814
     short_name: Skyloft - Sparring Hall Right Door Exit
   \Skyloft\Upper Skyloft\Goddess Statue\Exit:
     type: exit
@@ -10047,7 +10047,7 @@ exits:
     stage: F008r
     room: 0
     index: 0
-    req_index: 1816
+    req_index: 1815
     short_name: Goddess Statue - Exit
   \Skyloft\Upper Skyloft\Goddess Statue Exit:
     type: exit
@@ -10055,7 +10055,7 @@ exits:
     stage: F000
     room: 0
     index: 5
-    req_index: 1817
+    req_index: 1816
     short_name: Goddess Statue Exit
   \Skyloft\Central Skyloft\Waterfall Cave\Upper Exit:
     type: exit
@@ -10063,7 +10063,7 @@ exits:
     stage: D000
     room: 0
     index: 0
-    req_index: 1818
+    req_index: 1817
     short_name: Waterfall Cave - Upper Exit
   \Skyloft\Central Skyloft\Waterfall Cave\Lower Exit:
     type: exit
@@ -10071,7 +10071,7 @@ exits:
     stage: D000
     room: 0
     index: 1
-    req_index: 1819
+    req_index: 1818
     short_name: Waterfall Cave - Lower Exit
   \Skyloft\Central Skyloft\Waterfall Cave Upper Exit:
     type: exit
@@ -10079,7 +10079,7 @@ exits:
     stage: F000
     room: 0
     index: 6
-    req_index: 1820
+    req_index: 1819
     short_name: Waterfall Cave Upper Exit
   \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Exit:
     type: exit
@@ -10087,7 +10087,7 @@ exits:
     stage: F000
     room: 0
     index: 7
-    req_index: 1821
+    req_index: 1820
     short_name: Waterfall Cave Lower Exit
   \Skyloft\Central Skyloft\Bazaar\North Exit:
     type: exit
@@ -10095,7 +10095,7 @@ exits:
     stage: F004r
     room: 0
     index: 0
-    req_index: 1822
+    req_index: 1821
     short_name: Bazaar - North Exit
   \Skyloft\Central Skyloft\Bazaar\South Exit:
     type: exit
@@ -10103,7 +10103,7 @@ exits:
     stage: F004r
     room: 0
     index: 1
-    req_index: 1823
+    req_index: 1822
     short_name: Bazaar - South Exit
   \Skyloft\Central Skyloft\Bazaar\West Exit:
     type: exit
@@ -10111,7 +10111,7 @@ exits:
     stage: F004r
     room: 0
     index: 2
-    req_index: 1824
+    req_index: 1823
     short_name: Bazaar - West Exit
   \Skyloft\Central Skyloft\Bazaar North Exit:
     type: exit
@@ -10119,7 +10119,7 @@ exits:
     stage: F000
     room: 0
     index: 1
-    req_index: 1825
+    req_index: 1824
     short_name: Bazaar North Exit
   \Skyloft\Central Skyloft\Bazaar South Exit:
     type: exit
@@ -10127,7 +10127,7 @@ exits:
     stage: F000
     room: 0
     index: 2
-    req_index: 1826
+    req_index: 1825
     short_name: Bazaar South Exit
   \Skyloft\Central Skyloft\Bazaar West Exit:
     type: exit
@@ -10135,7 +10135,7 @@ exits:
     stage: F000
     room: 0
     index: 19
-    req_index: 1827
+    req_index: 1826
     short_name: Bazaar West Exit
   \Skyloft\Beedle's Shop\Day Exit:
     type: exit
@@ -10143,7 +10143,7 @@ exits:
     stage: F002r
     room: 0
     index: 0
-    req_index: 1828
+    req_index: 1827
     short_name: Beedle's Shop - Day Exit
   \Skyloft\Beedle's Shop\Night Exit:
     type: exit
@@ -10152,7 +10152,7 @@ exits:
     stage: F002r
     room: 0
     index: 2
-    req_index: 1829
+    req_index: 1828
     short_name: Beedle's Shop - Night Exit
   \Skyloft\Central Skyloft\Exit to Beedle's Shop:
     type: exit
@@ -10160,17 +10160,17 @@ exits:
     stage: F000
     room: 0
     index: 26
-    req_index: 1830
+    req_index: 1829
     short_name: Skyloft - Exit to Beedle's Shop
   \Skyloft\Skyloft Silent Realm\Exit:
     type: exit
     vanilla: Skyloft - Trial Gate Entrance
-    req_index: 1831
+    req_index: 1830
     short_name: Skyloft Silent Realm - Exit
   \Skyloft\Central Skyloft\Trial Gate Exit:
     type: exit
     vanilla: Skyloft Silent Realm - Entrance
-    req_index: 1832
+    req_index: 1831
     short_name: Skyloft - Trial Gate Exit
   \Skyloft\Central Skyloft\Near Temple Entrance\Exit to Sky Keep:
     type: exit
@@ -10178,7 +10178,7 @@ exits:
     stage: F000
     room: 0
     index: 48
-    req_index: 1833
+    req_index: 1832
     short_name: Skyloft - Exit to Sky Keep
   \Skyloft\Central Skyloft\Orielle and Parrow's House\Exit:
     type: exit
@@ -10186,7 +10186,7 @@ exits:
     stage: F005r
     room: 0
     index: 0
-    req_index: 1834
+    req_index: 1833
     short_name: Orielle and Parrow's House - Exit
   \Skyloft\Central Skyloft\Orielle and Parrow's House Exit:
     type: exit
@@ -10194,7 +10194,7 @@ exits:
     stage: F000
     room: 0
     index: 31
-    req_index: 1835
+    req_index: 1834
     short_name: Orielle and Parrow's House Exit
   \Skyloft\Central Skyloft\Peatrice's House\Exit:
     type: exit
@@ -10202,7 +10202,7 @@ exits:
     stage: F018r
     room: 0
     index: 0
-    req_index: 1836
+    req_index: 1835
     short_name: Peatrice's House - Exit
   \Skyloft\Central Skyloft\Peatrice's House Exit:
     type: exit
@@ -10210,7 +10210,7 @@ exits:
     stage: F000
     room: 0
     index: 38
-    req_index: 1837
+    req_index: 1836
     short_name: Peatrice's House Exit
   \Skyloft\Central Skyloft\Wryna's House\Exit:
     type: exit
@@ -10218,7 +10218,7 @@ exits:
     stage: F006r
     room: 0
     index: 0
-    req_index: 1838
+    req_index: 1837
     short_name: Wryna's House - Exit
   \Skyloft\Central Skyloft\Wryna's House Exit:
     type: exit
@@ -10226,7 +10226,7 @@ exits:
     stage: F000
     room: 0
     index: 10
-    req_index: 1839
+    req_index: 1838
     short_name: Wryna's House Exit
   \Skyloft\Skyloft Village\Bertie's House\Exit:
     type: exit
@@ -10234,7 +10234,7 @@ exits:
     stage: F014r
     room: 0
     index: 0
-    req_index: 1840
+    req_index: 1839
     short_name: Bertie's House - Exit
   \Skyloft\Skyloft Village\Bertie's House Exit:
     type: exit
@@ -10242,7 +10242,7 @@ exits:
     stage: F000
     room: 0
     index: 34
-    req_index: 1841
+    req_index: 1840
     short_name: Bertie's House Exit
   \Skyloft\Skyloft Village\Sparrot's House\Exit:
     type: exit
@@ -10250,7 +10250,7 @@ exits:
     stage: F013r
     room: 0
     index: 0
-    req_index: 1842
+    req_index: 1841
     short_name: Sparrot's House - Exit
   \Skyloft\Skyloft Village\Sparrot's House Exit:
     type: exit
@@ -10258,7 +10258,7 @@ exits:
     stage: F000
     room: 0
     index: 33
-    req_index: 1843
+    req_index: 1842
     short_name: Sparrot's House Exit
   \Skyloft\Skyloft Village\Mallara's House Exit:
     type: exit
@@ -10266,7 +10266,7 @@ exits:
     stage: F000
     room: 0
     index: 36
-    req_index: 1844
+    req_index: 1843
     short_name: Skyloft - Mallara's House Exit
   \Skyloft\Skyloft Village\Mallara's House\Exit:
     type: exit
@@ -10274,7 +10274,7 @@ exits:
     stage: F016r
     room: 0
     index: 0
-    req_index: 1845
+    req_index: 1844
     short_name: Mallara's House - Exit
   \Skyloft\Skyloft Village\Batreaux's House\Exit:
     type: exit
@@ -10282,7 +10282,7 @@ exits:
     stage: F012r
     room: 0
     index: 0
-    req_index: 1846
+    req_index: 1845
     short_name: Batreaux's House - Exit
   \Skyloft\Skyloft Village\Batreaux's House Exit:
     type: exit
@@ -10290,7 +10290,7 @@ exits:
     stage: F000
     room: 0
     index: 30
-    req_index: 1847
+    req_index: 1846
     short_name: Batreaux's House Exit
   \Skyloft\Skyloft Village\Gondo's House\Exit:
     type: exit
@@ -10298,7 +10298,7 @@ exits:
     stage: F015r
     room: 0
     index: 0
-    req_index: 1848
+    req_index: 1847
     short_name: Gondo's House - Exit
   \Skyloft\Skyloft Village\Gondo's House Exit:
     type: exit
@@ -10306,7 +10306,7 @@ exits:
     stage: F000
     room: 0
     index: 35
-    req_index: 1849
+    req_index: 1848
     short_name: Gondo's House Exit
   \Skyloft\Skyloft Village\Rupin's House\Exit:
     type: exit
@@ -10314,7 +10314,7 @@ exits:
     stage: F017r
     room: 0
     index: 1
-    req_index: 1850
+    req_index: 1849
     short_name: Rupin's House - Exit
   \Skyloft\Skyloft Village\Rupin's House Exit:
     type: exit
@@ -10322,7 +10322,7 @@ exits:
     stage: F000
     room: 0
     index: 37
-    req_index: 1851
+    req_index: 1850
     short_name: Rupin's House Exit
   \Skyloft\Central Skyloft\Piper's House\Exit:
     type: exit
@@ -10330,7 +10330,7 @@ exits:
     stage: F007r
     room: 0
     index: 0
-    req_index: 1852
+    req_index: 1851
     short_name: Piper's House - Exit
   \Skyloft\Central Skyloft\Piper's House Exit:
     type: exit
@@ -10338,17 +10338,17 @@ exits:
     stage: F000
     room: 0
     index: 32
-    req_index: 1853
+    req_index: 1852
     short_name: Piper's House Exit
   \Skyloft\Central Skyloft\Exit to Sky:
     type: exit
     vanilla: Sky - Entrance from Skyloft
-    req_index: 1854
+    req_index: 1853
     short_name: Skyloft - Exit to Sky
   \Sky\Around Skyloft\Exit to Skyloft:
     type: exit
     vanilla: Skyloft - Entrance from Sky
-    req_index: 1855
+    req_index: 1854
     short_name: Sky - Exit to Skyloft
   \Sky\North East\Bamboo Island\Inside\Exit:
     type: exit
@@ -10356,7 +10356,7 @@ exits:
     stage: F019r
     room: 0
     index: 2
-    req_index: 1856
+    req_index: 1855
     short_name: Bamboo Island - Inside - Exit
   \Sky\North East\Bamboo Island\Exit to Inside:
     type: exit
@@ -10364,7 +10364,7 @@ exits:
     stage: F020
     room: 0
     index: 13
-    req_index: 1857
+    req_index: 1856
     short_name: Bamboo Island - Exit to Inside
   \Sky\North East\Beedle's Island\Beedle's Ship Exit:
     type: exit
@@ -10373,7 +10373,7 @@ exits:
     stage: F020
     room: 0
     index: 14
-    req_index: 1858
+    req_index: 1857
     short_name: Sky - Beedle's Island - Beedle's Ship Exit
   \Sky\North East\Eldin Pillar\First Time Dive:
     type: exit
@@ -10381,7 +10381,7 @@ exits:
     stage: F020
     room: 0
     index: 1
-    req_index: 1859
+    req_index: 1858
     short_name: Sky - Eldin Pillar - First Time Dive
   \Sky\North East\Eldin Pillar\Temple Entrance Statue Dive:
     type: exit
@@ -10389,7 +10389,7 @@ exits:
     stage: F020
     room: 0
     index: 29
-    req_index: 1860
+    req_index: 1859
     short_name: Sky - Eldin Pillar - Temple Entrance Statue Dive
   \Sky\North East\Eldin Pillar\Inside the Volcano Statue Dive:
     type: exit
@@ -10397,7 +10397,7 @@ exits:
     stage: F020
     room: 0
     index: 30
-    req_index: 1861
+    req_index: 1860
     short_name: Sky - Eldin Pillar - Inside the Volcano Statue Dive
   \Sky\North East\Eldin Pillar\Volcano Entrance Statue Dive:
     type: exit
@@ -10405,7 +10405,7 @@ exits:
     stage: F020
     room: 0
     index: 50
-    req_index: 1862
+    req_index: 1861
     short_name: Sky - Eldin Pillar - Volcano Entrance Statue Dive
   \Sky\North East\Eldin Pillar\Volcano East Statue Dive:
     type: exit
@@ -10413,7 +10413,7 @@ exits:
     stage: F020
     room: 0
     index: 51
-    req_index: 1863
+    req_index: 1862
     short_name: Sky - Eldin Pillar - Volcano East Statue Dive
   \Sky\North East\Eldin Pillar\Volcano Ascent Statue Dive:
     type: exit
@@ -10421,7 +10421,7 @@ exits:
     stage: F020
     room: 0
     index: 52
-    req_index: 1864
+    req_index: 1863
     short_name: Sky - Eldin Pillar - Volcano Ascent Statue Dive
   \Sky\North East\Eldin Pillar\Fire Sanctuary Statue Dive:
     type: exit
@@ -10429,7 +10429,7 @@ exits:
     stage: F020
     room: 0
     index: 55
-    req_index: 1865
+    req_index: 1864
     short_name: Sky - Eldin Pillar - Fire Sanctuary Statue Dive
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Exit:
     type: exit
@@ -10437,7 +10437,7 @@ exits:
     stage: F011r
     room: 0
     index: 0
-    req_index: 1866
+    req_index: 1865
     short_name: Lumpy Pumpkin Building - Main Right Door Exit
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Exit:
     type: exit
@@ -10445,7 +10445,7 @@ exits:
     stage: F011r
     room: 0
     index: 1
-    req_index: 1867
+    req_index: 1866
     short_name: Lumpy Pumpkin Building - Main Left Door Exit
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Exit:
     type: exit
@@ -10453,7 +10453,7 @@ exits:
     stage: F011r
     room: 0
     index: 2
-    req_index: 1868
+    req_index: 1867
     short_name: Lumpy Pumpkin Building - Back Door Exit
   \Sky\South East\Lumpy Pumpkin\Main Right Door Exit:
     type: exit
@@ -10461,7 +10461,7 @@ exits:
     stage: F020
     room: 0
     index: 18
-    req_index: 1869
+    req_index: 1868
     short_name: Lumpy Pumpkin - Main Right Door Exit
   \Sky\South East\Lumpy Pumpkin\Main Left Door Exit:
     type: exit
@@ -10469,7 +10469,7 @@ exits:
     stage: F020
     room: 0
     index: 19
-    req_index: 1870
+    req_index: 1869
     short_name: Lumpy Pumpkin - Main Left Door Exit
   \Sky\South East\Lumpy Pumpkin\Back Door Exit:
     type: exit
@@ -10477,7 +10477,7 @@ exits:
     stage: F020
     room: 0
     index: 20
-    req_index: 1871
+    req_index: 1870
     short_name: Lumpy Pumpkin - Back Door Exit
   \Sky\South East\Faron Pillar\First Time Dive:
     type: exit
@@ -10485,7 +10485,7 @@ exits:
     stage: F020
     room: 0
     index: 0
-    req_index: 1872
+    req_index: 1871
     short_name: Sky - Faron Pillar - First Time Dive
   \Sky\South East\Faron Pillar\Sealed Grounds Statue Dive:
     type: exit
@@ -10493,7 +10493,7 @@ exits:
     stage: F020
     room: 0
     index: 68
-    req_index: 1873
+    req_index: 1872
     short_name: Sky - Faron Pillar - Sealed Grounds Statue Dive
   \Sky\South East\Faron Pillar\Forest Temple Statue Dive:
     type: exit
@@ -10501,7 +10501,7 @@ exits:
     stage: F020
     room: 0
     index: 27
-    req_index: 1874
+    req_index: 1873
     short_name: Sky - Faron Pillar - Forest Temple Statue Dive
   \Sky\South East\Faron Pillar\Behind the Temple Statue Dive:
     type: exit
@@ -10509,7 +10509,7 @@ exits:
     stage: F020
     room: 0
     index: 40
-    req_index: 1875
+    req_index: 1874
     short_name: Sky - Faron Pillar - Behind the Temple Statue Dive
   \Sky\South East\Faron Pillar\Faron Woods Entry Statue Dive:
     type: exit
@@ -10517,7 +10517,7 @@ exits:
     stage: F020
     room: 0
     index: 41
-    req_index: 1876
+    req_index: 1875
     short_name: Sky - Faron Pillar - Faron Woods Entry Statue Dive
   \Sky\South East\Faron Pillar\In the Woods Statue Dive:
     type: exit
@@ -10525,7 +10525,7 @@ exits:
     stage: F020
     room: 0
     index: 42
-    req_index: 1877
+    req_index: 1876
     short_name: Sky - Faron Pillar - In the Woods Statue Dive
   \Sky\South East\Faron Pillar\Viewing Platform Statue Dive:
     type: exit
@@ -10533,7 +10533,7 @@ exits:
     stage: F020
     room: 0
     index: 43
-    req_index: 1878
+    req_index: 1877
     short_name: Sky - Faron Pillar - Viewing Platform Statue Dive
   \Sky\South East\Faron Pillar\The Great Tree Statue Dive:
     type: exit
@@ -10541,7 +10541,7 @@ exits:
     stage: F020
     room: 0
     index: 44
-    req_index: 1879
+    req_index: 1878
     short_name: Sky - Faron Pillar - The Great Tree Statue Dive
   \Sky\South East\Faron Pillar\Deep Woods Statue Dive:
     type: exit
@@ -10549,7 +10549,7 @@ exits:
     stage: F020
     room: 0
     index: 46
-    req_index: 1880
+    req_index: 1879
     short_name: Sky - Faron Pillar - Deep Woods Statue Dive
   \Sky\South East\Faron Pillar\Lake Floria Statue Dive:
     type: exit
@@ -10557,7 +10557,7 @@ exits:
     stage: F020
     room: 0
     index: 47
-    req_index: 1881
+    req_index: 1880
     short_name: Sky - Faron Pillar - Lake Floria Statue Dive
   \Sky\South East\Faron Pillar\Floria Waterfall Statue Dive:
     type: exit
@@ -10565,7 +10565,7 @@ exits:
     stage: F020
     room: 0
     index: 48
-    req_index: 1882
+    req_index: 1881
     short_name: Sky - Faron Pillar - Floria Waterfall Statue Dive
   \Sky\South West\Lanayru Pillar\First Time Dive:
     type: exit
@@ -10573,7 +10573,7 @@ exits:
     stage: F020
     room: 0
     index: 2
-    req_index: 1883
+    req_index: 1882
     short_name: Sky - Lanayru Pillar - First Time Dive
   \Sky\South West\Lanayru Pillar\Lanayru Mine Entry Statue Dive:
     type: exit
@@ -10581,7 +10581,7 @@ exits:
     stage: F020
     room: 0
     index: 56
-    req_index: 1884
+    req_index: 1883
     short_name: Sky - Lanayru Pillar - Lanayru Mine Entry Statue Dive
   \Sky\South West\Lanayru Pillar\Desert Entrance Statue Dive:
     type: exit
@@ -10589,7 +10589,7 @@ exits:
     stage: F020
     room: 0
     index: 57
-    req_index: 1885
+    req_index: 1884
     short_name: Sky - Lanayru Pillar - Desert Entrance Statue Dive
   \Sky\South West\Lanayru Pillar\West Desert Statue Dive:
     type: exit
@@ -10597,7 +10597,7 @@ exits:
     stage: F020
     room: 0
     index: 58
-    req_index: 1886
+    req_index: 1885
     short_name: Sky - Lanayru Pillar - West Desert Statue Dive
   \Sky\South West\Lanayru Pillar\North Desert Statue Dive:
     type: exit
@@ -10605,7 +10605,7 @@ exits:
     stage: F020
     room: 0
     index: 59
-    req_index: 1887
+    req_index: 1886
     short_name: Sky - Lanayru Pillar - North Desert Statue Dive
   \Sky\South West\Lanayru Pillar\Stone Cache Statue Dive:
     type: exit
@@ -10613,7 +10613,7 @@ exits:
     stage: F020
     room: 0
     index: 60
-    req_index: 1888
+    req_index: 1887
     short_name: Sky - Lanayru Pillar - Stone Cache Statue Dive
   \Sky\South West\Lanayru Pillar\Desert Gorge Statue Dive:
     type: exit
@@ -10621,7 +10621,7 @@ exits:
     stage: F020
     room: 0
     index: 61
-    req_index: 1889
+    req_index: 1888
     short_name: Sky - Lanayru Pillar - Desert Gorge Statue Dive
   \Sky\South West\Lanayru Pillar\Temple of Time Statue Dive:
     type: exit
@@ -10629,7 +10629,7 @@ exits:
     stage: F020
     room: 0
     index: 62
-    req_index: 1890
+    req_index: 1889
     short_name: Sky - Lanayru Pillar - Temple of Time Statue Dive
   \Sky\South West\Lanayru Pillar\Ancient Harbour Statue Dive:
     type: exit
@@ -10637,7 +10637,7 @@ exits:
     stage: F020
     room: 0
     index: 63
-    req_index: 1891
+    req_index: 1890
     short_name: Sky - Lanayru Pillar - Ancient Harbour Statue Dive
   \Sky\South West\Lanayru Pillar\Skipper's Retreat Statue Dive:
     type: exit
@@ -10645,7 +10645,7 @@ exits:
     stage: F020
     room: 0
     index: 64
-    req_index: 1892
+    req_index: 1891
     short_name: Sky - Lanayru Pillar - Skipper's Retreat Statue Dive
   \Sky\South West\Lanayru Pillar\Shipyard Statue Dive:
     type: exit
@@ -10653,7 +10653,7 @@ exits:
     stage: F020
     room: 0
     index: 65
-    req_index: 1893
+    req_index: 1892
     short_name: Sky - Lanayru Pillar - Shipyard Statue Dive
   \Sky\South West\Lanayru Pillar\Pirate Stronghold Statue Dive:
     type: exit
@@ -10661,12 +10661,12 @@ exits:
     stage: F020
     room: 0
     index: 66
-    req_index: 1894
+    req_index: 1893
     short_name: Sky - Lanayru Pillar - Pirate Stronghold Statue Dive
   \Sky\South West\Lanayru Pillar\Lanayru Gorge Statue Dive:
     type: exit
     vanilla: Lanayru Gorge - Statue Entrance
-    req_index: 1895
+    req_index: 1894
     short_name: Sky - Lanayru Pillar - Lanayru Gorge Statue Dive
   \Sky\Around Skyloft\Exit to Thunderhead:
     type: exit
@@ -10674,7 +10674,7 @@ exits:
     stage: F020
     room: 0
     index: 25
-    req_index: 1896
+    req_index: 1895
     short_name: Sky - Exit to Thunderhead
   \Sky\Thunderhead\Exit:
     type: exit
@@ -10682,7 +10682,7 @@ exits:
     stage: F023
     room: 0
     index: 1
-    req_index: 1897
+    req_index: 1896
     short_name: Thunderhead - Exit
   \Sky\Thunderhead\Isle of Songs\Inside\Exit:
     type: exit
@@ -10690,7 +10690,7 @@ exits:
     stage: F010r
     room: 0
     index: 0
-    req_index: 1898
+    req_index: 1897
     short_name: Isle of Songs - Exit
   \Sky\Thunderhead\Isle of Songs\Exit to Inside:
     type: exit
@@ -10698,7 +10698,7 @@ exits:
     stage: F023
     room: 0
     index: 2
-    req_index: 1899
+    req_index: 1898
     short_name: Isle of Songs - Exit to Inside
   \Faron\Sealed Grounds\Spiral\Upper Part\Statue Exit:
     type: exit
@@ -10706,7 +10706,7 @@ exits:
     stage: F401
     room: 1
     index: 19
-    req_index: 1900
+    req_index: 1899
     short_name: Sealed Grounds Spiral - Statue Exit
   \Faron\Sealed Grounds\Spiral\Door Exit:
     type: exit
@@ -10714,7 +10714,7 @@ exits:
     stage: F401
     room: 1
     index: 0
-    req_index: 1901
+    req_index: 1900
     short_name: Sealed Grounds Spiral - Door Exit
   \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Exit to Behind the Temple:
     type: exit
@@ -10722,7 +10722,7 @@ exits:
     stage: F401
     room: 1
     index: 1
-    req_index: 1902
+    req_index: 1901
     short_name: Sealed Grounds Spiral - Shortcut Exit to Behind the Temple
   \Faron\Sealed Grounds\Sealed Temple\Main Exit:
     type: exit
@@ -10730,7 +10730,7 @@ exits:
     stage: F402
     room: 2
     index: 0
-    req_index: 1903
+    req_index: 1902
     short_name: Sealed Temple - Main Exit
   \Faron\Sealed Grounds\Sealed Temple\Side Exit:
     type: exit
@@ -10738,7 +10738,7 @@ exits:
     stage: F402
     room: 2
     index: 1
-    req_index: 1904
+    req_index: 1903
     short_name: Sealed Temple - Side Exit
   \Faron\Sealed Grounds\Sealed Temple\Gate of Time Exit:
     type: exit
@@ -10746,7 +10746,7 @@ exits:
     stage: F402
     room: 2
     index: 5
-    req_index: 1905
+    req_index: 1904
     short_name: Sealed Temple - Gate of Time Exit
   \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Exit:
     type: exit
@@ -10754,7 +10754,7 @@ exits:
     stage: F404
     room: 2
     index: 1
-    req_index: 1906
+    req_index: 1905
     short_name: Hylia's Temple - Gate of Time Exit
   \Faron\Sealed Grounds\Behind the Temple\Statue Exit:
     type: exit
@@ -10762,7 +10762,7 @@ exits:
     stage: F400
     room: 0
     index: 5
-    req_index: 1907
+    req_index: 1906
     short_name: Behind the Temple - Statue Exit
   \Faron\Sealed Grounds\Behind the Temple\Shortcut Exit to Spiral:
     type: exit
@@ -10770,7 +10770,7 @@ exits:
     stage: F400
     room: 0
     index: 0
-    req_index: 1908
+    req_index: 1907
     short_name: Behind the Temple - Shortcut Exit to Spiral
   \Faron\Sealed Grounds\Behind the Temple\Door Exit:
     type: exit
@@ -10778,7 +10778,7 @@ exits:
     stage: F400
     room: 0
     index: 1
-    req_index: 1909
+    req_index: 1908
     short_name: Behind the Temple - Door Exit
   \Faron\Sealed Grounds\Behind the Temple\Exit to Faron Woods:
     type: exit
@@ -10786,7 +10786,7 @@ exits:
     stage: F400
     room: 0
     index: 2
-    req_index: 1910
+    req_index: 1909
     short_name: Behind the Temple - Exit to Faron Woods
   \Faron\Faron Woods\Shared Statue Exit:
     type: exit
@@ -10794,7 +10794,7 @@ exits:
     stage: F100
     room: 0
     index: 10
-    req_index: 1911
+    req_index: 1910
     short_name: Faron Woods - Shared Statue Exit
   \Faron\Faron Woods\Entry\Exit to Behind the Temple:
     type: exit
@@ -10802,7 +10802,7 @@ exits:
     stage: F100
     room: 0
     index: 0
-    req_index: 1912
+    req_index: 1911
     short_name: Faron Woods - Exit to Behind the Temple
   \Faron\Faron Woods\Ledge To Deep Woods\Exit to Deep Woods:
     type: exit
@@ -10810,7 +10810,7 @@ exits:
     stage: F100
     room: 0
     index: 1
-    req_index: 1913
+    req_index: 1912
     short_name: Faron Woods - Exit to Deep Woods
   \Faron\Faron Woods\Lake Floria Dive:
     type: exit
@@ -10818,7 +10818,7 @@ exits:
     stage: F100
     room: 0
     index: 9
-    req_index: 1914
+    req_index: 1913
     short_name: Faron Woods - Lake Floria Dive
   \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Exit to Floria Waterfall:
     type: exit
@@ -10826,17 +10826,17 @@ exits:
     stage: F100
     room: 0
     index: 11
-    req_index: 1915
+    req_index: 1914
     short_name: Faron Woods - Shortcut Exit to Floria Waterfall
   \Faron\Faron Woods\Trial Gate Exit:
     type: exit
     vanilla: Faron Silent Realm - Entrance
-    req_index: 1916
+    req_index: 1915
     short_name: Faron Woods - Trial Gate Exit
   \Faron\Faron Silent Realm\Exit:
     type: exit
     vanilla: Faron Woods - Trial Gate Entrance
-    req_index: 1917
+    req_index: 1916
     short_name: Faron Silent Realm - Exit
   \Faron\Faron Woods\Great Tree\Platforms\Lower Exit to Great Tree:
     type: exit
@@ -10844,7 +10844,7 @@ exits:
     stage: F100
     room: 0
     index: 3
-    req_index: 1918
+    req_index: 1917
     short_name: Great Tree - Platforms - Lower Exit to Great Tree
   \Faron\Faron Woods\Great Tree\Platforms\Upper Exit to Great Tree:
     type: exit
@@ -10852,7 +10852,7 @@ exits:
     stage: F100
     room: 0
     index: 4
-    req_index: 1919
+    req_index: 1918
     short_name: Great Tree - Platforms - Upper Exit to Great Tree
   \Faron\Faron Woods\Great Tree\Top\Top Exit to Great Tree:
     type: exit
@@ -10860,7 +10860,7 @@ exits:
     stage: F100
     room: 0
     index: 5
-    req_index: 1920
+    req_index: 1919
     short_name: Great Tree - Top Exit to Great Tree
   \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Exit:
     type: exit
@@ -10868,7 +10868,7 @@ exits:
     stage: F100
     room: 0
     index: 6
-    req_index: 1921
+    req_index: 1920
     short_name: Great Tree - Underwater Hole Exit
   \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Exit to Platforms:
     type: exit
@@ -10876,7 +10876,7 @@ exits:
     stage: F100_1
     room: 0
     index: 1
-    req_index: 1922
+    req_index: 1921
     short_name: Great Tree - Lower Exit to Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Upper Exit to Platforms:
     type: exit
@@ -10884,7 +10884,7 @@ exits:
     stage: F100_1
     room: 0
     index: 2
-    req_index: 1923
+    req_index: 1922
     short_name: Great Tree - Upper Exit to Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Exit to Top:
     type: exit
@@ -10892,7 +10892,7 @@ exits:
     stage: F100_1
     room: 0
     index: 3
-    req_index: 1924
+    req_index: 1923
     short_name: Great Tree - Exit to Top
   \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Exit:
     type: exit
@@ -10900,37 +10900,37 @@ exits:
     stage: F100_1
     room: 0
     index: 4
-    req_index: 1925
+    req_index: 1924
     short_name: Great Tree - Underwater Tunnel Exit
   \Faron\Faron Woods\Great Tree\Upper Area\Exit to Flooded Great Tree:
     type: exit
     vanilla: Flooded Great Tree - Entrance
-    req_index: 1926
+    req_index: 1925
     short_name: Great Tree - Exit to Flooded Great Tree
   \Faron\Flooded Faron Woods\Flooded Great Tree\Exit:
     type: exit
     vanilla: Entrance from Flooded Great Tree
-    req_index: 1927
+    req_index: 1926
     short_name: Flooded Great Tree - Exit
   \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Upper Flooded Faron Woods:
     type: exit
     vanilla: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
-    req_index: 1928
+    req_index: 1927
     short_name: Flooded Great Tree - Exit to Upper Flooded Faron Woods
   \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Lower Flooded Faron Woods:
     type: exit
     vanilla: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
-    req_index: 1929
+    req_index: 1928
     short_name: Flooded Great Tree - Exit to Lower Flooded Faron Woods
   \Faron\Flooded Faron Woods\Exit to Upper Flooded Great Tree:
     type: exit
     vanilla: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
-    req_index: 1930
+    req_index: 1929
     short_name: Flooded Faron Woods - Exit to Upper Flooded Great Tree
   \Faron\Flooded Faron Woods\Exit to Lower Flooded Great Tree:
     type: exit
     vanilla: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
-    req_index: 1931
+    req_index: 1930
     short_name: Flooded Faron Woods - Exit to Lower Flooded Great Tree
   \Faron\Faron Woods\Deep Woods\Shared Statue Exit:
     type: exit
@@ -10938,7 +10938,7 @@ exits:
     stage: F101
     room: 0
     index: 2
-    req_index: 1932
+    req_index: 1931
     short_name: Deep Woods - Shared Statue Exit
   \Faron\Faron Woods\Deep Woods\Entry\Exit to Faron Woods:
     type: exit
@@ -10946,7 +10946,7 @@ exits:
     stage: F101
     room: 0
     index: 0
-    req_index: 1933
+    req_index: 1932
     short_name: Deep Woods - Exit to Faron Woods
   \Faron\Faron Woods\Deep Woods\Exit to Skyview Temple:
     type: exit
@@ -10954,7 +10954,7 @@ exits:
     stage: F101
     room: 0
     index: 1
-    req_index: 1934
+    req_index: 1933
     short_name: Deep Woods - Exit to Skyview Temple
   \Faron\Lake Floria\Below Rock\Emerged Area\Statue Exit:
     type: exit
@@ -10962,7 +10962,7 @@ exits:
     stage: F102
     room: 3
     index: 0
-    req_index: 1935
+    req_index: 1934
     short_name: Lake Floria - Below Rock - Statue Exit
   \Faron\Lake Floria\Below Rock\Exit to Farore's Lair:
     type: exit
@@ -10970,7 +10970,7 @@ exits:
     stage: F102
     room: 4
     index: 0
-    req_index: 1936
+    req_index: 1935
     short_name: Lake Floria - Exit to Farore's Lair
   \Faron\Lake Floria\Farore's Lair\Exit to Lake Floria:
     type: exit
@@ -10978,7 +10978,7 @@ exits:
     stage: F102_2
     room: 0
     index: 0
-    req_index: 1937
+    req_index: 1936
     short_name: Farore's Lair - Exit to Lake Floria
   \Faron\Lake Floria\Farore's Lair\Exit to Waterfall:
     type: exit
@@ -10986,7 +10986,7 @@ exits:
     stage: F102_2
     room: 0
     index: 1
-    req_index: 1938
+    req_index: 1937
     short_name: Farore's Lair - Exit to Waterfall
   \Faron\Lake Floria\Waterfall\Statue Exit:
     type: exit
@@ -10994,7 +10994,7 @@ exits:
     stage: F102_1
     room: 0
     index: 3
-    req_index: 1939
+    req_index: 1938
     short_name: Floria Waterfall - Statue Exit
   \Faron\Lake Floria\Waterfall\Exit to Farore's Lair:
     type: exit
@@ -11002,7 +11002,7 @@ exits:
     stage: F102_1
     room: 0
     index: 0
-    req_index: 1940
+    req_index: 1939
     short_name: Floria Waterfall - Exit to Farore's Lair
   \Faron\Lake Floria\Waterfall\Exit to Ancient Cistern:
     type: exit
@@ -11010,7 +11010,7 @@ exits:
     stage: F102_1
     room: 0
     index: 1
-    req_index: 1941
+    req_index: 1940
     short_name: Floria Waterfall - Exit to Ancient Cistern
   \Faron\Lake Floria\Waterfall\Exit to Faron Woods:
     type: exit
@@ -11018,57 +11018,57 @@ exits:
     stage: F102_1
     room: 0
     index: 2
-    req_index: 1942
+    req_index: 1941
     short_name: Floria Waterfall - Exit to Faron Woods
   \Skyview\Main\Entry\Main Exit:
     type: exit
     vanilla: Deep Woods - Entrance from Skyview Temple
-    req_index: 1943
+    req_index: 1942
     short_name: Skyview Temple - Main Exit
   \Skyview\Main\Last Room\After Rope\Boss Door Exit:
     type: exit
     vanilla: Skyview Temple - Boss Room - Entrance from Dungeon
-    req_index: 1944
+    req_index: 1943
     short_name: Skyview Temple - Boss Door Exit
   \Skyview\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Skyview Temple - Boss Door Entrance
-    req_index: 1945
+    req_index: 1944
     short_name: Skyview Temple - Boss Room - Exit to Dungeon
   \Skyview\Boss Room\Exit to Spring:
     type: exit
     vanilla: Skyview Temple - Spring - Entrance
-    req_index: 1946
+    req_index: 1945
     short_name: Skyview Temple - Boss Room - Exit to Spring
   \Skyview\Spring\Exit:
     type: exit
     vanilla: Skyview Temple - Boss Room - Entrance from Spring
-    req_index: 1947
+    req_index: 1946
     short_name: Skyview Temple - Spring - Exit
   \Ancient Cistern\Main\Main Room\Main Exit:
     type: exit
     vanilla: Floria Waterfall - Entrance from Ancient Cistern
-    req_index: 1948
+    req_index: 1947
     short_name: Ancient Cistern - Main Exit
   \Ancient Cistern\Main\Inside Statue\Boss Door Exit:
     type: exit
     vanilla: Ancient Cistern - Boss Room - Entrance from Dungeon
-    req_index: 1949
+    req_index: 1948
     short_name: Ancient Cistern - Boss Door Exit
   \Ancient Cistern\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Ancient Cistern - Boss Door Entrance
-    req_index: 1950
+    req_index: 1949
     short_name: Ancient Cistern - Boss Room - Exit to Dungeon
   \Ancient Cistern\Boss Room\Exit to Flame Room:
     type: exit
     vanilla: Ancient Cistern - Flame Room - Entrance
-    req_index: 1951
+    req_index: 1950
     short_name: Ancient Cistern - Boss Room - Exit to Flame Room
   \Ancient Cistern\Flame Room\Exit:
     type: exit
     vanilla: Ancient Cistern - Boss Room - Entrance from Flame Room
-    req_index: 1952
+    req_index: 1951
     short_name: Ancient Cistern - Flame Room - Exit
   \Eldin\Volcano\Entry\Volcano Entrance Statue Exit:
     type: exit
@@ -11076,7 +11076,7 @@ exits:
     stage: F200
     room: 0
     index: 0
-    req_index: 1953
+    req_index: 1952
     short_name: Eldin Volcano - Volcano Entrance Statue Exit
   \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit:
     type: exit
@@ -11084,7 +11084,7 @@ exits:
     stage: F200
     room: 2
     index: 2
-    req_index: 1954
+    req_index: 1953
     short_name: Eldin Volcano - Volcano East / Volcano Ascent Statue Exit
   \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Exit:
     type: exit
@@ -11092,7 +11092,7 @@ exits:
     stage: F200
     room: 4
     index: 2
-    req_index: 1955
+    req_index: 1954
     short_name: Eldin Volcano - Temple Entrance Statue Exit
   \Eldin\Volcano\East\Dive to Mogma Turf:
     type: exit
@@ -11100,7 +11100,7 @@ exits:
     stage: F200
     room: 2
     index: 1
-    req_index: 1956
+    req_index: 1955
     short_name: Eldin Volcano - Dive to Mogma Turf
   \Eldin\Volcano\Near Temple Entrance\Exit to Earth Temple:
     type: exit
@@ -11108,7 +11108,7 @@ exits:
     stage: F200
     room: 4
     index: 0
-    req_index: 1957
+    req_index: 1956
     short_name: Eldin Volcano - Exit to Earth Temple
   \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Exit:
     type: exit
@@ -11116,7 +11116,7 @@ exits:
     stage: F200
     room: 4
     index: 1
-    req_index: 1958
+    req_index: 1957
     short_name: Eldin Volcano - Thrill Digger Cave Exit
   \Eldin\Volcano\Hot Cave\Exit to Summit:
     type: exit
@@ -11124,27 +11124,27 @@ exits:
     stage: F200
     room: 5
     index: 1
-    req_index: 1959
+    req_index: 1958
     short_name: Eldin Volcano - Exit to Summit
   \Eldin\Volcano\Ascent\Trial Gate Exit:
     type: exit
     vanilla: Eldin Silent Realm - Entrance
-    req_index: 1960
+    req_index: 1959
     short_name: Eldin Volcano - Trial Gate Exit
   \Eldin\Volcano\Past Slide\Vent Exit near Ascent:
     type: exit
     vanilla: Eldin Volcano - Vent Entrance near Hot Cave
-    req_index: 1961
+    req_index: 1960
     short_name: Eldin Volcano - Vent Exit near Ascent
   \Eldin\Volcano\East\Exit to Bokoblin Base:
     type: exit
     vanilla: Bokoblin Base - Entrance
-    req_index: 1962
+    req_index: 1961
     short_name: Eldin Volcano - Exit to Bokoblin Base
   \Eldin\Bokoblin Base\Prison\Exit:
     type: exit
     vanilla: Entrance from Bokoblin Base
-    req_index: 1963
+    req_index: 1962
     short_name: Bokoblin Base - Exit
   \Eldin\Mogma Turf\Pre Vent\First Vent:
     type: exit
@@ -11152,7 +11152,7 @@ exits:
     stage: F210
     room: 0
     index: 0
-    req_index: 1964
+    req_index: 1963
     short_name: Mogma Turf - First Vent
   \Eldin\Mogma Turf\Past Vent\Second Vent:
     type: exit
@@ -11160,7 +11160,7 @@ exits:
     stage: F210
     room: 0
     index: 1
-    req_index: 1965
+    req_index: 1964
     short_name: Mogma Turf - Second Vent
   \Eldin\Volcano\Thrill Digger Cave\Exit:
     type: exit
@@ -11168,12 +11168,12 @@ exits:
     stage: F211
     room: 0
     index: 0
-    req_index: 1966
+    req_index: 1965
     short_name: Thrill Digger Cave - Exit
   \Eldin\Eldin Silent Realm\Exit:
     type: exit
     vanilla: Eldin Volcano - Trial Gate Entrance
-    req_index: 1967
+    req_index: 1966
     short_name: Eldin Silent Realm - Exit
   \Eldin\Volcano Summit\Exit to Eldin Volcano:
     type: exit
@@ -11181,7 +11181,7 @@ exits:
     stage: F201_1
     room: 0
     index: 0
-    req_index: 1968
+    req_index: 1967
     short_name: Volcano Summit - Exit to Eldin Volcano
   \Eldin\Volcano Summit\Exit to Waterfall:
     type: exit
@@ -11189,7 +11189,7 @@ exits:
     stage: F201_1
     room: 0
     index: 1
-    req_index: 1969
+    req_index: 1968
     short_name: Volcano Summit - Exit to Waterfall
   \Eldin\Volcano Summit\Exit to Outside Fire Sanctuary:
     type: exit
@@ -11197,7 +11197,7 @@ exits:
     stage: F201_1
     room: 0
     index: 2
-    req_index: 1970
+    req_index: 1969
     short_name: Volcano Summit - Exit to Outside Fire Sanctuary
   \Eldin\Volcano Summit\Waterfall\Exit:
     type: exit
@@ -11205,7 +11205,7 @@ exits:
     stage: F201_4
     room: 0
     index: 0
-    req_index: 1971
+    req_index: 1970
     short_name: Volcano Summit - Waterfall - Exit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Exit:
     type: exit
@@ -11213,7 +11213,7 @@ exits:
     stage: F201_3
     room: 0
     index: 2
-    req_index: 1972
+    req_index: 1971
     short_name: Outside Fire Sanctuary - Statue Exit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Exit to Summit:
     type: exit
@@ -11221,7 +11221,7 @@ exits:
     stage: F201_3
     room: 0
     index: 0
-    req_index: 1973
+    req_index: 1972
     short_name: Outside Fire Sanctuary - Exit to Summit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Exit to Fire Sanctuary:
     type: exit
@@ -11229,32 +11229,32 @@ exits:
     stage: F201_3
     room: 0
     index: 1
-    req_index: 1974
+    req_index: 1973
     short_name: Outside Fire Sanctuary - Exit to Fire Sanctuary
   \Earth Temple\Main\First Room\Main Exit:
     type: exit
     vanilla: Eldin Volcano - Entrance from Earth Temple
-    req_index: 1975
+    req_index: 1974
     short_name: Earth Temple - Main Exit
   \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Exit:
     type: exit
     vanilla: Earth Temple - Boss Room - Entrance from Dungeon
-    req_index: 1976
+    req_index: 1975
     short_name: Earth Temple - Boss Door Exit
   \Earth Temple\Boss Room\Entry\Exit to Dungeon:
     type: exit
     vanilla: Earth Temple - Boss Door Entrance
-    req_index: 1977
+    req_index: 1976
     short_name: Earth Temple - Boss Room - Exit to Dungeon
   \Earth Temple\Boss Room\Slope\Exit to Spring:
     type: exit
     vanilla: Earth Temple - Spring - Entrance
-    req_index: 1978
+    req_index: 1977
     short_name: Earth Temple - Boss Room - Exit to Spring
   \Earth Temple\Spring\Exit:
     type: exit
     vanilla: Earth Temple - Boss Room - Entrance from Spring
-    req_index: 1979
+    req_index: 1978
     short_name: Earth Temple - Spring - Exit
   \Fire Sanctuary\Main\Front of Boss Door\Statue Exit:
     type: exit
@@ -11262,52 +11262,52 @@ exits:
     stage: D201
     room: 10
     index: 3
-    req_index: 1980
+    req_index: 1979
     short_name: Fire Sanctuary - Statue Exit
   \Fire Sanctuary\Main\First Room\Main Exit:
     type: exit
     vanilla: Outside Fire Sanctuary - Entrance from Fire Sanctuary
-    req_index: 1981
+    req_index: 1980
     short_name: Fire Sanctuary - Main Exit
   \Fire Sanctuary\Main\First Room\Past Water Plant\Exit to Second Room:
     type: exit
     vanilla: Fire Sanctuary - Second Room - Entrance from First Room
-    req_index: 1982
+    req_index: 1981
     short_name: Fire Sanctuary - First Room - Exit to Second Room
   \Fire Sanctuary\Main\Second Room\Outside Section\Exit to First Room:
     type: exit
     vanilla: Fire Sanctuary - First Room - Entrance from Second Room
-    req_index: 1983
+    req_index: 1982
     short_name: Fire Sanctuary - Second Room - Exit to First Room
   \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Exit to West of Boss Door:
     type: exit
     vanilla: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight Room
-    req_index: 1984
+    req_index: 1983
     short_name: Fire Sanctuary - Magmanos Fight Room - Exit to West of Boss Door
   \Fire Sanctuary\Main\West of Boss Door\Entry\Exit to Magmanos Fight Room:
     type: exit
     vanilla: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss Door
-    req_index: 1985
+    req_index: 1984
     short_name: Fire Sanctuary - West of Boss Door - Exit to Magmanos Fight Room
   \Fire Sanctuary\Main\Front of Boss Door\Boss Door Exit:
     type: exit
     vanilla: Fire Sanctuary - Boss Room - Entrance from Dungeon
-    req_index: 1986
+    req_index: 1985
     short_name: Fire Sanctuary - Boss Door Exit
   \Fire Sanctuary\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Fire Sanctuary - Boss Door Entrance
-    req_index: 1987
+    req_index: 1986
     short_name: Fire Sanctuary - Boss Room - Exit to Dungeon
   \Fire Sanctuary\Boss Room\Exit to Flame Room:
     type: exit
     vanilla: Fire Sanctuary - Flame Room - Entrance
-    req_index: 1988
+    req_index: 1987
     short_name: Fire Sanctuary - Boss Room - Exit to Flame Room
   \Fire Sanctuary\Flame Room\Exit:
     type: exit
     vanilla: Fire Sanctuary - Boss Room - Entrance from Flame Room
-    req_index: 1989
+    req_index: 1988
     short_name: Fire Sanctuary - Flame Room - Exit
   \Lanayru\Mine\Entry\Statue Exit:
     type: exit
@@ -11315,7 +11315,7 @@ exits:
     stage: F300_1
     room: 0
     index: 0
-    req_index: 1990
+    req_index: 1989
     short_name: Lanayru Mine - Statue Exit
   \Lanayru\Mine\Entry\Caves Entrance\Exit to Caves:
     type: exit
@@ -11323,7 +11323,7 @@ exits:
     stage: F300_1
     room: 0
     index: 1
-    req_index: 1991
+    req_index: 1990
     short_name: Lanayru Mine - Exit to Caves
   \Lanayru\Mine\End\In Minecart\Exit to Desert:
     type: exit
@@ -11331,7 +11331,7 @@ exits:
     stage: F300_1
     room: 2
     index: 0
-    req_index: 1992
+    req_index: 1991
     short_name: Lanayru Mine - Exit to Desert
   \Lanayru\Desert\Shared Statue Exit:
     type: exit
@@ -11339,7 +11339,7 @@ exits:
     stage: F300
     room: 0
     index: 6
-    req_index: 1993
+    req_index: 1992
     short_name: Lanayru Desert - Shared Statue Exit
   \Lanayru\Desert\North Part\Lightning Node Exit:
     type: exit
@@ -11347,7 +11347,7 @@ exits:
     stage: F300
     room: 0
     index: 0
-    req_index: 1994
+    req_index: 1993
     short_name: Lanayru Desert - Lightning Node Exit
   \Lanayru\Desert\Entry\Exit to Mine:
     type: exit
@@ -11355,7 +11355,7 @@ exits:
     stage: F300
     room: 0
     index: 1
-    req_index: 1995
+    req_index: 1994
     short_name: Lanayru Desert - Exit to Mine
   \Lanayru\Desert\East\Fire Node Exit:
     type: exit
@@ -11363,7 +11363,7 @@ exits:
     stage: F300
     room: 0
     index: 2
-    req_index: 1996
+    req_index: 1995
     short_name: Lanayru Desert - Fire Node Exit
   \Lanayru\Desert\Near South Exit to Temple of Time\South Exit to Temple of Time:
     type: exit
@@ -11371,7 +11371,7 @@ exits:
     stage: F300
     room: 0
     index: 3
-    req_index: 1997
+    req_index: 1996
     short_name: Lanayru Desert - South Exit to Temple of Time
   \Lanayru\Desert\North Part\North Exit to Temple of Time:
     type: exit
@@ -11379,7 +11379,7 @@ exits:
     stage: F300
     room: 0
     index: 4
-    req_index: 1998
+    req_index: 1997
     short_name: Lanayru Desert - North Exit to Temple of Time
   \Lanayru\Desert\Top of LMF\Exit to Lanayru Mining Facility:
     type: exit
@@ -11387,7 +11387,7 @@ exits:
     stage: F300
     room: 0
     index: 5
-    req_index: 1999
+    req_index: 1998
     short_name: Lanayru Desert - Exit to Lanayru Mining Facility
   \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Exit to Caves:
     type: exit
@@ -11395,17 +11395,17 @@ exits:
     stage: F300
     room: 0
     index: 8
-    req_index: 2000
+    req_index: 1999
     short_name: Lanayru Desert - Exit to Caves
   \Lanayru\Desert\North Part\Trial Gate Exit:
     type: exit
     vanilla: Lanayru Silent Realm - Entrance
-    req_index: 2001
+    req_index: 2000
     short_name: Lanayru Desert - Trial Gate Exit
   \Lanayru\Lanayru Silent Realm\Exit:
     type: exit
     vanilla: Lanayru Desert - Trial Gate Entrance
-    req_index: 2002
+    req_index: 2001
     short_name: Lanayru Silent Realm - Exit
   \Lanayru\Desert\North Part\Lightning Node\Present\Exit:
     type: exit
@@ -11413,7 +11413,7 @@ exits:
     stage: F300_2
     room: 0
     index: 0
-    req_index: 2003
+    req_index: 2002
     short_name: Lightning Node - Exit
   \Lanayru\Desert\East\Fire Node\Present\Exit:
     type: exit
@@ -11421,7 +11421,7 @@ exits:
     stage: F300_3
     room: 0
     index: 0
-    req_index: 2004
+    req_index: 2003
     short_name: Fire Node - Exit
   \Lanayru\Temple of Time\Shared Statue Exit:
     type: exit
@@ -11429,7 +11429,7 @@ exits:
     stage: F300_4
     room: 0
     index: 2
-    req_index: 2005
+    req_index: 2004
     short_name: Temple of Time - Shared Statue Exit
   \Lanayru\Temple of Time\South East\South Exit to Desert:
     type: exit
@@ -11437,7 +11437,7 @@ exits:
     stage: F300_4
     room: 0
     index: 0
-    req_index: 2006
+    req_index: 2005
     short_name: Temple of Time - South Exit to Desert
   \Lanayru\Temple of Time\North East\North Exit to Desert:
     type: exit
@@ -11445,7 +11445,7 @@ exits:
     stage: F300_4
     room: 0
     index: 1
-    req_index: 2007
+    req_index: 2006
     short_name: Temple of Time - North Exit to Desert
   \Lanayru\Temple of Time\Inside\Exit to Lanayru Mining Facility:
     type: exit
@@ -11453,7 +11453,7 @@ exits:
     stage: F300_4
     room: 0
     index: 4
-    req_index: 2008
+    req_index: 2007
     short_name: Temple of Time - Exit to Lanayru Mining Facility
   \Lanayru\Caves\Exit to Mine:
     type: exit
@@ -11461,7 +11461,7 @@ exits:
     stage: F303
     room: 0
     index: 0
-    req_index: 2009
+    req_index: 2008
     short_name: Lanayru Caves - Exit to Mine
   \Lanayru\Caves\Exit to Desert:
     type: exit
@@ -11469,7 +11469,7 @@ exits:
     stage: F303
     room: 0
     index: 1
-    req_index: 2010
+    req_index: 2009
     short_name: Lanayru Caves - Exit to Desert
   \Lanayru\Caves\Past Door to Lanayru Sand Sea\Exit to Lanayru Sand Sea:
     type: exit
@@ -11477,22 +11477,22 @@ exits:
     stage: F303
     room: 0
     index: 2
-    req_index: 2011
+    req_index: 2010
     short_name: Lanayru Caves - Exit to Lanayru Sand Sea
   \Lanayru\Caves\Past Crawlspace\Exit to Gorge:
     type: exit
     vanilla: Lanayru Gorge - Entrance
-    req_index: 2012
+    req_index: 2011
     short_name: Lanayru Caves - Exit to Gorge
   \Lanayru\Lanayru Sand Sea\Gorge\Exit:
     type: exit
     vanilla: Lanayru Caves - Entrance from Gorge
-    req_index: 2013
+    req_index: 2012
     short_name: Lanayru Gorge - Exit
   \Lanayru\Lanayru Sand Sea\Gorge\Statue Exit:
     type: exit
     vanilla: Sky - Lanayru Pillar - Entrance
-    req_index: 2014
+    req_index: 2013
     short_name: Lanayru Gorge - Statue Exit
   \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Exit:
     type: exit
@@ -11500,7 +11500,7 @@ exits:
     stage: F301_1
     room: 0
     index: 0
-    req_index: 2015
+    req_index: 2014
     short_name: Lanayru Sand Sea - Ancient Harbour Dock Exit
   \Lanayru\Lanayru Sand Sea\Sandship Dock Exit:
     type: exit
@@ -11508,7 +11508,7 @@ exits:
     stage: F301_1
     room: 0
     index: 1
-    req_index: 2016
+    req_index: 2015
     short_name: Lanayru Sand Sea - Sandship Dock Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Exit:
     type: exit
@@ -11516,7 +11516,7 @@ exits:
     stage: F301_1
     room: 0
     index: 2
-    req_index: 2017
+    req_index: 2016
     short_name: Lanayru Sand Sea - Skipper's Retreat Dock Exit
   \Lanayru\Lanayru Sand Sea\Shipyard Dock Exit:
     type: exit
@@ -11524,7 +11524,7 @@ exits:
     stage: F301_1
     room: 0
     index: 3
-    req_index: 2018
+    req_index: 2017
     short_name: Lanayru Sand Sea - Shipyard Dock Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Exit:
     type: exit
@@ -11532,7 +11532,7 @@ exits:
     stage: F301_1
     room: 0
     index: 4
-    req_index: 2019
+    req_index: 2018
     short_name: Lanayru Sand Sea - Pirate Stronghold Dock Exit
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Exit:
     type: exit
@@ -11540,7 +11540,7 @@ exits:
     stage: F301
     room: 0
     index: 3
-    req_index: 2020
+    req_index: 2019
     short_name: Lanayru Sand Sea Docks - Statue Exit
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Exit to Sandship:
     type: exit
@@ -11548,7 +11548,7 @@ exits:
     stage: F301
     room: 0
     index: 0
-    req_index: 2021
+    req_index: 2020
     short_name: Lanayru Sand Sea Docks - Exit to Sandship
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Exit to Caves:
     type: exit
@@ -11556,7 +11556,7 @@ exits:
     stage: F301
     room: 0
     index: 1
-    req_index: 2022
+    req_index: 2021
     short_name: Lanayru Sand Sea Docks - Exit to Caves
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Exit:
     type: exit
@@ -11564,7 +11564,7 @@ exits:
     stage: F301
     room: 0
     index: 2
-    req_index: 2023
+    req_index: 2022
     short_name: Lanayru Sand Sea Docks - Dock Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Exit:
     type: exit
@@ -11572,7 +11572,7 @@ exits:
     stage: F301_3
     room: 0
     index: 1
-    req_index: 2024
+    req_index: 2023
     short_name: Skipper's Retreat - Statue Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Exit:
     type: exit
@@ -11580,7 +11580,7 @@ exits:
     stage: F301_3
     room: 0
     index: 2
-    req_index: 2025
+    req_index: 2024
     short_name: Skipper's Retreat - Dock Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Exit:
     type: exit
@@ -11588,7 +11588,7 @@ exits:
     stage: F301_3
     room: 0
     index: 3
-    req_index: 2026
+    req_index: 2025
     short_name: Skipper's Retreat - Shack Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Exit:
     type: exit
@@ -11596,7 +11596,7 @@ exits:
     stage: F301_5
     room: 0
     index: 0
-    req_index: 2027
+    req_index: 2026
     short_name: Skipper's Retreat - Shack - Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Statue Exit:
     type: exit
@@ -11604,7 +11604,7 @@ exits:
     stage: F301_4
     room: 0
     index: 1
-    req_index: 2028
+    req_index: 2027
     short_name: Shipyard - Statue Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Dock Exit:
     type: exit
@@ -11612,7 +11612,7 @@ exits:
     stage: F301_4
     room: 0
     index: 2
-    req_index: 2029
+    req_index: 2028
     short_name: Shipyard - Dock Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Exit:
     type: exit
@@ -11620,7 +11620,7 @@ exits:
     stage: F301_4
     room: 0
     index: 3
-    req_index: 2030
+    req_index: 2029
     short_name: Shipyard - Construction Bay Upper Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Exit:
     type: exit
@@ -11628,7 +11628,7 @@ exits:
     stage: F301_4
     room: 0
     index: 4
-    req_index: 2031
+    req_index: 2030
     short_name: Shipyard - Construction Bay Lower Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Exit:
     type: exit
@@ -11636,7 +11636,7 @@ exits:
     stage: F301_7
     room: 0
     index: 0
-    req_index: 2032
+    req_index: 2031
     short_name: Shipyard - Construction Bay - Lower Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Exit:
     type: exit
@@ -11644,7 +11644,7 @@ exits:
     stage: F301_7
     room: 0
     index: 1
-    req_index: 2033
+    req_index: 2032
     short_name: Shipyard - Construction Bay - Upper Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Exit:
     type: exit
@@ -11652,7 +11652,7 @@ exits:
     stage: F301_6
     room: 0
     index: 3
-    req_index: 2034
+    req_index: 2033
     short_name: Pirate Stronghold - Statue Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Exit:
     type: exit
@@ -11660,7 +11660,7 @@ exits:
     stage: F301_6
     room: 0
     index: 0
-    req_index: 2035
+    req_index: 2034
     short_name: Pirate Stronghold - Dock Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Exit:
     type: exit
@@ -11668,7 +11668,7 @@ exits:
     stage: F301_6
     room: 0
     index: 1
-    req_index: 2036
+    req_index: 2035
     short_name: Pirate Stronghold - Side Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Exit:
     type: exit
@@ -11676,7 +11676,7 @@ exits:
     stage: F301_6
     room: 0
     index: 2
-    req_index: 2037
+    req_index: 2036
     short_name: Pirate Stronghold - Top Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Exit:
     type: exit
@@ -11684,7 +11684,7 @@ exits:
     stage: F301_2
     room: 1
     index: 0
-    req_index: 2038
+    req_index: 2037
     short_name: Pirate Stronghold - Inside - First Door Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Exit:
     type: exit
@@ -11692,63 +11692,63 @@ exits:
     stage: F301_2
     room: 1
     index: 2
-    req_index: 2039
+    req_index: 2038
     short_name: Pirate Stronghold - Inside - Second Door Exit
   \Lanayru Mining Facility\Main\First Room\Main Exit:
     type: exit
     vanilla: Lanayru Desert - Entrance from Lanayru Mining Facility
-    req_index: 2040
+    req_index: 2039
     short_name: Lanayru Mining Facility - Main Exit
   \Lanayru Mining Facility\Main\First Hub\Exit to Big Hub:
     type: exit
     vanilla: Lanayru Mining Facility - Big Hub - Entrance from First Hub
-    req_index: 2041
+    req_index: 2040
     short_name: Lanayru Mining Facility - First Hub - Exit to Big Hub
   \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Exit to Big Hub:
     type: exit
     vanilla: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes Room
-    req_index: 2042
+    req_index: 2041
     short_name: Lanayru Mining Facility - Hop Across Boxes Room - Exit to Big Hub
   \Lanayru Mining Facility\Main\Armos Fight Room\Exit to Big Hub:
     type: exit
     vanilla: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
-    req_index: 2043
+    req_index: 2042
     short_name: Lanayru Mining Facility - Armos Fight Room - Exit to Big Hub
   \Lanayru Mining Facility\Main\Big Hub\Entry\Exit to First Hub:
     type: exit
     vanilla: Lanayru Mining Facility - First Hub - Entrance from Big Hub
-    req_index: 2044
+    req_index: 2043
     short_name: Lanayru Mining Facility - Big Hub - Exit to First Hub
   \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Exit to Hop Across Boxes Room:
     type: exit
     vanilla: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big Hub
-    req_index: 2045
+    req_index: 2044
     short_name: Lanayru Mining Facility - Big Hub - Exit to Hop Across Boxes Room
   \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Exit to Armos Fight Room:
     type: exit
     vanilla: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
-    req_index: 2046
+    req_index: 2045
     short_name: Lanayru Mining Facility - Big Hub - Exit to Armos Fight Room
   \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Exit:
     type: exit
     vanilla: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
-    req_index: 2047
+    req_index: 2046
     short_name: Lanayru Mining Facility - Boss Door Exit
   \Lanayru Mining Facility\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Lanayru Mining Facility - Boss Door Entrance
-    req_index: 2048
+    req_index: 2047
     short_name: Lanayru Mining Facility - Boss Room - Exit to Dungeon
   \Lanayru Mining Facility\Boss Room\After Sand Drain\Exit to Hall of Ancient Robots:
     type: exit
     vanilla: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
       Room
-    req_index: 2049
+    req_index: 2048
     short_name: Lanayru Mining Facility - Boss Room - Exit to Hall of Ancient Robots
   \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Exit to Boss Room:
     type: exit
     vanilla: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient Robots
-    req_index: 2050
+    req_index: 2049
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Boss Room
   \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit to Temple of Time:
     type: exit
@@ -11757,23 +11757,23 @@ exits:
     stage: F300_5
     room: 0
     index: 1
-    req_index: 2051
+    req_index: 2050
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Temple
       of Time
   \Sandship\Main\Deck\Main Exit:
     type: exit
     vanilla: Lanayru Sand Sea - Sandship Dock Entrance
-    req_index: 2052
+    req_index: 2051
     short_name: Sandship - Main Exit
   \Sandship\Main\Before Boss Door\Boss Door one-way Exit:
     type: exit
     vanilla: Sandship - Boss Room - Entrance
-    req_index: 2053
+    req_index: 2052
     short_name: Sandship - Boss Door one-way Exit
   \Sky Keep\Main\First Room\Bottom Exit:
     type: exit
     vanilla: Skyloft - Entrance from Sky Keep
-    req_index: 2054
+    req_index: 2053
     short_name: Sky Keep - First Room - Bottom Exit
 entrances:
   \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Start Entrance:
@@ -11787,7 +11787,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2055
+    req_index: 2054
     short_name: Skyloft - Knight Academy - Start Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Chimney:
     type: entrance
@@ -11798,7 +11798,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2056
+    req_index: 2055
     short_name: Skyloft - Knight Academy - Chimney
   \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Entrance:
     type: entrance
@@ -11809,7 +11809,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2058
+    req_index: 2057
     short_name: Skyloft - Knight Academy - Lower Right Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Entrance:
     type: entrance
@@ -11820,7 +11820,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2060
+    req_index: 2059
     short_name: Skyloft - Knight Academy - Lower Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Entrance:
     type: entrance
@@ -11831,7 +11831,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2062
+    req_index: 2061
     short_name: Skyloft - Knight Academy - Upper Right Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Entrance:
     type: entrance
@@ -11842,7 +11842,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2064
+    req_index: 2063
     short_name: Skyloft - Knight Academy - Upper Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Entrance:
     type: entrance
@@ -11853,7 +11853,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2066
+    req_index: 2065
     short_name: Skyloft - Knight Academy Lower Right Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Entrance:
     type: entrance
@@ -11864,7 +11864,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2068
+    req_index: 2067
     short_name: Skyloft - Knight Academy Lower Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Entrance:
     type: entrance
@@ -11875,7 +11875,7 @@ entrances:
     entrance: 23
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2070
+    req_index: 2069
     short_name: Skyloft - Knight Academy Upper Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Entrance:
     type: entrance
@@ -11886,7 +11886,7 @@ entrances:
     entrance: 24
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2072
+    req_index: 2071
     short_name: Skyloft - Knight Academy Upper Right Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Right Door Entrance:
     type: entrance
@@ -11897,7 +11897,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2074
+    req_index: 2073
     short_name: Sparring Hall - Right Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Left Door Entrance:
     type: entrance
@@ -11908,7 +11908,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2076
+    req_index: 2075
     short_name: Sparring Hall - Left Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall Left Door Entrance:
     type: entrance
@@ -11919,7 +11919,7 @@ entrances:
     entrance: 21
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2078
+    req_index: 2077
     short_name: Skyloft - Sparring Hall Left Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall Right Door Entrance:
     type: entrance
@@ -11930,7 +11930,7 @@ entrances:
     entrance: 26
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2080
+    req_index: 2079
     short_name: Skyloft - Sparring Hall Right Door Entrance
   \Skyloft\Upper Skyloft\Goddess Statue\Entrance:
     type: entrance
@@ -11941,7 +11941,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2082
+    req_index: 2081
     short_name: Goddess Statue - Entrance
   \Skyloft\Upper Skyloft\Goddess Statue Entrance:
     type: entrance
@@ -11952,7 +11952,7 @@ entrances:
     entrance: 6
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2084
+    req_index: 2083
     short_name: Goddess Statue Entrance
   \Skyloft\Central Skyloft\Waterfall Cave\Upper Entrance:
     type: entrance
@@ -11963,7 +11963,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2086
+    req_index: 2085
     short_name: Waterfall Cave - Upper Entrance
   \Skyloft\Central Skyloft\Waterfall Cave\Lower Entrance:
     type: entrance
@@ -11974,7 +11974,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2088
+    req_index: 2087
     short_name: Waterfall Cave - Lower Entrance
   \Skyloft\Central Skyloft\Waterfall Cave Upper Entrance:
     type: entrance
@@ -11985,7 +11985,7 @@ entrances:
     entrance: 7
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2090
+    req_index: 2089
     short_name: Waterfall Cave Upper Entrance
   \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Entrance:
     type: entrance
@@ -11996,7 +11996,7 @@ entrances:
     entrance: 8
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2092
+    req_index: 2091
     short_name: Waterfall Cave Lower Entrance
   \Skyloft\Central Skyloft\Bazaar\North Entrance:
     type: entrance
@@ -12007,7 +12007,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2094
+    req_index: 2093
     short_name: Bazaar - North Entrance
   \Skyloft\Central Skyloft\Bazaar\South Entrance:
     type: entrance
@@ -12018,7 +12018,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2095
+    req_index: 2094
     short_name: Bazaar - South Entrance
   \Skyloft\Central Skyloft\Bazaar\West Entrance:
     type: entrance
@@ -12029,7 +12029,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2096
+    req_index: 2095
     short_name: Bazaar - West Entrance
   \Skyloft\Central Skyloft\Bazaar North Entrance:
     type: entrance
@@ -12040,7 +12040,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2097
+    req_index: 2096
     short_name: Bazaar North Entrance
   \Skyloft\Central Skyloft\Bazaar South Entrance:
     type: entrance
@@ -12051,7 +12051,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2099
+    req_index: 2098
     short_name: Bazaar South Entrance
   \Skyloft\Central Skyloft\Bazaar West Entrance:
     type: entrance
@@ -12062,7 +12062,7 @@ entrances:
     entrance: 20
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2101
+    req_index: 2100
     short_name: Bazaar West Entrance
   \Skyloft\Beedle's Shop\Day Entrance:
     type: entrance
@@ -12073,7 +12073,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2103
+    req_index: 2102
     short_name: Beedle's Shop - Day Entrance
   \Skyloft\Beedle's Shop\Night Entrance:
     type: entrance
@@ -12085,7 +12085,7 @@ entrances:
     entrance: 0
     tod: 1
     allowed_time_of_day: 2
-    req_index: 2105
+    req_index: 2104
     short_name: Beedle's Shop - Night Entrance
   \Skyloft\Central Skyloft\Entrance from Beedle's Shop:
     type: entrance
@@ -12096,7 +12096,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2106
+    req_index: 2105
     short_name: Skyloft - Entrance from Beedle's Shop
   \Skyloft\Skyloft Silent Realm\Entrance:
     type: entrance
@@ -12104,7 +12104,7 @@ entrances:
     can-start-at: false
     tod: 0
     allowed_time_of_day: 3
-    req_index: 2108
+    req_index: 2107
     short_name: Skyloft Silent Realm - Entrance
   \Skyloft\Central Skyloft\Trial Gate Entrance:
     type: entrance
@@ -12112,7 +12112,7 @@ entrances:
     can-start-at: false
     tod: 0
     allowed_time_of_day: 3
-    req_index: 2110
+    req_index: 2109
     short_name: Skyloft - Trial Gate Entrance
   \Skyloft\Central Skyloft\Near Temple Entrance\Entrance from Sky Keep:
     type: entrance
@@ -12124,7 +12124,7 @@ entrances:
     entrance: 53
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2112
+    req_index: 2111
     short_name: Skyloft - Entrance from Sky Keep
   \Skyloft\Central Skyloft\Orielle and Parrow's House\Entrance:
     type: entrance
@@ -12135,7 +12135,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2113
+    req_index: 2112
     short_name: Orielle and Parrow's House - Entrance
   \Skyloft\Central Skyloft\Orielle and Parrow's House Entrance:
     type: entrance
@@ -12146,7 +12146,7 @@ entrances:
     entrance: 30
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2115
+    req_index: 2114
     short_name: Orielle and Parrow's House Entrance
   \Skyloft\Central Skyloft\Peatrice's House\Entrance:
     type: entrance
@@ -12157,7 +12157,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2117
+    req_index: 2116
     short_name: Peatrice's House - Entrance
   \Skyloft\Central Skyloft\Peatrice's House Entrance:
     type: entrance
@@ -12168,7 +12168,7 @@ entrances:
     entrance: 38
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2119
+    req_index: 2118
     short_name: Peatrice's House Entrance
   \Skyloft\Central Skyloft\Wryna's House\Entrance:
     type: entrance
@@ -12179,7 +12179,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2121
+    req_index: 2120
     short_name: Wryna's House - Entrance
   \Skyloft\Central Skyloft\Wryna's House Entrance:
     type: entrance
@@ -12190,7 +12190,7 @@ entrances:
     entrance: 31
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2123
+    req_index: 2122
     short_name: Wryna's House Entrance
   \Skyloft\Skyloft Village\Bertie's House\Entrance:
     type: entrance
@@ -12201,7 +12201,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2125
+    req_index: 2124
     short_name: Bertie's House - Entrance
   \Skyloft\Skyloft Village\Bertie's House Entrance:
     type: entrance
@@ -12212,7 +12212,7 @@ entrances:
     entrance: 34
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2127
+    req_index: 2126
     short_name: Bertie's House Entrance
   \Skyloft\Skyloft Village\Sparrot's House\Entrance:
     type: entrance
@@ -12223,7 +12223,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2129
+    req_index: 2128
     short_name: Sparrot's House - Entrance
   \Skyloft\Skyloft Village\Sparrot's House Entrance:
     type: entrance
@@ -12234,7 +12234,7 @@ entrances:
     entrance: 33
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2131
+    req_index: 2130
     short_name: Sparrot's House Entrance
   \Skyloft\Skyloft Village\Mallara's House Entrance:
     type: entrance
@@ -12245,7 +12245,7 @@ entrances:
     entrance: 36
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2133
+    req_index: 2132
     short_name: Skyloft - Mallara's House Entrance
   \Skyloft\Skyloft Village\Mallara's House\Entrance:
     type: entrance
@@ -12256,7 +12256,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2135
+    req_index: 2134
     short_name: Mallara's House - Entrance
   \Skyloft\Skyloft Village\Batreaux's House\Entrance:
     type: entrance
@@ -12267,7 +12267,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2137
+    req_index: 2136
     short_name: Batreaux's House - Entrance
   \Skyloft\Skyloft Village\Batreaux's House Entrance:
     type: entrance
@@ -12278,7 +12278,7 @@ entrances:
     entrance: 29
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2139
+    req_index: 2138
     short_name: Batreaux's House Entrance
   \Skyloft\Skyloft Village\Gondo's House\Entrance:
     type: entrance
@@ -12289,7 +12289,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2141
+    req_index: 2140
     short_name: Gondo's House - Entrance
   \Skyloft\Skyloft Village\Gondo's House Entrance:
     type: entrance
@@ -12300,7 +12300,7 @@ entrances:
     entrance: 35
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2143
+    req_index: 2142
     short_name: Gondo's House Entrance
   \Skyloft\Skyloft Village\Rupin's House\Entrance:
     type: entrance
@@ -12311,7 +12311,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2145
+    req_index: 2144
     short_name: Rupin's House - Entrance
   \Skyloft\Skyloft Village\Rupin's House Entrance:
     type: entrance
@@ -12322,7 +12322,7 @@ entrances:
     entrance: 37
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2147
+    req_index: 2146
     short_name: Rupin's House Entrance
   \Skyloft\Central Skyloft\Piper's House\Entrance:
     type: entrance
@@ -12333,7 +12333,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2149
+    req_index: 2148
     short_name: Piper's House - Entrance
   \Skyloft\Central Skyloft\Piper's House Entrance:
     type: entrance
@@ -12344,7 +12344,7 @@ entrances:
     entrance: 32
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2151
+    req_index: 2150
     short_name: Piper's House Entrance
   \Skyloft\Central Skyloft\Entrance from Sky:
     type: entrance
@@ -12352,7 +12352,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2153
+    req_index: 2152
     short_name: Skyloft - Entrance from Sky
   \Sky\Around Skyloft\Entrance from Skyloft:
     type: entrance
@@ -12360,7 +12360,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2155
+    req_index: 2154
     short_name: Sky - Entrance from Skyloft
   \Sky\North East\Bamboo Island\Inside\Entrance:
     type: entrance
@@ -12371,7 +12371,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2156
+    req_index: 2155
     short_name: Bamboo Island - Inside - Entrance
   \Sky\North East\Bamboo Island\Entrance from Inside:
     type: entrance
@@ -12382,7 +12382,7 @@ entrances:
     entrance: 11
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2157
+    req_index: 2156
     short_name: Bamboo Island - Entrance from Inside
   \Sky\North East\Beedle's Island\Beedle's Ship Entrance:
     type: entrance
@@ -12394,7 +12394,7 @@ entrances:
     entrance: 0
     tod: 1
     allowed_time_of_day: 2
-    req_index: 2158
+    req_index: 2157
     short_name: Sky - Beedle's Island - Beedle's Ship Entrance
   \Sky\North East\Eldin Pillar\Entrance:
     type: entrance
@@ -12406,7 +12406,7 @@ entrances:
     entrance: 13
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2159
+    req_index: 2158
     short_name: Sky - Eldin Pillar - Entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Entrance:
     type: entrance
@@ -12417,7 +12417,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2160
+    req_index: 2159
     short_name: Lumpy Pumpkin Building - Main Right Door Entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Entrance:
     type: entrance
@@ -12428,7 +12428,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2162
+    req_index: 2161
     short_name: Lumpy Pumpkin Building - Main Left Door Entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Entrance:
     type: entrance
@@ -12439,7 +12439,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2164
+    req_index: 2163
     short_name: Lumpy Pumpkin Building - Back Door Entrance
   \Sky\South East\Lumpy Pumpkin\Main Left Door Entrance:
     type: entrance
@@ -12450,7 +12450,7 @@ entrances:
     entrance: 22
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2166
+    req_index: 2165
     short_name: Lumpy Pumpkin - Main Left Door Entrance
   \Sky\South East\Lumpy Pumpkin\Main Right Door Entrance:
     type: entrance
@@ -12461,7 +12461,7 @@ entrances:
     entrance: 23
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2168
+    req_index: 2167
     short_name: Lumpy Pumpkin - Main Right Door Entrance
   \Sky\South East\Lumpy Pumpkin\Back Door Entrance:
     type: entrance
@@ -12472,7 +12472,7 @@ entrances:
     entrance: 24
     tod: 2
     allowed_time_of_day: 3
-    req_index: 2170
+    req_index: 2169
     short_name: Lumpy Pumpkin - Back Door Entrance
   \Sky\South East\Faron Pillar\Entrance:
     type: entrance
@@ -12484,7 +12484,7 @@ entrances:
     entrance: 12
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2172
+    req_index: 2171
     short_name: Sky - Faron Pillar - Entrance
   \Sky\South West\Lanayru Pillar\Entrance:
     type: entrance
@@ -12495,7 +12495,7 @@ entrances:
     entrance: 14
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2173
+    req_index: 2172
     short_name: Sky - Lanayru Pillar - Entrance
   \Sky\Around Skyloft\Entrance from Thunderhead:
     type: entrance
@@ -12507,7 +12507,7 @@ entrances:
     entrance: 28
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2174
+    req_index: 2173
     short_name: Sky - Entrance from Thunderhead
   \Sky\Thunderhead\Entrance:
     type: entrance
@@ -12519,7 +12519,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2175
+    req_index: 2174
     short_name: Thunderhead - Entrance
   \Sky\Thunderhead\Isle of Songs\Inside\Entrance:
     type: entrance
@@ -12531,7 +12531,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2176
+    req_index: 2175
     short_name: Isle of Songs - Entrance
   \Sky\Thunderhead\Isle of Songs\Entrance from Inside:
     type: entrance
@@ -12543,7 +12543,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2177
+    req_index: 2176
     short_name: Isle of Songs - Entrance from Inside
   \Faron\Sealed Grounds\Spiral\Upper Part\Statue Entrance:
     type: entrance
@@ -12556,7 +12556,7 @@ entrances:
     entrance: 8
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2178
+    req_index: 2177
     short_name: Sealed Grounds Spiral - Statue Entrance
   \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Entrance from Behind the Temple:
     type: entrance
@@ -12567,7 +12567,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2179
+    req_index: 2178
     short_name: Sealed Grounds Spiral - Shortcut Entrance from Behind the Temple
   \Faron\Sealed Grounds\Spiral\Door Entrance:
     type: entrance
@@ -12578,7 +12578,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2180
+    req_index: 2179
     short_name: Sealed Grounds Spiral - Door Entrance
   \Faron\Sealed Grounds\Sealed Temple\Main Entrance:
     type: entrance
@@ -12589,7 +12589,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2181
+    req_index: 2180
     short_name: Sealed Temple - Main Entrance
   \Faron\Sealed Grounds\Sealed Temple\Side Entrance:
     type: entrance
@@ -12600,7 +12600,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2182
+    req_index: 2181
     short_name: Sealed Temple - Side Entrance
   \Faron\Sealed Grounds\Sealed Temple\Gate of Time Entrance:
     type: entrance
@@ -12612,7 +12612,7 @@ entrances:
     entrance: 11
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2183
+    req_index: 2182
     short_name: Sealed Temple - Gate of Time Entrance
   \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Entrance:
     type: entrance
@@ -12624,7 +12624,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2184
+    req_index: 2183
     short_name: Hylia's Temple - Gate of Time Entrance
   \Faron\Sealed Grounds\Behind the Temple\Statue Entrance:
     type: entrance
@@ -12637,7 +12637,7 @@ entrances:
     entrance: 10
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2185
+    req_index: 2184
     short_name: Behind the Temple - Statue Entrance
   \Faron\Sealed Grounds\Behind the Temple\Door Entrance:
     type: entrance
@@ -12648,7 +12648,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2186
+    req_index: 2185
     short_name: Behind the Temple - Door Entrance
   \Faron\Sealed Grounds\Behind the Temple\Shortcut Entrance from Spiral:
     type: entrance
@@ -12660,7 +12660,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2187
+    req_index: 2186
     short_name: Behind the Temple - Shortcut Entrance from Spiral
   \Faron\Sealed Grounds\Behind the Temple\Entrance from Faron Woods:
     type: entrance
@@ -12671,7 +12671,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2188
+    req_index: 2187
     short_name: Behind the Temple - Entrance from Faron Woods
   \Faron\Faron Woods\Entry\Faron Woods Entry Statue Entrance:
     type: entrance
@@ -12684,7 +12684,7 @@ entrances:
     entrance: 50
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2189
+    req_index: 2188
     short_name: Faron Woods - Faron Woods Entry Statue Entrance
   \Faron\Faron Woods\In the Woods Statue Entrance:
     type: entrance
@@ -12697,7 +12697,7 @@ entrances:
     entrance: 51
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2190
+    req_index: 2189
     short_name: Faron Woods - In the Woods Statue Entrance
   \Faron\Faron Woods\Viewing Platform Statue Entrance:
     type: entrance
@@ -12710,7 +12710,7 @@ entrances:
     entrance: 52
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2191
+    req_index: 2190
     short_name: Faron Woods - Viewing Platform Statue Entrance
   \Faron\Faron Woods\Great Tree\Top\The Great Tree Statue Entrance:
     type: entrance
@@ -12723,7 +12723,7 @@ entrances:
     entrance: 53
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2192
+    req_index: 2191
     short_name: Great Tree - The Great Tree Statue Entrance
   \Faron\Faron Woods\Entry\Entrance from Behind the Temple:
     type: entrance
@@ -12734,7 +12734,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2193
+    req_index: 2192
     short_name: Faron Woods - Entrance from Behind the Temple
   \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Entrance from Floria Waterfall:
     type: entrance
@@ -12745,7 +12745,7 @@ entrances:
     entrance: 17
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2194
+    req_index: 2193
     short_name: Faron Woods - Shortcut Entrance from Floria Waterfall
   \Faron\Faron Woods\Ledge To Deep Woods\Entrance from Deep Woods:
     type: entrance
@@ -12756,7 +12756,7 @@ entrances:
     entrance: 45
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2195
+    req_index: 2194
     short_name: Faron Woods - Entrance from Deep Woods
   \Faron\Faron Woods\Trial Gate Entrance:
     type: entrance
@@ -12764,7 +12764,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2196
+    req_index: 2195
     short_name: Faron Woods - Trial Gate Entrance
   \Faron\Faron Silent Realm\Entrance:
     type: entrance
@@ -12772,7 +12772,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2197
+    req_index: 2196
     short_name: Faron Silent Realm - Entrance
   \Faron\Faron Woods\Great Tree\Platforms\Lower Entrance from Great Tree:
     type: entrance
@@ -12783,7 +12783,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2198
+    req_index: 2197
     short_name: Great Tree - Platforms - Lower Entrance from Great Tree
   \Faron\Faron Woods\Great Tree\Platforms\Upper Entrance from Great Tree:
     type: entrance
@@ -12794,7 +12794,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2199
+    req_index: 2198
     short_name: Great Tree - Platforms - Upper Entrance from Great Tree
   \Faron\Faron Woods\Great Tree\Top\Top Entrance from Great Tree:
     type: entrance
@@ -12805,7 +12805,7 @@ entrances:
     entrance: 6
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2200
+    req_index: 2199
     short_name: Great Tree - Top Entrance from Great Tree
   \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Entrance:
     type: entrance
@@ -12817,7 +12817,7 @@ entrances:
     entrance: 7
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2201
+    req_index: 2200
     short_name: Great Tree - Underwater Hole Entrance
   \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Entrance from Platforms:
     type: entrance
@@ -12828,7 +12828,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2202
+    req_index: 2201
     short_name: Great Tree - Lower Entrance from Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Upper Entrance from Platforms:
     type: entrance
@@ -12839,7 +12839,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2203
+    req_index: 2202
     short_name: Great Tree - Upper Entrance from Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Top:
     type: entrance
@@ -12850,7 +12850,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2204
+    req_index: 2203
     short_name: Great Tree - Entrance from Top
   \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Entrance:
     type: entrance
@@ -12862,7 +12862,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2205
+    req_index: 2204
     short_name: Great Tree - Underwater Tunnel Entrance
   \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Flooded Great Tree:
     type: entrance
@@ -12870,27 +12870,27 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2206
+    req_index: 2205
     short_name: Great Tree - Entrance from Flooded Great Tree
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2207
+    req_index: 2206
     short_name: Flooded Great Tree - Entrance
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Upper Flooded Faron Woods:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2208
+    req_index: 2207
     short_name: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Lower Flooded Faron Woods:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2209
+    req_index: 2208
     short_name: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
   \Faron\Flooded Faron Woods\Entrance from Upper Flooded Great Tree:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2210
+    req_index: 2209
     short_name: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
   \Faron\Flooded Faron Woods\Entrance from Lower Flooded Great Tree:
     type: entrance
@@ -12898,7 +12898,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2211
+    req_index: 2210
     short_name: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
   \Faron\Faron Woods\Deep Woods\Forest Temple Statue Entrance:
     type: entrance
@@ -12911,7 +12911,7 @@ entrances:
     entrance: 13
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2212
+    req_index: 2211
     short_name: Deep Woods - Forest Temple Statue Entrance
   \Faron\Faron Woods\Deep Woods\Deep Woods Statue Entrance:
     type: entrance
@@ -12924,7 +12924,7 @@ entrances:
     entrance: 14
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2213
+    req_index: 2212
     short_name: Deep Woods - Deep Woods Statue Entrance
   \Faron\Faron Woods\Deep Woods\Entry\Entrance from Faron Woods:
     type: entrance
@@ -12935,7 +12935,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2214
+    req_index: 2213
     short_name: Deep Woods - Entrance from Faron Woods
   \Faron\Faron Woods\Deep Woods\Entrance from Skyview Temple:
     type: entrance
@@ -12947,7 +12947,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2215
+    req_index: 2214
     short_name: Deep Woods - Entrance from Skyview Temple
   \Faron\Lake Floria\Below Rock\Emerged Area\Statue Entrance:
     type: entrance
@@ -12960,7 +12960,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2216
+    req_index: 2215
     short_name: Lake Floria - Below Rock - Statue Entrance
   \Faron\Lake Floria\Above Rock\Dive from Faron Woods:
     type: entrance
@@ -12972,7 +12972,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2217
+    req_index: 2216
     short_name: Lake Floria - Dive from Faron Woods
   \Faron\Lake Floria\Below Rock\Entrance from Farore's Lair:
     type: entrance
@@ -12984,7 +12984,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2218
+    req_index: 2217
     short_name: Lake Floria - Entrance from Farore's Lair
   \Faron\Lake Floria\Farore's Lair\Entrance from Lake Floria:
     type: entrance
@@ -12996,7 +12996,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2219
+    req_index: 2218
     short_name: Farore's Lair - Entrance from Lake Floria
   \Faron\Lake Floria\Farore's Lair\Entrance from Waterfall:
     type: entrance
@@ -13007,7 +13007,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2220
+    req_index: 2219
     short_name: Farore's Lair - Entrance from Waterfall
   \Faron\Lake Floria\Waterfall\Statue Entrance:
     type: entrance
@@ -13020,7 +13020,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2221
+    req_index: 2220
     short_name: Floria Waterfall - Statue Entrance
   \Faron\Lake Floria\Waterfall\Entrance from Farore's Lair:
     type: entrance
@@ -13031,7 +13031,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2222
+    req_index: 2221
     short_name: Floria Waterfall - Entrance from Farore's Lair
   \Faron\Lake Floria\Waterfall\Entrance from Ancient Cistern:
     type: entrance
@@ -13043,7 +13043,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2223
+    req_index: 2222
     short_name: Floria Waterfall - Entrance from Ancient Cistern
   \Faron\Lake Floria\Waterfall\Entrance from Faron Woods:
     type: entrance
@@ -13054,7 +13054,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2224
+    req_index: 2223
     short_name: Floria Waterfall - Entrance from Faron Woods
   \Skyview\Main\Entry\Main Entrance:
     type: entrance
@@ -13066,7 +13066,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2225
+    req_index: 2224
     short_name: Skyview Temple - Main Entrance
   \Skyview\Main\Last Room\After Rope\Boss Door Entrance:
     type: entrance
@@ -13074,7 +13074,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2226
+    req_index: 2225
     short_name: Skyview Temple - Boss Door Entrance
   \Skyview\Boss Room\Entrance from Dungeon:
     type: entrance
@@ -13082,7 +13082,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2227
+    req_index: 2226
     short_name: Skyview Temple - Boss Room - Entrance from Dungeon
   \Skyview\Boss Room\Entrance from Spring:
     type: entrance
@@ -13090,7 +13090,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2228
+    req_index: 2227
     short_name: Skyview Temple - Boss Room - Entrance from Spring
   \Skyview\Spring\Entrance:
     type: entrance
@@ -13098,7 +13098,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2229
+    req_index: 2228
     short_name: Skyview Temple - Spring - Entrance
   \Ancient Cistern\Main\Main Room\Main Entrance:
     type: entrance
@@ -13110,7 +13110,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2230
+    req_index: 2229
     short_name: Ancient Cistern - Main Entrance
   \Ancient Cistern\Main\Inside Statue\Boss Door Entrance:
     type: entrance
@@ -13118,7 +13118,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2231
+    req_index: 2230
     short_name: Ancient Cistern - Boss Door Entrance
   \Ancient Cistern\Boss Room\Entrance from Dungeon:
     type: entrance
@@ -13126,7 +13126,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2232
+    req_index: 2231
     short_name: Ancient Cistern - Boss Room - Entrance from Dungeon
   \Ancient Cistern\Boss Room\Entrance from Flame Room:
     type: entrance
@@ -13134,7 +13134,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2233
+    req_index: 2232
     short_name: Ancient Cistern - Boss Room - Entrance from Flame Room
   \Ancient Cistern\Flame Room\Entrance:
     type: entrance
@@ -13142,7 +13142,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2234
+    req_index: 2233
     short_name: Ancient Cistern - Flame Room - Entrance
   \Eldin\Volcano\Entry\First Time Entrance:
     type: entrance
@@ -13153,7 +13153,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2235
+    req_index: 2234
     short_name: Eldin Volcano - First Time Entrance
   \Eldin\Volcano\Entry\Volcano Entrance Statue Entrance:
     type: entrance
@@ -13166,7 +13166,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2236
+    req_index: 2235
     short_name: Eldin Volcano - Volcano Entrance Statue Entrance
   \Eldin\Volcano\East\Volcano East Statue Entrance:
     type: entrance
@@ -13179,7 +13179,7 @@ entrances:
     entrance: 6
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2237
+    req_index: 2236
     short_name: Eldin Volcano - Volcano East Statue Entrance
   \Eldin\Volcano\Ascent\Volcano Ascent Statue Entrance:
     type: entrance
@@ -13192,7 +13192,7 @@ entrances:
     entrance: 7
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2238
+    req_index: 2237
     short_name: Eldin Volcano - Volcano Ascent Statue Entrance
   \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Entrance:
     type: entrance
@@ -13205,7 +13205,7 @@ entrances:
     entrance: 7
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2239
+    req_index: 2238
     short_name: Eldin Volcano - Temple Entrance Statue Entrance
   \Eldin\Volcano\East\First Vent from Mogma Turf:
     type: entrance
@@ -13216,7 +13216,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2240
+    req_index: 2239
     short_name: Eldin Volcano - First Vent from Mogma Turf
   \Eldin\Volcano\Past Mogma Turf\Second Vent from Mogma Turf:
     type: entrance
@@ -13227,7 +13227,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2241
+    req_index: 2240
     short_name: Eldin Volcano - Second Vent from Mogma Turf
   \Eldin\Volcano\Near Temple Entrance\Entrance from Earth Temple:
     type: entrance
@@ -13238,7 +13238,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2242
+    req_index: 2241
     short_name: Eldin Volcano - Entrance from Earth Temple
   \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Entrance:
     type: entrance
@@ -13249,7 +13249,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2243
+    req_index: 2242
     short_name: Eldin Volcano - Thrill Digger Cave Entrance
   \Eldin\Volcano\Hot Cave\Entrance from Summit:
     type: entrance
@@ -13261,7 +13261,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2244
+    req_index: 2243
     short_name: Eldin Volcano - Entrance from Summit
   \Eldin\Volcano\Ascent\Trial Gate Entrance:
     type: entrance
@@ -13269,7 +13269,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2245
+    req_index: 2244
     short_name: Eldin Volcano - Trial Gate Entrance
   \Eldin\Volcano\Hot Cave\Vent Entrance near Hot Cave:
     type: entrance
@@ -13277,7 +13277,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2246
+    req_index: 2245
     short_name: Eldin Volcano - Vent Entrance near Hot Cave
   \Eldin\Volcano\East\Entrance from Bokoblin Base:
     type: entrance
@@ -13288,7 +13288,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2247
+    req_index: 2246
     short_name: Eldin Volcano - Entrance from Bokoblin Base
   \Eldin\Bokoblin Base\Prison\Entrance:
     type: entrance
@@ -13299,7 +13299,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2248
+    req_index: 2247
     short_name: Bokoblin Base - Entrance
   \Eldin\Mogma Turf\Pre Vent\Entrance:
     type: entrance
@@ -13310,7 +13310,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2249
+    req_index: 2248
     short_name: Mogma Turf - Entrance
   \Eldin\Volcano\Thrill Digger Cave\Entrance:
     type: entrance
@@ -13321,7 +13321,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2250
+    req_index: 2249
     short_name: Thrill Digger Cave - Entrance
   \Eldin\Eldin Silent Realm\Entrance:
     type: entrance
@@ -13329,7 +13329,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2251
+    req_index: 2250
     short_name: Eldin Silent Realm - Entrance
   \Eldin\Volcano Summit\Entrance from Outside Fire Sanctuary:
     type: entrance
@@ -13341,7 +13341,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2252
+    req_index: 2251
     short_name: Volcano Summit - Entrance from Outside Fire Sanctuary
   \Eldin\Volcano Summit\Entrance from Waterfall:
     type: entrance
@@ -13353,7 +13353,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2253
+    req_index: 2252
     short_name: Volcano Summit - Entrance from Waterfall
   \Eldin\Volcano Summit\Entrance from Eldin Volcano:
     type: entrance
@@ -13365,7 +13365,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2254
+    req_index: 2253
     short_name: Volcano Summit - Entrance from Eldin Volcano
   \Eldin\Volcano Summit\Waterfall\Entrance:
     type: entrance
@@ -13377,7 +13377,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2255
+    req_index: 2254
     short_name: Volcano Summit - Waterfall - Entrance
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Entrance:
     type: entrance
@@ -13390,7 +13390,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2256
+    req_index: 2255
     short_name: Outside Fire Sanctuary - Statue Entrance
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Entrance from Summit:
     type: entrance
@@ -13402,7 +13402,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2257
+    req_index: 2256
     short_name: Outside Fire Sanctuary - Entrance from Summit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Entrance from Fire Sanctuary:
     type: entrance
@@ -13414,7 +13414,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2258
+    req_index: 2257
     short_name: Outside Fire Sanctuary - Entrance from Fire Sanctuary
   \Earth Temple\Main\First Room\Main Entrance:
     type: entrance
@@ -13426,7 +13426,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2259
+    req_index: 2258
     short_name: Earth Temple - Main Entrance
   \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Entrance:
     type: entrance
@@ -13434,7 +13434,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2260
+    req_index: 2259
     short_name: Earth Temple - Boss Door Entrance
   \Earth Temple\Boss Room\Entry\Entrance from Dungeon:
     type: entrance
@@ -13442,7 +13442,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2261
+    req_index: 2260
     short_name: Earth Temple - Boss Room - Entrance from Dungeon
   \Earth Temple\Boss Room\Slope\Entrance from Spring:
     type: entrance
@@ -13450,7 +13450,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2262
+    req_index: 2261
     short_name: Earth Temple - Boss Room - Entrance from Spring
   \Earth Temple\Spring\Entrance:
     type: entrance
@@ -13458,7 +13458,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2263
+    req_index: 2262
     short_name: Earth Temple - Spring - Entrance
   \Fire Sanctuary\Main\Front of Boss Door\Statue Entrance:
     type: entrance
@@ -13472,7 +13472,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2264
+    req_index: 2263
     short_name: Fire Sanctuary - Statue Entrance
   \Fire Sanctuary\Main\First Room\Main Entrance:
     type: entrance
@@ -13484,7 +13484,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2265
+    req_index: 2264
     short_name: Fire Sanctuary - Main Entrance
   \Fire Sanctuary\Main\First Room\Past Water Plant\Entrance from Second Room:
     type: entrance
@@ -13492,7 +13492,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2266
+    req_index: 2265
     short_name: Fire Sanctuary - First Room - Entrance from Second Room
   \Fire Sanctuary\Main\Second Room\Outside Section\Entrance from First Room:
     type: entrance
@@ -13500,7 +13500,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2267
+    req_index: 2266
     short_name: Fire Sanctuary - Second Room - Entrance from First Room
   \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Entrance from West of Boss Door:
     type: entrance
@@ -13508,7 +13508,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2268
+    req_index: 2267
     short_name: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss
       Door
   \Fire Sanctuary\Main\West of Boss Door\Entry\Entrance from Magmanos Fight Room:
@@ -13517,7 +13517,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2269
+    req_index: 2268
     short_name: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight
       Room
   \Fire Sanctuary\Main\Front of Boss Door\Boss Door Entrance:
@@ -13526,7 +13526,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2270
+    req_index: 2269
     short_name: Fire Sanctuary - Boss Door Entrance
   \Fire Sanctuary\Boss Room\Entrance from Dungeon:
     type: entrance
@@ -13534,7 +13534,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2271
+    req_index: 2270
     short_name: Fire Sanctuary - Boss Room - Entrance from Dungeon
   \Fire Sanctuary\Boss Room\Entrance from Flame Room:
     type: entrance
@@ -13542,7 +13542,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2272
+    req_index: 2271
     short_name: Fire Sanctuary - Boss Room - Entrance from Flame Room
   \Fire Sanctuary\Flame Room\Entrance:
     type: entrance
@@ -13550,7 +13550,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2273
+    req_index: 2272
     short_name: Fire Sanctuary - Flame Room - Entrance
   \Lanayru\Mine\Entry\First Time Entrance:
     type: entrance
@@ -13561,7 +13561,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2274
+    req_index: 2273
     short_name: Lanayru Mine - First Time Entrance
   \Lanayru\Mine\Entry\Caves Entrance\Entrance from Caves:
     type: entrance
@@ -13572,7 +13572,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2275
+    req_index: 2274
     short_name: Lanayru Mine - Entrance from Caves
   \Lanayru\Mine\Entry\Statue Entrance:
     type: entrance
@@ -13585,7 +13585,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2276
+    req_index: 2275
     short_name: Lanayru Mine - Statue Entrance
   \Lanayru\Mine\End\In Minecart\Entrance from Desert:
     type: entrance
@@ -13596,7 +13596,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2277
+    req_index: 2276
     short_name: Lanayru Mine - Entrance from Desert
   \Lanayru\Desert\Entry\Desert Entrance Statue Entrance:
     type: entrance
@@ -13609,7 +13609,7 @@ entrances:
     entrance: 15
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2278
+    req_index: 2277
     short_name: Lanayru Desert - Desert Entrance Statue Entrance
   \Lanayru\Desert\West Part\West Desert Statue Entrance:
     type: entrance
@@ -13622,7 +13622,7 @@ entrances:
     entrance: 16
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2279
+    req_index: 2278
     short_name: Lanayru Desert - West Desert Statue Entrance
   \Lanayru\Desert\North Part\North Desert Statue Entrance:
     type: entrance
@@ -13635,7 +13635,7 @@ entrances:
     entrance: 17
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2280
+    req_index: 2279
     short_name: Lanayru Desert - North Desert Statue Entrance
   \Lanayru\Desert\East\Stone Cache Statue Entrance:
     type: entrance
@@ -13648,7 +13648,7 @@ entrances:
     entrance: 18
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2281
+    req_index: 2280
     short_name: Lanayru Desert - Stone Cache Statue Entrance
   \Lanayru\Desert\Near South Exit to Temple of Time\South Entrance from Temple of Time:
     type: entrance
@@ -13659,7 +13659,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2282
+    req_index: 2281
     short_name: Lanayru Desert - South Entrance from Temple of Time
   \Lanayru\Desert\North Part\North Entrance from Temple of Time:
     type: entrance
@@ -13670,7 +13670,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2283
+    req_index: 2282
     short_name: Lanayru Desert - North Entrance from Temple of Time
   \Lanayru\Desert\Entry\Entrance from Mine:
     type: entrance
@@ -13681,7 +13681,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2284
+    req_index: 2283
     short_name: Lanayru Desert - Entrance from Mine
   \Lanayru\Desert\East\Fire Node Entrance:
     type: entrance
@@ -13692,7 +13692,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2285
+    req_index: 2284
     short_name: Lanayru Desert - Fire Node Entrance
   \Lanayru\Desert\Top of LMF\Entrance from Lanayru Mining Facility:
     type: entrance
@@ -13704,7 +13704,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2286
+    req_index: 2285
     short_name: Lanayru Desert - Entrance from Lanayru Mining Facility
   \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Entrance from Caves:
     type: entrance
@@ -13715,7 +13715,7 @@ entrances:
     entrance: 6
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2287
+    req_index: 2286
     short_name: Lanayru Desert - Entrance from Caves
   \Lanayru\Desert\North Part\Lightning Node Entrance:
     type: entrance
@@ -13726,7 +13726,7 @@ entrances:
     entrance: 7
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2288
+    req_index: 2287
     short_name: Lanayru Desert - Lightning Node Entrance
   \Lanayru\Desert\North Part\Trial Gate Entrance:
     type: entrance
@@ -13734,7 +13734,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2289
+    req_index: 2288
     short_name: Lanayru Desert - Trial Gate Entrance
   \Lanayru\Lanayru Silent Realm\Entrance:
     type: entrance
@@ -13742,7 +13742,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2290
+    req_index: 2289
     short_name: Lanayru Silent Realm - Entrance
   \Lanayru\Desert\North Part\Lightning Node\Present\Entrance:
     type: entrance
@@ -13753,7 +13753,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2291
+    req_index: 2290
     short_name: Lightning Node - Entrance
   \Lanayru\Desert\East\Fire Node\Present\Entrance:
     type: entrance
@@ -13764,7 +13764,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2292
+    req_index: 2291
     short_name: Fire Node - Entrance
   \Lanayru\Temple of Time\South East\Desert Gorge Statue Entrance:
     type: entrance
@@ -13777,7 +13777,7 @@ entrances:
     entrance: 16
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2293
+    req_index: 2292
     short_name: Temple of Time - Desert Gorge Statue Entrance
   \Lanayru\Temple of Time\Inside\Temple of Time Statue Entrance:
     type: entrance
@@ -13790,7 +13790,7 @@ entrances:
     entrance: 17
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2294
+    req_index: 2293
     short_name: Temple of Time - Temple of Time Statue Entrance
   \Lanayru\Temple of Time\South East\South Entrance from Desert:
     type: entrance
@@ -13801,7 +13801,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2295
+    req_index: 2294
     short_name: Temple of Time - South Entrance from Desert
   \Lanayru\Temple of Time\North East\North Entrance from Desert:
     type: entrance
@@ -13812,7 +13812,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2296
+    req_index: 2295
     short_name: Temple of Time - North Entrance from Desert
   \Lanayru\Temple of Time\Inside\Entrance from Lanayru Mining Facility:
     type: entrance
@@ -13825,7 +13825,7 @@ entrances:
     entrance: 5
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2297
+    req_index: 2296
     short_name: Temple of Time - Entrance from Lanayru Mining Facility
   \Lanayru\Caves\Entrance from Mine:
     type: entrance
@@ -13836,7 +13836,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2298
+    req_index: 2297
     short_name: Lanayru Caves - Entrance from Mine
   \Lanayru\Caves\Entrance from Desert:
     type: entrance
@@ -13847,7 +13847,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2299
+    req_index: 2298
     short_name: Lanayru Caves - Entrance from Desert
   \Lanayru\Caves\Past Door to Lanayru Sand Sea\Entrance from Lanayru Sand Sea:
     type: entrance
@@ -13859,7 +13859,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2300
+    req_index: 2299
     short_name: Lanayru Caves - Entrance from Lanayru Sand Sea
   \Lanayru\Caves\Past Crawlspace\Entrance from Gorge:
     type: entrance
@@ -13870,7 +13870,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2301
+    req_index: 2300
     short_name: Lanayru Caves - Entrance from Gorge
   \Lanayru\Lanayru Sand Sea\Gorge\Entrance:
     type: entrance
@@ -13881,7 +13881,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2302
+    req_index: 2301
     short_name: Lanayru Gorge - Entrance
   \Lanayru\Lanayru Sand Sea\Gorge\Statue Entrance:
     type: entrance
@@ -13894,7 +13894,7 @@ entrances:
     entrance: 12
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2303
+    req_index: 2302
     short_name: Lanayru Gorge - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Entrance:
     type: entrance
@@ -13905,7 +13905,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2304
+    req_index: 2303
     short_name: Lanayru Sand Sea - Ancient Harbour Dock Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Entrance:
     type: entrance
@@ -13916,7 +13916,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2305
+    req_index: 2304
     short_name: Lanayru Sand Sea - Skipper's Retreat Dock Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard Dock Entrance:
     type: entrance
@@ -13927,7 +13927,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2306
+    req_index: 2305
     short_name: Lanayru Sand Sea - Shipyard Dock Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Entrance:
     type: entrance
@@ -13938,7 +13938,7 @@ entrances:
     entrance: 3
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2307
+    req_index: 2306
     short_name: Lanayru Sand Sea - Pirate Stronghold Dock Entrance
   \Lanayru\Lanayru Sand Sea\Sandship Dock Entrance:
     type: entrance
@@ -13950,7 +13950,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2308
+    req_index: 2307
     short_name: Lanayru Sand Sea - Sandship Dock Entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Entrance:
     type: entrance
@@ -13963,7 +13963,7 @@ entrances:
     entrance: 10
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2309
+    req_index: 2308
     short_name: Lanayru Sand Sea Docks - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Entrance from Caves:
     type: entrance
@@ -13975,7 +13975,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2310
+    req_index: 2309
     short_name: Lanayru Sand Sea Docks - Entrance from Caves
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Entrance:
     type: entrance
@@ -13986,7 +13986,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2311
+    req_index: 2310
     short_name: Lanayru Sand Sea Docks - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Entrance:
     type: entrance
@@ -13999,7 +13999,7 @@ entrances:
     entrance: 10
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2312
+    req_index: 2311
     short_name: Skipper's Retreat - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Entrance:
     type: entrance
@@ -14010,7 +14010,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2313
+    req_index: 2312
     short_name: Skipper's Retreat - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Entrance:
     type: entrance
@@ -14021,7 +14021,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2314
+    req_index: 2313
     short_name: Skipper's Retreat - Shack Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Entrance:
     type: entrance
@@ -14032,7 +14032,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2315
+    req_index: 2314
     short_name: Skipper's Retreat - Shack - Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Statue Entrance:
     type: entrance
@@ -14045,7 +14045,7 @@ entrances:
     entrance: 10
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2316
+    req_index: 2315
     short_name: Shipyard - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Dock Entrance:
     type: entrance
@@ -14056,7 +14056,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2317
+    req_index: 2316
     short_name: Shipyard - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Entrance:
     type: entrance
@@ -14068,7 +14068,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2318
+    req_index: 2317
     short_name: Shipyard - Construction Bay Lower Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Entrance:
     type: entrance
@@ -14080,7 +14080,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2319
+    req_index: 2318
     short_name: Shipyard - Construction Bay Upper Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Entrance:
     type: entrance
@@ -14092,7 +14092,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2320
+    req_index: 2319
     short_name: Shipyard - Construction Bay - Upper Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Entrance:
     type: entrance
@@ -14104,7 +14104,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2321
+    req_index: 2320
     short_name: Shipyard - Construction Bay - Lower Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Entrance:
     type: entrance
@@ -14117,7 +14117,7 @@ entrances:
     entrance: 10
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2322
+    req_index: 2321
     short_name: Pirate Stronghold - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Entrance:
     type: entrance
@@ -14128,7 +14128,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2323
+    req_index: 2322
     short_name: Pirate Stronghold - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Entrance:
     type: entrance
@@ -14139,7 +14139,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2324
+    req_index: 2323
     short_name: Pirate Stronghold - Side Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Entrance:
     type: entrance
@@ -14151,7 +14151,7 @@ entrances:
     entrance: 2
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2325
+    req_index: 2324
     short_name: Pirate Stronghold - Top Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Entrance:
     type: entrance
@@ -14162,7 +14162,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2326
+    req_index: 2325
     short_name: Pirate Stronghold - Inside - First Door Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Entrance:
     type: entrance
@@ -14174,7 +14174,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2327
+    req_index: 2326
     short_name: Pirate Stronghold - Inside - Second Door Entrance
   \Lanayru Mining Facility\Main\First Room\Main Entrance:
     type: entrance
@@ -14186,7 +14186,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2328
+    req_index: 2327
     short_name: Lanayru Mining Facility - Main Entrance
   \Lanayru Mining Facility\Main\First Hub\Entrance from Big Hub:
     type: entrance
@@ -14194,7 +14194,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2329
+    req_index: 2328
     short_name: Lanayru Mining Facility - First Hub - Entrance from Big Hub
   \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Entrance from Big Hub:
     type: entrance
@@ -14202,7 +14202,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2330
+    req_index: 2329
     short_name: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big
       Hub
   \Lanayru Mining Facility\Main\Armos Fight Room\Entrance from Big Hub:
@@ -14211,7 +14211,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2331
+    req_index: 2330
     short_name: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
   \Lanayru Mining Facility\Main\Big Hub\Entry\Entrance from First Hub:
     type: entrance
@@ -14219,7 +14219,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2332
+    req_index: 2331
     short_name: Lanayru Mining Facility - Big Hub - Entrance from First Hub
   \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Entrance from Hop Across Boxes Room:
     type: entrance
@@ -14227,7 +14227,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2333
+    req_index: 2332
     short_name: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes
       Room
   \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Entrance from Armos Fight Room:
@@ -14236,7 +14236,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2334
+    req_index: 2333
     short_name: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
   \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Entrance:
     type: entrance
@@ -14244,7 +14244,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2335
+    req_index: 2334
     short_name: Lanayru Mining Facility - Boss Door Entrance
   \Lanayru Mining Facility\Boss Room\Entrance from Dungeon:
     type: entrance
@@ -14252,7 +14252,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2336
+    req_index: 2335
     short_name: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
   \Lanayru Mining Facility\Boss Room\After Sand Drain\Entrance from Hall of Ancient Robots:
     type: entrance
@@ -14260,7 +14260,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2337
+    req_index: 2336
     short_name: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient
       Robots
   \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Entrance from Boss Room:
@@ -14269,7 +14269,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2338
+    req_index: 2337
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
       Room
   \Lanayru Mining Facility\Hall of Ancient Robots\End\Entrance from Temple of Time:
@@ -14283,7 +14283,7 @@ entrances:
     entrance: 1
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2339
+    req_index: 2338
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Temple
       of Time
   \Sandship\Main\Deck\Main Entrance:
@@ -14296,7 +14296,7 @@ entrances:
     entrance: 0
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2340
+    req_index: 2339
     short_name: Sandship - Main Entrance
   \Sandship\Boss Room\Entrance:
     type: entrance
@@ -14304,7 +14304,7 @@ entrances:
     can-start-at: false
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2341
+    req_index: 2340
     short_name: Sandship - Boss Room - Entrance
   \Sky Keep\Main\First Room\Bottom Entrance:
     type: entrance
@@ -14316,7 +14316,7 @@ entrances:
     entrance: 4
     tod: 2
     allowed_time_of_day: 1
-    req_index: 2342
+    req_index: 2341
     short_name: Sky Keep - First Room - Bottom Entrance
 linked_entrances:
   silent_realms:

--- a/dump.yaml
+++ b/dump.yaml
@@ -2413,13 +2413,14 @@ areas:
     Can Afford 100 Rupees: 'True'
     Can Afford 300 Rupees: \Can Medium Rupee Farm
     Can Afford 600 Rupees: "\\Can High Rupee Farm & (\\1 Extra Wallet | \\Big Wallet)"
-    Can Afford 800 Rupees: "\\Can High Rupee Farm & (\\2 Extra Wallets | \\Medium\
-      \ Wallet & \\1 Extra Wallet | \\Big Wallet)"
-    Can Afford 1000 Rupees: "\\Can High Rupee Farm & (\\3 Extra Wallets | \\Medium\
-      \ Wallet & \\2 Extra Wallets | \\Big Wallet)"
-    Can Afford 1200 Rupees: "\\Can High Rupee Farm & (\\3 Extra Wallets | \\Medium\
-      \ Wallet & \\3 Extra Wallets | \\Big Wallet & \\1 Extra Wallet | \\Giant Wallet)"
-    Can Afford 1600 Rupees: "\\Can High Rupee Farm & (\\Big Wallet & \\2 Extra Wallets\
+    Can Afford 800 Rupees: "\\Can High Rupee Farm & (\\2 Extra Wallets | (\\Medium\
+      \ Wallet & \\1 Extra Wallet) | \\Big Wallet)"
+    Can Afford 1000 Rupees: "\\Can High Rupee Farm & (\\3 Extra Wallets | (\\Medium\
+      \ Wallet & \\2 Extra Wallets) | \\Big Wallet)"
+    Can Afford 1200 Rupees: "\\Can High Rupee Farm & (\\3 Extra Wallets | (\\Medium\
+      \ Wallet & \\3 Extra Wallets) | (\\Big Wallet & \\1 Extra Wallet) | \\Giant\
+      \ Wallet)"
+    Can Afford 1600 Rupees: "\\Can High Rupee Farm & ((\\Big Wallet & \\2 Extra Wallets)\
       \ | \\Giant Wallet)"
     Can Medium Rupee Farm: "\\Sky\\North East\\Bamboo Island\\Inside\\Clean Cut Minigame\
       \ | \\Can High Rupee Farm"
@@ -2451,28 +2452,28 @@ areas:
     12 Gratitude Crystal Packs: Gratitude Crystal Pack x 12
     13 Gratitude Crystal Packs: Gratitude Crystal Pack x 13
     5 Gratitude Crystals: "\\5 Single Gratitude Crystals | \\1 Gratitude Crystal Pack"
-    10 Gratitude Crystals: "\\10 Single Gratitude Crystals | \\5 Single Gratitude\
-      \ Crystals & \\1 Gratitude Crystal Pack | \\2 Gratitude Crystal Packs"
-    30 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\3 Gratitude Crystal\
-      \ Packs | \\10 Single Gratitude Crystals & \\4 Gratitude Crystal Packs | \\\
-      5 Single Gratitude Crystals & \\5 Gratitude Crystal Packs | \\6 Gratitude Crystal\
-      \ Packs"
-    40 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\5 Gratitude Crystal\
-      \ Packs | \\10 Single Gratitude Crystals & \\6 Gratitude Crystal Packs | \\\
-      5 Single Gratitude Crystals & \\7 Gratitude Crystal Packs | \\8 Gratitude Crystal\
-      \ Packs"
-    50 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\7 Gratitude Crystal\
-      \ Packs | \\10 Single Gratitude Crystals & \\8 Gratitude Crystal Packs | \\\
-      5 Single Gratitude Crystals & \\9 Gratitude Crystal Packs | \\10 Gratitude Crystal\
-      \ Packs"
-    70 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\11 Gratitude Crystal\
-      \ Packs | \\10 Single Gratitude Crystals & \\12 Gratitude Crystal Packs | \\\
-      5 Single Gratitude Crystals & \\13 Gratitude Crystal Packs"
+    10 Gratitude Crystals: "\\10 Single Gratitude Crystals | (\\5 Single Gratitude\
+      \ Crystals & \\1 Gratitude Crystal Pack) | \\2 Gratitude Crystal Packs"
+    30 Gratitude Crystals: "(\\15 Single Gratitude Crystals & \\3 Gratitude Crystal\
+      \ Packs) | (\\10 Single Gratitude Crystals & \\4 Gratitude Crystal Packs) |\
+      \ (\\5 Single Gratitude Crystals & \\5 Gratitude Crystal Packs) | \\6 Gratitude\
+      \ Crystal Packs"
+    40 Gratitude Crystals: "(\\15 Single Gratitude Crystals & \\5 Gratitude Crystal\
+      \ Packs) | (\\10 Single Gratitude Crystals & \\6 Gratitude Crystal Packs) |\
+      \ (\\5 Single Gratitude Crystals & \\7 Gratitude Crystal Packs) | \\8 Gratitude\
+      \ Crystal Packs"
+    50 Gratitude Crystals: "(\\15 Single Gratitude Crystals & \\7 Gratitude Crystal\
+      \ Packs) | (\\10 Single Gratitude Crystals & \\8 Gratitude Crystal Packs) |\
+      \ (\\5 Single Gratitude Crystals & \\9 Gratitude Crystal Packs) | \\10 Gratitude\
+      \ Crystal Packs"
+    70 Gratitude Crystals: "(\\15 Single Gratitude Crystals & \\11 Gratitude Crystal\
+      \ Packs) | (\\10 Single Gratitude Crystals & \\12 Gratitude Crystal Packs) |\
+      \ (\\5 Single Gratitude Crystals & \\13 Gratitude Crystal Packs)"
     80 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\13 Gratitude Crystal\
       \ Packs"
     Sword: \Practice Sword
-    Long Range Skyward Strike: "\\Goddess Sword & Upgraded Skyward Strike option |\
-      \ \\True Master Sword"
+    Long Range Skyward Strike: "(\\Goddess Sword & Upgraded Skyward Strike option)\
+      \ | \\True Master Sword"
     Damaging Item: "\\Sword | Bomb Bag | \\Bow"
     Projectile Item: "\\Slingshot | \\Beetle | \\Bow"
     Distance Activator: "\\Slingshot | \\Beetle | Clawshots | \\Bow"
@@ -2481,15 +2482,15 @@ areas:
     Can Hit Switch: "\\Sword | Bomb Bag | Whip | \\Distance Activator"
     Can Hit Timeshift Stone: "\\Sword | Bomb Bag | Whip | \\Distance Activator"
     Can Hit Timeshift Stone in Minecart: "\\Sword | Bomb Bag | \\Distance Activator"
-    Early Lake Floria Tricks: "Early Lake Floria - Fence Hop Trick & \\Practice Sword\
+    Early Lake Floria Tricks: "(Early Lake Floria - Fence Hop Trick & \\Practice Sword)\
       \ | Early Lake Floria - Swordless Rope Floria Trick"
     Can bypass Boko Base Watch Tower: "\\Bow | Bomb Bag | \\Slingshot"
     Can Defeat Bokoblins: \Damaging Item
     Can Defeat Moblins: \Damaging Item
     Can Defeat Keeses: "\\Sword | \\Slingshot | \\Beetle | Whip | Clawshots | \\Bow\
       \ | Bomb Bag"
-    Can Defeat Lizalfos: "\\Sword | Advanced Lizalfos Combat Trick & (Bomb Bag | \\\
-      Bow)"
+    Can Defeat Lizalfos: "\\Sword | (Advanced Lizalfos Combat Trick & (Bomb Bag |\
+      \ \\Bow))"
     Can Defeat Ampilus: \Damaging Item
     Can Defeat Armos: "Gust Bellows & \\Sword"
     Can Defeat Beamos: "\\Sword | \\Bow"
@@ -2536,7 +2537,7 @@ areas:
                   to East Part
                 \Ancient Cistern\Main\Main Room\After Whip Hooks: Whip
                 \Ancient Cistern\Main\Main Room\Vines Area: "\\Ancient Cistern\\Main\\\
-                  Main Room\\Vines Area\\Activate Water Geyser | Whip & Clawshots"
+                  Main Room\\Vines Area\\Activate Water Geyser | (Whip & Clawshots)"
                 \Ancient Cistern\Main\Main Room\Behind the Waterfall: "\\Ancient Cistern\\\
                   Main\\Main Room\\Lever to Block Waterfall & Water Dragon's Scale"
                 \Ancient Cistern\Main\Inside Statue: "\\Ancient Cistern\\Can Lower\
@@ -2777,8 +2778,8 @@ areas:
               entrances: []
               exits:
                 \Ancient Cistern\Main\Inside Statue: 'True'
-                \Ancient Cistern\Main\Basement\Rotating Vines: "Whip & \\Ancient Cistern\\\
-                  Main\\Basement\\Blow Rock | Clawshots"
+                \Ancient Cistern\Main\Basement\Rotating Vines: "(Whip & \\Ancient\
+                  \ Cistern\\Main\\Basement\\Blow Rock) | Clawshots"
                 \Ancient Cistern\Main\Basement\Spider Thread: "\\Ancient Cistern\\\
                   Main\\Basement\\Spider Thread\\Activate Water Geyser | Ancient Cistern\
                   \ - Basement Highflip Trick"
@@ -2787,7 +2788,7 @@ areas:
               hint_region: Ancient Cistern
               locations:
                 Stop Cursed Waterfall: \Beetle
-                Blow Rock: "\\Hook Beetle | Bomb Bag & Bomb Throws Trick"
+                Blow Rock: "\\Hook Beetle | (Bomb Bag & Bomb Throws Trick)"
               name: \Ancient Cistern\Main\Basement
               sub_areas:
                 Rotating Vines:
@@ -2946,10 +2947,10 @@ areas:
               locations:
                 Vent Chest: \Digging Mitts
                 Rupee above Drawbridge: \Beetle
-                Lower Drawbridge: "\\Beetle | \\Bow | \\Long Range Skyward Strike\
-                  \ & Earth Temple - Keese Yeet Trick"
-                Dislodge Boulder: "\\Slingshot | \\Beetle & (Advanced Lizalfos Combat\
-                  \ Trick | \\Can Defeat Lizalfos) | Clawshots | \\Bow | \\Long Range\
+                Lower Drawbridge: "\\Beetle | \\Bow | (\\Long Range Skyward Strike\
+                  \ & Earth Temple - Keese Yeet Trick)"
+                Dislodge Boulder: "\\Slingshot | (\\Beetle & (Advanced Lizalfos Combat\
+                  \ Trick | \\Can Defeat Lizalfos)) | Clawshots | \\Bow | \\Long Range\
                   \ Skyward Strike"
               name: \Earth Temple\Main\First Room
               sub_areas: {}
@@ -2962,9 +2963,9 @@ areas:
               entrances: []
               exits:
                 \Earth Temple\Main\Hub Room\Past Lava Section: "\\Earth Temple\\Main\\\
-                  Hub Room\\Access to Boulder & (\\Earth Temple\\Main\\Hub Room\\\
+                  Hub Room\\Access to Boulder & ((\\Earth Temple\\Main\\Hub Room\\\
                   Wall to Lava Section & \\Earth Temple\\Main\\Hub Room\\Lower Lava\
-                  \ Section Portcullis | \\Earth Temple\\Main\\Hub Room\\Raise Bridge)"
+                  \ Section Portcullis) | \\Earth Temple\\Main\\Hub Room\\Raise Bridge)"
                 \Earth Temple\Main\East Room: \Earth Temple\Main\Hub Room\Access to
                   Boulder
                 \Earth Temple\Main\West Room: \Earth Temple\Main\Hub Room\Rock to
@@ -2981,8 +2982,8 @@ areas:
                   to Boulder
                 Ledd's Gift: \Can Defeat Lizalfos
                 Rock to West Room: "Bomb Bag | \\Hook Beetle"
-                Wall to Lava Section: "Bomb Bag | \\Hook Beetle & \\Earth Temple\\\
-                  Main\\Hub Room\\Access to Boulder"
+                Wall to Lava Section: "Bomb Bag | (\\Hook Beetle & \\Earth Temple\\\
+                  Main\\Hub Room\\Access to Boulder)"
                 Rupee in Lava Tunnel: "\\Earth Temple\\Main\\Hub Room\\Wall to Lava\
                   \ Section & \\Beetle"
                 Lower Lava Section Portcullis: "\\Earth Temple\\Main\\Hub Room\\Wall\
@@ -3051,8 +3052,8 @@ areas:
                 \Earth Temple\Main\Hub Room: 'True'
               hint_region: Earth Temple
               locations:
-                Rock in Second Slope Resting Area: "\\Digging Mitts & Bomb Bag | \\\
-                  Hook Beetle"
+                Rock in Second Slope Resting Area: "(\\Digging Mitts & Bomb Bag) |\
+                  \ \\Hook Beetle"
               name: \Earth Temple\Main\Room with Slopes
               sub_areas:
                 Front of Boss Door:
@@ -3119,8 +3120,8 @@ areas:
                   \ (\\Earth Temple\\Boss Room\\Slope\\Goddess Sword Strat | \\Earth\
                   \ Temple\\Boss Room\\Slope\\Longsword Strat | \\Earth Temple\\Boss\
                   \ Room\\Slope\\Master Sword Strat)"
-                Beat Scaldera: "Bomb Bag & \\Sword | \\Earth Temple\\Boss Room\\Slope\\\
-                  Bomb Flower Scaldera"
+                Beat Scaldera: "(Bomb Bag & \\Sword) | \\Earth Temple\\Boss Room\\\
+                  Slope\\Bomb Flower Scaldera"
                 Heart Container: \Earth Temple\Boss Room\Slope\Beat Scaldera
               name: \Earth Temple\Boss Room\Slope
               sub_areas: {}
@@ -3171,8 +3172,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Volcano Entrance Statue Entrance
               - First Time Entrance
+              - Volcano Entrance Statue Entrance
               exits:
                 Volcano Entrance Statue Exit: \Eldin\Volcano\Entry\Unlock Statue
                 \Eldin\Volcano\Ascent: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
@@ -3209,9 +3210,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Volcano East Statue Entrance
-              - Entrance from Bokoblin Base
               - First Vent from Mogma Turf
+              - Entrance from Bokoblin Base
+              - Volcano East Statue Entrance
               exits:
                 Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\East\Unlock
                   Statue
@@ -3331,8 +3332,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Earth Temple
               - Temple Entrance Statue Entrance
+              - Entrance from Earth Temple
               exits:
                 Temple Entrance Statue Exit: \Eldin\Volcano\Near Temple Entrance\Unlock
                   Statue
@@ -3380,8 +3381,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Vent Entrance near Hot Cave
               - Entrance from Summit
+              - Vent Entrance near Hot Cave
               exits:
                 Exit to Summit: Fireshield Earrings
                 \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Temple Entrance\Blow
@@ -3542,8 +3543,8 @@ areas:
           can_sleep: false
           entrances:
           - Entrance from Eldin Volcano
-          - Entrance from Waterfall
           - Entrance from Outside Fire Sanctuary
+          - Entrance from Waterfall
           exits:
             Exit to Eldin Volcano: Fireshield Earrings
             Exit to Waterfall: Fireshield Earrings
@@ -3956,9 +3957,9 @@ areas:
               can_sleep: false
               entrances:
               - Statue Entrance
+              - Entrance from Faron Woods
               - Shortcut Entrance from Spiral
               - Door Entrance
-              - Entrance from Faron Woods
               exits:
                 Statue Exit: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
                 Door Exit: 'True'
@@ -3980,9 +3981,9 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
+          - Trial Gate Entrance
           - Viewing Platform Statue Entrance
           - In the Woods Statue Entrance
-          - Trial Gate Entrance
           exits:
             \Faron\Faron Woods\Entry: 'True'
             Shared Statue Exit: "\\Faron\\Faron Woods\\Unlock In the Woods Statue\
@@ -4007,9 +4008,9 @@ areas:
             Amber Relic Farming: 'True'
             Hit Vine to Deep Woods: \Distance Activator
             Open Trial Gate: "Goddess's Harp & Farore's Courage"
-            Open Door to Lake Floria: "Open Lake Floria option & Water Dragon's Scale\
-              \ | \\Faron\\Faron Woods\\Great Tree\\Top\\Talk to Yerbal & (\\Goddess\
-              \ Sword | Talk to Yerbal option)"
+            Open Door to Lake Floria: "(Open Lake Floria option & Water Dragon's Scale)\
+              \ | (\\Faron\\Faron Woods\\Great Tree\\Top\\Talk to Yerbal & (\\Goddess\
+              \ Sword | Talk to Yerbal option))"
             Rupee on Hollow Tree Root: 'True'
             Rupee on Hollow Tree Branch: \Beetle
             Rupee on Platform near Floria Door: \Beetle
@@ -4208,8 +4209,8 @@ areas:
                   can_save: false
                   can_sleep: false
                   entrances:
-                  - Upper Entrance from Great Tree
                   - Lower Entrance from Great Tree
+                  - Upper Entrance from Great Tree
                   exits:
                     Lower Exit to Great Tree: 'True'
                     Upper Exit to Great Tree: 'True'
@@ -4226,9 +4227,9 @@ areas:
                   can_save: false
                   can_sleep: false
                   entrances:
+                  - Entrance from Top
                   - Entrance from Flooded Great Tree
                   - Upper Entrance from Platforms
-                  - Entrance from Top
                   exits:
                     \Faron\Faron Woods\Great Tree\Lower Area: \Faron\Faron Woods\Great
                       Tree\Upper Area\Remove Void Plane
@@ -4274,9 +4275,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Skyview Temple
               - Forest Temple Statue Entrance
               - Deep Woods Statue Entrance
+              - Entrance from Skyview Temple
               exits:
                 Shared Statue Exit: 'True'
                 \Faron\Faron Woods\Deep Woods\Entry: 'True'
@@ -4343,8 +4344,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Entrance from Upper Flooded Great Tree
           - Entrance from Lower Flooded Great Tree
+          - Entrance from Upper Flooded Great Tree
           exits:
             Exit to Upper Flooded Great Tree: 'True'
             Exit to Lower Flooded Great Tree: Water Dragon's Scale
@@ -4379,8 +4380,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance
               - Entrance from Lower Flooded Faron Woods
+              - Entrance
               - Entrance from Upper Flooded Faron Woods
               exits:
                 Exit: 'True'
@@ -4466,8 +4467,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Entrance from Lake Floria
               - Entrance from Waterfall
+              - Entrance from Lake Floria
               exits:
                 Exit to Waterfall: 'True'
                 Exit to Lake Floria: Water Dragon's Scale
@@ -4486,9 +4487,9 @@ areas:
               can_sleep: false
               entrances:
               - Statue Entrance
-              - Entrance from Faron Woods
-              - Entrance from Ancient Cistern
               - Entrance from Farore's Lair
+              - Entrance from Ancient Cistern
+              - Entrance from Faron Woods
               exits:
                 Statue Exit: \Faron\Lake Floria\Waterfall\Unlock Statue
                 Exit to Farore's Lair: 'True'
@@ -4924,9 +4925,9 @@ areas:
                 \Fire Sanctuary\Main\Front of Boss Door: "\\Fire Sanctuary\\Main\\\
                   West of Boss Door\\Hit Water Plant & \\Fire Sanctuary\\Main\\West\
                   \ of Boss Door\\Past Plats\\Release Lava"
-                \Fire Sanctuary\Main\West of Boss Door\Past Plats: "\\Fire Sanctuary\\\
+                \Fire Sanctuary\Main\West of Boss Door\Past Plats: "(\\Fire Sanctuary\\\
                   Main\\West of Boss Door\\Catch Plats & (\\Distance Activator | Bomb\
-                  \ Bag) | \\Fire Sanctuary\\Main\\West of Boss Door\\Past Plats\\\
+                  \ Bag)) | \\Fire Sanctuary\\Main\\West of Boss Door\\Past Plats\\\
                   Unlock Shortcut to Pre Plats"
               hint_region: Fire Sanctuary
               locations:
@@ -4979,8 +4980,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Statue Entrance
               - Boss Door Entrance
+              - Statue Entrance
               exits:
                 Statue Exit: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
                 Boss Door Exit: Fire Sanctuary Boss Key
@@ -5143,7 +5144,8 @@ areas:
                 Main Exit: 'True'
               hint_region: Lanayru Mining Facility
               locations:
-                Left Lever: "\\Hook Beetle | Whip & LMF - Whip First Room Switch Trick"
+                Left Lever: "\\Hook Beetle | (Whip & LMF - Whip First Room Switch\
+                  \ Trick)"
                 Right Lever: 'True'
                 Chest behind Bars: \Lanayru Mining Facility\Main\First Room\Right
                   Lever
@@ -5182,10 +5184,10 @@ areas:
                   Facility\Main\Key Locked Room\Activate Timeshift Stone
               hint_region: Lanayru Mining Facility
               locations:
-                Blow Up Boxes: "\\Hook Beetle | Bomb Bag & Bomb Throws Trick"
+                Blow Up Boxes: "\\Hook Beetle | (Bomb Bag & Bomb Throws Trick)"
                 Activate Timeshift Stone: "\\Lanayru Mining Facility\\Main\\Key Locked\
-                  \ Room\\Blow Up Boxes & (\\Bow | \\Beetle | \\Slingshot & LMF -\
-                  \ Keylocked Slingshot Trickshot Trick)"
+                  \ Room\\Blow Up Boxes & (\\Bow | \\Beetle | (\\Slingshot & LMF -\
+                  \ Keylocked Slingshot Trickshot Trick))"
                 Chest in Key Locked Room: \Lanayru Mining Facility\Main\Key Locked
                   Room\Activate Timeshift Stone
               name: \Lanayru Mining Facility\Main\Key Locked Room
@@ -5259,7 +5261,7 @@ areas:
               hint_region: Lanayru Mining Facility
               locations:
                 Activate Timeshift Stone: "Gust Bellows & (\\Slingshot | \\Bow | \\\
-                  Goddess Sword | LMF - Whip Armos Room Timeshift Stone Trick & Whip)"
+                  Goddess Sword | (LMF - Whip Armos Room Timeshift Stone Trick & Whip))"
                 Defeat Armos: "\\Lanayru Mining Facility\\Main\\Armos Fight Room\\\
                   Activate Timeshift Stone & \\Can Defeat Armos"
                 Chest after Armos Fight: \Lanayru Mining Facility\Main\Armos Fight
@@ -5401,7 +5403,7 @@ areas:
                     \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: 'True'
                     \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: 'True'
                     \Lanayru Mining Facility\Main\Near Boss Door: "Gust Bellows |\
-                      \ LMF - Minecart Jump Trick & \\Sword & (Bomb Bag | \\Beetle)"
+                      \ (LMF - Minecart Jump Trick & \\Sword & (Bomb Bag | \\Beetle))"
                   hint_region: Lanayru Mining Facility
                   locations:
                     Push Box: 'True'
@@ -5572,9 +5574,9 @@ areas:
       exits: {}
       hint_region: null
       locations:
-        All Three Nodes: "LMF Nodes On option | \\Lanayru\\Desert\\North Part\\Water\
+        All Three Nodes: "LMF Nodes On option | (\\Lanayru\\Desert\\North Part\\Water\
           \ Node & \\Lanayru\\Desert\\North Part\\Lightning Node\\Past\\Lightning\
-          \ Node & \\Lanayru\\Desert\\East\\Fire Node\\Past after Grate\\Fire Node"
+          \ Node & \\Lanayru\\Desert\\East\\Fire Node\\Past after Grate\\Fire Node)"
         Raise Lanayru Mining Facility: "Open LMF option | \\Lanayru\\Desert\\North\
           \ Part\\Activate Main Node"
         Can Navigate in Oasis: "\\Can Defeat Ampilus | \\Hook Beetle | \\Skyloft\\\
@@ -5599,8 +5601,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Statue Entrance
               - First Time Entrance
+              - Statue Entrance
               exits:
                 Statue Exit: \Lanayru\Mine\Entry\Unlock Statue
                 \Lanayru\Mine\Statues Area: \Lanayru\Mine\Entry\Timeshift Stone
@@ -5717,8 +5719,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Desert Entrance Statue Entrance
               - Entrance from Mine
+              - Desert Entrance Statue Entrance
               exits:
                 Exit to Mine: \Lanayru\Desert\Entry\Timeshift Stone
                 \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\Entry\Unlock Statue
@@ -5776,8 +5778,8 @@ areas:
                 Blow Statues to Sand Oasis Down: \Hook Beetle
                 Get Past Spume to Sand Oasis: "\\Lanayru\\Desert\\Near Caged Robot\\\
                   Blow Statues to Sand Oasis Down | \\Skyloft\\Central Skyloft\\Bazaar\\\
-                  Endurance Potion | Brakeslide Trick & Stuttersprint Trick & (Bomb\
-                  \ Bag | \\Bow | \\Long Range Skyward Strike)"
+                  Endurance Potion | (Brakeslide Trick & Stuttersprint Trick & (Bomb\
+                  \ Bag | \\Bow | \\Long Range Skyward Strike))"
               name: \Lanayru\Desert\Near Caged Robot
               sub_areas: {}
               toplevel_alias: null
@@ -5899,9 +5901,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
+              - Lightning Node Entrance
               - Trial Gate Entrance
               - North Entrance from Temple of Time
-              - Lightning Node Entrance
               - North Desert Statue Entrance
               exits:
                 North Exit to Temple of Time: 'True'
@@ -5923,8 +5925,8 @@ areas:
                   North Part\\Main Node Timeshift Stone & \\Sword"
                 Unlock Statue: 'True'
                 Open Trial Gate: "Nayru's Wisdom & Goddess's Harp"
-                Open Secret Passageway: "Bomb Bag | \\Hook Beetle & Secret Passageway\
-                  \ Hook Beetle Opening Trick | \\Tough Beetle"
+                Open Secret Passageway: "Bomb Bag | (\\Hook Beetle & Secret Passageway\
+                  \ Hook Beetle Opening Trick) | \\Tough Beetle"
                 Chest on Platform near Lightning Node: Clawshots
                 Open Lightning Node: 'True'
                 \Ancient Flower Farming: \Lanayru\Desert\North Part\Main Node Timeshift
@@ -5988,8 +5990,8 @@ areas:
                         \Lanayru\Desert\North Part\Lightning Node\Present: \Projectile
                           Item
                         \Lanayru\Desert\North Part\Lightning Node\Present from afar: "\\\
-                          Beetle | \\Bow | Lightning Node End with Bombs Trick & Bomb\
-                          \ Bag"
+                          Beetle | \\Bow | (Lightning Node End with Bombs Trick &\
+                          \ Bomb Bag)"
                       hint_region: Lanayru Desert
                       locations:
                         First Chest: 'True'
@@ -6023,8 +6025,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Fire Node Entrance
               - Stone Cache Statue Entrance
+              - Fire Node Entrance
               exits:
                 \Lanayru\Desert\North Part: 'True'
                 \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
@@ -6162,14 +6164,14 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Desert Gorge Statue Entrance
               - South Entrance from Desert
+              - Desert Gorge Statue Entrance
               exits:
                 South Exit to Desert: 'True'
                 \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\South
                   East\Unlock Statue
-                \Lanayru\Temple of Time\Front: "\\Hook Beetle | \\Slingshot & Temple\
-                  \ of Time - Slingshot Shot Trick"
+                \Lanayru\Temple of Time\Front: "\\Hook Beetle | (\\Slingshot & Temple\
+                  \ of Time - Slingshot Shot Trick)"
               hint_region: null
               locations:
                 Unlock Statue: 'True'
@@ -6190,8 +6192,8 @@ areas:
               hint_region: null
               locations:
                 Gossip Stone in Temple of Time Area: 'True'
-                Blow up Rock for Timeshift Stone: "\\Hook Beetle | Bomb Throws Trick\
-                  \ & (Bomb Bag | Cactus Bomb Whip Trick & Whip)"
+                Blow up Rock for Timeshift Stone: "\\Hook Beetle | (Bomb Throws Trick\
+                  \ & (Bomb Bag | (Cactus Bomb Whip Trick & Whip)))"
                 Timeshift Stone: "\\Lanayru\\Temple of Time\\Front\\Blow up Rock for\
                   \ Timeshift Stone & \\Distance Activator"
                 Save Robot: "\\Lanayru\\Temple of Time\\Front\\Timeshift Stone & \\\
@@ -6284,8 +6286,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Entrance from Desert
           - Entrance from Mine
+          - Entrance from Desert
           exits:
             \Lanayru\Caves\Past Door to Lanayru Sand Sea: "Clawshots & Lanayru Caves\
               \ Small Key"
@@ -6337,11 +6339,11 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Pirate Stronghold Dock Entrance
           - Ancient Harbour Dock Entrance
+          - Pirate Stronghold Dock Entrance
           - Sandship Dock Entrance
-          - Skipper's Retreat Dock Entrance
           - Shipyard Dock Entrance
+          - Skipper's Retreat Dock Entrance
           exits:
             Ancient Harbour Dock Exit: 'True'
             Sandship Dock Exit: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
@@ -6359,8 +6361,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Statue Entrance
               - Dock Entrance
+              - Statue Entrance
               exits:
                 Dock Exit: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Ship Timeshift
                   Stone
@@ -6409,8 +6411,8 @@ areas:
               hint_region: Lanayru Sand Sea
               locations:
                 Unlock Statue: 'True'
-                Blow up Rock: "Bomb Bag | \\Hook Beetle | Whip & Cactus Bomb Whip\
-                  \ Trick"
+                Blow up Rock: "Bomb Bag | \\Hook Beetle | (Whip & Cactus Bomb Whip\
+                  \ Trick)"
               name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat
               sub_areas:
                 Past Rock:
@@ -6430,8 +6432,8 @@ areas:
                     Chest after Moblin: 'True'
                     Goddess Cube in Skipper's Retreat: "Clawshots & \\Goddess Sword"
                     Whip Peahat: "Clawshots & Whip"
-                    Deal with Deku Baba: "\\Projectile Item | Skipper's Retreat Fast\
-                      \ Clawshots Trick & Clawshots"
+                    Deal with Deku Baba: "\\Projectile Item | (Skipper's Retreat Fast\
+                      \ Clawshots Trick & Clawshots)"
                   name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock
                   sub_areas: {}
                   toplevel_alias: null
@@ -6488,8 +6490,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Statue Entrance
               - Construction Bay Lower Entrance
+              - Statue Entrance
               - Dock Entrance
               - Construction Bay Upper Entrance
               exits:
@@ -6532,8 +6534,8 @@ areas:
               can_sleep: false
               entrances:
               - Statue Entrance
-              - Side Entrance
               - Dock Entrance
+              - Side Entrance
               exits:
                 Statue Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
                 Dock Exit: 'True'
@@ -6974,9 +6976,9 @@ areas:
                   can_sleep: false
                   entrances: []
                   exits:
-                    \Sky Keep\Main\Skyview Room\End: "Whip & \\Sky Keep\\Main\\Skyview\
+                    \Sky Keep\Main\Skyview Room\End: "(Whip & \\Sky Keep\\Main\\Skyview\
                       \ Room\\Beginning\\Free Rope & Clawshots & \\Sky Keep\\Main\\\
-                      Skyview Room\\Beginning\\Kill Pyrups & Gust Bellows | \\Sky\
+                      Skyview Room\\Beginning\\Kill Pyrups & Gust Bellows) | \\Sky\
                       \ Keep\\Main\\Skyview Room\\End\\Lever"
                   hint_region: Sky Keep
                   locations:
@@ -7505,8 +7507,8 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - Main Right Door Entrance
               - Back Door Entrance
+              - Main Right Door Entrance
               - Main Left Door Entrance
               exits:
                 \Sky\South East: Day
@@ -7534,8 +7536,8 @@ areas:
                   can_save: false
                   can_sleep: true
                   entrances:
-                  - Main Right Door Entrance
                   - Back Door Entrance
+                  - Main Right Door Entrance
                   - Main Left Door Entrance
                   exits:
                     Main Right Door Exit: 'True'
@@ -7843,13 +7845,13 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Knight Academy Upper Right Door Entrance
+          - Sparring Hall Right Door Entrance
           - Knight Academy Lower Left Door Entrance
           - Sparring Hall Left Door Entrance
-          - Knight Academy Upper Left Door Entrance
-          - Sparring Hall Right Door Entrance
-          - Goddess Statue Entrance
           - Knight Academy Lower Right Door Entrance
+          - Knight Academy Upper Left Door Entrance
+          - Goddess Statue Entrance
+          - Knight Academy Upper Right Door Entrance
           exits:
             Knight Academy Upper Right Door Exit: 'True'
             Knight Academy Upper Left Door Exit: 'True'
@@ -7873,10 +7875,10 @@ areas:
               can_save: false
               can_sleep: true
               entrances:
-              - Lower Right Door Entrance
+              - Upper Left Door Entrance
               - Lower Left Door Entrance
               - Upper Right Door Entrance
-              - Upper Left Door Entrance
+              - Lower Right Door Entrance
               exits:
                 Upper Right Door Exit: 'True'
                 Upper Left Door Exit: 'True'
@@ -7976,20 +7978,20 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Bazaar West Entrance
-          - Entrance from Sky
-          - Trial Gate Entrance
-          - Waterfall Cave Upper Entrance
-          - Bazaar North Entrance
-          - Wryna's House Entrance
-          - Peatrice's House Entrance
-          - Orielle and Parrow's House Entrance
-          - Entrance from Beedle's Shop
-          - Bazaar South Entrance
           - Piper's House Entrance
+          - Orielle and Parrow's House Entrance
+          - Trial Gate Entrance
+          - Bazaar West Entrance
+          - Peatrice's House Entrance
+          - Wryna's House Entrance
+          - Entrance from Sky
+          - Entrance from Beedle's Shop
+          - Bazaar North Entrance
+          - Waterfall Cave Upper Entrance
+          - Bazaar South Entrance
           exits:
-            Exit to Beedle's Shop: "Day & (\\Distance Activator | Beedle's Shop With\
-              \ Bombs Trick & Bomb Bag)"
+            Exit to Beedle's Shop: "Day & (\\Distance Activator | (Beedle's Shop With\
+              \ Bombs Trick & Bomb Bag))"
             Bazaar North Exit: Day
             Bazaar West Exit: Day
             Bazaar South Exit: Day
@@ -8054,9 +8056,9 @@ areas:
               can_save: false
               can_sleep: false
               entrances:
-              - West Entrance
-              - North Entrance
               - South Entrance
+              - North Entrance
+              - West Entrance
               exits:
                 North Exit: 'True'
                 West Exit: 'True'
@@ -8263,12 +8265,12 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Gondo's House Entrance
-          - Sparrot's House Entrance
           - Mallara's House Entrance
-          - Rupin's House Entrance
-          - Bertie's House Entrance
           - Batreaux's House Entrance
+          - Gondo's House Entrance
+          - Bertie's House Entrance
+          - Rupin's House Entrance
+          - Sparrot's House Entrance
           exits:
             \Skyloft\Central Skyloft: 'True'
             \Skyloft\Central Skyloft\Past Waterfall Cave: "Waterfall Cave Jump Trick\
@@ -8392,8 +8394,8 @@ areas:
           can_save: false
           can_sleep: true
           entrances:
-          - Night Entrance
           - Day Entrance
+          - Night Entrance
           exits:
             Night Exit: Night
             Day Exit: Day
@@ -8439,8 +8441,8 @@ areas:
       hint_region: Skyview
       locations:
         Skyview 2: Water Dragon's Scale
-        Can Hit High Skyview Switches: "\\Distance Activator | Bomb Bag & Bomb Throws\
-          \ Trick"
+        Can Hit High Skyview Switches: "\\Distance Activator | (Bomb Bag & Bomb Throws\
+          \ Trick)"
         Can Cut Tree: "\\Sword | Bomb Bag"
       name: \Skyview
       sub_areas:
@@ -8522,16 +8524,16 @@ areas:
                   to Left Room
                 \Skyview\Main\First Hub\Right Room\Lower Area: \Skyview\Main\First
                   Hub\Switch to Right Room
-                \Skyview\Main\First Hub\Right Room\Upper Area: "\\Skyview\\Main\\\
+                \Skyview\Main\First Hub\Right Room\Upper Area: "(\\Skyview\\Main\\\
                   First Hub\\Left Room\\Raise Water & \\Skyview\\Main\\First Hub\\\
-                  Right Room\\After Crawlspace\\Raise Water | Clawshots"
+                  Right Room\\After Crawlspace\\Raise Water) | Clawshots"
                 \Skyview\Main\Second Hub: "\\Skyview\\Main\\First Hub\\One Water Raise\
                   \ & Skyview Small Key"
               hint_region: Skyview
               locations:
                 \Skyview\Main\First Room\Destroy Barricade: 'True'
-                Switch to Left Room: "\\Can Hit Switch | \\Skyview\\Main\\First Hub\\\
-                  One Water Raise & Water Dragon's Scale"
+                Switch to Left Room: "\\Can Hit Switch | (\\Skyview\\Main\\First Hub\\\
+                  One Water Raise & Water Dragon's Scale)"
                 Switch to Right Room: \Skyview\Can Hit High Skyview Switches
                 One Water Raise: "\\Skyview\\Main\\First Hub\\Left Room\\Raise Water\
                   \ | \\Skyview\\Main\\First Hub\\Right Room\\After Crawlspace\\Raise\
@@ -8551,9 +8553,9 @@ areas:
                     Hit Vines: "\\Skyview\\Can Hit High Skyview Switches | \\Goddess\
                       \ Sword | Whip"
                     Spider Roll: Skyview - Spider Roll Trick
-                    Raise Water: "\\Skyview\\Main\\First Hub\\Left Room\\Hit Vines\
-                      \ & \\Can Hit Switch | \\Skyview\\Main\\First Hub\\Left Room\\\
-                      Spider Roll & \\Skyview\\Can Hit High Skyview Switches"
+                    Raise Water: "(\\Skyview\\Main\\First Hub\\Left Room\\Hit Vines\
+                      \ & \\Can Hit Switch) | (\\Skyview\\Main\\First Hub\\Left Room\\\
+                      Spider Roll & \\Skyview\\Can Hit High Skyview Switches)"
                     Chest on Tree Branch: "\\Skyview\\Main\\First Hub\\Left Room\\\
                       Hit Vines | \\Skyview\\Main\\First Hub\\Left Room\\Spider Roll"
                   name: \Skyview\Main\First Hub\Left Room
@@ -8655,8 +8657,8 @@ areas:
                 Rupee in Southwest Tunnel: \Beetle
                 Rupee in East Tunnel: \Beetle
                 Switch to Miniboss Room: \Distance Activator
-                Switch for Bars: "\\Beetle | \\Slingshot & Skyview Slingshot Shot\
-                  \ Trick"
+                Switch for Bars: "\\Beetle | (\\Slingshot & Skyview Slingshot Shot\
+                  \ Trick)"
                 Switch to Left Room: \Beetle
                 Item behind Bars: "\\Skyview\\Main\\Second Hub\\Switch for Bars |\
                   \ Whip"
@@ -8805,8 +8807,8 @@ areas:
           can_save: false
           can_sleep: false
           entrances:
-          - Entrance from Spring
           - Entrance from Dungeon
+          - Entrance from Spring
           exits:
             Exit to Dungeon: \Skyview\Boss Room\Beat Ghirahim
             Exit to Spring: \Skyview\Boss Room\Beat Ghirahim

--- a/dump.yaml
+++ b/dump.yaml
@@ -1,665 +1,178 @@
-areas: !!python/object:logic.logic_input.Area
+areas:
   abstract: true
-  allowed_time_of_day: &id002 !!python/object/apply:logic.logic_input.AllowedTimeOfDay
-  - 3
+  allowed_time_of_day: 3
   can_save: false
   can_sleep: false
   entrances: !!set {}
   exits:
-    Start: !!python/object:logic.logic_expression.BasicTextAtom
-      text: 'True'
+    Start: 'True'
   hint_region: null
   locations:
-    1 Extra Wallet: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Extra Wallet
-    1 Gratitude Crystal Pack: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack
-    10 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 10
-    10 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \10 Single Gratitude Crystals
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \5 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \1 Gratitude Crystal Pack
-        opaque: false
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \2 Gratitude Crystal Packs
-      opaque: false
-    10 Single Gratitude Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Gratitude Crystal x 10
-    11 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 11
-    12 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 12
-    13 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 13
-    15 Single Gratitude Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Gratitude Crystal x 15
-    2 Extra Wallets: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Extra Wallet x 2
-    2 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 2
-    3 Extra Wallets: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Extra Wallet x 3
-    3 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 3
-    30 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \15 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \3 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \10 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \4 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \5 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \5 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \6 Gratitude Crystal Packs
-      opaque: false
-    4 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 4
-    40 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \15 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \5 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \10 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \6 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \5 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \7 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \8 Gratitude Crystal Packs
-      opaque: false
-    5 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 5
-    5 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \5 Single Gratitude Crystals
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \1 Gratitude Crystal Pack
-      opaque: false
-    5 Single Gratitude Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Gratitude Crystal x 5
-    50 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \15 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \7 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \10 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \8 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \5 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \9 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \10 Gratitude Crystal Packs
-      opaque: false
-    6 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 6
-    7 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 7
-    70 Gratitude Crystals: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \15 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \11 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \10 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \12 Gratitude Crystal Packs
-        opaque: false
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \5 Single Gratitude Crystals
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \13 Gratitude Crystal Packs
-        opaque: false
-      opaque: false
-    8 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 8
-    80 Gratitude Crystals: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \15 Single Gratitude Crystals
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \13 Gratitude Crystal Packs
-      opaque: false
-    9 Gratitude Crystal Packs: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Gratitude Crystal Pack x 9
-    Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
-      text: 'False'
-    Beetle: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Progressive Beetle
-    Big Wallet: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Progressive Wallet x 2
-    Bottle: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Pouch
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Skyloft\Central Skyloft\Bazaar\Item Check Access
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Empty Bottle_
-      opaque: false
-    Bow: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Progressive Bow
-    Bug Net: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Progressive Bug Net
-    Can Afford 100 Rupees: !!python/object:logic.logic_expression.BasicTextAtom
-      text: 'True'
-    Can Afford 1000 Rupees: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Can High Rupee Farm
-      - !!python/object:logic.logic_expression.OrCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \3 Extra Wallets
-        - !!python/object:logic.logic_expression.AndCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Medium Wallet
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \2 Extra Wallets
-          opaque: false
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \Big Wallet
-        opaque: false
-      opaque: false
-    Can Afford 1200 Rupees: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Can High Rupee Farm
-      - !!python/object:logic.logic_expression.OrCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \3 Extra Wallets
-        - !!python/object:logic.logic_expression.AndCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Medium Wallet
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \3 Extra Wallets
-          opaque: false
-        - !!python/object:logic.logic_expression.AndCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Big Wallet
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \1 Extra Wallet
-          opaque: false
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \Giant Wallet
-        opaque: false
-      opaque: false
-    Can Afford 1600 Rupees: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Can High Rupee Farm
-      - !!python/object:logic.logic_expression.OrCombination
-        arguments:
-        - !!python/object:logic.logic_expression.AndCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Big Wallet
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \2 Extra Wallets
-          opaque: false
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \Giant Wallet
-        opaque: false
-      opaque: false
-    Can Afford 300 Rupees: !!python/object:logic.logic_expression.BasicTextAtom
-      text: \Can Medium Rupee Farm
-    Can Afford 50 Rupees: !!python/object:logic.logic_expression.BasicTextAtom
-      text: 'True'
-    Can Afford 600 Rupees: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Can High Rupee Farm
-      - !!python/object:logic.logic_expression.OrCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \1 Extra Wallet
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \Big Wallet
-        opaque: false
-      opaque: false
-    Can Afford 800 Rupees: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Can High Rupee Farm
-      - !!python/object:logic.logic_expression.OrCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \2 Extra Wallets
-        - !!python/object:logic.logic_expression.AndCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Medium Wallet
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \1 Extra Wallet
-          opaque: false
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \Big Wallet
-        opaque: false
-      opaque: false
-    Can Collect Water: !!python/object:logic.logic_expression.BasicTextAtom
-      text: 'False'
-    Can Cut Tree: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Bomb Bag
-      opaque: false
-    Can Defeat Ampilus: !!python/object:logic.logic_expression.BasicTextAtom
-      text: \Damaging Item
-    Can Defeat Armos: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Gust Bellows
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      opaque: false
-    Can Defeat Beamos: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Bow
-      opaque: false
-    Can Defeat Bokoblins: !!python/object:logic.logic_expression.BasicTextAtom
-      text: \Damaging Item
-    Can Defeat Cursed Bokoblins: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Bomb Bag
-      opaque: false
-    Can Defeat Keeses: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Slingshot
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Beetle
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Whip
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Clawshots
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Bow
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Bomb Bag
-      opaque: false
-    Can Defeat Lizalfos: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: Advanced Lizalfos Combat Trick
-        - !!python/object:logic.logic_expression.OrCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Bomb Bag
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Bow
-          opaque: false
-        opaque: false
-      opaque: false
-    Can Defeat Moblins: !!python/object:logic.logic_expression.BasicTextAtom
-      text: \Damaging Item
-    Can Defeat Scervo/Dreadfuse: !!python/object:logic.logic_expression.BasicTextAtom
-      text: \Sword
-    Can Defeat Stalfos: !!python/object:logic.logic_expression.BasicTextAtom
-      text: \Sword
-    Can Defeat Stalmaster: !!python/object:logic.logic_expression.BasicTextAtom
-      text: \Sword
-    Can High Rupee Farm: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sky\South West\Fun Fun Island\Fun Fun Island Minigame
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Eldin\Volcano\Thrill Digger Cave\Thrill Digger Minigame
-      opaque: false
-    Can Hit Switch: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Bomb Bag
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Whip
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Distance Activator
-      opaque: false
-    Can Hit Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Bomb Bag
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Whip
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Distance Activator
-      opaque: false
-    Can Hit Timeshift Stone in Minecart: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Bomb Bag
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Distance Activator
-      opaque: false
-    Can Medium Rupee Farm: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sky\North East\Bamboo Island\Inside\Clean Cut Minigame
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Can High Rupee Farm
-      opaque: false
-    Can Unlock Combination Lock: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Whip
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Clawshots
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Slingshot
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Bow
-      opaque: false
-    Can bypass Boko Base Watch Tower: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Bow
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Bomb Bag
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Slingshot
-      opaque: false
-    Complete Triforce: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Triforce of Courage
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Triforce of Wisdom
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Triforce of Power
-      opaque: false
-    Damaging Item: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Sword
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Bomb Bag
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Bow
-      opaque: false
-    Digging Mitts: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Progressive Mitts
-    Distance Activator: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Slingshot
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Beetle
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Clawshots
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Bow
-      opaque: false
-    Early Lake Floria Tricks: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: Early Lake Floria - Fence Hop Trick
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \Practice Sword
-        opaque: false
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Early Lake Floria - Swordless Rope Floria Trick
-      opaque: false
-    Empty Bottle_: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Empty Bottle
-    Giant Wallet: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Progressive Wallet x 3
-    Goddess Longsword: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Progressive Sword x 3
-    Goddess Sword: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Progressive Sword x 2
-    Goddess White Sword: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Progressive Sword x 4
-    Hook Beetle: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Progressive Beetle x 2
-    Long Range Skyward Strike: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.AndCombination
-        arguments:
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: \Goddess Sword
-        - !!python/object:logic.logic_expression.BasicTextAtom
-          text: Upgraded Skyward Strike option
-        opaque: false
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \True Master Sword
-      opaque: false
-    Master Sword: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Progressive Sword x 5
-    Medium Wallet: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Progressive Wallet
-    Mogma Mitts: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Progressive Mitts x 2
-    Pouch: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Progressive Pouch
-    Practice Sword: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Progressive Sword
-    Projectile Item: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Slingshot
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Beetle
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Bow
-      opaque: false
-    Quick Beetle: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Three Beetles
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades\Upgrade to Quick Beetle
-      opaque: true
-    Slingshot: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Progressive Slingshot
-    Song of the Hero: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Faron Song of the Hero Part
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Eldin Song of the Hero Part
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Lanayru Song of the Hero Part
-      opaque: false
-    Sword: !!python/object:logic.logic_expression.BasicTextAtom
-      text: \Practice Sword
-    Three Beetles: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Progressive Beetle x 3
-    Tough Beetle: !!python/object:logic.logic_expression.OrCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: Progressive Beetle x 4
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades\Upgrade to Tough Beetle
-      opaque: true
-    True Master Sword: !!python/object:logic.logic_expression.BasicTextAtom
-      opaque: true
-      text: Progressive Sword x 6
-    Tycoon Wallet: !!python/object:logic.logic_expression.BasicTextAtom
-      text: Progressive Wallet x 4
-    Water Bottle: !!python/object:logic.logic_expression.AndCombination
-      arguments:
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Bottle
-      - !!python/object:logic.logic_expression.BasicTextAtom
-        text: \Can Collect Water
-      opaque: false
+    1 Extra Wallet: Extra Wallet
+    1 Gratitude Crystal Pack: Gratitude Crystal Pack
+    10 Gratitude Crystal Packs: Gratitude Crystal Pack x 10
+    10 Gratitude Crystals: "\\10 Single Gratitude Crystals | \\5 Single Gratitude\
+      \ Crystals & \\1 Gratitude Crystal Pack | \\2 Gratitude Crystal Packs"
+    10 Single Gratitude Crystals: Gratitude Crystal x 10
+    11 Gratitude Crystal Packs: Gratitude Crystal Pack x 11
+    12 Gratitude Crystal Packs: Gratitude Crystal Pack x 12
+    13 Gratitude Crystal Packs: Gratitude Crystal Pack x 13
+    15 Single Gratitude Crystals: Gratitude Crystal x 15
+    2 Extra Wallets: Extra Wallet x 2
+    2 Gratitude Crystal Packs: Gratitude Crystal Pack x 2
+    3 Extra Wallets: Extra Wallet x 3
+    3 Gratitude Crystal Packs: Gratitude Crystal Pack x 3
+    30 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\3 Gratitude Crystal\
+      \ Packs | \\10 Single Gratitude Crystals & \\4 Gratitude Crystal Packs | \\\
+      5 Single Gratitude Crystals & \\5 Gratitude Crystal Packs | \\6 Gratitude Crystal\
+      \ Packs"
+    4 Gratitude Crystal Packs: Gratitude Crystal Pack x 4
+    40 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\5 Gratitude Crystal\
+      \ Packs | \\10 Single Gratitude Crystals & \\6 Gratitude Crystal Packs | \\\
+      5 Single Gratitude Crystals & \\7 Gratitude Crystal Packs | \\8 Gratitude Crystal\
+      \ Packs"
+    5 Gratitude Crystal Packs: Gratitude Crystal Pack x 5
+    5 Gratitude Crystals: "\\5 Single Gratitude Crystals | \\1 Gratitude Crystal Pack"
+    5 Single Gratitude Crystals: Gratitude Crystal x 5
+    50 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\7 Gratitude Crystal\
+      \ Packs | \\10 Single Gratitude Crystals & \\8 Gratitude Crystal Packs | \\\
+      5 Single Gratitude Crystals & \\9 Gratitude Crystal Packs | \\10 Gratitude Crystal\
+      \ Packs"
+    6 Gratitude Crystal Packs: Gratitude Crystal Pack x 6
+    7 Gratitude Crystal Packs: Gratitude Crystal Pack x 7
+    70 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\11 Gratitude Crystal\
+      \ Packs | \\10 Single Gratitude Crystals & \\12 Gratitude Crystal Packs | \\\
+      5 Single Gratitude Crystals & \\13 Gratitude Crystal Packs"
+    8 Gratitude Crystal Packs: Gratitude Crystal Pack x 8
+    80 Gratitude Crystals: "\\15 Single Gratitude Crystals & \\13 Gratitude Crystal\
+      \ Packs"
+    9 Gratitude Crystal Packs: Gratitude Crystal Pack x 9
+    Ancient Flower Farming: 'False'
+    Beetle: Progressive Beetle
+    Big Wallet: Progressive Wallet x 2
+    Bottle: "\\Pouch & \\Skyloft\\Central Skyloft\\Bazaar\\Item Check Access & \\\
+      Empty Bottle_"
+    Bow: Progressive Bow
+    Bug Net: Progressive Bug Net
+    Can Afford 100 Rupees: 'True'
+    Can Afford 1000 Rupees: "\\Can High Rupee Farm & (\\3 Extra Wallets | \\Medium\
+      \ Wallet & \\2 Extra Wallets | \\Big Wallet)"
+    Can Afford 1200 Rupees: "\\Can High Rupee Farm & (\\3 Extra Wallets | \\Medium\
+      \ Wallet & \\3 Extra Wallets | \\Big Wallet & \\1 Extra Wallet | \\Giant Wallet)"
+    Can Afford 1600 Rupees: "\\Can High Rupee Farm & (\\Big Wallet & \\2 Extra Wallets\
+      \ | \\Giant Wallet)"
+    Can Afford 300 Rupees: \Can Medium Rupee Farm
+    Can Afford 50 Rupees: 'True'
+    Can Afford 600 Rupees: "\\Can High Rupee Farm & (\\1 Extra Wallet | \\Big Wallet)"
+    Can Afford 800 Rupees: "\\Can High Rupee Farm & (\\2 Extra Wallets | \\Medium\
+      \ Wallet & \\1 Extra Wallet | \\Big Wallet)"
+    Can Collect Water: 'False'
+    Can Cut Tree: "\\Sword | Bomb Bag"
+    Can Defeat Ampilus: \Damaging Item
+    Can Defeat Armos: "Gust Bellows & \\Sword"
+    Can Defeat Beamos: "\\Sword | \\Bow"
+    Can Defeat Bokoblins: \Damaging Item
+    Can Defeat Cursed Bokoblins: "\\Sword | Bomb Bag"
+    Can Defeat Keeses: "\\Sword | \\Slingshot | \\Beetle | Whip | Clawshots | \\Bow\
+      \ | Bomb Bag"
+    Can Defeat Lizalfos: "\\Sword | Advanced Lizalfos Combat Trick & (Bomb Bag | \\\
+      Bow)"
+    Can Defeat Moblins: \Damaging Item
+    Can Defeat Scervo/Dreadfuse: \Sword
+    Can Defeat Stalfos: \Sword
+    Can Defeat Stalmaster: \Sword
+    Can High Rupee Farm: "\\Sky\\South West\\Fun Fun Island\\Fun Fun Island Minigame\
+      \ | \\Eldin\\Volcano\\Thrill Digger Cave\\Thrill Digger Minigame"
+    Can Hit Switch: "\\Sword | Bomb Bag | Whip | \\Distance Activator"
+    Can Hit Timeshift Stone: "\\Sword | Bomb Bag | Whip | \\Distance Activator"
+    Can Hit Timeshift Stone in Minecart: "\\Sword | Bomb Bag | \\Distance Activator"
+    Can Medium Rupee Farm: "\\Sky\\North East\\Bamboo Island\\Inside\\Clean Cut Minigame\
+      \ | \\Can High Rupee Farm"
+    Can Unlock Combination Lock: "\\Sword | Whip | Clawshots | \\Slingshot | \\Bow"
+    Can bypass Boko Base Watch Tower: "\\Bow | Bomb Bag | \\Slingshot"
+    Complete Triforce: "Triforce of Courage & Triforce of Wisdom & Triforce of Power"
+    Damaging Item: "\\Sword | Bomb Bag | \\Bow"
+    Digging Mitts: Progressive Mitts
+    Distance Activator: "\\Slingshot | \\Beetle | Clawshots | \\Bow"
+    Early Lake Floria Tricks: "Early Lake Floria - Fence Hop Trick & \\Practice Sword\
+      \ | Early Lake Floria - Swordless Rope Floria Trick"
+    Empty Bottle_: Empty Bottle
+    Giant Wallet: Progressive Wallet x 3
+    Goddess Longsword: Progressive Sword x 3
+    Goddess Sword: Progressive Sword x 2
+    Goddess White Sword: Progressive Sword x 4
+    Hook Beetle: Progressive Beetle x 2
+    Long Range Skyward Strike: "\\Goddess Sword & Upgraded Skyward Strike option |\
+      \ \\True Master Sword"
+    Master Sword: Progressive Sword x 5
+    Medium Wallet: Progressive Wallet
+    Mogma Mitts: Progressive Mitts x 2
+    Pouch: Progressive Pouch
+    Practice Sword: Progressive Sword
+    Projectile Item: "\\Slingshot | \\Beetle | \\Bow"
+    Quick Beetle: "\\Three Beetles | \\Skyloft\\Central Skyloft\\Bazaar\\Gondo's Upgrades\\\
+      Upgrade to Quick Beetle"
+    Slingshot: Progressive Slingshot
+    Song of the Hero: "Faron Song of the Hero Part & Eldin Song of the Hero Part &\
+      \ Lanayru Song of the Hero Part"
+    Sword: \Practice Sword
+    Three Beetles: Progressive Beetle x 3
+    Tough Beetle: "Progressive Beetle x 4 | \\Skyloft\\Central Skyloft\\Bazaar\\Gondo's\
+      \ Upgrades\\Upgrade to Tough Beetle"
+    True Master Sword: Progressive Sword x 6
+    Tycoon Wallet: Progressive Wallet x 4
+    Water Bottle: "\\Bottle & \\Can Collect Water"
   name: ''
   sub_areas:
-    Ancient Cistern: !!python/object:logic.logic_input.Area
+    Ancient Cistern:
       abstract: true
-      allowed_time_of_day: &id001 !!python/object/apply:logic.logic_input.AllowedTimeOfDay
-      - 1
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
       exits: {}
       hint_region: Ancient Cistern
       locations:
-        Can Freely Raise and Lower Statue: !!python/object:logic.logic_expression.BasicTextAtom
-          text: 'False'
-        Can Lower Statue: !!python/object:logic.logic_expression.BasicTextAtom
-          text: \Ancient Cistern\Can Freely Raise and Lower Statue
+        Can Freely Raise and Lower Statue: 'False'
+        Can Lower Statue: \Ancient Cistern\Can Freely Raise and Lower Statue
       name: \Ancient Cistern
       sub_areas:
-        Boss Room: !!python/object:logic.logic_input.Area
+        Boss Room:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance from Dungeon: null
             Entrance from Flame Room: null
           exits:
-            Exit to Dungeon: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Ancient Cistern\Boss Room\Beat Koloktos
-            Exit to Flame Room: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Ancient Cistern\Boss Room\Beat Koloktos
+            Exit to Dungeon: \Ancient Cistern\Boss Room\Beat Koloktos
+            Exit to Flame Room: \Ancient Cistern\Boss Room\Beat Koloktos
           hint_region: Ancient Cistern
           locations:
-            Beat Koloktos: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Whip
-              - !!python/object:logic.logic_expression.OrCombination
-                arguments:
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sword
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Bomb Bag
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Bow
-                opaque: false
-              opaque: false
-            Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Ancient Cistern\Boss Room\Beat Koloktos
+            Beat Koloktos: "Whip & (\\Sword | Bomb Bag | \\Bow)"
+            Heart Container: \Ancient Cistern\Boss Room\Beat Koloktos
           name: \Ancient Cistern\Boss Room
           sub_areas: {}
           toplevel_alias: null
-        Flame Room: !!python/object:logic.logic_input.Area
+        Flame Room:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance: null
           exits:
-            Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit: 'True'
           hint_region: Ancient Cistern
           locations:
-            Farore's Flame: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Goddess Sword
+            Farore's Flame: \Goddess Sword
           name: \Ancient Cistern\Flame Room
           sub_areas: {}
           toplevel_alias: null
-        Main: !!python/object:logic.logic_input.Area
+        Main:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -668,567 +181,362 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Ancient Cistern\Main
           sub_areas:
-            Basement: !!python/object:logic.logic_input.Area
+            Basement:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Ancient Cistern\Main\Basement\Rotating Vines: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Ancient Cistern\Main\Basement\Blow Rock
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  opaque: false
-                \Ancient Cistern\Main\Basement\Spider Thread: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Ancient Cistern\Main\Basement\Spider Thread\Activate Water
-                      Geyser
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ancient Cistern - Basement Highflip Trick
-                  opaque: false
-                \Ancient Cistern\Main\Basement\Under the Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Ancient Cistern - Basement Highflip Trick
-                \Ancient Cistern\Main\Inside Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Ancient Cistern\Main\Basement\Rotating Vines: "Whip & \\Ancient Cistern\\\
+                  Main\\Basement\\Blow Rock | Clawshots"
+                \Ancient Cistern\Main\Basement\Spider Thread: "\\Ancient Cistern\\\
+                  Main\\Basement\\Spider Thread\\Activate Water Geyser | Ancient Cistern\
+                  \ - Basement Highflip Trick"
+                \Ancient Cistern\Main\Basement\Under the Statue: Ancient Cistern -
+                  Basement Highflip Trick
+                \Ancient Cistern\Main\Inside Statue: 'True'
               hint_region: Ancient Cistern
               locations:
-                Blow Rock: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Bomb Bag
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Bomb Throws Trick
-                    opaque: false
-                  opaque: false
-                Stop Cursed Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
+                Blow Rock: "\\Hook Beetle | Bomb Bag & Bomb Throws Trick"
+                Stop Cursed Waterfall: \Beetle
               name: \Ancient Cistern\Main\Basement
               sub_areas:
-                Rotating Vines: !!python/object:logic.logic_input.Area
+                Rotating Vines:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Basement: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Ancient Cistern\Main\Basement\Spider Thread: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
+                    \Ancient Cistern\Main\Basement: 'True'
+                    \Ancient Cistern\Main\Basement\Spider Thread: Whip
                   hint_region: Ancient Cistern
                   locations: {}
                   name: \Ancient Cistern\Main\Basement\Rotating Vines
                   sub_areas: {}
                   toplevel_alias: null
-                Spider Thread: !!python/object:logic.logic_input.Area
+                Spider Thread:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Basement: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Ancient Cistern\Main\Basement\Under the Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Ancient Cistern\Can Freely Raise and Lower Statue
-                    \Ancient Cistern\Main\Main Room\Spider Thread Area: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Ancient Cistern\Main\Basement: 'True'
+                    \Ancient Cistern\Main\Basement\Under the Statue: \Ancient Cistern\Can
+                      Freely Raise and Lower Statue
+                    \Ancient Cistern\Main\Main Room\Spider Thread Area: 'True'
                   hint_region: Ancient Cistern
                   locations:
-                    Activate Water Geyser: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
+                    Activate Water Geyser: Whip
                   name: \Ancient Cistern\Main\Basement\Spider Thread
                   sub_areas: {}
                   toplevel_alias: null
-                Under the Statue: !!python/object:logic.logic_input.Area
+                Under the Statue:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Basement: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Ancient Cistern\Main\Basement: 'True'
                   hint_region: Ancient Cistern
                   locations:
-                    Boss Key Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Ancient Cistern\Can Lower Statue
-                    \Ancient Cistern\Can Lower Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Boss Key Chest: \Ancient Cistern\Can Lower Statue
+                    \Ancient Cistern\Can Lower Statue: 'True'
                   name: \Ancient Cistern\Main\Basement\Under the Statue
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Basement Gutters: !!python/object:logic.logic_input.Area
+            Basement Gutters:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Ancient Cistern\Main\Basement Gutters\Past Skulltula: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Ancient Cistern\Main\Basement Gutters\Can Get Past Skulltula
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Water Dragon's Scale
-                  opaque: false
+                \Ancient Cistern\Main\Basement Gutters\Past Skulltula: "\\Ancient\
+                  \ Cistern\\Main\\Basement Gutters\\Can Get Past Skulltula & Water\
+                  \ Dragon's Scale"
               hint_region: Ancient Cistern
               locations:
-                Can Get Past Skulltula: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Beetle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  opaque: false
+                Can Get Past Skulltula: "\\Beetle | \\Bow"
               name: \Ancient Cistern\Main\Basement Gutters
               sub_areas:
-                Past Skulltula: !!python/object:logic.logic_input.Area
+                Past Skulltula:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Basement Gutters: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Water Dragon's Scale
-                    \Ancient Cistern\Main\Main Room\After Gutters: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Ancient Cistern Small Key x 2
+                    \Ancient Cistern\Main\Basement Gutters: Water Dragon's Scale
+                    \Ancient Cistern\Main\Main Room\After Gutters: Ancient Cistern
+                      Small Key x 2
                   hint_region: Ancient Cistern
                   locations:
-                    Bokoblin: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
+                    Bokoblin: Whip
                   name: \Ancient Cistern\Main\Basement Gutters\Past Skulltula
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            East Part: !!python/object:logic.logic_input.Area
+            East Part:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Ancient Cistern\Main\East Part\Second Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Ancient Cistern\Main\East Part\Unlock Combination Lock Door
-                \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Ancient Cistern\Main\East Part\Second Room: \Ancient Cistern\Main\East
+                  Part\Unlock Combination Lock Door
+                \Ancient Cistern\Main\Main Room: 'True'
               hint_region: Ancient Cistern
               locations:
-                Unlock Combination Lock Door: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Unlock Combination Lock
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Ancient Cistern\Main\Main Room\Lock Combination Knowledge
-                  opaque: false
+                Unlock Combination Lock Door: "\\Can Unlock Combination Lock & \\\
+                  Ancient Cistern\\Main\\Main Room\\Lock Combination Knowledge"
               name: \Ancient Cistern\Main\East Part
               sub_areas:
-                Chest Ledge: !!python/object:logic.logic_input.Area
+                Chest Ledge:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Ancient Cistern\Main\Main Room: 'True'
                   hint_region: Ancient Cistern
                   locations:
-                    Chest in East Part: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Chest in East Part: 'True'
                   name: \Ancient Cistern\Main\East Part\Chest Ledge
                   sub_areas: {}
                   toplevel_alias: null
-                Second Room: !!python/object:logic.logic_input.Area
+                Second Room:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\East Part: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Ancient Cistern\Main\East Part\Chest Ledge: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\East Part\Second Room\Flip Main
-                          Lilypad
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Water Dragon's Scale
-                      opaque: false
+                    \Ancient Cistern\Main\East Part: 'True'
+                    \Ancient Cistern\Main\East Part\Chest Ledge: "\\Ancient Cistern\\\
+                      Main\\East Part\\Second Room\\Flip Main Lilypad & Water Dragon's\
+                      \ Scale"
                   hint_region: Ancient Cistern
                   locations:
-                    First Rupee in East Part in Short Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Water Dragon's Scale
-                    Flip Main Lilypad: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Flip Side Lilypad: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Rupee in East Part in Cubby: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\East Part\Second Room\Flip Side
-                          Lilypad
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Water Dragon's Scale
-                      opaque: false
-                    Rupee in East Part in Main Tunnel: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\East Part\Second Room\Flip Main
-                          Lilypad
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Water Dragon's Scale
-                      opaque: false
-                    Second Rupee in East Part in Short Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Water Dragon's Scale
-                    Third Rupee in East Part in Short Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Water Dragon's Scale
+                    First Rupee in East Part in Short Tunnel: Water Dragon's Scale
+                    Flip Main Lilypad: 'True'
+                    Flip Side Lilypad: 'True'
+                    Rupee in East Part in Cubby: "\\Ancient Cistern\\Main\\East Part\\\
+                      Second Room\\Flip Side Lilypad & Water Dragon's Scale"
+                    Rupee in East Part in Main Tunnel: "\\Ancient Cistern\\Main\\\
+                      East Part\\Second Room\\Flip Main Lilypad & Water Dragon's Scale"
+                    Second Rupee in East Part in Short Tunnel: Water Dragon's Scale
+                    Third Rupee in East Part in Short Tunnel: Water Dragon's Scale
                   name: \Ancient Cistern\Main\East Part\Second Room
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Inside Statue: !!python/object:logic.logic_input.Area
+            Inside Statue:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Boss Door Entrance: null
               exits:
-                Boss Door Exit: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ancient Cistern Boss Key
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Ancient Cistern\Main\Inside Statue\Activate Water Geysers
-                  opaque: false
-                \Ancient Cistern\Main\Basement: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Ancient Cistern\Can Lower Statue
-                \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ancient Cistern Small Key x 2
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Can Defeat Stalmaster
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Ancient Cistern\Can Lower Statue
-                    opaque: false
-                  opaque: false
-                \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Ancient Cistern\Main\Inside Statue\Activate Water Geysers
+                Boss Door Exit: "Ancient Cistern Boss Key & \\Ancient Cistern\\Main\\\
+                  Inside Statue\\Activate Water Geysers"
+                \Ancient Cistern\Main\Basement: \Ancient Cistern\Can Lower Statue
+                \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest: "Ancient\
+                  \ Cistern Small Key x 2 & (\\Can Defeat Stalmaster | \\Ancient Cistern\\\
+                  Can Lower Statue)"
+                \Ancient Cistern\Main\Main Room: \Ancient Cistern\Main\Inside Statue\Activate
+                  Water Geysers
               hint_region: Ancient Cistern
               locations:
-                Activate Water Geysers: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Whip
+                Activate Water Geysers: Whip
               name: \Ancient Cistern\Main\Inside Statue
               sub_areas:
-                Key Locked Room with Chest: !!python/object:logic.logic_input.Area
+                Key Locked Room with Chest:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Inside Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Ancient Cistern Small Key x 2
+                    \Ancient Cistern\Main\Inside Statue: Ancient Cistern Small Key
+                      x 2
                   hint_region: Ancient Cistern
                   locations:
-                    Chest in Key Locked Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Chest in Key Locked Room: 'True'
                   name: \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Main Room: !!python/object:logic.logic_input.Area
+            Main Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Main Entrance: null
               exits:
-                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Ancient Cistern\Main\Basement\Under the Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Ancient Cistern - Cistern Clip Trick
-                \Ancient Cistern\Main\East Part: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Ancient Cistern\Main\Main Room\Lever to East Part
-                \Ancient Cistern\Main\Inside Statue: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Ancient Cistern\Can Lower Statue
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ancient Cistern Small Key x 2
-                  opaque: false
-                \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ancient Cistern - Cistern Clip Trick
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ancient Cistern - Cistern Whip Room Clip Trick
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Water Dragon's Scale
-                  opaque: false
-                \Ancient Cistern\Main\Main Room\After Whip Hooks: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Whip
-                \Ancient Cistern\Main\Main Room\Behind the Waterfall: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Ancient Cistern\Main\Main Room\Lever to Block Waterfall
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Water Dragon's Scale
-                  opaque: false
-                \Ancient Cistern\Main\Main Room\Vines Area: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Ancient Cistern\Main\Main Room\Vines Area\Activate Water
-                      Geyser
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
-                    opaque: false
-                  opaque: false
+                Main Exit: 'True'
+                \Ancient Cistern\Main\Basement\Under the Statue: Ancient Cistern -
+                  Cistern Clip Trick
+                \Ancient Cistern\Main\East Part: \Ancient Cistern\Main\Main Room\Lever
+                  to East Part
+                \Ancient Cistern\Main\Inside Statue: "\\Ancient Cistern\\Can Lower\
+                  \ Statue | Ancient Cistern Small Key x 2"
+                \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest: "Ancient\
+                  \ Cistern - Cistern Clip Trick & Ancient Cistern - Cistern Whip\
+                  \ Room Clip Trick & Water Dragon's Scale"
+                \Ancient Cistern\Main\Main Room\After Whip Hooks: Whip
+                \Ancient Cistern\Main\Main Room\Behind the Waterfall: "\\Ancient Cistern\\\
+                  Main\\Main Room\\Lever to Block Waterfall & Water Dragon's Scale"
+                \Ancient Cistern\Main\Main Room\Vines Area: "\\Ancient Cistern\\Main\\\
+                  Main Room\\Vines Area\\Activate Water Geyser | Whip & Clawshots"
               hint_region: Ancient Cistern
               locations:
-                Lever to Block Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Whip
-                Lever to East Part: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Lock Combination Knowledge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Rupee in East Hand: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                Rupee in West Hand: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
+                Lever to Block Waterfall: Whip
+                Lever to East Part: 'True'
+                Lock Combination Knowledge: 'True'
+                Rupee in East Hand: Water Dragon's Scale
+                Rupee in West Hand: Water Dragon's Scale
               name: \Ancient Cistern\Main\Main Room
               sub_areas:
-                After Gutters: !!python/object:logic.logic_input.Area
+                After Gutters:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\Main Room\After Gutters\Flip First
-                          Lilypad
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\Main Room\After Gutters\Activate
-                          Water Geyser
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\Main Room\After Gutters\Flip Second
-                          Lilypad 2
-                      opaque: false
-                    \Ancient Cistern\Main\Main Room\After Whip Hooks: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: "\\\
+                      Ancient Cistern\\Main\\Main Room\\After Gutters\\Flip First\
+                      \ Lilypad & \\Ancient Cistern\\Main\\Main Room\\After Gutters\\\
+                      Activate Water Geyser & \\Ancient Cistern\\Main\\Main Room\\\
+                      After Gutters\\Flip Second Lilypad 2"
+                    \Ancient Cistern\Main\Main Room\After Whip Hooks: 'True'
                   hint_region: Ancient Cistern
                   locations:
-                    Activate Water Geyser: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\Main Room\After Gutters\Flip Second
-                          Lilypad 1
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Water Dragon's Scale
-                      opaque: false
-                    Flip First Lilypad: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Water Dragon's Scale
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Whip
-                      opaque: false
-                    Flip Second Lilypad 1: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Ancient Cistern\Main\Main Room\After Gutters\Flip First
-                        Lilypad
-                    Flip Second Lilypad 2: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\Main Room\After Gutters\Flip First
-                          Lilypad
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\Main Room\After Gutters\Activate
-                          Water Geyser
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Whip
-                      opaque: false
-                    Lower Lever: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Rupee under Lilypad: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\Main Room\After Gutters\Flip Second
-                          Lilypad 1
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Water Dragon's Scale
-                      opaque: false
+                    Activate Water Geyser: "\\Ancient Cistern\\Main\\Main Room\\After\
+                      \ Gutters\\Flip Second Lilypad 1 & Water Dragon's Scale"
+                    Flip First Lilypad: "Water Dragon's Scale & Whip"
+                    Flip Second Lilypad 1: \Ancient Cistern\Main\Main Room\After Gutters\Flip
+                      First Lilypad
+                    Flip Second Lilypad 2: "\\Ancient Cistern\\Main\\Main Room\\After\
+                      \ Gutters\\Flip First Lilypad & \\Ancient Cistern\\Main\\Main\
+                      \ Room\\After Gutters\\Activate Water Geyser & Whip"
+                    Lower Lever: 'True'
+                    Rupee under Lilypad: "\\Ancient Cistern\\Main\\Main Room\\After\
+                      \ Gutters\\Flip Second Lilypad 1 & Water Dragon's Scale"
                   name: \Ancient Cistern\Main\Main Room\After Gutters
                   sub_areas:
-                    Upper Area: !!python/object:logic.logic_input.Area
+                    Upper Area:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Ancient Cistern\Main\Main Room\After Gutters: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        \Ancient Cistern\Main\Main Room\Vines Area: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Ancient Cistern\Main\Main Room\After Gutters\Upper
-                            Area\Upper Lever
+                        \Ancient Cistern\Main\Main Room\After Gutters: 'True'
+                        \Ancient Cistern\Main\Main Room\Vines Area: \Ancient Cistern\Main\Main
+                          Room\After Gutters\Upper Area\Upper Lever
                       hint_region: Ancient Cistern
                       locations:
-                        Upper Lever: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Whip
+                        Upper Lever: Whip
                       name: \Ancient Cistern\Main\Main Room\After Gutters\Upper Area
                       sub_areas: {}
                       toplevel_alias: null
                   toplevel_alias: null
-                After Whip Hooks: !!python/object:logic.logic_input.Area
+                After Whip Hooks:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Ancient Cistern\Main\Main Room\After Gutters: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Ancient Cistern\Main\Main Room\After Gutters\Lower Lever
-                    \Ancient Cistern\Main\Main Room\Vines Area: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
+                    \Ancient Cistern\Main\Main Room: 'True'
+                    \Ancient Cistern\Main\Main Room\After Gutters: \Ancient Cistern\Main\Main
+                      Room\After Gutters\Lower Lever
+                    \Ancient Cistern\Main\Main Room\Vines Area: Clawshots
                   hint_region: Ancient Cistern
                   locations:
-                    Chest after Whip Hooks: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Chest after Whip Hooks: 'True'
                   name: \Ancient Cistern\Main\Main Room\After Whip Hooks
                   sub_areas: {}
                   toplevel_alias: null
-                Behind the Waterfall: !!python/object:logic.logic_input.Area
+                Behind the Waterfall:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Basement Gutters: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Ancient Cistern\Main\Main Room\Behind the Waterfall\Toilet
-                        Flush
+                    \Ancient Cistern\Main\Basement Gutters: \Ancient Cistern\Main\Main
+                      Room\Behind the Waterfall\Toilet Flush
                   hint_region: Ancient Cistern
                   locations:
-                    Chest behind the Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    First Lever: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
-                    Second Lever: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\Main Room\Behind the Waterfall\First
-                          Lever
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Whip
-                      opaque: false
-                    Toilet Flush: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\Main Room\Behind the Waterfall\First
-                          Lever
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Cistern\Main\Main Room\Behind the Waterfall\Second
-                          Lever
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Whip
-                      opaque: false
+                    Chest behind the Waterfall: 'True'
+                    First Lever: Whip
+                    Second Lever: "\\Ancient Cistern\\Main\\Main Room\\Behind the\
+                      \ Waterfall\\First Lever & Whip"
+                    Toilet Flush: "\\Ancient Cistern\\Main\\Main Room\\Behind the\
+                      \ Waterfall\\First Lever & \\Ancient Cistern\\Main\\Main Room\\\
+                      Behind the Waterfall\\Second Lever & Whip"
                   name: \Ancient Cistern\Main\Main Room\Behind the Waterfall
                   sub_areas: {}
                   toplevel_alias: null
-                Spider Thread Area: !!python/object:logic.logic_input.Area
+                Spider Thread Area:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Basement: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Ancient Cistern\Main\Main Room\Vines Area: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Ancient Cistern\Main\Main Room\Spider Thread Area\Extend
-                        Platform
+                    \Ancient Cistern\Main\Basement: 'True'
+                    \Ancient Cistern\Main\Main Room: 'True'
+                    \Ancient Cistern\Main\Main Room\Vines Area: \Ancient Cistern\Main\Main
+                      Room\Spider Thread Area\Extend Platform
                   hint_region: Ancient Cistern
                   locations:
-                    Extend Platform: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Ancient Cistern\Can Freely Raise and Lower Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
+                    Extend Platform: 'True'
+                    \Ancient Cistern\Can Freely Raise and Lower Statue: Whip
                   name: \Ancient Cistern\Main\Main Room\Spider Thread Area
                   sub_areas: {}
                   toplevel_alias: null
-                Vines Area: !!python/object:logic.logic_input.Area
+                Vines Area:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Ancient Cistern\Main\Main Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Ancient Cistern\Main\Main Room\After Gutters\Upper Area\Upper
-                        Lever
-                    \Ancient Cistern\Main\Main Room\After Whip Hooks: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sword
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Ancient Cistern - Map Chest Jump Trick
-                      opaque: false
-                    \Ancient Cistern\Main\Main Room\Spider Thread Area: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Ancient Cistern\Main\Main Room\Spider Thread Area\Extend
-                        Platform
+                    \Ancient Cistern\Main\Main Room: 'True'
+                    \Ancient Cistern\Main\Main Room\After Gutters\Upper Area: \Ancient
+                      Cistern\Main\Main Room\After Gutters\Upper Area\Upper Lever
+                    \Ancient Cistern\Main\Main Room\After Whip Hooks: "\\Sword & Ancient\
+                      \ Cistern - Map Chest Jump Trick"
+                    \Ancient Cistern\Main\Main Room\Spider Thread Area: \Ancient Cistern\Main\Main
+                      Room\Spider Thread Area\Extend Platform
                   hint_region: Ancient Cistern
                   locations:
-                    Activate Water Geyser: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
-                    Chest near Vines: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Ancient Cistern\Can Lower Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
-                    \Ancient Cistern\Main\Main Room\Lever to Block Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Ancient Cistern - Lever Jump Trick
+                    Activate Water Geyser: Whip
+                    Chest near Vines: 'True'
+                    \Ancient Cistern\Can Lower Statue: Whip
+                    \Ancient Cistern\Main\Main Room\Lever to Block Waterfall: Ancient
+                      Cistern - Lever Jump Trick
                   name: \Ancient Cistern\Main\Main Room\Vines Area
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
           toplevel_alias: null
       toplevel_alias: null
-    Earth Temple: !!python/object:logic.logic_input.Area
+    Earth Temple:
       abstract: false
-      allowed_time_of_day: *id001
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
@@ -1237,9 +545,9 @@ areas: !!python/object:logic.logic_input.Area
       locations: {}
       name: \Earth Temple
       sub_areas:
-        Boss Room: !!python/object:logic.logic_input.Area
+        Boss Room:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -1248,86 +556,49 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Earth Temple\Boss Room
           sub_areas:
-            Entry: !!python/object:logic.logic_input.Area
+            Entry:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Dungeon: null
               exits:
-                Exit to Dungeon: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Boss Room\Slope\Beat Scaldera
-                \Earth Temple\Boss Room\Slope: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit to Dungeon: \Earth Temple\Boss Room\Slope\Beat Scaldera
+                \Earth Temple\Boss Room\Slope: 'True'
               hint_region: Earth Temple
               locations: {}
               name: \Earth Temple\Boss Room\Entry
               sub_areas: {}
               toplevel_alias: null
-            Slope: !!python/object:logic.logic_input.Area
+            Slope:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Spring: null
               exits:
-                Exit to Spring: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Boss Room\Slope\Beat Scaldera
+                Exit to Spring: \Earth Temple\Boss Room\Slope\Beat Scaldera
               hint_region: Earth Temple
               locations:
-                Beat Scaldera: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Bomb Bag
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sword
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Earth Temple\Boss Room\Slope\Bomb Flower Scaldera
-                  opaque: false
-                Bomb Flower Scaldera: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Earth Temple - Bomb Flower Scaldera Trick
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Earth Temple\Boss Room\Slope\Goddess Sword Strat
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Earth Temple\Boss Room\Slope\Longsword Strat
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Earth Temple\Boss Room\Slope\Master Sword Strat
-                    opaque: false
-                  opaque: false
-                Goddess Sword Strat: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Upgraded Skyward Strike option
-                  opaque: false
-                Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Boss Room\Slope\Beat Scaldera
-                Longsword Strat: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Longsword
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Upgraded Skyward Strike option
-                  opaque: false
-                Master Sword Strat: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Master Sword
+                Beat Scaldera: "Bomb Bag & \\Sword | \\Earth Temple\\Boss Room\\Slope\\\
+                  Bomb Flower Scaldera"
+                Bomb Flower Scaldera: "Earth Temple - Bomb Flower Scaldera Trick &\
+                  \ (\\Earth Temple\\Boss Room\\Slope\\Goddess Sword Strat | \\Earth\
+                  \ Temple\\Boss Room\\Slope\\Longsword Strat | \\Earth Temple\\Boss\
+                  \ Room\\Slope\\Master Sword Strat)"
+                Goddess Sword Strat: "\\Goddess Sword & Upgraded Skyward Strike option"
+                Heart Container: \Earth Temple\Boss Room\Slope\Beat Scaldera
+                Longsword Strat: "\\Goddess Longsword & Upgraded Skyward Strike option"
+                Master Sword Strat: \Master Sword
               name: \Earth Temple\Boss Room\Slope
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
-        Main: !!python/object:logic.logic_input.Area
+        Main:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -1336,309 +607,181 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Earth Temple\Main
           sub_areas:
-            East Room: !!python/object:logic.logic_input.Area
+            East Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Earth Temple\Main\Hub Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Earth Temple\Main\Hub Room: 'True'
               hint_region: Earth Temple
               locations:
-                Chest after Double Lizalfos Fight: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Defeat Lizalfos
+                Chest after Double Lizalfos Fight: \Can Defeat Lizalfos
               name: \Earth Temple\Main\East Room
               sub_areas: {}
               toplevel_alias: null
-            First Room: !!python/object:logic.logic_input.Area
+            First Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Main Entrance: null
               exits:
-                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Earth Temple\Main\Hub Room: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Earth Temple\Main\First Room\Lower Drawbridge
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Earth Temple\Main\First Room\Dislodge Boulder
-                  opaque: false
+                Main Exit: 'True'
+                \Earth Temple\Main\Hub Room: "\\Earth Temple\\Main\\First Room\\Lower\
+                  \ Drawbridge & \\Earth Temple\\Main\\First Room\\Dislodge Boulder"
               hint_region: Earth Temple
               locations:
-                Dislodge Boulder: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Slingshot
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Beetle
-                    - !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Advanced Lizalfos Combat Trick
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Can Defeat Lizalfos
-                      opaque: false
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Long Range Skyward Strike
-                  opaque: false
-                Lower Drawbridge: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Beetle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Long Range Skyward Strike
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Earth Temple - Keese Yeet Trick
-                    opaque: false
-                  opaque: false
-                Rupee above Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Vent Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Digging Mitts
+                Dislodge Boulder: "\\Slingshot | \\Beetle & (Advanced Lizalfos Combat\
+                  \ Trick | \\Can Defeat Lizalfos) | Clawshots | \\Bow | \\Long Range\
+                  \ Skyward Strike"
+                Lower Drawbridge: "\\Beetle | \\Bow | \\Long Range Skyward Strike\
+                  \ & Earth Temple - Keese Yeet Trick"
+                Rupee above Drawbridge: \Beetle
+                Vent Chest: \Digging Mitts
               name: \Earth Temple\Main\First Room
               sub_areas: {}
               toplevel_alias: null
-            Hub Room: !!python/object:logic.logic_input.Area
+            Hub Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Earth Temple\Main\East Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Main\Hub Room\Access to Boulder
-                \Earth Temple\Main\Hub Room\Past Lava Section: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Earth Temple\Main\Hub Room\Access to Boulder
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Earth Temple\Main\Hub Room\Wall to Lava Section
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Earth Temple\Main\Hub Room\Lower Lava Section Portcullis
-                      opaque: false
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Earth Temple\Main\Hub Room\Raise Bridge
-                    opaque: false
-                  opaque: false
-                \Earth Temple\Main\Room with Slopes: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Main\Hub Room\Raise Bridge
-                \Earth Temple\Main\West Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Main\Hub Room\Rock to West Room
+                \Earth Temple\Main\East Room: \Earth Temple\Main\Hub Room\Access to
+                  Boulder
+                \Earth Temple\Main\Hub Room\Past Lava Section: "\\Earth Temple\\Main\\\
+                  Hub Room\\Access to Boulder & (\\Earth Temple\\Main\\Hub Room\\\
+                  Wall to Lava Section & \\Earth Temple\\Main\\Hub Room\\Lower Lava\
+                  \ Section Portcullis | \\Earth Temple\\Main\\Hub Room\\Raise Bridge)"
+                \Earth Temple\Main\Room with Slopes: \Earth Temple\Main\Hub Room\Raise
+                  Bridge
+                \Earth Temple\Main\West Room: \Earth Temple\Main\Hub Room\Rock to
+                  West Room
               hint_region: Earth Temple
               locations:
-                Access to Boulder: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Main\First Room\Dislodge Boulder
-                Chest Left of Main Room Bridge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Main\Hub Room\Access to Boulder
-                Chest behind Bombable Rock: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Main\Hub Room\Access to Boulder
-                Ledd's Gift: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Defeat Lizalfos
-                Left Peg: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Main\Hub Room\Access to Boulder
-                Lower Lava Section Portcullis: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Earth Temple\Main\Hub Room\Wall to Lava Section
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Beetle
-                  opaque: false
-                Raise Bridge: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Earth Temple\Main\Hub Room\Left Peg
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Earth Temple\Main\Hub Room\Past Lava Section\Right Peg
-                  opaque: false
-                Rock to West Room: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  opaque: false
-                Rupee in Lava Tunnel: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Earth Temple\Main\Hub Room\Wall to Lava Section
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Beetle
-                  opaque: false
-                Wall to Lava Section: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Hook Beetle
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Earth Temple\Main\Hub Room\Access to Boulder
-                    opaque: false
-                  opaque: false
-                \Earth Temple\Main\First Room\Rupee above Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
+                Access to Boulder: \Earth Temple\Main\First Room\Dislodge Boulder
+                Chest Left of Main Room Bridge: \Earth Temple\Main\Hub Room\Access
+                  to Boulder
+                Chest behind Bombable Rock: \Earth Temple\Main\Hub Room\Access to
+                  Boulder
+                Ledd's Gift: \Can Defeat Lizalfos
+                Left Peg: \Earth Temple\Main\Hub Room\Access to Boulder
+                Lower Lava Section Portcullis: "\\Earth Temple\\Main\\Hub Room\\Wall\
+                  \ to Lava Section & \\Beetle"
+                Raise Bridge: "\\Earth Temple\\Main\\Hub Room\\Left Peg & \\Earth\
+                  \ Temple\\Main\\Hub Room\\Past Lava Section\\Right Peg"
+                Rock to West Room: "Bomb Bag | \\Hook Beetle"
+                Rupee in Lava Tunnel: "\\Earth Temple\\Main\\Hub Room\\Wall to Lava\
+                  \ Section & \\Beetle"
+                Wall to Lava Section: "Bomb Bag | \\Hook Beetle & \\Earth Temple\\\
+                  Main\\Hub Room\\Access to Boulder"
+                \Earth Temple\Main\First Room\Rupee above Drawbridge: \Beetle
               name: \Earth Temple\Main\Hub Room
               sub_areas:
-                Past Lava Section: !!python/object:logic.logic_input.Area
+                Past Lava Section:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Earth Temple\Main\Hub Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Earth Temple\Main\Hub Room: 'True'
                   hint_region: Earth Temple
                   locations:
-                    Chest Guarded by Lizalfos: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Right Peg: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Chest Guarded by Lizalfos: 'True'
+                    Right Peg: 'True'
                   name: \Earth Temple\Main\Hub Room\Past Lava Section
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Room with Slopes: !!python/object:logic.logic_input.Area
+            Room with Slopes:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Earth Temple\Main\Hub Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Earth Temple\Main\Room with Slopes\Front of Boss Door: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Earth Temple\Main\Room with Slopes\Rock in Second Slope
-                      Resting Area
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Earth Temple - Slope Stuttersprint Trick
-                  opaque: false
+                \Earth Temple\Main\Hub Room: 'True'
+                \Earth Temple\Main\Room with Slopes\Front of Boss Door: "\\Earth Temple\\\
+                  Main\\Room with Slopes\\Rock in Second Slope Resting Area | Earth\
+                  \ Temple - Slope Stuttersprint Trick"
               hint_region: Earth Temple
               locations:
-                Rock in Second Slope Resting Area: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Digging Mitts
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Bomb Bag
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  opaque: false
+                Rock in Second Slope Resting Area: "\\Digging Mitts & Bomb Bag | \\\
+                  Hook Beetle"
               name: \Earth Temple\Main\Room with Slopes
               sub_areas:
-                Front of Boss Door: !!python/object:logic.logic_input.Area
+                Front of Boss Door:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Boss Door Entrance: null
                   exits:
-                    Boss Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Earth Temple\Main\Room with Slopes\Front of Boss Door\Open
-                        Boss Door
-                    \Earth Temple\Main\Room with Slopes: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Boss Door Exit: \Earth Temple\Main\Room with Slopes\Front of Boss
+                      Door\Open Boss Door
+                    \Earth Temple\Main\Room with Slopes: 'True'
                   hint_region: Earth Temple
                   locations:
-                    Boss Key Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Open Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Earth Temple Boss Key
+                    Boss Key Chest: 'True'
+                    Open Boss Door: Earth Temple Boss Key
                   name: \Earth Temple\Main\Room with Slopes\Front of Boss Door
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            West Room: !!python/object:logic.logic_input.Area
+            West Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Earth Temple\Main\Hub Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Earth Temple\Main\West Room\Rock to Hub Room
+                \Earth Temple\Main\Hub Room: \Earth Temple\Main\West Room\Rock to
+                  Hub Room
               hint_region: Earth Temple
               locations:
-                Chest in West Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Rock to Hub Room: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  opaque: false
+                Chest in West Room: 'True'
+                Rock to Hub Room: "Bomb Bag | \\Hook Beetle"
               name: \Earth Temple\Main\West Room
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
-        Spring: !!python/object:logic.logic_input.Area
+        Spring:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance: null
           exits:
-            Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit: 'True'
           hint_region: Earth Temple
           locations:
-            Strike Crest: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Goddess Sword
+            Strike Crest: \Goddess Sword
           name: \Earth Temple\Spring
           sub_areas: {}
           toplevel_alias: null
       toplevel_alias: null
-    Eldin: !!python/object:logic.logic_input.Area
+    Eldin:
       abstract: true
-      allowed_time_of_day: *id001
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
       exits: {}
       hint_region: null
       locations:
-        Can Survive Hot Cave: !!python/object:logic.logic_expression.OrCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Nonlethal Hot Cave
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Fireshield Earrings
-          opaque: false
+        Can Survive Hot Cave: "Nonlethal Hot Cave | Fireshield Earrings"
       name: \Eldin
       sub_areas:
-        Bokoblin Base: !!python/object:logic.logic_input.Area
+        Bokoblin Base:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -1647,321 +790,204 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Eldin\Bokoblin Base
           sub_areas:
-            After Drawbridge: !!python/object:logic.logic_input.Area
+            After Drawbridge:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Bokoblin Base\Before Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
-                \Eldin\Bokoblin Base\Lower Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Bokoblin Base\Outside Earth Temple: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Bokoblin Base\Volcano East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Eldin\Bokoblin Base\Before Drawbridge: Clawshots
+                \Eldin\Bokoblin Base\Lower Platform Cave: 'True'
+                \Eldin\Bokoblin Base\Outside Earth Temple: 'True'
+                \Eldin\Bokoblin Base\Volcano East: 'True'
               hint_region: Bokoblin Base
               locations: {}
               name: \Eldin\Bokoblin Base\After Drawbridge
               sub_areas: {}
               toplevel_alias: null
-            Before Drawbridge: !!python/object:logic.logic_input.Area
+            Before Drawbridge:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Bokoblin Base\After Drawbridge: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Whip
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  opaque: false
-                \Eldin\Bokoblin Base\Volcano East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Eldin\Bokoblin Base\After Drawbridge: "Whip & Clawshots"
+                \Eldin\Bokoblin Base\Volcano East: 'True'
               hint_region: Bokoblin Base
               locations:
-                Chest near Drawbridge: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can bypass Boko Base Watch Tower
-                  opaque: false
+                Chest near Drawbridge: "Clawshots | \\Can bypass Boko Base Watch Tower"
               name: \Eldin\Bokoblin Base\Before Drawbridge
               sub_areas: {}
               toplevel_alias: null
-            Bokoblin Base Summit: !!python/object:logic.logic_input.Area
+            Bokoblin Base Summit:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Bokoblin Base\Fire Dragon's Lair: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Fireshield Earrings
-                \Eldin\Bokoblin Base\Hot Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Fireshield Earrings
+                \Eldin\Bokoblin Base\Fire Dragon's Lair: Fireshield Earrings
+                \Eldin\Bokoblin Base\Hot Cave: Fireshield Earrings
               hint_region: Bokoblin Base
               locations:
-                Chest in Volcano Summit Alcove: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Fireshield Earrings
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Practice Sword
-                  opaque: false
-                First Chest in Volcano Summit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Fireshield Earrings
-                Goddess Cube inside Volcano Summit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Fireshield Earrings
-                Raised Chest in Volcano Summit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Fireshield Earrings
+                Chest in Volcano Summit Alcove: "Fireshield Earrings & \\Practice\
+                  \ Sword"
+                First Chest in Volcano Summit: Fireshield Earrings
+                Goddess Cube inside Volcano Summit: Fireshield Earrings
+                Raised Chest in Volcano Summit: Fireshield Earrings
               name: \Eldin\Bokoblin Base\Bokoblin Base Summit
               sub_areas: {}
               toplevel_alias: null
-            Fire Dragon's Lair: !!python/object:logic.logic_input.Area
+            Fire Dragon's Lair:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Bokoblin Base\Bokoblin Base Summit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Eldin\Bokoblin Base\Bokoblin Base Summit: 'True'
               hint_region: Bokoblin Base
               locations:
-                Beaten Boko Base: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Beetle
-                  opaque: false
-                Fire Dragon's Reward: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
+                Beaten Boko Base: "\\Bow | \\Beetle"
+                Fire Dragon's Reward: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten
+                  Boko Base
               name: \Eldin\Bokoblin Base\Fire Dragon's Lair
               sub_areas: {}
               toplevel_alias: null
-            Hot Cave: !!python/object:logic.logic_input.Area
+            Hot Cave:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Bokoblin Base\After Drawbridge: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Fireshield Earrings
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  opaque: false
-                \Eldin\Bokoblin Base\Bokoblin Base Summit: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Fireshield Earrings
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  opaque: false
+                \Eldin\Bokoblin Base\After Drawbridge: "Fireshield Earrings & Bomb\
+                  \ Bag"
+                \Eldin\Bokoblin Base\Bokoblin Base Summit: "Fireshield Earrings &\
+                  \ Bomb Bag"
               hint_region: Bokoblin Base
               locations: {}
               name: \Eldin\Bokoblin Base\Hot Cave
               sub_areas: {}
               toplevel_alias: null
-            Lower Platform Cave: !!python/object:logic.logic_input.Area
+            Lower Platform Cave:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Bokoblin Base\After Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
-                \Eldin\Bokoblin Base\Before Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Bokoblin Base\Volcano East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Eldin\Bokoblin Base\After Drawbridge: Clawshots
+                \Eldin\Bokoblin Base\Before Drawbridge: 'True'
+                \Eldin\Bokoblin Base\Volcano East: 'True'
               hint_region: Bokoblin Base
               locations:
-                Gossip Stone in Lower Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Gossip Stone in Lower Platform Cave: 'True'
               name: \Eldin\Bokoblin Base\Lower Platform Cave
               sub_areas: {}
               toplevel_alias: null
-            Outside Earth Temple: !!python/object:logic.logic_input.Area
+            Outside Earth Temple:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Bokoblin Base\Hot Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Bokoblin Base\Upper Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Eldin\Bokoblin Base\Hot Cave: 'True'
+                \Eldin\Bokoblin Base\Upper Platform Cave: 'True'
               hint_region: Bokoblin Base
               locations:
-                Chest East of Earth Temple Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Chest West of Earth Temple Entrance: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Slingshot
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Bow
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Bomb Bag
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Goddess Sword
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can bypass Boko Base Watch Tower
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Mogma Mitts
-                  opaque: false
-                Goddess Cube East of Earth Temple Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                Goddess Cube West of Earth Temple Entrance: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can bypass Boko Base Watch Tower
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Mogma Mitts
-                  opaque: false
+                Chest East of Earth Temple Entrance: 'True'
+                Chest West of Earth Temple Entrance: "(\\Slingshot | \\Bow | Bomb\
+                  \ Bag | \\Goddess Sword) & \\Can bypass Boko Base Watch Tower &\
+                  \ \\Mogma Mitts"
+                Goddess Cube East of Earth Temple Entrance: \Goddess Sword
+                Goddess Cube West of Earth Temple Entrance: "\\Goddess Sword & \\\
+                  Can bypass Boko Base Watch Tower & \\Mogma Mitts"
               name: \Eldin\Bokoblin Base\Outside Earth Temple
               sub_areas: {}
               toplevel_alias: null
-            Prison: !!python/object:logic.logic_input.Area
+            Prison:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Bokoblin Base\Volcano East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Mogma Mitts
+                Exit: 'True'
+                \Eldin\Bokoblin Base\Volcano East: \Mogma Mitts
               hint_region: Bokoblin Base
               locations:
-                Plats' Gift: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Plats' Gift: 'True'
               name: \Eldin\Bokoblin Base\Prison
               sub_areas: {}
               toplevel_alias: null
-            Upper Platform Cave: !!python/object:logic.logic_input.Area
+            Upper Platform Cave:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Bokoblin Base\Outside Earth Temple: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Eldin\Bokoblin Base\Outside Earth Temple: 'True'
               hint_region: Bokoblin Base
               locations:
-                Gossip Stone in Upper Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Gossip Stone in Upper Platform Cave: 'True'
               name: \Eldin\Bokoblin Base\Upper Platform Cave
               sub_areas: {}
               toplevel_alias: null
-            Volcano East: !!python/object:logic.logic_input.Area
+            Volcano East:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Bokoblin Base\After Drawbridge: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  opaque: false
-                \Eldin\Bokoblin Base\Before Drawbridge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Bokoblin Base\Prison: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Mogma Mitts
+                \Eldin\Bokoblin Base\After Drawbridge: "Clawshots & Bomb Bag"
+                \Eldin\Bokoblin Base\Before Drawbridge: 'True'
+                \Eldin\Bokoblin Base\Prison: \Mogma Mitts
               hint_region: Bokoblin Base
               locations:
-                Chest near Bone Bridge: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can bypass Boko Base Watch Tower
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Mogma Mitts
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Gust Bellows
-                  opaque: false
-                Chest on Cliff: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Can bypass Boko Base Watch Tower
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Mogma Mitts
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Gust Bellows
-                  opaque: false
-                Goddess Cube near Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
+                Chest near Bone Bridge: "\\Can bypass Boko Base Watch Tower | \\Mogma\
+                  \ Mitts | Gust Bellows"
+                Chest on Cliff: "(\\Can bypass Boko Base Watch Tower | \\Mogma Mitts)\
+                  \ & Gust Bellows"
+                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
               name: \Eldin\Bokoblin Base\Volcano East
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: Bokoblin Base
-        Eldin Silent Realm: !!python/object:logic.logic_input.Area
+        Eldin Silent Realm:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance: null
           exits:
-            Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit: 'True'
           hint_region: Eldin Silent Realm
           locations:
-            Relic 1: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 10: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 2: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 3: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 4: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 5: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 6: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 7: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 8: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 9: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Trial Reward: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Relic 1: 'True'
+            Relic 10: 'True'
+            Relic 2: 'True'
+            Relic 3: 'True'
+            Relic 4: 'True'
+            Relic 5: 'True'
+            Relic 6: 'True'
+            Relic 7: 'True'
+            Relic 8: 'True'
+            Relic 9: 'True'
+            Trial Reward: 'True'
           name: \Eldin\Eldin Silent Realm
           sub_areas: {}
           toplevel_alias: null
-        Mogma Turf: !!python/object:logic.logic_input.Area
+        Mogma Turf:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -1970,80 +996,62 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Eldin\Mogma Turf
           sub_areas:
-            Past Vent: !!python/object:logic.logic_input.Area
+            Past Vent:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                Second Vent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Mogma Turf\Pre Vent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Mogma Turf\Sand Slide Platform: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Second Vent: 'True'
+                \Eldin\Mogma Turf\Pre Vent: 'True'
+                \Eldin\Mogma Turf\Sand Slide Platform: 'True'
               hint_region: Mogma Turf
               locations:
-                Chest behind Bombable Wall in Fire Maze: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Chest behind Bombable Wall in Fire Maze: 'True'
               name: \Eldin\Mogma Turf\Past Vent
               sub_areas: {}
               toplevel_alias: null
-            Pre Vent: !!python/object:logic.logic_input.Area
+            Pre Vent:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance: null
               exits:
-                First Vent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Mogma Turf\Past Vent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Mogma Turf\Pre Vent\Open Vent
+                First Vent: 'True'
+                \Eldin\Mogma Turf\Past Vent: \Eldin\Mogma Turf\Pre Vent\Open Vent
               hint_region: Mogma Turf
               locations:
-                Chest behind Bombable Wall at Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Defeat Bokoblins: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Defeat Bokoblins
-                Free Fall Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Goddess Cube in Mogma Turf: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                Open Vent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Digging Mitts
-                Pick up Guld: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sky\South East\Lumpy Pumpkin\Start Kina's Quest
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Scrapper
-                  opaque: false
+                Chest behind Bombable Wall at Entrance: 'True'
+                Defeat Bokoblins: \Can Defeat Bokoblins
+                Free Fall Chest: 'True'
+                Goddess Cube in Mogma Turf: \Goddess Sword
+                Open Vent: \Digging Mitts
+                Pick up Guld: "\\Sky\\South East\\Lumpy Pumpkin\\Start Kina's Quest\
+                  \ & Scrapper"
               name: \Eldin\Mogma Turf\Pre Vent
               sub_areas: {}
               toplevel_alias: null
-            Sand Slide Platform: !!python/object:logic.logic_input.Area
+            Sand Slide Platform:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Mogma Turf\Pre Vent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Eldin\Mogma Turf\Pre Vent: 'True'
               hint_region: Mogma Turf
               locations:
-                Sand Slide Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Sand Slide Chest: 'True'
               name: \Eldin\Mogma Turf\Sand Slide Platform
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
-        Volcano: !!python/object:logic.logic_input.Area
+        Volcano:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -2052,65 +1060,38 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Eldin\Volcano
           sub_areas:
-            Ascent: !!python/object:logic.logic_input.Area
+            Ascent:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Trial Gate Entrance: null
                 Volcano Ascent Statue Entrance: null
               exits:
-                Trial Gate Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Ascent\Open Trial Gate
-                \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Ascent\Unlock Statue
-                \Eldin\Volcano\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
-                \Eldin\Volcano\Near Thrill Digger Cave: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Eldin\Volcano\Ascent\Defeat Slope Bokoblins
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Stuttersprint Trick
-                  opaque: false
-                \Eldin\Volcano\Past Slide: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Past Slide\Unlock Shortcut to Ascent
+                Trial Gate Exit: \Eldin\Volcano\Ascent\Open Trial Gate
+                \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\Ascent\Unlock
+                  Statue
+                \Eldin\Volcano\Entry: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
+                \Eldin\Volcano\Near Thrill Digger Cave: "\\Eldin\\Volcano\\Ascent\\\
+                  Defeat Slope Bokoblins | Stuttersprint Trick"
+                \Eldin\Volcano\Past Slide: \Eldin\Volcano\Past Slide\Unlock Shortcut
+                  to Ascent
               hint_region: Eldin Volcano
               locations:
-                Chest behind Bombable Wall near Volcano Ascent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Defeat Slope Bokoblins: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Slingshot
-                  opaque: false
-                Open Trial Gate: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Goddess's Harp
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Din's Power
-                  opaque: false
-                Unlock Shortcut to Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Volcano\Past Slide\Unlock Shortcut to Ascent: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  opaque: false
+                Chest behind Bombable Wall near Volcano Ascent: 'True'
+                Defeat Slope Bokoblins: "\\Bow | \\Slingshot"
+                Open Trial Gate: "Goddess's Harp & Din's Power"
+                Unlock Shortcut to Entry: 'True'
+                Unlock Statue: 'True'
+                \Eldin\Volcano\Past Slide\Unlock Shortcut to Ascent: "Bomb Bag | \\\
+                  Hook Beetle"
               name: \Eldin\Volcano\Ascent
               sub_areas: {}
               toplevel_alias: null
-            East: !!python/object:logic.logic_input.Area
+            East:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -2118,338 +1099,251 @@ areas: !!python/object:logic.logic_input.Area
                 First Vent from Mogma Turf: null
                 Volcano East Statue Entrance: null
               exits:
-                Dive to Mogma Turf: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\East\Drain Lava
-                Exit to Bokoblin Base: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Volcano East / Volcano Ascent Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\East\Unlock Statue
-                \Eldin\Volcano\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
-                \Eldin\Volcano\First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\First Room\Blow up Rock to East
-                \Eldin\Volcano\Past Mogma Turf: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf
+                Dive to Mogma Turf: \Eldin\Volcano\East\Drain Lava
+                Exit to Bokoblin Base: 'True'
+                Volcano East / Volcano Ascent Statue Exit: \Eldin\Volcano\East\Unlock
+                  Statue
+                \Eldin\Volcano\Entry: Clawshots
+                \Eldin\Volcano\First Room: \Eldin\Volcano\First Room\Blow up Rock
+                  to East
+                \Eldin\Volcano\Past Mogma Turf: \Eldin\Volcano\Past Mogma Turf\Unlock
+                  Shortcut to Pre Turf
               hint_region: Eldin Volcano
               locations:
-                Chest after Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Chest behind Bombable Wall near Cliff: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Drain Lava: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Goddess Cube near Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                Item on Cliff: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                North Rupee above Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Southeast Rupee above Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Volcano\First Room\Blow up Rock to East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Bomb Bag
-                \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  opaque: false
+                Chest after Crawlspace: 'True'
+                Chest behind Bombable Wall near Cliff: 'True'
+                Drain Lava: 'True'
+                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
+                Item on Cliff: 'True'
+                North Rupee above Mogma Turf Entrance: \Beetle
+                Southeast Rupee above Mogma Turf Entrance: \Beetle
+                Unlock Statue: 'True'
+                \Eldin\Volcano\First Room\Blow up Rock to East: Bomb Bag
+                \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf: "Bomb\
+                  \ Bag | \\Hook Beetle"
               name: \Eldin\Volcano\East
               sub_areas: {}
               toplevel_alias: null
-            Entry: !!python/object:logic.logic_input.Area
+            Entry:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 First Time Entrance: null
                 Volcano Entrance Statue Entrance: null
               exits:
-                Volcano Entrance Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Entry\Unlock Statue
-                \Eldin\Volcano\Ascent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
-                \Eldin\Volcano\First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Volcano Entrance Statue Exit: \Eldin\Volcano\Entry\Unlock Statue
+                \Eldin\Volcano\Ascent: \Eldin\Volcano\Ascent\Unlock Shortcut to Entry
+                \Eldin\Volcano\First Room: 'True'
               hint_region: Eldin Volcano
               locations:
-                Goddess Cube at Eldin Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                Rupee on Ledge before First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Volcano\Ascent\Unlock Shortcut to Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Bomb Bag
+                Goddess Cube at Eldin Entrance: \Goddess Sword
+                Rupee on Ledge before First Room: 'True'
+                Unlock Statue: 'True'
+                \Eldin\Volcano\Ascent\Unlock Shortcut to Entry: Bomb Bag
               name: \Eldin\Volcano\Entry
               sub_areas: {}
               toplevel_alias: null
-            First Room: !!python/object:logic.logic_input.Area
+            First Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Volcano\East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\First Room\Blow up Rock to East
+                \Eldin\Volcano\East: \Eldin\Volcano\First Room\Blow up Rock to East
               hint_region: Eldin Volcano
               locations:
-                Blow up Rock to East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Chest behind Bombable Wall in First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Rupee behind Bombable Wall in First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Rupee in Crawlspace in First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Blow up Rock to East: 'True'
+                Chest behind Bombable Wall in First Room: 'True'
+                Rupee behind Bombable Wall in First Room: 'True'
+                Rupee in Crawlspace in First Room: 'True'
               name: \Eldin\Volcano\First Room
               sub_areas: {}
               toplevel_alias: null
-            Hot Cave: !!python/object:logic.logic_input.Area
+            Hot Cave:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Summit: null
                 Vent Entrance near Hot Cave: null
               exits:
-                Exit to Summit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Fireshield Earrings
-                \Eldin\Volcano\Near Temple Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Near Temple Entrance\Blow down Watchtower to
-                    Hot Cave
-                \Eldin\Volcano\Sand Slide: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Can Survive Hot Cave
+                Exit to Summit: Fireshield Earrings
+                \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Temple Entrance\Blow
+                  down Watchtower to Hot Cave
+                \Eldin\Volcano\Sand Slide: \Eldin\Can Survive Hot Cave
               hint_region: Eldin Volcano
               locations:
-                \Eldin\Volcano\Near Temple Entrance\Blow down Watchtower to Hot Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'False'
+                \Eldin\Volcano\Near Temple Entrance\Blow down Watchtower to Hot Cave: 'False'
               name: \Eldin\Volcano\Hot Cave
               sub_areas: {}
               toplevel_alias: null
-            Lower Platform Cave: !!python/object:logic.logic_input.Area
+            Lower Platform Cave:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Volcano\East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
-                \Eldin\Volcano\Past Mogma Turf: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
-                \Eldin\Volcano\Past Slide: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
+                \Eldin\Volcano\East: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten
+                  Boko Base
+                \Eldin\Volcano\Past Mogma Turf: \Eldin\Bokoblin Base\Fire Dragon's
+                  Lair\Beaten Boko Base
+                \Eldin\Volcano\Past Slide: Clawshots
               hint_region: Eldin Volcano
               locations:
-                Gossip Stone in Lower Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Gossip Stone in Lower Platform Cave: 'True'
               name: \Eldin\Volcano\Lower Platform Cave
               sub_areas: {}
               toplevel_alias: null
-            Near Temple Entrance: !!python/object:logic.logic_input.Area
+            Near Temple Entrance:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Earth Temple: null
                 Temple Entrance Statue Entrance: null
               exits:
-                Exit to Earth Temple: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Open ET option
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Key Piece x 5
-                  opaque: false
-                Temple Entrance Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Near Temple Entrance\Unlock Statue
-                \Eldin\Volcano\Hot Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Near Temple Entrance\Blow down Watchtower to
-                    Hot Cave
-                \Eldin\Volcano\Near Thrill Digger Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Near Thrill Digger Cave\Blow down Watchtower
-                \Eldin\Volcano\Upper Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
+                Exit to Earth Temple: "Open ET option | Key Piece x 5"
+                Temple Entrance Statue Exit: \Eldin\Volcano\Near Temple Entrance\Unlock
+                  Statue
+                \Eldin\Volcano\Hot Cave: \Eldin\Volcano\Near Temple Entrance\Blow
+                  down Watchtower to Hot Cave
+                \Eldin\Volcano\Near Thrill Digger Cave: \Eldin\Volcano\Near Thrill
+                  Digger Cave\Blow down Watchtower
+                \Eldin\Volcano\Upper Platform Cave: \Eldin\Bokoblin Base\Fire Dragon's
+                  Lair\Beaten Boko Base
               hint_region: Eldin Volcano
               locations:
-                Blow down Watchtower to Hot Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Digging Spot behind Boulder on Sandy Slope: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Digging Mitts
-                Digging Spot below Tower: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Digging Mitts
-                Digging Spot in front of Earth Temple: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Digging Mitts
-                Goddess Cube East of Earth Temple Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                Goddess Cube West of Earth Temple Entrance: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Digging Mitts
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  opaque: false
-                Gossip Stone next to Earth Temple: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Digging Mitts
-                Retrieve Crystal Ball: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Scrapper
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyloft\Skyloft Village\Sparrot's House\Start Sparrot's
-                      Quest
-                  opaque: false
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Blow down Watchtower to Hot Cave: 'True'
+                Digging Spot behind Boulder on Sandy Slope: \Digging Mitts
+                Digging Spot below Tower: \Digging Mitts
+                Digging Spot in front of Earth Temple: \Digging Mitts
+                Goddess Cube East of Earth Temple Entrance: \Goddess Sword
+                Goddess Cube West of Earth Temple Entrance: "\\Digging Mitts & \\\
+                  Goddess Sword"
+                Gossip Stone next to Earth Temple: \Digging Mitts
+                Retrieve Crystal Ball: "Clawshots & Scrapper & \\Skyloft\\Skyloft\
+                  \ Village\\Sparrot's House\\Start Sparrot's Quest"
+                Unlock Statue: 'True'
               name: \Eldin\Volcano\Near Temple Entrance
               sub_areas: {}
               toplevel_alias: null
-            Near Thrill Digger Cave: !!python/object:logic.logic_input.Area
+            Near Thrill Digger Cave:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Thrill Digger Cave Entrance: null
               exits:
-                Thrill Digger Cave Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Volcano\Ascent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Volcano\Near Temple Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Near Thrill Digger Cave\Blow down Watchtower
+                Thrill Digger Cave Exit: 'True'
+                \Eldin\Volcano\Ascent: 'True'
+                \Eldin\Volcano\Near Temple Entrance: \Eldin\Volcano\Near Thrill Digger
+                  Cave\Blow down Watchtower
               hint_region: Eldin Volcano
               locations:
-                Blow down Watchtower: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Left Rupee behind Bombable Wall on First Slope: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Right Rupee behind Bombable Wall on First Slope: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Blow down Watchtower: 'True'
+                Left Rupee behind Bombable Wall on First Slope: 'True'
+                Right Rupee behind Bombable Wall on First Slope: 'True'
               name: \Eldin\Volcano\Near Thrill Digger Cave
               sub_areas: {}
               toplevel_alias: null
-            Past Mogma Turf: !!python/object:logic.logic_input.Area
+            Past Mogma Turf:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Second Vent from Mogma Turf: null
               exits:
-                \Eldin\Volcano\Ascent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Past Mogma Turf\Watch Bridge Cutscene
-                \Eldin\Volcano\East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut to Pre Turf
+                \Eldin\Volcano\Ascent: \Eldin\Volcano\Past Mogma Turf\Watch Bridge
+                  Cutscene
+                \Eldin\Volcano\East: \Eldin\Volcano\Past Mogma Turf\Unlock Shortcut
+                  to Pre Turf
               hint_region: Eldin Volcano
               locations:
-                Goddess Cube near Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                North Rupee above Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Southeast Rupee above Mogma Turf Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Unlock Shortcut to Pre Turf: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Watch Bridge Cutscene: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Goddess Cube near Mogma Turf Entrance: \Goddess Sword
+                North Rupee above Mogma Turf Entrance: \Beetle
+                Southeast Rupee above Mogma Turf Entrance: \Beetle
+                Unlock Shortcut to Pre Turf: 'True'
+                Watch Bridge Cutscene: 'True'
               name: \Eldin\Volcano\Past Mogma Turf
               sub_areas: {}
               toplevel_alias: null
-            Past Slide: !!python/object:logic.logic_input.Area
+            Past Slide:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                Vent Exit near Ascent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Volcano\Ascent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Past Slide\Unlock Shortcut to Ascent
-                \Eldin\Volcano\Lower Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
+                Vent Exit near Ascent: 'True'
+                \Eldin\Volcano\Ascent: \Eldin\Volcano\Past Slide\Unlock Shortcut to
+                  Ascent
+                \Eldin\Volcano\Lower Platform Cave: \Eldin\Bokoblin Base\Fire Dragon's
+                  Lair\Beaten Boko Base
               hint_region: Eldin Volcano
               locations:
-                Digging Spot after Draining Lava: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Digging Mitts
-                Unlock Shortcut to Ascent: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Digging Spot after Draining Lava: \Digging Mitts
+                Unlock Shortcut to Ascent: 'True'
               name: \Eldin\Volcano\Past Slide
               sub_areas: {}
               toplevel_alias: null
-            Sand Slide: !!python/object:logic.logic_input.Area
+            Sand Slide:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Volcano\Past Slide: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Eldin\Volcano\Past Slide: 'True'
               hint_region: Eldin Volcano
               locations:
-                Digging Spot after Vents: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Digging Mitts
-                Goddess Cube on Sand Slide: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
+                Digging Spot after Vents: \Digging Mitts
+                Goddess Cube on Sand Slide: \Goddess Sword
               name: \Eldin\Volcano\Sand Slide
               sub_areas: {}
               toplevel_alias: null
-            Thrill Digger Cave: !!python/object:logic.logic_input.Area
+            Thrill Digger Cave:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Eldin Volcano
               locations:
-                Gossip Stone in Thrill Digger Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Thrill Digger Minigame: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Digging Mitts
+                Gossip Stone in Thrill Digger Cave: 'True'
+                Thrill Digger Minigame: \Digging Mitts
               name: \Eldin\Volcano\Thrill Digger Cave
               sub_areas: {}
               toplevel_alias: null
-            Upper Platform Cave: !!python/object:logic.logic_input.Area
+            Upper Platform Cave:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Eldin\Volcano\Near Temple Entrance: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Eldin\Bokoblin Base\Fire Dragon's Lair\Beaten Boko Base
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  opaque: false
+                \Eldin\Volcano\Near Temple Entrance: "\\Eldin\\Bokoblin Base\\Fire\
+                  \ Dragon's Lair\\Beaten Boko Base | Clawshots"
               hint_region: Eldin Volcano
               locations:
-                Gossip Stone in Upper Platform Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Gossip Stone in Upper Platform Cave: 'True'
               name: \Eldin\Volcano\Upper Platform Cave
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: Eldin Volcano
-        Volcano Summit: !!python/object:logic.logic_input.Area
+        Volcano Summit:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
@@ -2457,151 +1351,116 @@ areas: !!python/object:logic.logic_input.Area
             Entrance from Outside Fire Sanctuary: null
             Entrance from Waterfall: null
           exits:
-            Exit to Eldin Volcano: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Fireshield Earrings
-            Exit to Outside Fire Sanctuary: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Fireshield Earrings
-            Exit to Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Fireshield Earrings
+            Exit to Eldin Volcano: Fireshield Earrings
+            Exit to Outside Fire Sanctuary: Fireshield Earrings
+            Exit to Waterfall: Fireshield Earrings
           hint_region: Volcano Summit
           locations:
-            Goddess Cube inside Volcano Summit: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Fireshield Earrings
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Long Range Skyward Strike
-              opaque: false
+            Goddess Cube inside Volcano Summit: "Fireshield Earrings & \\Long Range\
+              \ Skyward Strike"
           name: \Eldin\Volcano Summit
           sub_areas:
-            Outside Fire Sanctuary: !!python/object:logic.logic_input.Area
+            Outside Fire Sanctuary:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Fire Sanctuary: null
                 Statue Entrance: null
               exits:
-                Exit to Fire Sanctuary: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Hydrate Giant
-                    Frog
-                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
-                \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty
-                    Frogs\Hydrate Second Frog
+                Exit to Fire Sanctuary: \Eldin\Volcano Summit\Outside Fire Sanctuary\Hydrate
+                  Giant Frog
+                Statue Exit: \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
+                \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: \Eldin\Volcano
+                  Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Hydrate Second
+                  Frog
               hint_region: Volcano Summit
               locations:
-                Goddess Cube near Fire Sanctuary Entrance: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  opaque: false
-                Hydrate Giant Frog: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Goddess Cube near Fire Sanctuary Entrance: "Clawshots & \\Goddess\
+                  \ Sword"
+                Hydrate Giant Frog: 'True'
+                Unlock Statue: 'True'
               name: \Eldin\Volcano Summit\Outside Fire Sanctuary
               sub_areas:
-                Before Thirsty Frogs: !!python/object:logic.logic_input.Area
+                Before Thirsty Frogs:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Summit: null
                   exits:
-                    Exit to Summit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty
-                        Frogs\Hydrate First Frog
+                    Exit to Summit: 'True'
+                    \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs: \Eldin\Volcano
+                      Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Hydrate First
+                      Frog
                   hint_region: Volcano Summit
                   locations:
-                    Hydrate First Frog: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Water Bottle
+                    Hydrate First Frog: \Water Bottle
                   name: \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty
                     Frogs
                   sub_areas: {}
                   toplevel_alias: null
-                Between Thirsty Frogs: !!python/object:logic.logic_input.Area
+                Between Thirsty Frogs:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Eldin\Volcano Summit\Outside Fire Sanctuary: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty
-                        Frogs\Hydrate Second Frog
-                    \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty
-                        Frogs\Hydrate First Frog
+                    \Eldin\Volcano Summit\Outside Fire Sanctuary: \Eldin\Volcano Summit\Outside
+                      Fire Sanctuary\Between Thirsty Frogs\Hydrate Second Frog
+                    \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs: \Eldin\Volcano
+                      Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Hydrate First
+                      Frog
                   hint_region: Volcano Summit
                   locations:
-                    Gossip Stone near Second Thirsty Frog: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Hydrate Second Frog: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Water Bottle
-                      opaque: false
-                    Item behind Digging: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Mogma Mitts
+                    Gossip Stone near Second Thirsty Frog: 'True'
+                    Hydrate Second Frog: "Clawshots & \\Water Bottle"
+                    Item behind Digging: \Mogma Mitts
                   name: \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty
                     Frogs
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Waterfall: !!python/object:logic.logic_input.Area
+            Waterfall:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Eldin\Volcano Summit\Waterfall\Higher Area: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
+                Exit: 'True'
+                \Eldin\Volcano Summit\Waterfall\Higher Area: Clawshots
               hint_region: Volcano Summit
               locations:
-                Goddess Cube in Summit Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                \Can Collect Water: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Goddess Cube in Summit Waterfall: \Goddess Sword
+                \Can Collect Water: 'True'
               name: \Eldin\Volcano Summit\Waterfall
               sub_areas:
-                Higher Area: !!python/object:logic.logic_input.Area
+                Higher Area:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Eldin\Volcano Summit\Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Eldin\Volcano Summit\Waterfall: 'True'
                   hint_region: Volcano Summit
                   locations:
-                    Chest behind Bombable Wall in Waterfall Area: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Gossip Stone in Waterfall Area: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Chest behind Bombable Wall in Waterfall Area: 'True'
+                    Gossip Stone in Waterfall Area: 'True'
                   name: \Eldin\Volcano Summit\Waterfall\Higher Area
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
           toplevel_alias: null
       toplevel_alias: null
-    Faron: !!python/object:logic.logic_input.Area
+    Faron:
       abstract: false
-      allowed_time_of_day: *id001
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
@@ -2610,46 +1469,34 @@ areas: !!python/object:logic.logic_input.Area
       locations: {}
       name: \Faron
       sub_areas:
-        Faron Silent Realm: !!python/object:logic.logic_input.Area
+        Faron Silent Realm:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance: null
           exits:
-            Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit: 'True'
           hint_region: Faron Silent Realm
           locations:
-            Relic 1: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 10: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 2: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 3: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 4: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 5: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 6: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 7: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 8: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 9: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Trial Reward: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Relic 1: 'True'
+            Relic 10: 'True'
+            Relic 2: 'True'
+            Relic 3: 'True'
+            Relic 4: 'True'
+            Relic 5: 'True'
+            Relic 6: 'True'
+            Relic 7: 'True'
+            Relic 8: 'True'
+            Relic 9: 'True'
+            Trial Reward: 'True'
           name: \Faron\Faron Silent Realm
           sub_areas: {}
           toplevel_alias: null
-        Faron Woods: !!python/object:logic.logic_input.Area
+        Faron Woods:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
@@ -2657,152 +1504,75 @@ areas: !!python/object:logic.logic_input.Area
             Trial Gate Entrance: null
             Viewing Platform Statue Entrance: null
           exits:
-            Lake Floria Dive: !!python/object:logic.logic_expression.OrCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Faron\Faron Woods\Open Door to Lake Floria
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Early Lake Floria Tricks
-              opaque: false
-            Shared Statue Exit: !!python/object:logic.logic_expression.OrCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Faron\Faron Woods\Unlock In the Woods Statue
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Faron\Faron Woods\Unlock Viewing Platform Statue
-              opaque: false
-            Trial Gate Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Faron\Faron Woods\Open Trial Gate
-            \Faron\Faron Woods\Behind the Crawlspace and Rope: !!python/object:logic.logic_expression.OrCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Bomb Bag
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Faron\Faron Woods\Ledge to Lake Floria\Push Log
-              opaque: false
-            \Faron\Faron Woods\Clawshot Target Branch: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Clawshots
-            \Faron\Faron Woods\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Faron\Faron Woods\Great Tree\Near Underwater Hole: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            \Faron\Faron Woods\Great Tree\Platforms: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Clawshots
-            \Faron\Faron Woods\Ledge To Deep Woods: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Faron\Faron Woods\Hit Vine to Deep Woods
-            \Faron\Faron Woods\Ledge to Lake Floria: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Faron\Faron Woods\Ledge to Lake Floria\Push Log
+            Lake Floria Dive: "\\Faron\\Faron Woods\\Open Door to Lake Floria | \\\
+              Early Lake Floria Tricks"
+            Shared Statue Exit: "\\Faron\\Faron Woods\\Unlock In the Woods Statue\
+              \ | \\Faron\\Faron Woods\\Unlock Viewing Platform Statue"
+            Trial Gate Exit: \Faron\Faron Woods\Open Trial Gate
+            \Faron\Faron Woods\Behind the Crawlspace and Rope: "Bomb Bag | \\Faron\\\
+              Faron Woods\\Ledge to Lake Floria\\Push Log"
+            \Faron\Faron Woods\Clawshot Target Branch: Clawshots
+            \Faron\Faron Woods\Entry: 'True'
+            \Faron\Faron Woods\Great Tree\Near Underwater Hole: Water Dragon's Scale
+            \Faron\Faron Woods\Great Tree\Platforms: Clawshots
+            \Faron\Faron Woods\Ledge To Deep Woods: \Faron\Faron Woods\Hit Vine to
+              Deep Woods
+            \Faron\Faron Woods\Ledge to Lake Floria: \Faron\Faron Woods\Ledge to Lake
+              Floria\Push Log
           hint_region: Faron Woods
           locations:
-            All Kikwis Saved: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.OrCombination
-                arguments:
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sword
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                opaque: false
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Can Defeat Bokoblins
-              opaque: false
-            Amber Relic Farming: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Chest behind Upper Bombable Rock: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Bomb Bag
-            Hit Vine to Deep Woods: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Distance Activator
-            Item behind Lower Bombable Rock: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Bomb Bag
-            Item on Tree: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Kikwi Elder's Reward: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Faron\Faron Woods\All Kikwis Saved
-            Open Door to Lake Floria: !!python/object:logic.logic_expression.OrCombination
-              arguments:
-              - !!python/object:logic.logic_expression.AndCombination
-                arguments:
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Open Lake Floria option
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                opaque: false
-              - !!python/object:logic.logic_expression.AndCombination
-                arguments:
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Faron Woods\Great Tree\Top\Talk to Yerbal
-                - !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Talk to Yerbal option
-                  opaque: false
-                opaque: false
-              opaque: false
-            Open Trial Gate: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Goddess's Harp
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Farore's Courage
-              opaque: false
-            Push Log to Sealed Grounds: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Rupee on Hollow Tree Branch: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Beetle
-            Rupee on Hollow Tree Root: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Rupee on Platform near Floria Door: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Beetle
-            Unlock In the Woods Statue: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Unlock Viewing Platform Statue: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            All Kikwis Saved: "(\\Sword | \\Beetle) & \\Can Defeat Bokoblins"
+            Amber Relic Farming: 'True'
+            Chest behind Upper Bombable Rock: Bomb Bag
+            Hit Vine to Deep Woods: \Distance Activator
+            Item behind Lower Bombable Rock: Bomb Bag
+            Item on Tree: 'True'
+            Kikwi Elder's Reward: \Faron\Faron Woods\All Kikwis Saved
+            Open Door to Lake Floria: "Open Lake Floria option & Water Dragon's Scale\
+              \ | \\Faron\\Faron Woods\\Great Tree\\Top\\Talk to Yerbal & (\\Goddess\
+              \ Sword | Talk to Yerbal option)"
+            Open Trial Gate: "Goddess's Harp & Farore's Courage"
+            Push Log to Sealed Grounds: 'True'
+            Rupee on Hollow Tree Branch: \Beetle
+            Rupee on Hollow Tree Root: 'True'
+            Rupee on Platform near Floria Door: \Beetle
+            Unlock In the Woods Statue: 'True'
+            Unlock Viewing Platform Statue: 'True'
           name: \Faron\Faron Woods
           sub_areas:
-            Behind the Crawlspace and Rope: !!python/object:logic.logic_input.Area
+            Behind the Crawlspace and Rope:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Faron\Faron Woods: 'True'
               hint_region: Faron Woods
               locations:
-                Push Log: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Retrieve Oolo: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Scrapper
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyloft\Upper Skyloft\Knight Academy\Start Owlan's Quest
-                  opaque: false
+                Push Log: 'True'
+                Retrieve Oolo: "Scrapper & \\Skyloft\\Upper Skyloft\\Knight Academy\\\
+                  Start Owlan's Quest"
               name: \Faron\Faron Woods\Behind the Crawlspace and Rope
               sub_areas: {}
               toplevel_alias: null
-            Clawshot Target Branch: !!python/object:logic.logic_input.Area
+            Clawshot Target Branch:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Faron\Faron Woods: 'True'
               hint_region: Faron Woods
               locations:
-                Goddess Cube on East Great Tree with Clawshots Target: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
+                Goddess Cube on East Great Tree with Clawshots Target: \Goddess Sword
               name: \Faron\Faron Woods\Clawshot Target Branch
               sub_areas: {}
               toplevel_alias: null
-            Deep Woods: !!python/object:logic.logic_input.Area
+            Deep Woods:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -2810,98 +1580,62 @@ areas: !!python/object:logic.logic_input.Area
                 Entrance from Skyview Temple: null
                 Forest Temple Statue Entrance: null
               exits:
-                Exit to Skyview Temple: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Distance Activator
-                Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Faron\Faron Woods\Deep Woods\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit to Skyview Temple: \Distance Activator
+                Shared Statue Exit: 'True'
+                \Faron\Faron Woods\Deep Woods\Entry: 'True'
               hint_region: Faron Woods
               locations:
-                Deep Woods Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Goddess Cube in Deep Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                Goddess Cube on top of Skyview: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  opaque: false
-                Gossip Stone in Deep Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Initial Goddess Cube: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                Push Shortcut Logs: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Unlock Deep Woods Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Unlock Forest Temple Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Deep Woods Chest: 'True'
+                Goddess Cube in Deep Woods: \Goddess Sword
+                Goddess Cube on top of Skyview: "\\Goddess Sword & Clawshots"
+                Gossip Stone in Deep Woods: 'True'
+                Initial Goddess Cube: \Goddess Sword
+                Push Shortcut Logs: 'True'
+                Unlock Deep Woods Statue: 'True'
+                Unlock Forest Temple Statue: 'True'
               name: \Faron\Faron Woods\Deep Woods
               sub_areas:
-                Entry: !!python/object:logic.logic_input.Area
+                Entry:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Faron Woods: null
                   exits:
-                    Exit to Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Faron\Faron Woods\Deep Woods: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Faron\Faron Woods\Deep Woods\Push Shortcut Logs
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Distance Activator
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Goddess Sword
-                      opaque: false
+                    Exit to Faron Woods: 'True'
+                    \Faron\Faron Woods\Deep Woods: "\\Faron\\Faron Woods\\Deep Woods\\\
+                      Push Shortcut Logs | \\Distance Activator | \\Goddess Sword"
                   hint_region: Faron Woods
                   locations:
-                    Hornet Larvae Farming: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Hornet Larvae Farming: 'True'
                   name: \Faron\Faron Woods\Deep Woods\Entry
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Entry: !!python/object:logic.logic_input.Area
+            Entry:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Behind the Temple: null
                 Faron Woods Entry Statue Entrance: null
               exits:
-                Exit to Behind the Temple: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Faron\Faron Woods: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Faron Woods\Push Log to Sealed Grounds
-                  opaque: false
-                \Faron\Faron Woods\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Faron Woods\Entry\Unlock Statue
+                Exit to Behind the Temple: 'True'
+                \Faron\Faron Woods: "\\Sword | Bomb Bag | Clawshots | \\Faron\\Faron\
+                  \ Woods\\Push Log to Sealed Grounds"
+                \Faron\Faron Woods\Shared Statue Exit: \Faron\Faron Woods\Entry\Unlock
+                  Statue
               hint_region: Faron Woods
               locations:
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Unlock Statue: 'True'
               name: \Faron\Faron Woods\Entry
               sub_areas: {}
               toplevel_alias: null
-            Great Tree: !!python/object:logic.logic_input.Area
+            Great Tree:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
@@ -2910,144 +1644,112 @@ areas: !!python/object:logic.logic_input.Area
               locations: {}
               name: \Faron\Faron Woods\Great Tree
               sub_areas:
-                Lower Area: !!python/object:logic.logic_input.Area
+                Lower Area:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Underwater Tunnel Entrance: null
                   exits:
-                    Underwater Tunnel Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Water Dragon's Scale
-                    \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
-                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
+                    Underwater Tunnel Exit: Water Dragon's Scale
+                    \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: Gust Bellows
+                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: Gust Bellows
                   hint_region: Faron Woods
                   locations: {}
                   name: \Faron\Faron Woods\Great Tree\Lower Area
                   sub_areas:
-                    Near Exit: !!python/object:logic.logic_input.Area
+                    Near Exit:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set
                         Lower Entrance from Platforms: null
                       exits:
-                        Lower Exit to Platforms: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        \Faron\Faron Woods\Great Tree\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        Lower Exit to Platforms: 'True'
+                        \Faron\Faron Woods\Great Tree\Lower Area: 'True'
                       hint_region: Faron Woods
                       locations: {}
                       name: \Faron\Faron Woods\Great Tree\Lower Area\Near Exit
                       sub_areas: {}
                       toplevel_alias: null
-                    Path to Chest: !!python/object:logic.logic_input.Area
+                    Path to Chest:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Faron\Faron Woods\Great Tree\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        \Faron\Faron Woods\Great Tree\Lower Area: 'True'
+                        \Faron\Faron Woods\Great Tree\Lower Area\Near Exit: 'True'
                       hint_region: Faron Woods
                       locations:
-                        Chest inside Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        Chest inside Great Tree: 'True'
                       name: \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest
                       sub_areas: {}
                       toplevel_alias: null
                   toplevel_alias: null
-                Near Underwater Hole: !!python/object:logic.logic_input.Area
+                Near Underwater Hole:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Underwater Hole Entrance: null
                   exits:
-                    Underwater Hole Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Water Dragon's Scale
-                    \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Underwater Hole Exit: Water Dragon's Scale
+                    \Faron\Faron Woods: 'True'
                   hint_region: Faron Woods
                   locations: {}
                   name: \Faron\Faron Woods\Great Tree\Near Underwater Hole
                   sub_areas: {}
                   toplevel_alias: null
-                Platforms: !!python/object:logic.logic_input.Area
+                Platforms:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Lower Entrance from Great Tree: null
                     Upper Entrance from Great Tree: null
                   exits:
-                    Lower Exit to Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Upper Exit to Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Faron\Faron Woods\West Branch: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Lower Exit to Great Tree: 'True'
+                    Upper Exit to Great Tree: 'True'
+                    \Faron\Faron Woods: 'True'
+                    \Faron\Faron Woods\West Branch: 'True'
                   hint_region: Faron Woods
                   locations: {}
                   name: \Faron\Faron Woods\Great Tree\Platforms
                   sub_areas: {}
                   toplevel_alias: null
-                Top: !!python/object:logic.logic_input.Area
+                Top:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     The Great Tree Statue Entrance: null
                     Top Entrance from Great Tree: null
                   exits:
-                    Top Exit to Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Faron\Faron Woods\Clawshot Target Branch: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Faron\Faron Woods\Great Tree\Platforms: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Faron\Faron Woods\Rope Branch: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Faron\Faron Woods\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Faron\Faron Woods\Great Tree\Top\Unlock Statue
+                    Top Exit to Great Tree: 'True'
+                    \Faron\Faron Woods\Clawshot Target Branch: 'True'
+                    \Faron\Faron Woods\Great Tree\Platforms: 'True'
+                    \Faron\Faron Woods\Rope Branch: 'True'
+                    \Faron\Faron Woods\Shared Statue Exit: \Faron\Faron Woods\Great
+                      Tree\Top\Unlock Statue
                   hint_region: Faron Woods
                   locations:
-                    Rupee on Great Tree North Branch: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Beetle
-                    Rupee on Great Tree West Branch: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Beetle
-                    Talk to Yerbal: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Water Dragon's Scale
-                      - !!python/object:logic.logic_expression.OrCombination
-                        arguments:
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Slingshot
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Beetle
-                        opaque: false
-                      opaque: false
-                    Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Rupee on Great Tree North Branch: \Beetle
+                    Rupee on Great Tree West Branch: \Beetle
+                    Talk to Yerbal: "Water Dragon's Scale & (\\Slingshot | \\Beetle)"
+                    Unlock Statue: 'True'
                   name: \Faron\Faron Woods\Great Tree\Top
                   sub_areas: {}
                   toplevel_alias: null
-                Upper Area: !!python/object:logic.logic_input.Area
+                Upper Area:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
@@ -3055,161 +1757,120 @@ areas: !!python/object:logic.logic_input.Area
                     Entrance from Top: null
                     Upper Entrance from Platforms: null
                   exits:
-                    Exit to Flooded Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Exit to Top: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Upper Exit to Platforms: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Faron\Faron Woods\Great Tree\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Faron\Faron Woods\Great Tree\Upper Area\Remove Void Plane
-                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Faron\Faron Woods\Great Tree\Upper Area\Remove Void Plane
+                    Exit to Flooded Great Tree: 'True'
+                    Exit to Top: 'True'
+                    Upper Exit to Platforms: 'True'
+                    \Faron\Faron Woods\Great Tree\Lower Area: \Faron\Faron Woods\Great
+                      Tree\Upper Area\Remove Void Plane
+                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: \Faron\Faron
+                      Woods\Great Tree\Upper Area\Remove Void Plane
                   hint_region: Faron Woods
                   locations:
-                    Remove Void Plane: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Can Defeat Moblins
+                    Remove Void Plane: \Can Defeat Moblins
                   name: \Faron\Faron Woods\Great Tree\Upper Area
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Ledge To Deep Woods: !!python/object:logic.logic_input.Area
+            Ledge To Deep Woods:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Deep Woods: null
               exits:
-                Exit to Deep Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit to Deep Woods: 'True'
+                \Faron\Faron Woods: 'True'
               hint_region: Faron Woods
               locations: {}
               name: \Faron\Faron Woods\Ledge To Deep Woods
               sub_areas: {}
               toplevel_alias: null
-            Ledge to Lake Floria: !!python/object:logic.logic_input.Area
+            Ledge to Lake Floria:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Shortcut Entrance from Floria Waterfall: null
               exits:
-                Shortcut Exit to Floria Waterfall: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Faron Woods\Open Door to Lake Floria
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Early Lake Floria Tricks
-                  opaque: false
-                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Shortcut Exit to Floria Waterfall: "\\Faron\\Faron Woods\\Open Door\
+                  \ to Lake Floria | \\Early Lake Floria Tricks"
+                \Faron\Faron Woods: 'True'
               hint_region: Faron Woods
               locations:
-                Push Log: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Push Log: 'True'
               name: \Faron\Faron Woods\Ledge to Lake Floria
               sub_areas: {}
               toplevel_alias: null
-            Rope Branch: !!python/object:logic.logic_input.Area
+            Rope Branch:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Faron\Faron Woods: 'True'
               hint_region: Faron Woods
               locations:
-                Goddess Cube on East Great Tree with Rope: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
+                Goddess Cube on East Great Tree with Rope: \Goddess Sword
               name: \Faron\Faron Woods\Rope Branch
               sub_areas: {}
               toplevel_alias: null
-            West Branch: !!python/object:logic.logic_input.Area
+            West Branch:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Faron\Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Faron\Faron Woods: 'True'
               hint_region: Faron Woods
               locations:
-                Goddess Cube on West Great Tree near Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
+                Goddess Cube on West Great Tree near Exit: \Goddess Sword
               name: \Faron\Faron Woods\West Branch
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: Faron Woods
-        Flooded Faron Woods: !!python/object:logic.logic_input.Area
+        Flooded Faron Woods:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance from Lower Flooded Great Tree: null
             Entrance from Upper Flooded Great Tree: null
           exits:
-            Exit to Lower Flooded Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            Exit to Upper Flooded Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit to Lower Flooded Great Tree: Water Dragon's Scale
+            Exit to Upper Flooded Great Tree: 'True'
           hint_region: Flooded Faron Woods
           locations:
-            16 Dark Blue Tadtones in the South West: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            2 Dark Blue Tadtones in Grass West of Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            2 Red Tadtones in Grass near Lower Bombable Rock: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            4 Light Blue Moving Tadtones under Kikwi Elder: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            4 Purple Moving Tadtones near Floria Gate: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            4 Purple Tadtones under Viewing Platform: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            4 Red Moving Tadtones North West of Great Tree: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            4 Yellow Tadtones under Small Hollow Tree: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            8 Green Tadtones in West Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            8 Light Blue Tadtones near Viewing Platform: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            8 Purple Tadtones in Clearing after Small Hollow Tree: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            8 Yellow Tadtones near Kikwi Elder: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            Can Watch Completed Tadtones Cutscene: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Dark Blue Moving Tadtone inside Small Hollow Tree: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            Green Tadtone behind Upper Bombable Rock: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            Light Blue Tadtone under Great Tree Root: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            Red Moving Tadtone near Viewing Platform: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            Yellow Tadtone under Lilypad: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            \Faron\Faron Woods\Behind the Crawlspace and Rope\Retrieve Oolo: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Scrapper
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Skyloft\Upper Skyloft\Knight Academy\Start Owlan's Quest
-              opaque: false
+            16 Dark Blue Tadtones in the South West: Water Dragon's Scale
+            2 Dark Blue Tadtones in Grass West of Great Tree: Water Dragon's Scale
+            2 Red Tadtones in Grass near Lower Bombable Rock: Water Dragon's Scale
+            4 Light Blue Moving Tadtones under Kikwi Elder: Water Dragon's Scale
+            4 Purple Moving Tadtones near Floria Gate: Water Dragon's Scale
+            4 Purple Tadtones under Viewing Platform: Water Dragon's Scale
+            4 Red Moving Tadtones North West of Great Tree: Water Dragon's Scale
+            4 Yellow Tadtones under Small Hollow Tree: Water Dragon's Scale
+            8 Green Tadtones in West Tunnel: Water Dragon's Scale
+            8 Light Blue Tadtones near Viewing Platform: Water Dragon's Scale
+            8 Purple Tadtones in Clearing after Small Hollow Tree: Water Dragon's
+              Scale
+            8 Yellow Tadtones near Kikwi Elder: Water Dragon's Scale
+            Can Watch Completed Tadtones Cutscene: 'True'
+            Dark Blue Moving Tadtone inside Small Hollow Tree: Water Dragon's Scale
+            Green Tadtone behind Upper Bombable Rock: Water Dragon's Scale
+            Light Blue Tadtone under Great Tree Root: Water Dragon's Scale
+            Red Moving Tadtone near Viewing Platform: Water Dragon's Scale
+            Yellow Tadtone under Lilypad: Water Dragon's Scale
+            \Faron\Faron Woods\Behind the Crawlspace and Rope\Retrieve Oolo: "Scrapper\
+              \ & \\Skyloft\\Upper Skyloft\\Knight Academy\\Start Owlan's Quest"
           name: \Faron\Flooded Faron Woods
           sub_areas:
-            Flooded Great Tree: !!python/object:logic.logic_input.Area
+            Flooded Great Tree:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -3217,29 +1878,20 @@ areas: !!python/object:logic.logic_input.Area
                 Entrance from Lower Flooded Faron Woods: null
                 Entrance from Upper Flooded Faron Woods: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Exit to Lower Flooded Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                Exit to Upper Flooded Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
+                Exit to Lower Flooded Faron Woods: Water Dragon's Scale
+                Exit to Upper Flooded Faron Woods: 'True'
               hint_region: Flooded Faron Woods
               locations:
-                Water Dragon's Reward: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Group of Tadtones x 17
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Flooded Faron Woods\Can Watch Completed Tadtones
-                      Cutscene
-                  opaque: false
+                Water Dragon's Reward: "Group of Tadtones x 17 & \\Faron\\Flooded\
+                  \ Faron Woods\\Can Watch Completed Tadtones Cutscene"
               name: \Faron\Flooded Faron Woods\Flooded Great Tree
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: Flooded Faron Woods
-        Lake Floria: !!python/object:logic.logic_input.Area
+        Lake Floria:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -3248,105 +1900,83 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Faron\Lake Floria
           sub_areas:
-            Above Rock: !!python/object:logic.logic_input.Area
+            Above Rock:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Dive from Faron Woods: null
               exits:
-                \Faron\Lake Floria\Below Rock: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Lake Floria\Above Rock\Blow Rock
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Water Dragon's Scale
-                  opaque: false
+                \Faron\Lake Floria\Below Rock: "\\Faron\\Lake Floria\\Above Rock\\\
+                  Blow Rock & Water Dragon's Scale"
               hint_region: Lake Floria
               locations:
-                Blow Rock: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                Left Rupee behind Northwest Boulder: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                Right Rupee behind Northwest Boulder: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                Rupee behind Southwest Boulder: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                Rupee under Central Boulder: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
+                Blow Rock: Water Dragon's Scale
+                Left Rupee behind Northwest Boulder: Water Dragon's Scale
+                Right Rupee behind Northwest Boulder: Water Dragon's Scale
+                Rupee behind Southwest Boulder: Water Dragon's Scale
+                Rupee under Central Boulder: Water Dragon's Scale
               name: \Faron\Lake Floria\Above Rock
               sub_areas: {}
               toplevel_alias: null
-            Below Rock: !!python/object:logic.logic_input.Area
+            Below Rock:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Farore's Lair: null
               exits:
-                Exit to Farore's Lair: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                \Faron\Lake Floria\Above Rock: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                \Faron\Lake Floria\Below Rock\Emerged Area: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
+                Exit to Farore's Lair: Water Dragon's Scale
+                \Faron\Lake Floria\Above Rock: Water Dragon's Scale
+                \Faron\Lake Floria\Below Rock\Emerged Area: Water Dragon's Scale
               hint_region: Lake Floria
               locations: {}
               name: \Faron\Lake Floria\Below Rock
               sub_areas:
-                Emerged Area: !!python/object:logic.logic_input.Area
+                Emerged Area:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Statue Entrance: null
                   exits:
-                    Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Faron\Lake Floria\Below Rock\Emerged Area\Unlock Statue
-                    \Faron\Lake Floria\Below Rock: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Water Dragon's Scale
+                    Statue Exit: \Faron\Lake Floria\Below Rock\Emerged Area\Unlock
+                      Statue
+                    \Faron\Lake Floria\Below Rock: Water Dragon's Scale
                   hint_region: Lake Floria
                   locations:
-                    Goddess Cube in Lake Floria: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Goddess Sword
-                    Lake Floria Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Goddess Cube in Lake Floria: \Goddess Sword
+                    Lake Floria Chest: 'True'
+                    Unlock Statue: 'True'
                   name: \Faron\Lake Floria\Below Rock\Emerged Area
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Farore's Lair: !!python/object:logic.logic_input.Area
+            Farore's Lair:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Lake Floria: null
                 Entrance from Waterfall: null
               exits:
-                Exit to Lake Floria: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                Exit to Waterfall: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit to Lake Floria: Water Dragon's Scale
+                Exit to Waterfall: 'True'
               hint_region: Lake Floria
               locations:
-                Dragon Lair East Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Dragon Lair South Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                Talk to Farore: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Dragon Lair East Chest: 'True'
+                Dragon Lair South Chest: Water Dragon's Scale
+                Talk to Farore: 'True'
               name: \Faron\Lake Floria\Farore's Lair
               sub_areas: {}
               toplevel_alias: null
-            Waterfall: !!python/object:logic.logic_input.Area
+            Waterfall:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -3355,36 +1985,23 @@ areas: !!python/object:logic.logic_input.Area
                 Entrance from Farore's Lair: null
                 Statue Entrance: null
               exits:
-                Exit to Ancient Cistern: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Water Dragon's Scale
-                Exit to Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Exit to Farore's Lair: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Lake Floria\Waterfall\Unlock Statue
+                Exit to Ancient Cistern: Water Dragon's Scale
+                Exit to Faron Woods: 'True'
+                Exit to Farore's Lair: 'True'
+                Statue Exit: \Faron\Lake Floria\Waterfall\Unlock Statue
               hint_region: Lake Floria
               locations:
-                Goddess Cube in Floria Waterfall: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  opaque: false
-                Gossip Stone outside Ancient Cistern: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Rupee on High Ledge outside Ancient Cistern Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Goddess Cube in Floria Waterfall: "Clawshots & \\Goddess Sword"
+                Gossip Stone outside Ancient Cistern: 'True'
+                Rupee on High Ledge outside Ancient Cistern Entrance: \Beetle
+                Unlock Statue: 'True'
               name: \Faron\Lake Floria\Waterfall
               sub_areas: {}
               toplevel_alias: Floria Waterfall
           toplevel_alias: null
-        Sealed Grounds: !!python/object:logic.logic_input.Area
+        Sealed Grounds:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -3393,9 +2010,9 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Faron\Sealed Grounds
           sub_areas:
-            Behind the Temple: !!python/object:logic.logic_input.Area
+            Behind the Temple:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -3404,59 +2021,38 @@ areas: !!python/object:logic.logic_input.Area
                 Shortcut Entrance from Spiral: null
                 Statue Entrance: null
               exits:
-                Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Exit to Faron Woods: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Shortcut Exit to Spiral: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
+                Door Exit: 'True'
+                Exit to Faron Woods: 'True'
+                Shortcut Exit to Spiral: 'True'
+                Statue Exit: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
               hint_region: Sealed Grounds
               locations:
-                Gorko's Goddess Wall Reward: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Goddess's Harp
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ballad of the Goddess
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  opaque: false
-                Gossip Stone behind the Temple: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Gorko's Goddess Wall Reward: "Goddess's Harp & Ballad of the Goddess\
+                  \ & \\Goddess Sword"
+                Gossip Stone behind the Temple: 'True'
+                Unlock Statue: 'True'
               name: \Faron\Sealed Grounds\Behind the Temple
               sub_areas: {}
               toplevel_alias: null
-            Hylia's Temple: !!python/object:logic.logic_input.Area
+            Hylia's Temple:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Gate of Time Entrance: null
               exits:
-                Gate of Time Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Gate of Time Exit: 'True'
               hint_region: Sealed Grounds
               locations:
-                Defeat Demise: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Horde Door Requirement
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  opaque: false
-                Zelda's Blessing: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Defeat Demise: "Horde Door Requirement & \\Sword"
+                Zelda's Blessing: 'True'
               name: \Faron\Sealed Grounds\Hylia's Temple
               sub_areas: {}
               toplevel_alias: null
-            Sealed Temple: !!python/object:logic.logic_input.Area
+            Sealed Temple:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -3464,94 +2060,66 @@ areas: !!python/object:logic.logic_input.Area
                 Main Entrance: null
                 Side Entrance: null
               exits:
-                Gate of Time Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Sealed Grounds\Sealed Temple\Open Gate of Time
-                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Side Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Gate of Time Exit: \Faron\Sealed Grounds\Sealed Temple\Open Gate of
+                  Time
+                Main Exit: 'True'
+                Side Exit: 'True'
               hint_region: Sealed Grounds
               locations:
-                Chest inside Sealed Temple: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Open Gate of Time: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Sealed Grounds\Sealed Temple\Raise Gate of Time
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: GoT Opening Requirement
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Sealed Grounds\Spiral\Defeat Imprisoned 2
-                  opaque: false
-                Raise Gate of Time: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: GoT Raising Requirement
-                Song from Impa: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Goddess's Harp
-                Start Imprisoned 2: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Sealed Grounds\Sealed Temple\Raise Gate of Time
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: GoT Opening Requirement
-                  opaque: false
+                Chest inside Sealed Temple: 'True'
+                Open Gate of Time: "\\Faron\\Sealed Grounds\\Sealed Temple\\Raise\
+                  \ Gate of Time & GoT Opening Requirement & \\Faron\\Sealed Grounds\\\
+                  Spiral\\Defeat Imprisoned 2"
+                Raise Gate of Time: GoT Raising Requirement
+                Song from Impa: Goddess's Harp
+                Start Imprisoned 2: "\\Faron\\Sealed Grounds\\Sealed Temple\\Raise\
+                  \ Gate of Time & GoT Opening Requirement"
               name: \Faron\Sealed Grounds\Sealed Temple
               sub_areas: {}
               toplevel_alias: null
-            Spiral: !!python/object:logic.logic_input.Area
+            Spiral:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Door Entrance: null
               exits:
-                Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Faron\Sealed Grounds\Spiral\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Sealed Grounds\Spiral\Defeat Imprisoned 2
+                Door Exit: 'True'
+                \Faron\Sealed Grounds\Spiral\Upper Part: \Faron\Sealed Grounds\Spiral\Defeat
+                  Imprisoned 2
               hint_region: Sealed Grounds
               locations:
-                Defeat Imprisoned 2: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Sealed Grounds\Sealed Temple\Start Imprisoned 2
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  opaque: false
+                Defeat Imprisoned 2: "\\Faron\\Sealed Grounds\\Sealed Temple\\Start\
+                  \ Imprisoned 2 & \\Goddess Sword"
               name: \Faron\Sealed Grounds\Spiral
               sub_areas:
-                Upper Part: !!python/object:logic.logic_input.Area
+                Upper Part:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Statue Entrance: null
                   exits:
-                    Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Faron\Sealed Grounds\Spiral\Upper Part\Unlock Statue
-                    \Faron\Sealed Grounds\Spiral: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Statue Exit: \Faron\Sealed Grounds\Spiral\Upper Part\Unlock Statue
+                    \Faron\Sealed Grounds\Spiral: 'True'
+                    \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple: 'True'
                   hint_region: Sealed Grounds
                   locations:
-                    Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Unlock Statue: 'True'
                   name: \Faron\Sealed Grounds\Spiral\Upper Part
                   sub_areas:
-                    From Behind the Temple: !!python/object:logic.logic_input.Area
+                    From Behind the Temple:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set
                         Shortcut Entrance from Behind the Temple: null
                       exits:
-                        Shortcut Exit to Behind the Temple: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        \Faron\Sealed Grounds\Spiral\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        Shortcut Exit to Behind the Temple: 'True'
+                        \Faron\Sealed Grounds\Spiral\Upper Part: 'True'
                       hint_region: Sealed Grounds
                       locations: {}
                       name: \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the
@@ -3562,9 +2130,9 @@ areas: !!python/object:logic.logic_input.Area
               toplevel_alias: Sealed Grounds Spiral
           toplevel_alias: null
       toplevel_alias: null
-    Fire Sanctuary: !!python/object:logic.logic_input.Area
+    Fire Sanctuary:
       abstract: false
-      allowed_time_of_day: *id001
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
@@ -3573,48 +2141,42 @@ areas: !!python/object:logic.logic_input.Area
       locations: {}
       name: \Fire Sanctuary
       sub_areas:
-        Boss Room: !!python/object:logic.logic_input.Area
+        Boss Room:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance from Dungeon: null
             Entrance from Flame Room: null
           exits:
-            Exit to Dungeon: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Fire Sanctuary\Boss Room\Beat Ghirahim
-            Exit to Flame Room: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Fire Sanctuary\Boss Room\Beat Ghirahim
+            Exit to Dungeon: \Fire Sanctuary\Boss Room\Beat Ghirahim
+            Exit to Flame Room: \Fire Sanctuary\Boss Room\Beat Ghirahim
           hint_region: Fire Sanctuary
           locations:
-            Beat Ghirahim: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Sword
-            Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Fire Sanctuary\Boss Room\Beat Ghirahim
+            Beat Ghirahim: \Sword
+            Heart Container: \Fire Sanctuary\Boss Room\Beat Ghirahim
           name: \Fire Sanctuary\Boss Room
           sub_areas: {}
           toplevel_alias: null
-        Flame Room: !!python/object:logic.logic_input.Area
+        Flame Room:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance: null
           exits:
-            Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit: 'True'
           hint_region: Fire Sanctuary
           locations:
-            Din's Flame: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Goddess Sword
+            Din's Flame: \Goddess Sword
           name: \Fire Sanctuary\Flame Room
           sub_areas: {}
           toplevel_alias: null
-        Main: !!python/object:logic.logic_input.Area
+        Main:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -3623,229 +2185,173 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Fire Sanctuary\Main
           sub_areas:
-            Boss Key Room: !!python/object:logic.logic_input.Area
+            Boss Key Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Fire Sanctuary\Main\Front of Boss Door\Past Bars: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Fire Sanctuary\Main\Staircase Room\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Fire Sanctuary\Main\Front of Boss Door\Past Bars: 'True'
+                \Fire Sanctuary\Main\Staircase Room\Upper Part: 'True'
               hint_region: Fire Sanctuary
               locations:
-                Boss Key Chest: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Boss Key Room\Solve Puzzle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Boss Key Room\Defeat Moldorm
-                  opaque: false
-                Defeat Moldorm: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Boss Key Room\Solve Puzzle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Mogma Mitts
-                  opaque: false
-                Solve Puzzle: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Mogma Mitts
+                Boss Key Chest: "\\Fire Sanctuary\\Main\\Boss Key Room\\Solve Puzzle\
+                  \ & \\Fire Sanctuary\\Main\\Boss Key Room\\Defeat Moldorm"
+                Defeat Moldorm: "\\Fire Sanctuary\\Main\\Boss Key Room\\Solve Puzzle\
+                  \ & \\Mogma Mitts"
+                Solve Puzzle: \Mogma Mitts
               name: \Fire Sanctuary\Main\Boss Key Room
               sub_areas: {}
               toplevel_alias: null
-            First Bridge: !!python/object:logic.logic_input.Area
+            First Bridge:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Fire Sanctuary\Main\Room with Water Plant: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\First Bridge\Lizalfos Fight
-                \Fire Sanctuary\Main\Second Bridge\Left: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\Second Bridge\Left\Unlock Shortcut to
-                    First Bridge
-                \Fire Sanctuary\Main\Second Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\First Bridge\Lizalfos Fight
+                \Fire Sanctuary\Main\Room with Water Plant: \Fire Sanctuary\Main\First
+                  Bridge\Lizalfos Fight
+                \Fire Sanctuary\Main\Second Bridge\Left: \Fire Sanctuary\Main\Second
+                  Bridge\Left\Unlock Shortcut to First Bridge
+                \Fire Sanctuary\Main\Second Room: \Fire Sanctuary\Main\First Bridge\Lizalfos
+                  Fight
               hint_region: Fire Sanctuary
               locations:
-                Lizalfos Fight: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Defeat Lizalfos
+                Lizalfos Fight: \Can Defeat Lizalfos
               name: \Fire Sanctuary\Main\First Bridge
               sub_areas: {}
               toplevel_alias: null
-            First Room: !!python/object:logic.logic_input.Area
+            First Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Main Entrance: null
               exits:
-                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Fire Sanctuary\Main\First Room\Past Water Plant: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\First Room\Hit Water Plant
+                Main Exit: 'True'
+                \Fire Sanctuary\Main\First Room\Past Water Plant: \Fire Sanctuary\Main\First
+                  Room\Hit Water Plant
               hint_region: Fire Sanctuary
               locations:
-                Hit Water Plant: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Distance Activator
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  opaque: false
+                Hit Water Plant: "\\Distance Activator | Bomb Bag"
               name: \Fire Sanctuary\Main\First Room
               sub_areas:
-                Past Water Plant: !!python/object:logic.logic_input.Area
+                Past Water Plant:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Second Room: null
                   exits:
-                    Exit to Second Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Fire Sanctuary Small Key
-                    \Fire Sanctuary\Main\First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\First Room\Hit Water Plant
+                    Exit to Second Room: Fire Sanctuary Small Key
+                    \Fire Sanctuary\Main\First Room: \Fire Sanctuary\Main\First Room\Hit
+                      Water Plant
                   hint_region: Fire Sanctuary
                   locations:
-                    Chest in First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\First Room\Past Water Plant\Defeat
-                        Last Bokoblin
-                    Defeat Last Bokoblin: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Can Defeat Bokoblins
-                    \Fire Sanctuary\Main\First Room\Hit Water Plant: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Distance Activator
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      opaque: false
+                    Chest in First Room: \Fire Sanctuary\Main\First Room\Past Water
+                      Plant\Defeat Last Bokoblin
+                    Defeat Last Bokoblin: \Can Defeat Bokoblins
+                    \Fire Sanctuary\Main\First Room\Hit Water Plant: "\\Distance Activator\
+                      \ | Bomb Bag"
                   name: \Fire Sanctuary\Main\First Room\Past Water Plant
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            First Trapped Mogma Room: !!python/object:logic.logic_input.Area
+            First Trapped Mogma Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos
-                    Fight
-                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: \Fire Sanctuary\Main\Magmanos
+                  Fight Room\Upper Part\Magmanos Fight
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: 'True'
               hint_region: Fire Sanctuary
               locations:
-                Chest near First Trapped Mogma: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Gust Bellows
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  opaque: false
+                Chest near First Trapped Mogma: "Gust Bellows | Clawshots"
               name: \Fire Sanctuary\Main\First Trapped Mogma Room
               sub_areas:
-                Lower Area: !!python/object:logic.logic_input.Area
+                Lower Area:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\First Trapped Mogma Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos
-                        Fight
-                    \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Mogma Mitts
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Fire Sanctuary\Main\First Trapped Mogma Room\Lower
-                          Area\Blow up Rock in Tunnel
-                      opaque: false
-                    \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos
-                        Fight
+                    \Fire Sanctuary\Main\First Trapped Mogma Room: \Fire Sanctuary\Main\Magmanos
+                      Fight Room\Upper Part\Magmanos Fight
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: "\\Mogma\
+                      \ Mitts & \\Fire Sanctuary\\Main\\First Trapped Mogma Room\\\
+                      Lower Area\\Blow up Rock in Tunnel"
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part: \Fire Sanctuary\Main\Magmanos
+                      Fight Room\Upper Part\Magmanos Fight
                   hint_region: Fire Sanctuary
                   locations:
-                    Blow up Rock in Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Mogma Mitts
-                    Rescue First Trapped Mogma: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Blow up Rock in Tunnel: \Mogma Mitts
+                    Rescue First Trapped Mogma: 'True'
                   name: \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Front of Boss Door: !!python/object:logic.logic_input.Area
+            Front of Boss Door:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Boss Door Entrance: null
                 Statue Entrance: null
               exits:
-                Boss Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Fire Sanctuary Boss Key
-                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
-                \Fire Sanctuary\Main\Front of Boss Door\Past Bars: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\Front of Boss Door\Past Bars\Unlock Way
-                    to Front
-                \Fire Sanctuary\Main\Lizalfos Fight Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Boss Door Exit: Fire Sanctuary Boss Key
+                Statue Exit: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
+                \Fire Sanctuary\Main\Front of Boss Door\Past Bars: \Fire Sanctuary\Main\Front
+                  of Boss Door\Past Bars\Unlock Way to Front
+                \Fire Sanctuary\Main\Lizalfos Fight Room: 'True'
               hint_region: Fire Sanctuary
               locations:
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Unlock Statue: 'True'
               name: \Fire Sanctuary\Main\Front of Boss Door
               sub_areas:
-                Past Bars: !!python/object:logic.logic_input.Area
+                Past Bars:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\Boss Key Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Fire Sanctuary\Main\Front of Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Front of Boss Door\Past Bars\Unlock
-                        Way to Front
+                    \Fire Sanctuary\Main\Boss Key Room: 'True'
+                    \Fire Sanctuary\Main\Front of Boss Door: \Fire Sanctuary\Main\Front
+                      of Boss Door\Past Bars\Unlock Way to Front
                   hint_region: Fire Sanctuary
                   locations:
-                    Unlock Way to Front: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Unlock Way to Front: 'True'
                   name: \Fire Sanctuary\Main\Front of Boss Door\Past Bars
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Lizalfos Fight Room: !!python/object:logic.logic_input.Area
+            Lizalfos Fight Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Fire Sanctuary\Main\Staircase Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\Lizalfos Fight Room\Fight
+                \Fire Sanctuary\Main\Staircase Room: \Fire Sanctuary\Main\Lizalfos
+                  Fight Room\Fight
               hint_region: Fire Sanctuary
               locations:
-                Fight: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Defeat Lizalfos
+                Fight: \Can Defeat Lizalfos
               name: \Fire Sanctuary\Main\Lizalfos Fight Room
               sub_areas: {}
               toplevel_alias: null
-            Magmanos Fight Room: !!python/object:logic.logic_input.Area
+            Magmanos Fight Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
@@ -3854,56 +2360,40 @@ areas: !!python/object:logic.logic_input.Area
               locations: {}
               name: \Fire Sanctuary\Main\Magmanos Fight Room
               sub_areas:
-                Lower Part: !!python/object:logic.logic_input.Area
+                Lower Part:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from West of Boss Door: null
                   exits:
-                    Exit to West of Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Unlock
-                        Key Door
-                    \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Mogma Mitts
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Fire Sanctuary\Main\First Trapped Mogma Room\Lower
-                          Area\Blow up Rock in Tunnel
-                      opaque: false
-                    \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Past Sliding Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Move
-                        Sliding Door
+                    Exit to West of Boss Door: \Fire Sanctuary\Main\Magmanos Fight
+                      Room\Lower Part\Unlock Key Door
+                    \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area: "\\\
+                      Mogma Mitts & \\Fire Sanctuary\\Main\\First Trapped Mogma Room\\\
+                      Lower Area\\Blow up Rock in Tunnel"
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Past Sliding Door: \Fire
+                      Sanctuary\Main\Magmanos Fight Room\Lower Part\Move Sliding Door
                   hint_region: Fire Sanctuary
                   locations:
-                    Move Sliding Door: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Uncover
-                          Dig Spot
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Mogma Mitts
-                      opaque: false
-                    Uncover Dig Spot: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
-                    Unlock Key Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Fire Sanctuary Small Key x 3
+                    Move Sliding Door: "\\Fire Sanctuary\\Main\\Magmanos Fight Room\\\
+                      Lower Part\\Uncover Dig Spot & \\Mogma Mitts"
+                    Uncover Dig Spot: Gust Bellows
+                    Unlock Key Door: Fire Sanctuary Small Key x 3
                   name: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part
                   sub_areas:
-                    Past Sliding Door: !!python/object:logic.logic_input.Area
+                    Past Sliding Door:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Move
-                            Sliding Door
-                        \Fire Sanctuary\Main\Second Bridge\Left: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part: \Fire
+                          Sanctuary\Main\Magmanos Fight Room\Lower Part\Move Sliding
+                          Door
+                        \Fire Sanctuary\Main\Second Bridge\Left: 'True'
                       hint_region: Fire Sanctuary
                       locations: {}
                       name: \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Past
@@ -3911,86 +2401,63 @@ areas: !!python/object:logic.logic_input.Area
                       sub_areas: {}
                       toplevel_alias: null
                   toplevel_alias: null
-                Upper Part: !!python/object:logic.logic_input.Area
+                Upper Part:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\First Trapped Mogma Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos
-                        Fight
-                    \Fire Sanctuary\Main\Water Fruit Room\After Frog: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part\Magmanos
-                        Fight
+                    \Fire Sanctuary\Main\First Trapped Mogma Room: \Fire Sanctuary\Main\Magmanos
+                      Fight Room\Upper Part\Magmanos Fight
+                    \Fire Sanctuary\Main\Water Fruit Room\After Frog: \Fire Sanctuary\Main\Magmanos
+                      Fight Room\Upper Part\Magmanos Fight
                   hint_region: Fire Sanctuary
                   locations:
-                    Magmanos Fight: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sword
+                    Magmanos Fight: \Sword
                   name: \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Room with Water Plant: !!python/object:logic.logic_input.Area
+            Room with Water Plant:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Fire Sanctuary\Main\First Bridge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Room with Water Plant\Blow up Rock
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Room with Water Plant\Hit Water Plant
-                  opaque: false
+                \Fire Sanctuary\Main\First Bridge: 'True'
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: "\\Fire Sanctuary\\\
+                  Main\\Room with Water Plant\\Blow up Rock & \\Fire Sanctuary\\Main\\\
+                  Room with Water Plant\\Hit Water Plant"
               hint_region: Fire Sanctuary
               locations:
-                Blow up Rock: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Hook Beetle
-                Hit Water Plant: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Distance Activator
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  opaque: false
+                Blow up Rock: \Hook Beetle
+                Hit Water Plant: "\\Distance Activator | Bomb Bag"
               name: \Fire Sanctuary\Main\Room with Water Plant
               sub_areas:
-                Past Lava: !!python/object:logic.logic_input.Area
+                Past Lava:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\First Trapped Mogma Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Fire Sanctuary\Main\Room with Water Plant: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Fire Sanctuary\Main\Room with Water Plant\Blow up Rock
-                      opaque: false
-                    \Fire Sanctuary\Main\Water Fruit Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Room with Water Plant\Past Lava\Unlock
-                        Key Door
+                    \Fire Sanctuary\Main\First Trapped Mogma Room: 'True'
+                    \Fire Sanctuary\Main\Room with Water Plant: "Clawshots | \\Fire\
+                      \ Sanctuary\\Main\\Room with Water Plant\\Blow up Rock"
+                    \Fire Sanctuary\Main\Water Fruit Room: \Fire Sanctuary\Main\Room
+                      with Water Plant\Past Lava\Unlock Key Door
                   hint_region: Fire Sanctuary
                   locations:
-                    Unlock Key Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Fire Sanctuary Small Key x 2
+                    Unlock Key Door: Fire Sanctuary Small Key x 2
                   name: \Fire Sanctuary\Main\Room with Water Plant\Past Lava
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Second Bridge: !!python/object:logic.logic_input.Area
+            Second Bridge:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
@@ -3999,531 +2466,380 @@ areas: !!python/object:logic.logic_input.Area
               locations: {}
               name: \Fire Sanctuary\Main\Second Bridge
               sub_areas:
-                Bottom Part: !!python/object:logic.logic_input.Area
+                Bottom Part:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\Second Bridge\Left: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
-                    \Fire Sanctuary\Main\Second Bridge\Right: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
+                    \Fire Sanctuary\Main\Second Bridge\Left: Clawshots
+                    \Fire Sanctuary\Main\Second Bridge\Right: Clawshots
                   hint_region: Fire Sanctuary
                   locations: {}
                   name: \Fire Sanctuary\Main\Second Bridge\Bottom Part
                   sub_areas: {}
                   toplevel_alias: null
-                Left: !!python/object:logic.logic_input.Area
+                Left:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\First Bridge: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Second Bridge\Left\Unlock Shortcut
-                        to First Bridge
-                    \Fire Sanctuary\Main\Second Bridge\Bottom Part: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Fire Sanctuary\Main\Second Bridge\Right: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
+                    \Fire Sanctuary\Main\First Bridge: \Fire Sanctuary\Main\Second
+                      Bridge\Left\Unlock Shortcut to First Bridge
+                    \Fire Sanctuary\Main\Second Bridge\Bottom Part: 'True'
+                    \Fire Sanctuary\Main\Second Bridge\Right: Clawshots
                   hint_region: Fire Sanctuary
                   locations:
-                    Unlock Shortcut to First Bridge: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Unlock Shortcut to First Bridge: 'True'
                   name: \Fire Sanctuary\Main\Second Bridge\Left
                   sub_areas: {}
                   toplevel_alias: null
-                Right: !!python/object:logic.logic_input.Area
+                Right:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\Second Bridge\Bottom Part: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Fire Sanctuary\Main\Second Bridge\Left: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
-                    \Fire Sanctuary\Main\Second Trapped Mogma Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Fire Sanctuary\Main\Second Bridge\Bottom Part: 'True'
+                    \Fire Sanctuary\Main\Second Bridge\Left: Clawshots
+                    \Fire Sanctuary\Main\Second Trapped Mogma Room: 'True'
                   hint_region: Fire Sanctuary
                   locations: {}
                   name: \Fire Sanctuary\Main\Second Bridge\Right
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Second Room: !!python/object:logic.logic_input.Area
+            Second Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Fire Sanctuary\Main\First Bridge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Fire Sanctuary\Main\Second Room\Balcony: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\Second Room\Defeat Magmanos
-                \Fire Sanctuary\Main\Second Room\Outside Section: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Fire Sanctuary\Main\First Bridge: 'True'
+                \Fire Sanctuary\Main\Second Room\Balcony: \Fire Sanctuary\Main\Second
+                  Room\Defeat Magmanos
+                \Fire Sanctuary\Main\Second Room\Outside Section: 'True'
               hint_region: Fire Sanctuary
               locations:
-                Chest in Second Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Defeat Magmanos: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Second Room\Open Doors to Water Fruit
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  opaque: false
-                Open Doors to Water Fruit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Mogma Mitts
+                Chest in Second Room: 'True'
+                Defeat Magmanos: "\\Fire Sanctuary\\Main\\Second Room\\Open Doors\
+                  \ to Water Fruit & \\Sword"
+                Open Doors to Water Fruit: \Mogma Mitts
               name: \Fire Sanctuary\Main\Second Room
               sub_areas:
-                Balcony: !!python/object:logic.logic_input.Area
+                Balcony:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\Second Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Second Room\Defeat Magmanos
+                    \Fire Sanctuary\Main\Second Room: \Fire Sanctuary\Main\Second
+                      Room\Defeat Magmanos
                   hint_region: Fire Sanctuary
                   locations:
-                    Chest on Balcony: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Chest on Balcony: 'True'
                   name: \Fire Sanctuary\Main\Second Room\Balcony
                   sub_areas: {}
                   toplevel_alias: null
-                Outside Section: !!python/object:logic.logic_input.Area
+                Outside Section:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from First Room: null
                   exits:
-                    Exit to First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Fire Sanctuary\Main\Second Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Exit to First Room: 'True'
+                    \Fire Sanctuary\Main\Second Room: 'True'
                   hint_region: Fire Sanctuary
                   locations: {}
                   name: \Fire Sanctuary\Main\Second Room\Outside Section
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Second Trapped Mogma Room: !!python/object:logic.logic_input.Area
+            Second Trapped Mogma Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Fire Sanctuary\Main\Second Bridge\Right: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Hydrate Frog
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Blow up Wall
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Mogma Mitts
-                  opaque: false
+                \Fire Sanctuary\Main\Second Bridge\Right: 'True'
+                \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall: "\\\
+                  Fire Sanctuary\\Main\\Second Trapped Mogma Room\\Hydrate Frog &\
+                  \ \\Fire Sanctuary\\Main\\Second Trapped Mogma Room\\Blow up Wall\
+                  \ & \\Mogma Mitts"
               hint_region: Fire Sanctuary
               locations:
-                Blow up Wall: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Hydrate Frog
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  opaque: false
-                Hydrate Frog: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Move Sliding
-                      Doors Correctly
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  opaque: false
-                Move Sliding Doors Correctly: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Mogma Mitts
-                Rescue Mogma: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Hydrate Frog
-                Rescue Second Trapped Mogma: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Mogma
+                Blow up Wall: "\\Fire Sanctuary\\Main\\Second Trapped Mogma Room\\\
+                  Hydrate Frog & Bomb Bag"
+                Hydrate Frog: "\\Fire Sanctuary\\Main\\Second Trapped Mogma Room\\\
+                  Move Sliding Doors Correctly & \\Sword"
+                Move Sliding Doors Correctly: \Mogma Mitts
+                Rescue Mogma: \Fire Sanctuary\Main\Second Trapped Mogma Room\Hydrate
+                  Frog
+                Rescue Second Trapped Mogma: \Fire Sanctuary\Main\Second Trapped Mogma
+                  Room\Rescue Mogma
               name: \Fire Sanctuary\Main\Second Trapped Mogma Room
               sub_areas:
-                Past Bombable Wall: !!python/object:logic.logic_input.Area
+                Past Bombable Wall:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\Second Trapped Mogma Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Fire Sanctuary\Main\Second Trapped Mogma Room: 'True'
                   hint_region: Fire Sanctuary
                   locations:
-                    Chest after Bombable Wall: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Chest after Bombable Wall: 'True'
                   name: \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable
                     Wall
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Staircase Room: !!python/object:logic.logic_input.Area
+            Staircase Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Fire Sanctuary\Main\Staircase Room\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
+                \Fire Sanctuary\Main\Staircase Room\Upper Part: Clawshots
               hint_region: Fire Sanctuary
               locations:
-                Chest in Staircase Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
+                Chest in Staircase Room: Clawshots
               name: \Fire Sanctuary\Main\Staircase Room
               sub_areas:
-                Upper Part: !!python/object:logic.logic_input.Area
+                Upper Part:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\Boss Key Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Fire Sanctuary\Main\Staircase Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Fire Sanctuary\Main\Boss Key Room: 'True'
+                    \Fire Sanctuary\Main\Staircase Room: 'True'
                   hint_region: Fire Sanctuary
                   locations: {}
                   name: \Fire Sanctuary\Main\Staircase Room\Upper Part
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Water Fruit Room: !!python/object:logic.logic_input.Area
+            Water Fruit Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\Room with Water Plant\Past Lava\Unlock
-                    Key Door
-                \Fire Sanctuary\Main\Water Fruit Room\After Frog: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\Water Fruit Room\Hydrate Frog
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava: \Fire Sanctuary\Main\Room
+                  with Water Plant\Past Lava\Unlock Key Door
+                \Fire Sanctuary\Main\Water Fruit Room\After Frog: \Fire Sanctuary\Main\Water
+                  Fruit Room\Hydrate Frog
               hint_region: Fire Sanctuary
               locations:
-                First Chest in Water Fruit Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Hydrate Frog: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sword
-                Second Chest in Water Fruit Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Fire Sanctuary\Main\Room with Water Plant\Past Lava\Unlock Key Door: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Fire Sanctuary Small Key x 2
+                First Chest in Water Fruit Room: 'True'
+                Hydrate Frog: \Sword
+                Second Chest in Water Fruit Room: 'True'
+                \Fire Sanctuary\Main\Room with Water Plant\Past Lava\Unlock Key Door: Fire
+                  Sanctuary Small Key x 2
               name: \Fire Sanctuary\Main\Water Fruit Room
               sub_areas:
-                After Frog: !!python/object:logic.logic_input.Area
+                After Frog:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Fire Sanctuary\Main\Water Fruit Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\Water Fruit Room\Hydrate Frog
+                    \Fire Sanctuary\Main\Magmanos Fight Room\Upper Part: 'True'
+                    \Fire Sanctuary\Main\Water Fruit Room: \Fire Sanctuary\Main\Water
+                      Fruit Room\Hydrate Frog
                   hint_region: Fire Sanctuary
                   locations: {}
                   name: \Fire Sanctuary\Main\Water Fruit Room\After Frog
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            West of Boss Door: !!python/object:logic.logic_input.Area
+            West of Boss Door:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Fire Sanctuary\Main\Front of Boss Door: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\West of Boss Door\Past Plats\Release
-                      Lava
-                  opaque: false
-                \Fire Sanctuary\Main\West of Boss Door\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant
-                \Fire Sanctuary\Main\West of Boss Door\Past Plats: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\West of Boss Door\Catch Plats
-                    - !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Distance Activator
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      opaque: false
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\West of Boss Door\Past Plats\Unlock
-                      Shortcut to Pre Plats
-                  opaque: false
+                \Fire Sanctuary\Main\Front of Boss Door: "\\Fire Sanctuary\\Main\\\
+                  West of Boss Door\\Hit Water Plant & \\Fire Sanctuary\\Main\\West\
+                  \ of Boss Door\\Past Plats\\Release Lava"
+                \Fire Sanctuary\Main\West of Boss Door\Entry: \Fire Sanctuary\Main\West
+                  of Boss Door\Hit Water Plant
+                \Fire Sanctuary\Main\West of Boss Door\Past Plats: "\\Fire Sanctuary\\\
+                  Main\\West of Boss Door\\Catch Plats & (\\Distance Activator | Bomb\
+                  \ Bag) | \\Fire Sanctuary\\Main\\West of Boss Door\\Past Plats\\\
+                  Unlock Shortcut to Pre Plats"
               hint_region: Fire Sanctuary
               locations:
-                Catch Plats: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Mogma Mitts
-                Hit Water Plant: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Distance Activator
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  opaque: false
-                Plats' Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Fire Sanctuary\Main\West of Boss Door\Catch Plats
+                Catch Plats: \Mogma Mitts
+                Hit Water Plant: "\\Distance Activator | Bomb Bag"
+                Plats' Chest: \Fire Sanctuary\Main\West of Boss Door\Catch Plats
               name: \Fire Sanctuary\Main\West of Boss Door
               sub_areas:
-                Entry: !!python/object:logic.logic_input.Area
+                Entry:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Magmanos Fight Room: null
                   exits:
-                    Exit to Magmanos Fight Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Fire Sanctuary\Main\Front of Boss Door: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Fire Sanctuary\Main\West of Boss Door\Past Plats\Release
-                          Lava
-                      opaque: false
-                    \Fire Sanctuary\Main\West of Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant
+                    Exit to Magmanos Fight Room: 'True'
+                    \Fire Sanctuary\Main\Front of Boss Door: "\\Fire Sanctuary\\Main\\\
+                      West of Boss Door\\Hit Water Plant & \\Fire Sanctuary\\Main\\\
+                      West of Boss Door\\Past Plats\\Release Lava"
+                    \Fire Sanctuary\Main\West of Boss Door: \Fire Sanctuary\Main\West
+                      of Boss Door\Hit Water Plant
                   hint_region: Fire Sanctuary
                   locations:
-                    \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Distance Activator
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      opaque: false
+                    \Fire Sanctuary\Main\West of Boss Door\Hit Water Plant: "\\Distance\
+                      \ Activator | Bomb Bag"
                   name: \Fire Sanctuary\Main\West of Boss Door\Entry
                   sub_areas: {}
                   toplevel_alias: null
-                Past Plats: !!python/object:logic.logic_input.Area
+                Past Plats:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: true
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Fire Sanctuary\Main\West of Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Fire Sanctuary\Main\West of Boss Door\Past Plats\Unlock
-                        Shortcut to Pre Plats
+                    \Fire Sanctuary\Main\West of Boss Door: \Fire Sanctuary\Main\West
+                      of Boss Door\Past Plats\Unlock Shortcut to Pre Plats
                   hint_region: Fire Sanctuary
                   locations:
-                    Release Lava: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Mogma Mitts
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: FS Lava Flow option
-                      opaque: false
-                    Unlock Shortcut to Pre Plats: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Release Lava: "\\Mogma Mitts | FS Lava Flow option"
+                    Unlock Shortcut to Pre Plats: 'True'
                   name: \Fire Sanctuary\Main\West of Boss Door\Past Plats
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
           toplevel_alias: null
       toplevel_alias: null
-    Lanayru: !!python/object:logic.logic_input.Area
+    Lanayru:
       abstract: true
-      allowed_time_of_day: *id001
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
       exits: {}
       hint_region: null
       locations:
-        All Three Nodes: !!python/object:logic.logic_expression.OrCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: LMF Nodes On option
-          - !!python/object:logic.logic_expression.AndCombination
-            arguments:
-            - !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Lanayru\Desert\North Part\Water Node
-            - !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Lanayru\Desert\North Part\Lightning Node\Past\Lightning Node
-            - !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Lanayru\Desert\East\Fire Node\Past after Grate\Fire Node
-            opaque: false
-          opaque: false
-        Can Navigate in Oasis: !!python/object:logic.logic_expression.OrCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Can Defeat Ampilus
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Hook Beetle
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Brakeslide Trick
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Stuttersprint Trick
-          opaque: false
-        Raise Lanayru Mining Facility: !!python/object:logic.logic_expression.OrCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Open LMF option
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Lanayru\Desert\North Part\Activate Main Node
-          opaque: false
+        All Three Nodes: "LMF Nodes On option | \\Lanayru\\Desert\\North Part\\Water\
+          \ Node & \\Lanayru\\Desert\\North Part\\Lightning Node\\Past\\Lightning\
+          \ Node & \\Lanayru\\Desert\\East\\Fire Node\\Past after Grate\\Fire Node"
+        Can Navigate in Oasis: "\\Can Defeat Ampilus | \\Hook Beetle | \\Skyloft\\\
+          Central Skyloft\\Bazaar\\Endurance Potion | Brakeslide Trick | Stuttersprint\
+          \ Trick"
+        Raise Lanayru Mining Facility: "Open LMF option | \\Lanayru\\Desert\\North\
+          \ Part\\Activate Main Node"
       name: \Lanayru
       sub_areas:
-        Caves: !!python/object:logic.logic_input.Area
+        Caves:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance from Desert: null
             Entrance from Mine: null
           exits:
-            Exit to Desert: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Exit to Mine: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Lanayru\Caves\Past Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Lanayru\Caves\Past Door to Lanayru Sand Sea: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Clawshots
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Lanayru Caves Small Key
-              opaque: false
+            Exit to Desert: 'True'
+            Exit to Mine: 'True'
+            \Lanayru\Caves\Past Crawlspace: 'True'
+            \Lanayru\Caves\Past Door to Lanayru Sand Sea: "Clawshots & Lanayru Caves\
+              \ Small Key"
           hint_region: Lanayru Caves
           locations:
-            Chest: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Golo's Gift: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Gossip Stone in Center: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Chest: 'True'
+            Golo's Gift: 'True'
+            Gossip Stone in Center: 'True'
           name: \Lanayru\Caves
           sub_areas:
-            Past Crawlspace: !!python/object:logic.logic_input.Area
+            Past Crawlspace:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Gorge: null
               exits:
-                Exit to Gorge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Caves: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Bomb Bag
+                Exit to Gorge: 'True'
+                \Lanayru\Caves: Bomb Bag
               hint_region: Lanayru Caves
               locations:
-                Gossip Stone towards Lanayru Gorge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Gossip Stone towards Lanayru Gorge: 'True'
               name: \Lanayru\Caves\Past Crawlspace
               sub_areas: {}
               toplevel_alias: null
-            Past Door to Lanayru Sand Sea: !!python/object:logic.logic_input.Area
+            Past Door to Lanayru Sand Sea:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Lanayru Sand Sea: null
               exits:
-                Exit to Lanayru Sand Sea: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Caves: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Lanayru Caves Small Key
+                Exit to Lanayru Sand Sea: 'True'
+                \Lanayru\Caves: Lanayru Caves Small Key
               hint_region: Lanayru Caves
               locations: {}
               name: \Lanayru\Caves\Past Door to Lanayru Sand Sea
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: Lanayru Caves
-        Desert: !!python/object:logic.logic_input.Area
+        Desert:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
           exits:
-            Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'False'
+            Shared Statue Exit: 'False'
           hint_region: Lanayru Desert
           locations: {}
           name: \Lanayru\Desert
           sub_areas:
-            East: !!python/object:logic.logic_input.Area
+            East:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Fire Node Entrance: null
                 Stone Cache Statue Entrance: null
               exits:
-                Fire Node Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Near Caged Robot: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\East\Open Wall Shortcut
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Temple of Time Skip - Brakeslide Trick
-                  opaque: false
-                \Lanayru\Desert\North Part: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Top of LMF: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Raise Lanayru Mining Facility
+                Fire Node Exit: 'True'
+                \Lanayru\Desert\Near Caged Robot: "\\Lanayru\\Desert\\East\\Open Wall\
+                  \ Shortcut | Temple of Time Skip - Brakeslide Trick"
+                \Lanayru\Desert\North Part: 'True'
+                \Lanayru\Desert\Shared Statue Exit: 'True'
+                \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
               hint_region: Lanayru Desert
               locations:
-                Chest on Platform near Fire Node: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
-                Open Wall Shortcut: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Chest on Platform near Fire Node: Clawshots
+                Open Wall Shortcut: 'True'
+                Unlock Statue: 'True'
               name: \Lanayru\Desert\East
               sub_areas:
-                Fire Node: !!python/object:logic.logic_input.Area
+                Fire Node:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
@@ -4532,304 +2848,195 @@ areas: !!python/object:logic.logic_input.Area
                   locations: {}
                   name: \Lanayru\Desert\East\Fire Node
                   sub_areas:
-                    Past: !!python/object:logic.logic_input.Area
+                    Past:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Lanayru\Desert\East\Fire Node\Past after Void: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Lanayru\Desert\East\Fire Node\Present after Sand\Push
-                            Box
-                        \Lanayru\Desert\East\Fire Node\Present: !!python/object:logic.logic_expression.OrCombination
-                          arguments:
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Projectile Item
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: Bomb Bag
-                          opaque: false
-                        \Lanayru\Desert\East\Fire Node\Present\Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        \Lanayru\Desert\East\Fire Node\Past after Void: \Lanayru\Desert\East\Fire
+                          Node\Present after Sand\Push Box
+                        \Lanayru\Desert\East\Fire Node\Present: "\\Projectile Item\
+                          \ | Bomb Bag"
+                        \Lanayru\Desert\East\Fire Node\Present\Exit: 'True'
                       hint_region: Lanayru Desert
                       locations:
-                        First Small Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        Second Small Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        First Small Chest: 'True'
+                        Second Small Chest: 'True'
                       name: \Lanayru\Desert\East\Fire Node\Past
                       sub_areas: {}
                       toplevel_alias: null
-                    Past after Grate: !!python/object:logic.logic_input.Area
+                    Past after Grate:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Lanayru\Desert\East\Fire Node\Past after Void: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        \Lanayru\Desert\East\Fire Node\Past after Void: 'True'
                       hint_region: Lanayru Desert
                       locations:
-                        Fire Node: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Sword
-                        Left Ending Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        Right Ending Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        Fire Node: \Sword
+                        Left Ending Chest: 'True'
+                        Right Ending Chest: 'True'
                       name: \Lanayru\Desert\East\Fire Node\Past after Grate
                       sub_areas: {}
                       toplevel_alias: null
-                    Past after Void: !!python/object:logic.logic_input.Area
+                    Past after Void:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Lanayru\Desert\East\Fire Node\Past: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        \Lanayru\Desert\East\Fire Node\Past after Grate: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Lanayru\Desert\East\Fire Node\Past after Void\Open
-                            Grate
+                        \Lanayru\Desert\East\Fire Node\Past: 'True'
+                        \Lanayru\Desert\East\Fire Node\Past after Grate: \Lanayru\Desert\East\Fire
+                          Node\Past after Void\Open Grate
                       hint_region: Lanayru Desert
                       locations:
-                        Open Grate: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Hook Beetle
+                        Open Grate: \Hook Beetle
                       name: \Lanayru\Desert\East\Fire Node\Past after Void
                       sub_areas: {}
                       toplevel_alias: null
-                    Present: !!python/object:logic.logic_input.Area
+                    Present:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set
                         Entrance: null
                       exits:
-                        Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        \Lanayru\Desert\East\Fire Node\Past: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Lanayru\Desert\East\Fire Node\Present\Timeshift Stone
-                        \Lanayru\Desert\East\Fire Node\Present after Sand: !!python/object:logic.logic_expression.OrCombination
-                          arguments:
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Can Defeat Ampilus
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: Brakeslide Trick
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Lanayru\Desert\East\Fire Node\Present after Sand\Push
-                              Box
-                          opaque: false
+                        Exit: 'True'
+                        \Lanayru\Desert\East\Fire Node\Past: \Lanayru\Desert\East\Fire
+                          Node\Present\Timeshift Stone
+                        \Lanayru\Desert\East\Fire Node\Present after Sand: "\\Can\
+                          \ Defeat Ampilus | Brakeslide Trick | \\Lanayru\\Desert\\\
+                          East\\Fire Node\\Present after Sand\\Push Box"
                       hint_region: Lanayru Desert
                       locations:
-                        Blow up Rock for Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Bomb Bag
-                        Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
-                          arguments:
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Lanayru\Desert\East\Fire Node\Present\Blow up Rock
-                              for Timeshift Stone
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Can Hit Timeshift Stone
-                          opaque: false
+                        Blow up Rock for Timeshift Stone: Bomb Bag
+                        Timeshift Stone: "\\Lanayru\\Desert\\East\\Fire Node\\Present\\\
+                          Blow up Rock for Timeshift Stone & \\Can Hit Timeshift Stone"
                       name: \Lanayru\Desert\East\Fire Node\Present
                       sub_areas: {}
                       toplevel_alias: null
-                    Present after Sand: !!python/object:logic.logic_input.Area
+                    Present after Sand:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Lanayru\Desert\East\Fire Node\Past after Void: !!python/object:logic.logic_expression.AndCombination
-                          arguments:
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Lanayru\Desert\East\Fire Node\Present\Timeshift
-                              Stone
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Projectile Item
-                          opaque: false
-                        \Lanayru\Desert\East\Fire Node\Present: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        \Lanayru\Desert\East\Fire Node\Past after Void: "\\Lanayru\\\
+                          Desert\\East\\Fire Node\\Present\\Timeshift Stone & \\Projectile\
+                          \ Item"
+                        \Lanayru\Desert\East\Fire Node\Present: 'True'
                       hint_region: Lanayru Desert
                       locations:
-                        Push Box: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        Shortcut Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        Push Box: 'True'
+                        Shortcut Chest: 'True'
                       name: \Lanayru\Desert\East\Fire Node\Present after Sand
                       sub_areas: {}
                       toplevel_alias: null
                   toplevel_alias: null
               toplevel_alias: null
-            Entry: !!python/object:logic.logic_input.Area
+            Entry:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Desert Entrance Statue Entrance: null
                 Entrance from Mine: null
               exits:
-                Exit to Mine: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\Entry\Timeshift Stone
-                \Lanayru\Desert\Entry\High Ledge after Vines: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\Entry\Timeshift Stone
-                \Lanayru\Desert\Near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\Entry\Unlock Statue
+                Exit to Mine: \Lanayru\Desert\Entry\Timeshift Stone
+                \Lanayru\Desert\Entry\High Ledge after Vines: \Lanayru\Desert\Entry\Timeshift
+                  Stone
+                \Lanayru\Desert\Near Caged Robot: 'True'
+                \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\Entry\Unlock Statue
               hint_region: Lanayru Desert
               locations:
-                Blow up Rock for Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Bomb Bag
-                Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\Entry\Blow up Rock for Timeshift Stone
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Hit Timeshift Stone
-                  opaque: false
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Blow up Rock for Timeshift Stone: Bomb Bag
+                Timeshift Stone: "\\Lanayru\\Desert\\Entry\\Blow up Rock for Timeshift\
+                  \ Stone & \\Can Hit Timeshift Stone"
+                Unlock Statue: 'True'
               name: \Lanayru\Desert\Entry
               sub_areas:
-                High Ledge after Vines: !!python/object:logic.logic_input.Area
+                High Ledge after Vines:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits: {}
                   hint_region: Lanayru Desert
                   locations:
-                    Chest near Party Wheel: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Retrieve Party Wheel: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Scrapper
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sky\South West\Fun Fun Island\Start Dodoh's Quest
-                      opaque: false
-                    \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Chest near Party Wheel: 'True'
+                    Retrieve Party Wheel: "Scrapper & \\Sky\\South West\\Fun Fun Island\\\
+                      Start Dodoh's Quest"
+                    \Ancient Flower Farming: 'True'
                   name: \Lanayru\Desert\Entry\High Ledge after Vines
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Near Caged Robot: !!python/object:logic.logic_input.Area
+            Near Caged Robot:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru\Desert\East: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Temple of Time Skip - Brakeslide Trick
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\East\Open Wall Shortcut
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
-                  opaque: false
-                \Lanayru\Desert\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Sand Oasis: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\Near Caged Robot\Get Past Spume to Sand Oasis
-                \Lanayru\Desert\Top of LMF: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Raise Lanayru Mining Facility
-                \Lanayru\Desert\Top of West Wall: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
+                \Lanayru\Desert\East: "Temple of Time Skip - Brakeslide Trick | \\\
+                  Lanayru\\Desert\\East\\Open Wall Shortcut | Clawshots | \\Skyloft\\\
+                  Central Skyloft\\Bazaar\\Endurance Potion"
+                \Lanayru\Desert\Entry: 'True'
+                \Lanayru\Desert\Sand Oasis: \Lanayru\Desert\Near Caged Robot\Get Past
+                  Spume to Sand Oasis
+                \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
+                \Lanayru\Desert\Top of West Wall: Clawshots
               hint_region: Lanayru Desert
               locations:
-                Blow Statues to Sand Oasis Down: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Hook Beetle
-                Blow up Rock for Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Lanayru Desert - Ampilus Bomb Toss Trick
-                  opaque: false
-                Chest near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Get Past Spume to Sand Oasis: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\Near Caged Robot\Blow Statues to Sand Oasis
-                      Down
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Brakeslide Trick
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Stuttersprint Trick
-                    - !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Long Range Skyward Strike
-                      opaque: false
-                    opaque: false
-                  opaque: false
-                Goddess Cube near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Long Range Skyward Strike
-                Rescue Caged Robot: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\Near Caged Robot\Blow up Rock for Timeshift
-                      Stone
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Defeat Bokoblins
-                  opaque: false
+                Blow Statues to Sand Oasis Down: \Hook Beetle
+                Blow up Rock for Timeshift Stone: "Bomb Bag | \\Hook Beetle | Lanayru\
+                  \ Desert - Ampilus Bomb Toss Trick"
+                Chest near Caged Robot: 'True'
+                Get Past Spume to Sand Oasis: "\\Lanayru\\Desert\\Near Caged Robot\\\
+                  Blow Statues to Sand Oasis Down | \\Skyloft\\Central Skyloft\\Bazaar\\\
+                  Endurance Potion | Brakeslide Trick & Stuttersprint Trick & (Bomb\
+                  \ Bag | \\Bow | \\Long Range Skyward Strike)"
+                Goddess Cube near Caged Robot: \Long Range Skyward Strike
+                Rescue Caged Robot: "\\Lanayru\\Desert\\Near Caged Robot\\Blow up\
+                  \ Rock for Timeshift Stone & \\Can Defeat Bokoblins"
               name: \Lanayru\Desert\Near Caged Robot
               sub_areas: {}
               toplevel_alias: null
-            Near South Exit to Temple of Time: !!python/object:logic.logic_input.Area
+            Near South Exit to Temple of Time:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 South Entrance from Temple of Time: null
               exits:
-                South Exit to Temple of Time: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
-                \Lanayru\Desert\West Part: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                South Exit to Temple of Time: 'True'
+                \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves: Clawshots
+                \Lanayru\Desert\West Part: 'True'
               hint_region: Lanayru Desert
               locations:
-                Push Minecart: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Push Minecart: 'True'
               name: \Lanayru\Desert\Near South Exit to Temple of Time
               sub_areas:
-                Ledge to Caves: !!python/object:logic.logic_input.Area
+                Ledge to Caves:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Caves: null
                   exits:
-                    Exit to Caves: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru\Desert\Near South Exit to Temple of Time: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Exit to Caves: 'True'
+                    \Lanayru\Desert\Near South Exit to Temple of Time: 'True'
                   hint_region: Lanayru Desert
                   locations: {}
                   name: \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to
@@ -4837,9 +3044,9 @@ areas: !!python/object:logic.logic_input.Area
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            North Part: !!python/object:logic.logic_input.Area
+            North Part:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -4848,92 +3055,36 @@ areas: !!python/object:logic.logic_input.Area
                 North Entrance from Temple of Time: null
                 Trial Gate Entrance: null
               exits:
-                Lightning Node Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\North Part\Open Lightning Node
-                North Exit to Temple of Time: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Trial Gate Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\North Part\Open Trial Gate
-                \Lanayru\Desert\East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\North Part\Secret Passageway: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\North Part\Open Secret Passageway
-                \Lanayru\Desert\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\North Part\Unlock Statue
-                \Lanayru\Desert\Top of LMF: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Raise Lanayru Mining Facility
+                Lightning Node Exit: \Lanayru\Desert\North Part\Open Lightning Node
+                North Exit to Temple of Time: 'True'
+                Trial Gate Exit: \Lanayru\Desert\North Part\Open Trial Gate
+                \Lanayru\Desert\East: 'True'
+                \Lanayru\Desert\North Part\Secret Passageway: \Lanayru\Desert\North
+                  Part\Open Secret Passageway
+                \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\North Part\Unlock
+                  Statue
+                \Lanayru\Desert\Top of LMF: \Lanayru\Raise Lanayru Mining Facility
               hint_region: Lanayru Desert
               locations:
-                Activate Main Node: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\All Three Nodes
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\North Part\Main Node Timeshift Stone
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  opaque: false
-                Blow up Main Node Timeshift Stone Rock: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  opaque: false
-                Chest on Platform near Lightning Node: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
-                Main Node Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\North Part\Blow up Main Node Timeshift Stone
-                      Rock
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Hit Timeshift Stone
-                  opaque: false
-                Open Lightning Node: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Open Secret Passageway: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Hook Beetle
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Secret Passageway Hook Beetle Opening Trick
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Tough Beetle
-                  opaque: false
-                Open Trial Gate: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Nayru's Wisdom
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Goddess's Harp
-                  opaque: false
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Water Node: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Bomb Bag
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Hook Beetle
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  opaque: false
-                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\North Part\Main Node Timeshift Stone
+                Activate Main Node: "\\Lanayru\\All Three Nodes & \\Lanayru\\Desert\\\
+                  North Part\\Main Node Timeshift Stone & \\Sword"
+                Blow up Main Node Timeshift Stone Rock: "Bomb Bag | \\Hook Beetle"
+                Chest on Platform near Lightning Node: Clawshots
+                Main Node Timeshift Stone: "\\Lanayru\\Desert\\North Part\\Blow up\
+                  \ Main Node Timeshift Stone Rock & \\Can Hit Timeshift Stone"
+                Open Lightning Node: 'True'
+                Open Secret Passageway: "Bomb Bag | \\Hook Beetle & Secret Passageway\
+                  \ Hook Beetle Opening Trick | \\Tough Beetle"
+                Open Trial Gate: "Nayru's Wisdom & Goddess's Harp"
+                Unlock Statue: 'True'
+                Water Node: "(Bomb Bag | \\Hook Beetle) & \\Sword"
+                \Ancient Flower Farming: \Lanayru\Desert\North Part\Main Node Timeshift
+                  Stone
               name: \Lanayru\Desert\North Part
               sub_areas:
-                Lightning Node: !!python/object:logic.logic_input.Area
+                Lightning Node:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
@@ -4942,237 +3093,164 @@ areas: !!python/object:logic.logic_input.Area
                   locations: {}
                   name: \Lanayru\Desert\North Part\Lightning Node
                   sub_areas:
-                    Past: !!python/object:logic.logic_input.Area
+                    Past:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Lanayru\Desert\North Part\Lightning Node\Present: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Projectile Item
-                        \Lanayru\Desert\North Part\Lightning Node\Present from afar: !!python/object:logic.logic_expression.OrCombination
-                          arguments:
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Beetle
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Bow
-                          - !!python/object:logic.logic_expression.AndCombination
-                            arguments:
-                            - !!python/object:logic.logic_expression.BasicTextAtom
-                              text: Lightning Node End with Bombs Trick
-                            - !!python/object:logic.logic_expression.BasicTextAtom
-                              text: Bomb Bag
-                            opaque: false
-                          opaque: false
-                        \Lanayru\Desert\North Part\Lightning Node\Present\Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        \Lanayru\Desert\North Part\Lightning Node\Present: \Projectile
+                          Item
+                        \Lanayru\Desert\North Part\Lightning Node\Present from afar: "\\\
+                          Beetle | \\Bow | Lightning Node End with Bombs Trick & Bomb\
+                          \ Bag"
+                        \Lanayru\Desert\North Part\Lightning Node\Present\Exit: 'True'
                       hint_region: Lanayru Desert
                       locations:
-                        First Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        Lightning Node: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Sword
-                        Second Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        First Chest: 'True'
+                        Lightning Node: \Sword
+                        Second Chest: 'True'
                       name: \Lanayru\Desert\North Part\Lightning Node\Past
                       sub_areas: {}
                       toplevel_alias: null
-                    Present: !!python/object:logic.logic_input.Area
+                    Present:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set
                         Entrance: null
                       exits:
-                        Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        \Lanayru\Desert\North Part\Lightning Node\Past: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Lanayru\Desert\North Part\Lightning Node\Present\Timeshift
-                            Stone
+                        Exit: 'True'
+                        \Lanayru\Desert\North Part\Lightning Node\Past: \Lanayru\Desert\North
+                          Part\Lightning Node\Present\Timeshift Stone
                       hint_region: Lanayru Desert
                       locations:
-                        Blow up Rock for Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Bomb Bag
-                        Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
-                          arguments:
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Lanayru\Desert\North Part\Lightning Node\Present\Blow
-                              up Rock for Timeshift Stone
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Can Hit Timeshift Stone
-                          opaque: false
+                        Blow up Rock for Timeshift Stone: Bomb Bag
+                        Timeshift Stone: "\\Lanayru\\Desert\\North Part\\Lightning\
+                          \ Node\\Present\\Blow up Rock for Timeshift Stone & \\Can\
+                          \ Hit Timeshift Stone"
                       name: \Lanayru\Desert\North Part\Lightning Node\Present
                       sub_areas: {}
                       toplevel_alias: null
-                    Present from afar: !!python/object:logic.logic_input.Area
+                    Present from afar:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Lanayru\Desert\North Part\Lightning Node\Past: !!python/object:logic.logic_expression.OrCombination
-                          arguments:
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Beetle
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Bow
-                          opaque: false
-                        \Lanayru\Desert\North Part\Lightning Node\Present: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        \Lanayru\Desert\North Part\Lightning Node\Past: "\\Beetle\
+                          \ | \\Bow"
+                        \Lanayru\Desert\North Part\Lightning Node\Present: 'True'
                       hint_region: Lanayru Desert
                       locations:
-                        Raised Chest near Generator: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        Raised Chest near Generator: 'True'
                       name: \Lanayru\Desert\North Part\Lightning Node\Present from
                         afar
                       sub_areas: {}
                       toplevel_alias: null
                   toplevel_alias: null
-                Secret Passageway: !!python/object:logic.logic_input.Area
+                Secret Passageway:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Lanayru\Desert\North Part: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Lanayru\Desert\North Part: 'True'
                   hint_region: Lanayru Desert
                   locations:
-                    Goddess Cube in Secret Passageway: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Goddess Sword
-                      opaque: false
-                    Secret Passageway Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Goddess Cube in Secret Passageway: "Clawshots & \\Goddess Sword"
+                    Secret Passageway Chest: 'True'
                   name: \Lanayru\Desert\North Part\Secret Passageway
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Sand Oasis: !!python/object:logic.logic_input.Area
+            Sand Oasis:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru\Desert\Near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Top of West Wall: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\Top of West Wall\Push Minecart
-                  opaque: false
-                \Lanayru\Desert\West Part: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Can Navigate in Oasis
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\West Part\Push Minecart
-                  opaque: false
+                \Lanayru\Desert\Near Caged Robot: 'True'
+                \Lanayru\Desert\Top of West Wall: "Clawshots | \\Lanayru\\Desert\\\
+                  Top of West Wall\\Push Minecart"
+                \Lanayru\Desert\West Part: "\\Lanayru\\Can Navigate in Oasis | \\\
+                  Lanayru\\Desert\\West Part\\Push Minecart"
               hint_region: Lanayru Desert
               locations:
-                Goddess Cube in Sand Oasis: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Can Navigate in Oasis
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  opaque: false
+                Goddess Cube in Sand Oasis: "\\Lanayru\\Can Navigate in Oasis & \\\
+                  Goddess Sword"
               name: \Lanayru\Desert\Sand Oasis
               sub_areas: {}
               toplevel_alias: null
-            Top of LMF: !!python/object:logic.logic_input.Area
+            Top of LMF:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Lanayru Mining Facility: null
               exits:
-                Exit to Lanayru Mining Facility: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\North Part: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit to Lanayru Mining Facility: 'True'
+                \Lanayru\Desert\East: 'True'
+                \Lanayru\Desert\Near Caged Robot: 'True'
+                \Lanayru\Desert\North Part: 'True'
               hint_region: Lanayru Desert
               locations:
-                Chest on top of Lanayru Mining Facility: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Chest on top of Lanayru Mining Facility: 'True'
               name: \Lanayru\Desert\Top of LMF
               sub_areas: {}
               toplevel_alias: null
-            Top of West Wall: !!python/object:logic.logic_input.Area
+            Top of West Wall:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru\Desert\Near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Sand Oasis: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\West Part: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Lanayru\Desert\Near Caged Robot: 'True'
+                \Lanayru\Desert\Sand Oasis: 'True'
+                \Lanayru\Desert\West Part: 'True'
               hint_region: Lanayru Desert
               locations:
-                Chest near Sand Oasis: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Push Minecart: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Near Caged Robot\Goddess Cube near Caged Robot: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
+                Chest near Sand Oasis: 'True'
+                Push Minecart: 'True'
+                \Lanayru\Desert\Near Caged Robot\Goddess Cube near Caged Robot: \Goddess
+                  Sword
               name: \Lanayru\Desert\Top of West Wall
               sub_areas: {}
               toplevel_alias: null
-            West Part: !!python/object:logic.logic_input.Area
+            West Part:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 West Desert Statue Entrance: null
               exits:
-                \Lanayru\Desert\Near South Exit to Temple of Time: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Can Navigate in Oasis
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\Near South Exit to Temple of Time\Push Minecart
-                  opaque: false
-                \Lanayru\Desert\Sand Oasis: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\West Part\Unlock Statue
-                \Lanayru\Desert\Top of West Wall: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
+                \Lanayru\Desert\Near South Exit to Temple of Time: "\\Lanayru\\Can\
+                  \ Navigate in Oasis | \\Lanayru\\Desert\\Near South Exit to Temple\
+                  \ of Time\\Push Minecart"
+                \Lanayru\Desert\Sand Oasis: 'True'
+                \Lanayru\Desert\Shared Statue Exit: \Lanayru\Desert\West Part\Unlock
+                  Statue
+                \Lanayru\Desert\Top of West Wall: Clawshots
               hint_region: Lanayru Desert
               locations:
-                Push Minecart: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Desert\Sand Oasis\Goddess Cube in Sand Oasis: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
+                Push Minecart: 'True'
+                Unlock Statue: 'True'
+                \Lanayru\Desert\Sand Oasis\Goddess Cube in Sand Oasis: \Goddess Sword
               name: \Lanayru\Desert\West Part
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: Lanayru Desert
-        Lanayru Sand Sea: !!python/object:logic.logic_input.Area
+        Lanayru Sand Sea:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
@@ -5182,179 +3260,106 @@ areas: !!python/object:logic.logic_input.Area
             Shipyard Dock Entrance: null
             Skipper's Retreat Dock Entrance: null
           exits:
-            Ancient Harbour Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Pirate Stronghold Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Sandship Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
-            Shipyard Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Skipper's Retreat Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Ancient Harbour Dock Exit: 'True'
+            Pirate Stronghold Dock Exit: 'True'
+            Sandship Dock Exit: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
+            Shipyard Dock Exit: 'True'
+            Skipper's Retreat Dock Exit: 'True'
           hint_region: Lanayru Sand Sea
           locations:
-            Shoot down Sandship: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Sea Chart
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Sword
-              opaque: false
+            Shoot down Sandship: "Sea Chart & \\Sword"
           name: \Lanayru\Lanayru Sand Sea
           sub_areas:
-            Ancient Harbour: !!python/object:logic.logic_input.Area
+            Ancient Harbour:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Dock Entrance: null
                 Statue Entrance: null
               exits:
-                Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Ship Timeshift Stone
-                Exit to Sandship: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
-                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Unlock Statue
-                \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
+                Dock Exit: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Ship Timeshift
+                  Stone
+                Exit to Sandship: \Lanayru\Lanayru Sand Sea\Shoot down Sandship
+                Statue Exit: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Unlock Statue
+                \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves: Clawshots
               hint_region: Lanayru Sand Sea
               locations:
-                Goddess Cube in Ancient Harbour: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Goddess Sword
-                  opaque: false
-                Ship Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Distance Activator
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  opaque: false
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Goddess Cube in Ancient Harbour: "Clawshots & \\Goddess Sword"
+                Ship Timeshift Stone: "\\Distance Activator | \\Sword | Bomb Bag"
+                Unlock Statue: 'True'
               name: \Lanayru\Lanayru Sand Sea\Ancient Harbour
               sub_areas:
-                Near Exit to Caves: !!python/object:logic.logic_input.Area
+                Near Exit to Caves:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Caves: null
                   exits:
-                    Exit to Caves: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru\Lanayru Sand Sea\Ancient Harbour: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
+                    Exit to Caves: 'True'
+                    \Lanayru\Lanayru Sand Sea\Ancient Harbour: Clawshots
                   hint_region: Lanayru Sand Sea
                   locations:
-                    Left Rupee on Entrance Crown: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Quick Beetle
-                    Right Rupee on Entrance Crown: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Quick Beetle
-                    Rupee on First Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Beetle
+                    Left Rupee on Entrance Crown: \Quick Beetle
+                    Right Rupee on Entrance Crown: \Quick Beetle
+                    Rupee on First Pillar: \Beetle
                   name: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: Lanayru Sand Sea Docks
-            Gorge: !!python/object:logic.logic_input.Area
+            Gorge:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance: null
                 Statue Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Gorge\Unlock Statue
-                \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Gorge\Activate Timeshift Stone
+                Exit: 'True'
+                Statue Exit: \Lanayru\Lanayru Sand Sea\Gorge\Unlock Statue
+                \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge: \Lanayru\Lanayru Sand
+                  Sea\Gorge\Activate Timeshift Stone
               hint_region: Lanayru Gorge
               locations:
-                Activate Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Hit Timeshift Stone in Minecart
-                Boss Rush -- 4 Bosses: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: 'False'
-                  opaque: false
-                Boss Rush -- 8 Bosses: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: 'False'
-                  opaque: false
-                Item on Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Thunder Dragon's Reward: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Gorge\Activate Timeshift Stone
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Life Tree Fruit
-                  opaque: false
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Activate Timeshift Stone: \Can Hit Timeshift Stone in Minecart
+                Boss Rush -- 4 Bosses: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Thunder\
+                  \ Dragon's Reward & False"
+                Boss Rush -- 8 Bosses: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Thunder\
+                  \ Dragon's Reward & False"
+                Item on Pillar: \Beetle
+                Thunder Dragon's Reward: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Activate\
+                  \ Timeshift Stone & Life Tree Fruit"
+                Unlock Statue: 'True'
               name: \Lanayru\Lanayru Sand Sea\Gorge
               sub_areas:
-                Beyond Bridge: !!python/object:logic.logic_input.Area
+                Beyond Bridge:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Lanayru\Lanayru Sand Sea\Gorge: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      opaque: false
+                    \Lanayru\Lanayru Sand Sea\Gorge: "\\Beetle | \\Bow"
                   hint_region: Lanayru Gorge
                   locations:
-                    Activate Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Gust Bellows
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Can Hit Timeshift Stone
-                      opaque: false
-                    Digging Spot: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Activate
-                          Timeshift Stone
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Digging Mitts
-                      opaque: false
-                    Goddess Cube in Lanayru Gorge: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Goddess Sword
-                    \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Activate
-                        Timeshift Stone
+                    Activate Timeshift Stone: "Gust Bellows & \\Can Hit Timeshift\
+                      \ Stone"
+                    Digging Spot: "\\Lanayru\\Lanayru Sand Sea\\Gorge\\Beyond Bridge\\\
+                      Activate Timeshift Stone & \\Digging Mitts"
+                    Goddess Cube in Lanayru Gorge: \Goddess Sword
+                    \Ancient Flower Farming: \Lanayru\Lanayru Sand Sea\Gorge\Beyond
+                      Bridge\Activate Timeshift Stone
                   name: \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: Lanayru Gorge
-            Pirate Stronghold: !!python/object:logic.logic_input.Area
+            Pirate Stronghold:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -5362,102 +3367,68 @@ areas: !!python/object:logic.logic_input.Area
                 Side Entrance: null
                 Statue Entrance: null
               exits:
-                Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Side Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
-                \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
-                    Minidungeon
+                Dock Exit: 'True'
+                Side Exit: 'True'
+                Statue Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
+                \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head: \Lanayru\Lanayru
+                  Sand Sea\Pirate Stronghold\Inside\Finish Minidungeon
               hint_region: Lanayru Sand Sea
               locations:
-                Rupee on Bird Statue Pillar or Nose: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Rupee on East Sea Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Quick Beetle
-                Rupee on West Sea Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Quick Beetle
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Rupee on Bird Statue Pillar or Nose: \Beetle
+                Rupee on East Sea Pillar: \Quick Beetle
+                Rupee on West Sea Pillar: \Quick Beetle
+                Unlock Statue: 'True'
               name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold
               sub_areas:
-                Inside: !!python/object:logic.logic_input.Area
+                Inside:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     First Door Entrance: null
                     Second Door Entrance: null
                   exits:
-                    First Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Second Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
-                        Minidungeon
+                    First Door Exit: 'True'
+                    Second Door Exit: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
+                      Minidungeon
                   hint_region: Lanayru Sand Sea
                   locations:
-                    Finish Minidungeon: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Can Defeat Beamos
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Can Defeat Armos
-                      opaque: false
-                    First Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Second Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Third Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Finish Minidungeon: "\\Can Defeat Beamos & \\Can Defeat Armos"
+                    First Chest: 'True'
+                    Second Chest: 'True'
+                    Third Chest: 'True'
+                    \Ancient Flower Farming: 'True'
                   name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside
                   sub_areas: {}
                   toplevel_alias: null
-                Inside the Shark Head: !!python/object:logic.logic_input.Area
+                Inside the Shark Head:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Top Entrance: null
                   exits:
-                    Top Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Finish
-                          Minidungeon
-                      opaque: false
+                    Top Exit: 'True'
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold: "Clawshots | \\Lanayru\\\
+                      Lanayru Sand Sea\\Pirate Stronghold\\Inside\\Finish Minidungeon"
                   hint_region: Lanayru Sand Sea
                   locations:
-                    Goddess Cube in Pirate Stronghold: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Goddess Sword
-                      opaque: false
-                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Beetle
-                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Quick Beetle
-                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Quick Beetle
+                    Goddess Cube in Pirate Stronghold: "Clawshots & \\Goddess Sword"
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose: \Beetle
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar: \Quick
+                      Beetle
+                    \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar: \Quick
+                      Beetle
                   name: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark
                     Head
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Shipyard: !!python/object:logic.logic_input.Area
+            Shipyard:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -5466,242 +3437,156 @@ areas: !!python/object:logic.logic_input.Area
                 Dock Entrance: null
                 Statue Entrance: null
               exits:
-                Construction Bay Lower Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
-                    Moldarach
-                Construction Bay Upper Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
+                Construction Bay Lower Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Construction
+                  Bay\Defeat Moldarach
+                Construction Bay Upper Exit: 'True'
+                Dock Exit: 'True'
+                Statue Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
               hint_region: Lanayru Sand Sea
               locations:
-                Gossip Stone in Shipyard: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Rickety Coaster -- Heart Stopping Track in 1'05: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
-                    Moldarach
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Gossip Stone in Shipyard: 'True'
+                Rickety Coaster -- Heart Stopping Track in 1'05: \Lanayru\Lanayru
+                  Sand Sea\Shipyard\Construction Bay\Defeat Moldarach
+                Unlock Statue: 'True'
               name: \Lanayru\Lanayru Sand Sea\Shipyard
               sub_areas:
-                Construction Bay: !!python/object:logic.logic_input.Area
+                Construction Bay:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Lower Entrance: null
                     Upper Entrance: null
                   exits:
-                    Lower Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
-                        Moldarach
-                    Upper Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Lower Exit: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Defeat
+                      Moldarach
+                    Upper Exit: 'True'
                   hint_region: Lanayru Sand Sea
                   locations:
-                    Defeat Moldarach: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Gust Bellows
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sword
-                      opaque: false
+                    Defeat Moldarach: "Gust Bellows & \\Sword"
                   name: \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Skipper's Retreat: !!python/object:logic.logic_input.Area
+            Skipper's Retreat:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Dock Entrance: null
                 Statue Entrance: null
               exits:
-                Dock Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Unlock Statue
-                \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Blow up Rock
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  opaque: false
+                Dock Exit: 'True'
+                Statue Exit: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Unlock Statue
+                \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: "\\Lanayru\\\
+                  Lanayru Sand Sea\\Skipper's Retreat\\Blow up Rock & Clawshots"
               hint_region: Lanayru Sand Sea
               locations:
-                Blow up Rock: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Cactus Bomb Whip Trick
-                    opaque: false
-                  opaque: false
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Blow up Rock: "Bomb Bag | \\Hook Beetle | Whip & Cactus Bomb Whip\
+                  \ Trick"
+                Unlock Statue: 'True'
               name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat
               sub_areas:
-                Past Rock: !!python/object:logic.logic_input.Area
+                Past Rock:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Whip
-                          Peahat
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Deal
-                          with Deku Baba
-                      opaque: false
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat: 'True'
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part: "Clawshots\
+                      \ & \\Lanayru\\Lanayru Sand Sea\\Skipper's Retreat\\Past Rock\\\
+                      Whip Peahat & \\Lanayru\\Lanayru Sand Sea\\Skipper's Retreat\\\
+                      Past Rock\\Deal with Deku Baba"
                   hint_region: Lanayru Sand Sea
                   locations:
-                    Chest after Moblin: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Deal with Deku Baba: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Projectile Item
-                      - !!python/object:logic.logic_expression.AndCombination
-                        arguments:
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Skipper's Retreat Fast Clawshots Trick
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Clawshots
-                        opaque: false
-                      opaque: false
-                    Goddess Cube in Skipper's Retreat: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Goddess Sword
-                      opaque: false
-                    Whip Peahat: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Whip
-                      opaque: false
+                    Chest after Moblin: 'True'
+                    Deal with Deku Baba: "\\Projectile Item | Skipper's Retreat Fast\
+                      \ Clawshots Trick & Clawshots"
+                    Goddess Cube in Skipper's Retreat: "Clawshots & \\Goddess Sword"
+                    Whip Peahat: "Clawshots & Whip"
                   name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock
                   sub_areas: {}
                   toplevel_alias: null
-                Shack: !!python/object:logic.logic_input.Area
+                Shack:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance: null
                   exits:
-                    Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Exit: 'True'
                   hint_region: Lanayru Sand Sea
                   locations:
-                    Chest in Shack: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
+                    Chest in Shack: Gust Bellows
                   name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack
                   sub_areas: {}
                   toplevel_alias: null
-                Skydive Platform: !!python/object:logic.logic_input.Area
+                Skydive Platform:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat: Clawshots
                   hint_region: Lanayru Sand Sea
                   locations:
-                    Skydive Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Skydive Chest: 'True'
                   name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform
                   sub_areas: {}
                   toplevel_alias: null
-                Top Part: !!python/object:logic.logic_input.Area
+                Top Part:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Shack Entrance: null
                   exits:
-                    Shack Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Shack Exit: 'True'
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock: 'True'
+                    \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform: 'True'
                   hint_region: Lanayru Sand Sea
                   locations:
-                    Chest on top of Cacti Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
+                    Chest on top of Cacti Pillar: Clawshots
                   name: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
           toplevel_alias: Lanayru Sand Sea
-        Lanayru Silent Realm: !!python/object:logic.logic_input.Area
+        Lanayru Silent Realm:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance: null
           exits:
-            Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit: 'True'
           hint_region: Lanayru Silent Realm
           locations:
-            Relic 1: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 10: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 2: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 3: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 4: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 5: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 6: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 7: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 8: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 9: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Trial Reward: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Relic 1: 'True'
+            Relic 10: 'True'
+            Relic 2: 'True'
+            Relic 3: 'True'
+            Relic 4: 'True'
+            Relic 5: 'True'
+            Relic 6: 'True'
+            Relic 7: 'True'
+            Relic 8: 'True'
+            Relic 9: 'True'
+            Trial Reward: 'True'
           name: \Lanayru\Lanayru Silent Realm
           sub_areas: {}
           toplevel_alias: null
-        Mine: !!python/object:logic.logic_input.Area
+        Mine:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -5710,403 +3595,273 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Lanayru\Mine
           sub_areas:
-            End: !!python/object:logic.logic_input.Area
+            End:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru\Mine\End\In Minecart: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Mine\End\Blow up Rock on Track
-                \Lanayru\Mine\Statues Area: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Mine\Statues Area\Blow Statues Down
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Brakeslide Trick
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
-                  opaque: false
+                \Lanayru\Mine\End\In Minecart: \Lanayru\Mine\End\Blow up Rock on Track
+                \Lanayru\Mine\Statues Area: "\\Lanayru\\Mine\\Statues Area\\Blow Statues\
+                  \ Down | Brakeslide Trick | \\Skyloft\\Central Skyloft\\Bazaar\\\
+                  Endurance Potion"
               hint_region: Lanayru Mine
               locations:
-                Blow up Rock on Track: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Chest at the End of Mine: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Hit Timeshift Stone
+                Blow up Rock on Track: 'True'
+                Chest at the End of Mine: 'True'
+                \Ancient Flower Farming: \Can Hit Timeshift Stone
               name: \Lanayru\Mine\End
               sub_areas:
-                In Minecart: !!python/object:logic.logic_input.Area
+                In Minecart:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Desert: null
                   exits:
-                    Exit to Desert: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Exit to Desert: 'True'
                   hint_region: Lanayru Mine
                   locations:
-                    Blow up Rock on Track: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Lanayru Mine - Quick Bomb Trick
-                      opaque: false
+                    Blow up Rock on Track: "Bomb Bag & Lanayru Mine - Quick Bomb Trick"
                   name: \Lanayru\Mine\End\In Minecart
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Entry: !!python/object:logic.logic_input.Area
+            Entry:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 First Time Entrance: null
                 Statue Entrance: null
               exits:
-                Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Mine\Entry\Unlock Statue
-                \Lanayru\Mine\Entry\Higher Area: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
-                \Lanayru\Mine\Statues Area: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Mine\Entry\Timeshift Stone
+                Statue Exit: \Lanayru\Mine\Entry\Unlock Statue
+                \Lanayru\Mine\Entry\Higher Area: Clawshots
+                \Lanayru\Mine\Statues Area: \Lanayru\Mine\Entry\Timeshift Stone
               hint_region: Lanayru Mine
               locations:
-                Chest near First Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Mine\Entry\Timeshift Stone
-                Goddess Cube at Lanayru Mine Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Hit Timeshift Stone
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Itemless First Timeshift Stone Trick
-                  opaque: false
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Mine\Entry\Timeshift Stone
+                Chest near First Timeshift Stone: \Lanayru\Mine\Entry\Timeshift Stone
+                Goddess Cube at Lanayru Mine Entrance: \Goddess Sword
+                Timeshift Stone: "\\Can Hit Timeshift Stone | Itemless First Timeshift\
+                  \ Stone Trick"
+                Unlock Statue: 'True'
+                \Ancient Flower Farming: \Lanayru\Mine\Entry\Timeshift Stone
               name: \Lanayru\Mine\Entry
               sub_areas:
-                Caves Entrance: !!python/object:logic.logic_input.Area
+                Caves Entrance:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Caves: null
                   exits:
-                    Exit to Caves: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru\Mine\Entry\Higher Area: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
+                    Exit to Caves: 'True'
+                    \Lanayru\Mine\Entry\Higher Area: Clawshots
                   hint_region: Lanayru Mine
                   locations: {}
                   name: \Lanayru\Mine\Entry\Caves Entrance
                   sub_areas: {}
                   toplevel_alias: null
-                Higher Area: !!python/object:logic.logic_input.Area
+                Higher Area:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Lanayru\Mine\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru\Mine\Entry\Caves Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
+                    \Lanayru\Mine\Entry: 'True'
+                    \Lanayru\Mine\Entry\Caves Entrance: Clawshots
                   hint_region: Lanayru Mine
                   locations:
-                    Chest behind First Landing: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Chest behind First Landing: 'True'
                   name: \Lanayru\Mine\Entry\Higher Area
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Statues Area: !!python/object:logic.logic_input.Area
+            Statues Area:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru\Mine\End: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Mine\Statues Area\Blow Statues Down
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Brakeslide Trick
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
-                  opaque: false
-                \Lanayru\Mine\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Lanayru\Mine\End: "\\Lanayru\\Mine\\Statues Area\\Blow Statues Down\
+                  \ | Brakeslide Trick | \\Skyloft\\Central Skyloft\\Bazaar\\Endurance\
+                  \ Potion"
+                \Lanayru\Mine\Entry: 'True'
               hint_region: Lanayru Mine
               locations:
-                Blow Statues Down: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  opaque: false
-                Chest behind Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Mine\Statues Area\Blow Statues Down
+                Blow Statues Down: "Bomb Bag | \\Hook Beetle"
+                Chest behind Statue: \Lanayru\Mine\Statues Area\Blow Statues Down
               name: \Lanayru\Mine\Statues Area
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: Lanayru Mine
-        Temple of Time: !!python/object:logic.logic_input.Area
+        Temple of Time:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
           exits:
-            Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'False'
+            Shared Statue Exit: 'False'
           hint_region: null
           locations: {}
           name: \Lanayru\Temple of Time
           sub_areas:
-            Front: !!python/object:logic.logic_input.Area
+            Front:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru\Temple of Time\Inside: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Temple of Time\Near Goddess Cube: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Temple of Time\Near Goddess Cube\Timeshift Stone
+                \Lanayru\Temple of Time\Inside: 'True'
+                \Lanayru\Temple of Time\Near Goddess Cube: \Lanayru\Temple of Time\Near
+                  Goddess Cube\Timeshift Stone
               hint_region: null
               locations:
-                Blow up Rock for Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Bomb Throws Trick
-                    - !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      - !!python/object:logic.logic_expression.AndCombination
-                        arguments:
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Cactus Bomb Whip Trick
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Whip
-                        opaque: false
-                      opaque: false
-                    opaque: false
-                  opaque: false
-                Gossip Stone in Temple of Time Area: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Save Robot: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Temple of Time\Front\Timeshift Stone
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Defeat Bokoblins
-                  opaque: false
-                Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Temple of Time\Front\Blow up Rock for Timeshift
-                      Stone
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Distance Activator
-                  opaque: false
-                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Hook Beetle
-                \Lanayru\Temple of Time\Near Goddess Cube\Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Long Range Skyward Strike
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Distance Activator
-                  opaque: false
+                Blow up Rock for Timeshift Stone: "\\Hook Beetle | Bomb Throws Trick\
+                  \ & (Bomb Bag | Cactus Bomb Whip Trick & Whip)"
+                Gossip Stone in Temple of Time Area: 'True'
+                Save Robot: "\\Lanayru\\Temple of Time\\Front\\Timeshift Stone & \\\
+                  Can Defeat Bokoblins"
+                Timeshift Stone: "\\Lanayru\\Temple of Time\\Front\\Blow up Rock for\
+                  \ Timeshift Stone & \\Distance Activator"
+                \Ancient Flower Farming: \Hook Beetle
+                \Lanayru\Temple of Time\Near Goddess Cube\Timeshift Stone: "\\Long\
+                  \ Range Skyward Strike | \\Distance Activator"
               name: \Lanayru\Temple of Time\Front
               sub_areas: {}
               toplevel_alias: null
-            Inside: !!python/object:logic.logic_input.Area
+            Inside:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Lanayru Mining Facility: null
                 Temple of Time Statue Entrance: null
               exits:
-                Exit to Lanayru Mining Facility: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Temple of Time\Front: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Temple of Time\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Temple of Time\Inside\Unlock Statue
+                Exit to Lanayru Mining Facility: 'True'
+                \Lanayru\Temple of Time\Front: 'True'
+                \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\Inside\Unlock
+                  Statue
               hint_region: null
               locations:
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Unlock Statue: 'True'
               name: \Lanayru\Temple of Time\Inside
               sub_areas: {}
               toplevel_alias: null
-            Near Goddess Cube: !!python/object:logic.logic_input.Area
+            Near Goddess Cube:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru\Temple of Time\North East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Lanayru\Temple of Time\North East: 'True'
               hint_region: null
               locations:
-                Goddess Cube at Ride near Temple of Time: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Goddess Sword
-                Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'False'
+                Goddess Cube at Ride near Temple of Time: \Goddess Sword
+                Timeshift Stone: 'False'
               name: \Lanayru\Temple of Time\Near Goddess Cube
               sub_areas: {}
               toplevel_alias: null
-            North East: !!python/object:logic.logic_input.Area
+            North East:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 North Entrance from Desert: null
               exits:
-                North Exit to Desert: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Distance Activator
-                \Lanayru\Temple of Time\South East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Distance Activator
+                North Exit to Desert: 'True'
+                \Ancient Flower Farming: \Distance Activator
+                \Lanayru\Temple of Time\South East: \Distance Activator
               hint_region: null
               locations: {}
               name: \Lanayru\Temple of Time\North East
               sub_areas: {}
               toplevel_alias: null
-            South East: !!python/object:logic.logic_input.Area
+            South East:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Desert Gorge Statue Entrance: null
                 South Entrance from Desert: null
               exits:
-                South Exit to Desert: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru\Temple of Time\Front: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Slingshot
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Temple of Time - Slingshot Shot Trick
-                    opaque: false
-                  opaque: false
-                \Lanayru\Temple of Time\Shared Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Temple of Time\South East\Unlock Statue
+                South Exit to Desert: 'True'
+                \Lanayru\Temple of Time\Front: "\\Hook Beetle | \\Slingshot & Temple\
+                  \ of Time - Slingshot Shot Trick"
+                \Lanayru\Temple of Time\Shared Statue Exit: \Lanayru\Temple of Time\South
+                  East\Unlock Statue
               hint_region: null
               locations:
-                Unlock Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Ancient Flower Farming: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Distance Activator
+                Unlock Statue: 'True'
+                \Ancient Flower Farming: \Distance Activator
               name: \Lanayru\Temple of Time\South East
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
       toplevel_alias: null
-    Lanayru Mining Facility: !!python/object:logic.logic_input.Area
+    Lanayru Mining Facility:
       abstract: true
-      allowed_time_of_day: *id001
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
       exits: {}
       hint_region: Lanayru Mining Facility
       locations:
-        Can Activate Minecart Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Sword
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Whip
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Bomb Bag
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Distance Activator
-          opaque: false
+        Can Activate Minecart Timeshift Stone: "\\Sword | Whip | Bomb Bag | \\Distance\
+          \ Activator"
       name: \Lanayru Mining Facility
       sub_areas:
-        Boss Room: !!python/object:logic.logic_input.Area
+        Boss Room:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance from Dungeon: null
           exits:
-            Exit to Dungeon: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat Moldarach
-            \Lanayru Mining Facility\Boss Room\After Sand Drain: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit to Dungeon: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat
+              Moldarach
+            \Lanayru Mining Facility\Boss Room\After Sand Drain: 'True'
           hint_region: Lanayru Mining Facility
           locations: {}
           name: \Lanayru Mining Facility\Boss Room
           sub_areas:
-            After Sand Drain: !!python/object:logic.logic_input.Area
+            After Sand Drain:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Hall of Ancient Robots: null
               exits:
-                Exit to Hall of Ancient Robots: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat Moldarach
+                Exit to Hall of Ancient Robots: \Lanayru Mining Facility\Boss Room\After
+                  Sand Drain\Beat Moldarach
               hint_region: Lanayru Mining Facility
               locations:
-                Beat Moldarach: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: LMF - Moldarach without Gust Bellows Trick
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  opaque: false
-                Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat Moldarach
+                Beat Moldarach: "(Gust Bellows | LMF - Moldarach without Gust Bellows\
+                  \ Trick) & \\Sword"
+                Heart Container: \Lanayru Mining Facility\Boss Room\After Sand Drain\Beat
+                  Moldarach
               name: \Lanayru Mining Facility\Boss Room\After Sand Drain
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
-        Hall of Ancient Robots: !!python/object:logic.logic_input.Area
+        Hall of Ancient Robots:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -6115,52 +3870,42 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Lanayru Mining Facility\Hall of Ancient Robots
           sub_areas:
-            End: !!python/object:logic.logic_input.Area
+            End:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Temple of Time: null
               exits:
-                Exit to Temple of Time: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit to Temple of Time: 'True'
               hint_region: Lanayru Mining Facility
               locations:
-                Exit Hall of Ancient Robots: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit Hall of Ancient Robots: 'True'
               name: \Lanayru Mining Facility\Hall of Ancient Robots\End
               sub_areas: {}
               toplevel_alias: null
-            Entry: !!python/object:logic.logic_input.Area
+            Entry:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Boss Room: null
               exits:
-                Exit to Boss Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru Mining Facility\Hall of Ancient Robots\End: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Hit
-                    Timeshift Stone
+                Exit to Boss Room: 'True'
+                \Lanayru Mining Facility\Hall of Ancient Robots\End: \Lanayru Mining
+                  Facility\Hall of Ancient Robots\Entry\Hit Timeshift Stone
               hint_region: Lanayru Mining Facility
               locations:
-                Hit Timeshift Stone: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Beetle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  opaque: false
+                Hit Timeshift Stone: "\\Beetle | \\Bow"
               name: \Lanayru Mining Facility\Hall of Ancient Robots\Entry
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
-        Main: !!python/object:logic.logic_input.Area
+        Main:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -6169,55 +3914,30 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Lanayru Mining Facility\Main
           sub_areas:
-            Armos Fight Room: !!python/object:logic.logic_input.Area
+            Armos Fight Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Big Hub: null
               exits:
-                Exit to Big Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\Armos Fight Room\Defeat Armos
+                Exit to Big Hub: \Lanayru Mining Facility\Main\Armos Fight Room\Defeat
+                  Armos
               hint_region: Lanayru Mining Facility
               locations:
-                Activate Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Gust Bellows
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Slingshot
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Bow
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Goddess Sword
-                    - !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: LMF - Whip Armos Room Timeshift Stone Trick
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Whip
-                      opaque: false
-                    opaque: false
-                  opaque: false
-                Chest after Armos Fight: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\Armos Fight Room\Defeat Armos
-                Defeat Armos: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru Mining Facility\Main\Armos Fight Room\Activate
-                      Timeshift Stone
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Defeat Armos
-                  opaque: false
+                Activate Timeshift Stone: "Gust Bellows & (\\Slingshot | \\Bow | \\\
+                  Goddess Sword | LMF - Whip Armos Room Timeshift Stone Trick & Whip)"
+                Chest after Armos Fight: \Lanayru Mining Facility\Main\Armos Fight
+                  Room\Defeat Armos
+                Defeat Armos: "\\Lanayru Mining Facility\\Main\\Armos Fight Room\\\
+                  Activate Timeshift Stone & \\Can Defeat Armos"
               name: \Lanayru Mining Facility\Main\Armos Fight Room
               sub_areas: {}
               toplevel_alias: null
-            Big Hub: !!python/object:logic.logic_input.Area
+            Big Hub:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
@@ -6226,547 +3946,344 @@ areas: !!python/object:logic.logic_input.Area
               locations: {}
               name: \Lanayru Mining Facility\Main\Big Hub
               sub_areas:
-                After Wooden Boxes: !!python/object:logic.logic_input.Area
+                After Wooden Boxes:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Lanayru Mining Facility\Main\Big Hub\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop
-                        Across Boxes Room\Push Box
+                    \Lanayru Mining Facility\Main\Big Hub\Entry: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room: \Lanayru
+                      Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Push
+                      Box
                   hint_region: Lanayru Mining Facility
                   locations:
-                    First Chest in Hub Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    First Chest in Hub Room: 'True'
                   name: \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes
                   sub_areas: {}
                   toplevel_alias: null
-                Between Wind Gates: !!python/object:logic.logic_input.Area
+                Between Wind Gates:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Lanayru Mining Facility\Main\Big Hub\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Open
-                        First Wind Gate
-                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Activate
-                        Minecart Stone to Boss Key Room
-                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room
-                        Second Exit\Push Box
+                    \Lanayru Mining Facility\Main\Big Hub\Entry: \Lanayru Mining Facility\Main\Big
+                      Hub\Between Wind Gates\Open First Wind Gate
+                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: \Lanayru
+                      Mining Facility\Main\Big Hub\Between Wind Gates\Activate Minecart
+                      Stone to Boss Key Room
+                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: \Lanayru
+                      Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Push
+                      Box
                   hint_region: Lanayru Mining Facility
                   locations:
-                    Activate Minecart Stone to Boss Key Room: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Gust Bellows
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Lanayru Mining Facility\Can Activate Minecart Timeshift
-                          Stone
-                      opaque: false
-                    Get Minecart: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Near Boss Door\Open Second
-                        Wind Gate
-                    Open First Wind Gate: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Get
-                          Minecart
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Lanayru Mining Facility\Can Activate Minecart Timeshift
-                          Stone
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Gust Bellows
-                      opaque: false
-                    Unlock Exit to Boss Key Room: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Activate
-                          Minecart Stone to Boss Key Room
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Gust Bellows
-                      opaque: false
+                    Activate Minecart Stone to Boss Key Room: "Gust Bellows & \\Lanayru\
+                      \ Mining Facility\\Can Activate Minecart Timeshift Stone"
+                    Get Minecart: \Lanayru Mining Facility\Main\Near Boss Door\Open
+                      Second Wind Gate
+                    Open First Wind Gate: "\\Lanayru Mining Facility\\Main\\Big Hub\\\
+                      Between Wind Gates\\Get Minecart & \\Lanayru Mining Facility\\\
+                      Can Activate Minecart Timeshift Stone & Gust Bellows"
+                    Unlock Exit to Boss Key Room: "\\Lanayru Mining Facility\\Main\\\
+                      Big Hub\\Between Wind Gates\\Activate Minecart Stone to Boss\
+                      \ Key Room & Gust Bellows"
                   name: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates
                   sub_areas: {}
                   toplevel_alias: null
-                Entry: !!python/object:logic.logic_input.Area
+                Entry:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from First Hub: null
                   exits:
-                    Exit to First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Entry\Blow Up Boxes
-                    \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Open
-                        First Wind Gate
-                    \Lanayru Mining Facility\Main\Big Hub\Past West Gate: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Open
-                        Gate
+                    Exit to First Hub: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: \Lanayru
+                      Mining Facility\Main\Big Hub\Entry\Blow Up Boxes
+                    \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: \Lanayru
+                      Mining Facility\Main\Big Hub\Between Wind Gates\Open First Wind
+                      Gate
+                    \Lanayru Mining Facility\Main\Big Hub\Past West Gate: \Lanayru
+                      Mining Facility\Main\Big Hub\Past West Gate\Open Gate
                   hint_region: Lanayru Mining Facility
                   locations:
-                    Blow Up Boxes: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Hook Beetle
-                      opaque: false
+                    Blow Up Boxes: "Bomb Bag | \\Hook Beetle"
                   name: \Lanayru Mining Facility\Main\Big Hub\Entry
                   sub_areas: {}
                   toplevel_alias: null
-                Near Boss Key Room First Exit: !!python/object:logic.logic_input.Area
+                Near Boss Key Room First Exit:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Lanayru Mining Facility\Main\Boss Key Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates\Unlock
-                        Exit to Boss Key Room
+                    \Lanayru Mining Facility\Main\Boss Key Room: \Lanayru Mining Facility\Main\Big
+                      Hub\Between Wind Gates\Unlock Exit to Boss Key Room
                   hint_region: Lanayru Mining Facility
                   locations: {}
                   name: \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First
                     Exit
                   sub_areas: {}
                   toplevel_alias: null
-                Near Boss Key Room Second Exit: !!python/object:logic.logic_input.Area
+                Near Boss Key Room Second Exit:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru Mining Facility\Main\Near Boss Door: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Gust Bellows
-                      - !!python/object:logic.logic_expression.AndCombination
-                        arguments:
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: LMF - Minecart Jump Trick
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Sword
-                        - !!python/object:logic.logic_expression.OrCombination
-                          arguments:
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: Bomb Bag
-                          - !!python/object:logic.logic_expression.BasicTextAtom
-                            text: \Beetle
-                          opaque: false
-                        opaque: false
-                      opaque: false
+                    \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room First Exit: 'True'
+                    \Lanayru Mining Facility\Main\Near Boss Door: "Gust Bellows |\
+                      \ LMF - Minecart Jump Trick & \\Sword & (Bomb Bag | \\Beetle)"
                   hint_region: Lanayru Mining Facility
                   locations:
-                    Push Box: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Shortcut Chest in Main Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Push Box: 'True'
+                    Shortcut Chest in Main Hub: 'True'
                   name: \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second
                     Exit
                   sub_areas: {}
                   toplevel_alias: null
-                Near Exit to Hop Across Boxes Room: !!python/object:logic.logic_input.Area
+                Near Exit to Hop Across Boxes Room:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Hop Across Boxes Room: null
                   exits:
-                    Exit to Hop Across Boxes Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Exit to Hop Across Boxes Room: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes: 'True'
                   hint_region: Lanayru Mining Facility
                   locations:
-                    Push Box: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Push Box: 'True'
                   name: \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across
                     Boxes Room
                   sub_areas: {}
                   toplevel_alias: null
-                Past West Gate: !!python/object:logic.logic_input.Area
+                Past West Gate:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Armos Fight Room: null
                   exits:
-                    Exit to Armos Fight Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Lanayru Mining Facility\Main\Big Hub\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Open
-                        Gate
-                    \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Blow
-                        Off Pile for Second Crawlspace
+                    Exit to Armos Fight Room: 'True'
+                    \Lanayru Mining Facility\Main\Big Hub\Entry: \Lanayru Mining Facility\Main\Big
+                      Hub\Past West Gate\Open Gate
+                    \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze: \Lanayru
+                      Mining Facility\Main\Big Hub\Past West Gate\Blow Off Pile for
+                      Second Crawlspace
                   hint_region: Lanayru Mining Facility
                   locations:
-                    Blow Off Pile for First Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
-                    Blow Off Pile for Second Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
-                    Chest behind First Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Blow
-                        Off Pile for First Crawlspace
-                    Open Gate: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Blow Off Pile for First Crawlspace: Gust Bellows
+                    Blow Off Pile for Second Crawlspace: Gust Bellows
+                    Chest behind First Crawlspace: \Lanayru Mining Facility\Main\Big
+                      Hub\Past West Gate\Blow Off Pile for First Crawlspace
+                    Open Gate: 'True'
                   name: \Lanayru Mining Facility\Main\Big Hub\Past West Gate
                   sub_areas: {}
                   toplevel_alias: null
-                Sand Spike Maze: !!python/object:logic.logic_input.Area
+                Sand Spike Maze:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Lanayru Mining Facility\Main\Near Boss Door: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Switch
-                          under Sand
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Lanayru Mining Facility\Can Activate Minecart Timeshift
-                          Stone
-                      opaque: false
+                    \Lanayru Mining Facility\Main\Near Boss Door: "\\Lanayru Mining\
+                      \ Facility\\Main\\Big Hub\\Sand Spike Maze\\Switch under Sand\
+                      \ & \\Lanayru Mining Facility\\Can Activate Minecart Timeshift\
+                      \ Stone"
                   hint_region: Lanayru Mining Facility
                   locations:
-                    Chest in Spike Maze: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
-                    Switch under Sand: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
+                    Chest in Spike Maze: Gust Bellows
+                    Switch under Sand: Gust Bellows
                   name: \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Boss Key Room: !!python/object:logic.logic_input.Area
+            Boss Key Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\Boss Key Room\Can Beat Room
+                \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: \Lanayru
+                  Mining Facility\Main\Boss Key Room\Can Beat Room
               hint_region: Lanayru Mining Facility
               locations:
-                Boss Key Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\Boss Key Room\Can Beat Room
-                Can Beat Room: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Gust Bellows
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  opaque: false
+                Boss Key Chest: \Lanayru Mining Facility\Main\Boss Key Room\Can Beat
+                  Room
+                Can Beat Room: "Bomb Bag & Gust Bellows & \\Sword"
               name: \Lanayru Mining Facility\Main\Boss Key Room
               sub_areas: {}
               toplevel_alias: null
-            First Hub: !!python/object:logic.logic_input.Area
+            First Hub:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Big Hub: null
               exits:
-                Exit to Big Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru Mining Facility\Main\First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru Mining Facility\Main\First West Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\First Hub\Push Box on Switch
-                \Lanayru Mining Facility\Main\Key Locked Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Lanayru Mining Facility Small Key
+                Exit to Big Hub: 'True'
+                \Lanayru Mining Facility\Main\First Room: 'True'
+                \Lanayru Mining Facility\Main\First West Room: \Lanayru Mining Facility\Main\First
+                  Hub\Push Box on Switch
+                \Lanayru Mining Facility\Main\Key Locked Room: Lanayru Mining Facility
+                  Small Key
               hint_region: Lanayru Mining Facility
               locations:
-                Push Box on Switch: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Gust Bellows
+                Push Box on Switch: Gust Bellows
               name: \Lanayru Mining Facility\Main\First Hub
               sub_areas: {}
               toplevel_alias: null
-            First Room: !!python/object:logic.logic_input.Area
+            First Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Main Entrance: null
               exits:
-                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru Mining Facility\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\First Room\Left Lever
+                Main Exit: 'True'
+                \Lanayru Mining Facility\Main\First Hub: \Lanayru Mining Facility\Main\First
+                  Room\Left Lever
               hint_region: Lanayru Mining Facility
               locations:
-                Chest behind Bars: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\First Room\Right Lever
-                Left Lever: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Whip
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: LMF - Whip First Room Switch Trick
-                    opaque: false
-                  opaque: false
-                Right Lever: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Chest behind Bars: \Lanayru Mining Facility\Main\First Room\Right
+                  Lever
+                Left Lever: "\\Hook Beetle | Whip & LMF - Whip First Room Switch Trick"
+                Right Lever: 'True'
               name: \Lanayru Mining Facility\Main\First Room
               sub_areas: {}
               toplevel_alias: null
-            First West Room: !!python/object:logic.logic_input.Area
+            First West Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru Mining Facility\Main\Armos Fight Room: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Gust Bellows
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Defeat Beamos
-                  opaque: false
-                \Lanayru Mining Facility\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Lanayru Mining Facility\Main\Armos Fight Room: "Gust Bellows & \\\
+                  Can Defeat Beamos"
+                \Lanayru Mining Facility\Main\First Hub: 'True'
               hint_region: Lanayru Mining Facility
               locations:
-                Chest in First West Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Gust Bellows
+                Chest in First West Room: Gust Bellows
               name: \Lanayru Mining Facility\Main\First West Room
               sub_areas: {}
               toplevel_alias: null
-            Hop Across Boxes Room: !!python/object:logic.logic_input.Area
+            Hop Across Boxes Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Blow
-                      Up Rocks
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near
-                      Exit\Push Shortcut Box
-                  opaque: false
+                \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit: "\\\
+                  Lanayru Mining Facility\\Main\\Hop Across Boxes Room\\Blow Up Rocks\
+                  \ | \\Lanayru Mining Facility\\Main\\Hop Across Boxes Room\\Near\
+                  \ Exit\\Push Shortcut Box"
               hint_region: Lanayru Mining Facility
               locations:
-                Blow Up Rocks: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Slingshot
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Beetle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Gust Bellows
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Whip
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  opaque: false
-                Lower Chest in Hop across Boxes Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Blow Up
-                    Rocks
-                Raised Chest in Hop across Boxes Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Blow Up
-                    Rocks
+                Blow Up Rocks: "\\Sword | \\Slingshot | \\Beetle | Bomb Bag | Gust\
+                  \ Bellows | Whip | Clawshots | \\Bow"
+                Lower Chest in Hop across Boxes Room: \Lanayru Mining Facility\Main\Hop
+                  Across Boxes Room\Blow Up Rocks
+                Raised Chest in Hop across Boxes Room: \Lanayru Mining Facility\Main\Hop
+                  Across Boxes Room\Blow Up Rocks
               name: \Lanayru Mining Facility\Main\Hop Across Boxes Room
               sub_areas:
-                Near Exit: !!python/object:logic.logic_input.Area
+                Near Exit:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance from Big Hub: null
                   exits:
-                    Exit to Big Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near
-                        Exit\Remove Dust Pile at Door
+                    Exit to Big Hub: \Lanayru Mining Facility\Main\Hop Across Boxes
+                      Room\Near Exit\Remove Dust Pile at Door
                   hint_region: Lanayru Mining Facility
                   locations:
-                    Push Shortcut Box: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Remove Dust Pile at Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Push Shortcut Box: 'True'
+                    Remove Dust Pile at Door: 'True'
                   name: \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Key Locked Room: !!python/object:logic.logic_input.Area
+            Key Locked Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Lanayru Mining Facility\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Lanayru Mining Facility\Main\Hop Across Boxes Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\Key Locked Room\Activate Timeshift
-                    Stone
+                \Lanayru Mining Facility\Main\First Hub: 'True'
+                \Lanayru Mining Facility\Main\Hop Across Boxes Room: \Lanayru Mining
+                  Facility\Main\Key Locked Room\Activate Timeshift Stone
               hint_region: Lanayru Mining Facility
               locations:
-                Activate Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru Mining Facility\Main\Key Locked Room\Blow Up Boxes
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Bow
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Beetle
-                    - !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Slingshot
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: LMF - Keylocked Slingshot Trickshot Trick
-                      opaque: false
-                    opaque: false
-                  opaque: false
-                Blow Up Boxes: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Hook Beetle
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Bomb Bag
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Bomb Throws Trick
-                    opaque: false
-                  opaque: false
-                Chest in Key Locked Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru Mining Facility\Main\Key Locked Room\Activate Timeshift
-                    Stone
+                Activate Timeshift Stone: "\\Lanayru Mining Facility\\Main\\Key Locked\
+                  \ Room\\Blow Up Boxes & (\\Bow | \\Beetle | \\Slingshot & LMF -\
+                  \ Keylocked Slingshot Trickshot Trick)"
+                Blow Up Boxes: "\\Hook Beetle | Bomb Bag & Bomb Throws Trick"
+                Chest in Key Locked Room: \Lanayru Mining Facility\Main\Key Locked
+                  Room\Activate Timeshift Stone
               name: \Lanayru Mining Facility\Main\Key Locked Room
               sub_areas: {}
               toplevel_alias: null
-            Near Boss Door: !!python/object:logic.logic_input.Area
+            Near Boss Door:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Boss Door Entrance: null
               exits:
-                Boss Door Exit: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Lanayru Mining Facility Boss Key
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru Mining Facility\Can Activate Minecart Timeshift
-                      Stone
-                  opaque: false
-                \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru Mining Facility\Main\Near Boss Door\Open Second
-                      Wind Gate
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Defeat Beamos
-                  opaque: false
-                \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: LMF - Minecart Jump Trick
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sword
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Bomb Bag
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Beetle
-                    opaque: false
-                  opaque: false
+                Boss Door Exit: "Lanayru Mining Facility Boss Key & \\Lanayru Mining\
+                  \ Facility\\Can Activate Minecart Timeshift Stone"
+                \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: "\\Lanayru\
+                  \ Mining Facility\\Main\\Near Boss Door\\Open Second Wind Gate &\
+                  \ \\Can Defeat Beamos"
+                \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit: "LMF\
+                  \ - Minecart Jump Trick & \\Sword & (Bomb Bag | \\Beetle)"
               hint_region: Lanayru Mining Facility
               locations:
-                Get Minecart to Wind Gate: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Gust Bellows
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru Mining Facility\Can Activate Minecart Timeshift
-                      Stone
-                  opaque: false
-                Open Second Wind Gate: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru Mining Facility\Main\Near Boss Door\Get Minecart
-                      to Wind Gate
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Gust Bellows
-                  opaque: false
+                Get Minecart to Wind Gate: "Gust Bellows & \\Lanayru Mining Facility\\\
+                  Can Activate Minecart Timeshift Stone"
+                Open Second Wind Gate: "\\Lanayru Mining Facility\\Main\\Near Boss\
+                  \ Door\\Get Minecart to Wind Gate & Gust Bellows"
               name: \Lanayru Mining Facility\Main\Near Boss Door
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
       toplevel_alias: null
-    Sandship: !!python/object:logic.logic_input.Area
+    Sandship:
       abstract: true
-      allowed_time_of_day: *id001
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
       exits: {}
       hint_region: Sandship
       locations:
-        Pass Spume: !!python/object:logic.logic_expression.OrCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Goddess Sword
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Bow
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Bomb Bag
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Slingshot
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Sandship - Itemless Spume Skip Trick
-          opaque: false
+        Pass Spume: "\\Goddess Sword | \\Bow | Bomb Bag | \\Slingshot | Sandship -\
+          \ Itemless Spume Skip Trick"
       name: \Sandship
       sub_areas:
-        Boss Room: !!python/object:logic.logic_input.Area
+        Boss Room:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
@@ -6774,23 +4291,15 @@ areas: !!python/object:logic.logic_input.Area
           exits: {}
           hint_region: Sandship
           locations:
-            Beat Tentalus: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Bow
-            Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Sandship\Boss Room\Beat Tentalus
-            Nayru's Flame: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Sandship\Boss Room\Beat Tentalus
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Goddess Sword
-              opaque: false
+            Beat Tentalus: \Bow
+            Heart Container: \Sandship\Boss Room\Beat Tentalus
+            Nayru's Flame: "\\Sandship\\Boss Room\\Beat Tentalus & \\Goddess Sword"
           name: \Sandship\Boss Room
           sub_areas: {}
           toplevel_alias: null
-        Main: !!python/object:logic.logic_input.Area
+        Main:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -6799,379 +4308,243 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Sandship\Main
           sub_areas:
-            Before Boss Door: !!python/object:logic.logic_input.Area
+            Before Boss Door:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                Boss Door one-way Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sandship\Main\Before Boss Door\Open Boss Door
-                \Sandship\Main\Corridor: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Boss Door one-way Exit: \Sandship\Main\Before Boss Door\Open Boss
+                  Door
+                \Sandship\Main\Corridor: 'True'
               hint_region: Sandship
               locations:
-                Chest behind Combination Lock: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sandship\Main\Before Boss Door\Combination Lock
-                Combination Lock: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Sandship - No Combination Hint Trick
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Unlock Combination Lock
-                  opaque: false
-                Open Boss Door: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Sandship Boss Key
-                  opaque: false
+                Chest behind Combination Lock: \Sandship\Main\Before Boss Door\Combination
+                  Lock
+                Combination Lock: "(Gust Bellows | \\Sandship\\Main\\Deck\\Freely\
+                  \ Usable Timeshift Stone | Sandship - No Combination Hint Trick)\
+                  \ & \\Can Unlock Combination Lock"
+                Open Boss Door: "\\Sandship\\Main\\Deck\\Freely Usable Timeshift Stone\
+                  \ & Sandship Boss Key"
               name: \Sandship\Main\Before Boss Door
               sub_areas: {}
               toplevel_alias: null
-            Before Ship's Bow: !!python/object:logic.logic_input.Area
+            Before Ship's Bow:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sandship\Main\Corridor: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Pass Spume
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
-                  opaque: false
-                \Sandship\Main\Ship's Bow: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Sandship Small Key x 2
+                \Sandship\Main\Corridor: "\\Sandship\\Pass Spume | \\Sandship\\Main\\\
+                  Deck\\Freely Usable Timeshift Stone"
+                \Sandship\Main\Ship's Bow: Sandship Small Key x 2
               hint_region: Sandship
               locations:
-                Chest before 4-Door Corridor: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                Chest before 4-Door Corridor: \Sandship\Main\Deck\Freely Usable Timeshift
+                  Stone
               name: \Sandship\Main\Before Ship's Bow
               sub_areas: {}
               toplevel_alias: null
-            Brig: !!python/object:logic.logic_input.Area
+            Brig:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sandship\Main\Brig Prison: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Starboard Rooms\Generator
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Whip
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Port Rooms\Generator
-                  opaque: false
-                \Sandship\Main\Starboard Rooms: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sandship\Main\Starboard Rooms\Switch
-                \Sandship\Main\Treasure Room: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Starboard Rooms\Generator
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Whip
-                  opaque: false
+                \Sandship\Main\Brig Prison: "\\Sandship\\Main\\Starboard Rooms\\Generator\
+                  \ & Whip & \\Sandship\\Main\\Port Rooms\\Generator"
+                \Sandship\Main\Starboard Rooms: \Sandship\Main\Starboard Rooms\Switch
+                \Sandship\Main\Treasure Room: "\\Sandship\\Main\\Starboard Rooms\\\
+                  Generator & Whip"
               hint_region: Sandship
               locations: {}
               name: \Sandship\Main\Brig
               sub_areas: {}
               toplevel_alias: null
-            Brig Prison: !!python/object:logic.logic_input.Area
+            Brig Prison:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sandship\Main\Brig: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Sandship\Main\Brig: 'True'
               hint_region: Sandship
               locations:
-                Robot in Brig's Reward: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Robot in Brig's Reward: 'True'
               name: \Sandship\Main\Brig Prison
               sub_areas: {}
               toplevel_alias: null
-            Corridor: !!python/object:logic.logic_input.Area
+            Corridor:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sandship\Main\Before Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Sandship\Main\Before Ship's Bow: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Pass Spume
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
-                  opaque: false
-                \Sandship\Main\Port Rooms: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sandship\Main\Port Rooms\Switch
-                \Sandship\Main\Starboard Rooms: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
+                \Sandship\Main\Before Boss Door: 'True'
+                \Sandship\Main\Before Ship's Bow: "\\Sandship\\Pass Spume | \\Sandship\\\
+                  Main\\Deck\\Freely Usable Timeshift Stone"
+                \Sandship\Main\Port Rooms: \Sandship\Main\Port Rooms\Switch
+                \Sandship\Main\Starboard Rooms: \Sandship\Main\Deck\Freely Usable
+                  Timeshift Stone
               hint_region: Sandship
               locations:
-                \Sandship\Main\Port Rooms\Switch: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Bow
+                \Sandship\Main\Port Rooms\Switch: \Bow
               name: \Sandship\Main\Corridor
               sub_areas: {}
               toplevel_alias: null
-            Deck: !!python/object:logic.logic_input.Area
+            Deck:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Main Entrance: null
               exits:
-                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Sandship\Main\Before Ship's Bow: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Sandship\Main\Deck\Captain's Cabin: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Sandship Small Key x 2
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sandship\Main\Deck\Start Mast Sequence
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
-                    opaque: false
-                  opaque: false
-                \Sandship\Main\Deck\Mast: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Deck\Start Mast Sequence
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
-                  opaque: false
-                \Sandship\Main\Starboard Rooms: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Starboard Rooms\Switch
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  opaque: false
+                Main Exit: 'True'
+                \Sandship\Main\Before Ship's Bow: 'True'
+                \Sandship\Main\Deck\Captain's Cabin: "Sandship Small Key x 2 & (\\\
+                  Sandship\\Main\\Deck\\Start Mast Sequence | \\Sandship\\Main\\Deck\\\
+                  Freely Usable Timeshift Stone)"
+                \Sandship\Main\Deck\Mast: "\\Sandship\\Main\\Deck\\Start Mast Sequence\
+                  \ | \\Sandship\\Main\\Deck\\Freely Usable Timeshift Stone"
+                \Sandship\Main\Starboard Rooms: "\\Sandship\\Main\\Starboard Rooms\\\
+                  Switch & \\Bow"
               hint_region: Sandship
               locations:
-                Freely Usable Timeshift Stone: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Deck\Mast\Finish Mast Sequence
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  opaque: false
-                Raise Timeshift Stone: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Bow
-                Start Mast Sequence: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Deck\Raise Timeshift Stone
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  opaque: false
+                Freely Usable Timeshift Stone: "\\Sandship\\Main\\Deck\\Mast\\Finish\
+                  \ Mast Sequence & \\Bow"
+                Raise Timeshift Stone: \Bow
+                Start Mast Sequence: "\\Sandship\\Main\\Deck\\Raise Timeshift Stone\
+                  \ & \\Bow"
               name: \Sandship\Main\Deck
               sub_areas:
-                Captain's Cabin: !!python/object:logic.logic_input.Area
+                Captain's Cabin:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sandship\Main\Deck: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Sandship Small Key x 2
+                    \Sandship\Main\Deck: Sandship Small Key x 2
                   hint_region: Sandship
                   locations:
-                    Bars: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Can Defeat Beamos
-                    Boss Key Chest: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sandship\Main\Deck\Captain's Cabin\Switch
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sandship\Main\Deck\Captain's Cabin\Bars
-                      opaque: false
-                    Switch: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
-                      opaque: false
+                    Bars: \Can Defeat Beamos
+                    Boss Key Chest: "\\Sandship\\Main\\Deck\\Captain's Cabin\\Switch\
+                      \ & \\Sandship\\Main\\Deck\\Captain's Cabin\\Bars"
+                    Switch: "\\Bow & \\Sandship\\Main\\Deck\\Freely Usable Timeshift\
+                      \ Stone"
                   name: \Sandship\Main\Deck\Captain's Cabin
                   sub_areas: {}
                   toplevel_alias: null
-                Mast: !!python/object:logic.logic_input.Area
+                Mast:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sandship\Main\Deck: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    \Sandship\Main\Deck\Stern: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      - !!python/object:logic.logic_expression.OrCombination
-                        arguments:
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Clawshots
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Sandship - Mast Jump Trick
-                        opaque: false
-                      opaque: false
+                    \Sandship\Main\Deck: 'True'
+                    \Sandship\Main\Deck\Stern: "\\Bow & (Clawshots | Sandship - Mast\
+                      \ Jump Trick)"
                   hint_region: Sandship
                   locations:
-                    Finish Mast Sequence: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sword
-                      opaque: false
+                    Finish Mast Sequence: "\\Bow & \\Sword"
                   name: \Sandship\Main\Deck\Mast
                   sub_areas: {}
                   toplevel_alias: null
-                Stern: !!python/object:logic.logic_input.Area
+                Stern:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sandship\Main\Deck: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
+                    \Sandship\Main\Deck: Clawshots
                   hint_region: Sandship
                   locations:
-                    Chest at the Stern: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Chest at the Stern: 'True'
                   name: \Sandship\Main\Deck\Stern
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Port Rooms: !!python/object:logic.logic_input.Area
+            Port Rooms:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sandship\Main\Corridor: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sandship\Main\Port Rooms\Switch
+                \Sandship\Main\Corridor: \Sandship\Main\Port Rooms\Switch
               hint_region: Sandship
               locations:
-                Generator: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
-                  opaque: false
-                Switch: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Bow
+                Generator: "\\Bow & \\Sandship\\Main\\Deck\\Freely Usable Timeshift\
+                  \ Stone"
+                Switch: \Bow
               name: \Sandship\Main\Port Rooms
               sub_areas: {}
               toplevel_alias: null
-            Ship's Bow: !!python/object:logic.logic_input.Area
+            Ship's Bow:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sandship\Main\Before Ship's Bow: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Caves\Chest
+                \Sandship\Main\Before Ship's Bow: \Lanayru\Caves\Chest
               hint_region: Sandship
               locations:
-                Chest after Scervo Fight: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Defeat Scervo/Dreadfuse
+                Chest after Scervo Fight: \Can Defeat Scervo/Dreadfuse
               name: \Sandship\Main\Ship's Bow
               sub_areas: {}
               toplevel_alias: null
-            Starboard Rooms: !!python/object:logic.logic_input.Area
+            Starboard Rooms:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sandship\Main\Brig: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sandship\Main\Starboard Rooms\Switch
-                \Sandship\Main\Corridor: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
-                \Sandship\Main\Deck: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Starboard Rooms\Switch
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  opaque: false
+                \Sandship\Main\Brig: \Sandship\Main\Starboard Rooms\Switch
+                \Sandship\Main\Corridor: \Sandship\Main\Deck\Freely Usable Timeshift
+                  Stone
+                \Sandship\Main\Deck: "\\Sandship\\Main\\Starboard Rooms\\Switch &\
+                  \ \\Bow"
               hint_region: Sandship
               locations:
-                Generator: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sandship\Main\Deck\Freely Usable Timeshift Stone
-                  opaque: false
-                Switch: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Generator: "\\Bow & \\Sandship\\Main\\Deck\\Freely Usable Timeshift\
+                  \ Stone"
+                Switch: 'True'
               name: \Sandship\Main\Starboard Rooms
               sub_areas: {}
               toplevel_alias: null
-            Treasure Room: !!python/object:logic.logic_input.Area
+            Treasure Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sandship\Main\Brig: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Sandship\Main\Brig: 'True'
               hint_region: Sandship
               locations:
-                Treasure Room Fifth Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Treasure Room First Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Treasure Room Fourth Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Treasure Room Second Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Treasure Room Third Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Treasure Room Fifth Chest: 'True'
+                Treasure Room First Chest: 'True'
+                Treasure Room Fourth Chest: 'True'
+                Treasure Room Second Chest: 'True'
+                Treasure Room Third Chest: 'True'
               name: \Sandship\Main\Treasure Room
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
       toplevel_alias: null
-    Sky: !!python/object:logic.logic_input.Area
+    Sky:
       abstract: false
-      allowed_time_of_day: *id001
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
@@ -7180,360 +4553,219 @@ areas: !!python/object:logic.logic_input.Area
       locations: {}
       name: \Sky
       sub_areas:
-        Around Skyloft: !!python/object:logic.logic_input.Area
+        Around Skyloft:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance from Skyloft: null
             Entrance from Thunderhead: null
           exits:
-            Exit to Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Exit to Thunderhead: !!python/object:logic.logic_expression.OrCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Open Thunderhead option
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Ballad of the Goddess
-              opaque: false
-            \Sky\North East: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South East: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit to Skyloft: 'True'
+            Exit to Thunderhead: "Open Thunderhead option | Ballad of the Goddess"
+            \Sky\North East: 'True'
+            \Sky\South East: 'True'
+            \Sky\South West: 'True'
           hint_region: Sky
           locations: {}
           name: \Sky\Around Skyloft
           sub_areas: {}
           toplevel_alias: null
-        North East: !!python/object:logic.logic_input.Area
+        North East:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
           exits:
-            \Sky\Around Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\North East\Bamboo Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\North East\Beedle's Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\North East\Beedle's Island\Cage: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Sky - Beedle's Island Cage Chest Dive Trick
-            \Sky\North East\Beedle's Island\Top: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\North East\Eldin Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South East: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            \Sky\Around Skyloft: 'True'
+            \Sky\North East\Bamboo Island: 'True'
+            \Sky\North East\Beedle's Island: 'True'
+            \Sky\North East\Beedle's Island\Cage: Sky - Beedle's Island Cage Chest
+              Dive Trick
+            \Sky\North East\Beedle's Island\Top: 'True'
+            \Sky\North East\Eldin Pillar: 'True'
+            \Sky\South East: 'True'
           hint_region: Sky
           locations:
-            Goddess Chest in Cave on Island next to Bamboo Island: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Lanayru\Desert\North Part\Secret Passageway\Goddess Cube in
-                  Secret Passageway
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Water Dragon's Scale
-              opaque: false
-            Goddess Chest on Island next to Bamboo Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Eldin\Volcano\East\Goddess Cube near Mogma Turf Entrance
-            Northeast Island Cage Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Eldin\Volcano\Near Temple Entrance\Goddess Cube East of Earth
-                Temple Entrance
-            Northeast Island Goddess Chest behind Bombable Rocks: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Lanayru\Mine\Entry\Goddess Cube at Lanayru Mine Entrance
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Bomb Bag
-              opaque: false
+            Goddess Chest in Cave on Island next to Bamboo Island: "\\Lanayru\\Desert\\\
+              North Part\\Secret Passageway\\Goddess Cube in Secret Passageway & Water\
+              \ Dragon's Scale"
+            Goddess Chest on Island next to Bamboo Island: \Eldin\Volcano\East\Goddess
+              Cube near Mogma Turf Entrance
+            Northeast Island Cage Goddess Chest: \Eldin\Volcano\Near Temple Entrance\Goddess
+              Cube East of Earth Temple Entrance
+            Northeast Island Goddess Chest behind Bombable Rocks: "\\Lanayru\\Mine\\\
+              Entry\\Goddess Cube at Lanayru Mine Entrance & Bomb Bag"
           name: \Sky\North East
           sub_areas:
-            Bamboo Island: !!python/object:logic.logic_input.Area
+            Bamboo Island:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Inside: null
               exits:
-                Exit to Inside: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Sky\North East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                Exit to Inside: 'True'
+                \Sky\North East: Day
               hint_region: Sky
               locations:
-                Bamboo Island Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Near Temple Entrance\Goddess Cube West of Earth
-                    Temple Entrance
+                Bamboo Island Goddess Chest: \Eldin\Volcano\Near Temple Entrance\Goddess
+                  Cube West of Earth Temple Entrance
               name: \Sky\North East\Bamboo Island
               sub_areas:
-                Inside: !!python/object:logic.logic_input.Area
+                Inside:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance: null
                   exits:
-                    Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Exit: 'True'
                   hint_region: Sky
                   locations:
-                    Clean Cut Minigame: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sword
-                    Gossip Stone on Bamboo Island: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Clean Cut Minigame: \Sword
+                    Gossip Stone on Bamboo Island: 'True'
                   name: \Sky\North East\Bamboo Island\Inside
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Beedle's Island: !!python/object:logic.logic_input.Area
+            Beedle's Island:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: false
               entrances: !!set
                 Beedle's Ship Entrance: null
               exits:
-                Beedle's Ship Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Night
-                \Sky\North East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
-                \Sky\North East\Beedle's Island\Cage: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Night
+                Beedle's Ship Exit: Night
+                \Sky\North East: Day
+                \Sky\North East\Beedle's Island\Cage: Night
               hint_region: Sky
               locations:
-                Beedle's Crystals: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Horned Colossus Beetle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Night
-                  opaque: false
-                Crystal on Beedle's Ship: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Night
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Beetle
-                  opaque: false
+                Beedle's Crystals: "Horned Colossus Beetle & Night"
+                Crystal on Beedle's Ship: "Night & \\Beetle"
               name: \Sky\North East\Beedle's Island
               sub_areas:
-                Cage: !!python/object:logic.logic_input.Area
+                Cage:
                   abstract: false
-                  allowed_time_of_day: *id002
+                  allowed_time_of_day: 3
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky\North East\Beedle's Island: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Sky\North East\Beedle's Island: 'True'
                   hint_region: Sky
                   locations:
-                    Beedle's Island Cage Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Faron\Faron Woods\Deep Woods\Goddess Cube on top of Skyview
+                    Beedle's Island Cage Goddess Chest: \Faron\Faron Woods\Deep Woods\Goddess
+                      Cube on top of Skyview
                   name: \Sky\North East\Beedle's Island\Cage
                   sub_areas: {}
                   toplevel_alias: null
-                Top: !!python/object:logic.logic_input.Area
+                Top:
                   abstract: false
-                  allowed_time_of_day: *id002
+                  allowed_time_of_day: 3
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky\North East\Beedle's Island: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Sky\North East\Beedle's Island: 'True'
                   hint_region: Sky
                   locations:
-                    Beedle's Island Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Lanayru\Temple of Time\Near Goddess Cube\Goddess Cube
-                        at Ride near Temple of Time
+                    Beedle's Island Goddess Chest: \Lanayru\Temple of Time\Near Goddess
+                      Cube\Goddess Cube at Ride near Temple of Time
                   name: \Sky\North East\Beedle's Island\Top
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Eldin Pillar: !!python/object:logic.logic_input.Area
+            Eldin Pillar:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance: null
               exits:
-                Fire Sanctuary Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ruby Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Fire Sanctuary\Main\Front of Boss Door\Unlock Statue
-                  opaque: false
-                First Time Dive: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Ruby Tablet
-                Inside the Volcano Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ruby Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Unlock Statue
-                  opaque: false
-                Temple Entrance Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ruby Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Eldin\Volcano\Near Temple Entrance\Unlock Statue
-                  opaque: false
-                Volcano Ascent Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ruby Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Eldin\Volcano\Ascent\Unlock Statue
-                  opaque: false
-                Volcano East Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ruby Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Eldin\Volcano\East\Unlock Statue
-                  opaque: false
-                Volcano Entrance Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ruby Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Eldin\Volcano\Entry\Unlock Statue
-                  opaque: false
-                \Sky\North East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Fire Sanctuary Statue Dive: "Ruby Tablet & \\Fire Sanctuary\\Main\\\
+                  Front of Boss Door\\Unlock Statue"
+                First Time Dive: Ruby Tablet
+                Inside the Volcano Statue Dive: "Ruby Tablet & \\Eldin\\Volcano Summit\\\
+                  Outside Fire Sanctuary\\Unlock Statue"
+                Temple Entrance Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\Near\
+                  \ Temple Entrance\\Unlock Statue"
+                Volcano Ascent Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\Ascent\\\
+                  Unlock Statue"
+                Volcano East Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\East\\\
+                  Unlock Statue"
+                Volcano Entrance Statue Dive: "Ruby Tablet & \\Eldin\\Volcano\\Entry\\\
+                  Unlock Statue"
+                \Sky\North East: 'True'
               hint_region: Sky
               locations: {}
               name: \Sky\North East\Eldin Pillar
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
-        South East: !!python/object:logic.logic_input.Area
+        South East:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
           exits:
-            \Sky\Around Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\North East: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South East\Faron Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South East\Lumpy Pumpkin: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            \Sky\Around Skyloft: 'True'
+            \Sky\North East: 'True'
+            \Sky\South East\Faron Pillar: 'True'
+            \Sky\South East\Lumpy Pumpkin: 'True'
+            \Sky\South West: 'True'
           hint_region: Sky
           locations:
-            Chest in Breakable Boulder near Lumpy Pumpkin: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Spiral Charge
-            Goddess Chest on Island Closest to Faron Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Faron\Faron Woods\Deep Woods\Goddess Cube in Deep Woods
+            Chest in Breakable Boulder near Lumpy Pumpkin: Spiral Charge
+            Goddess Chest on Island Closest to Faron Pillar: \Faron\Faron Woods\Deep
+              Woods\Goddess Cube in Deep Woods
           name: \Sky\South East
           sub_areas:
-            Faron Pillar: !!python/object:logic.logic_input.Area
+            Faron Pillar:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance: null
               exits:
-                Behind the Temple Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Emerald Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Sealed Grounds\Behind the Temple\Unlock Statue
-                  opaque: false
-                Deep Woods Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Emerald Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Faron Woods\Deep Woods\Unlock Deep Woods Statue
-                  opaque: false
-                Faron Woods Entry Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Emerald Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Faron Woods\Entry\Unlock Statue
-                  opaque: false
-                First Time Dive: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Emerald Tablet
-                Floria Waterfall Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Emerald Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Lake Floria\Waterfall\Unlock Statue
-                  opaque: false
-                Forest Temple Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Emerald Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Faron Woods\Deep Woods\Unlock Forest Temple Statue
-                  opaque: false
-                In the Woods Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Emerald Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Faron Woods\Unlock In the Woods Statue
-                  opaque: false
-                Lake Floria Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Emerald Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Lake Floria\Below Rock\Emerged Area\Unlock Statue
-                  opaque: false
-                Sealed Grounds Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Emerald Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Sealed Grounds\Spiral\Upper Part\Unlock Statue
-                  opaque: false
-                The Great Tree Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Emerald Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Faron Woods\Great Tree\Top\Unlock Statue
-                  opaque: false
-                Viewing Platform Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Emerald Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Faron Woods\Unlock Viewing Platform Statue
-                  opaque: false
-                \Sky\South East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Behind the Temple Statue Dive: "Emerald Tablet & \\Faron\\Sealed Grounds\\\
+                  Behind the Temple\\Unlock Statue"
+                Deep Woods Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\Deep\
+                  \ Woods\\Unlock Deep Woods Statue"
+                Faron Woods Entry Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
+                  Entry\\Unlock Statue"
+                First Time Dive: Emerald Tablet
+                Floria Waterfall Statue Dive: "Emerald Tablet & \\Faron\\Lake Floria\\\
+                  Waterfall\\Unlock Statue"
+                Forest Temple Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
+                  Deep Woods\\Unlock Forest Temple Statue"
+                In the Woods Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
+                  Unlock In the Woods Statue"
+                Lake Floria Statue Dive: "Emerald Tablet & \\Faron\\Lake Floria\\\
+                  Below Rock\\Emerged Area\\Unlock Statue"
+                Sealed Grounds Statue Dive: "Emerald Tablet & \\Faron\\Sealed Grounds\\\
+                  Spiral\\Upper Part\\Unlock Statue"
+                The Great Tree Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
+                  Great Tree\\Top\\Unlock Statue"
+                Viewing Platform Statue Dive: "Emerald Tablet & \\Faron\\Faron Woods\\\
+                  Unlock Viewing Platform Statue"
+                \Sky\South East: 'True'
               hint_region: Sky
               locations: {}
               name: \Sky\South East\Faron Pillar
               sub_areas: {}
               toplevel_alias: null
-            Lumpy Pumpkin: !!python/object:logic.logic_input.Area
+            Lumpy Pumpkin:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -7541,57 +4773,28 @@ areas: !!python/object:logic.logic_input.Area
                 Main Left Door Entrance: null
                 Main Right Door Entrance: null
               exits:
-                Back Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Main Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Main Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Sky\South East: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                Back Door Exit: 'True'
+                Main Left Door Exit: 'True'
+                Main Right Door Exit: 'True'
+                \Sky\South East: Day
               hint_region: Sky
               locations:
-                Crystal outside Lumpy Pumpkin: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Night
-                Goddess Chest on the Roof: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyview\Spring\Goddess Cube in Skyview Spring
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Day
-                  opaque: false
-                Gossip Stone on Lumpy Pumpkin: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Kina's Crystals: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Eldin\Mogma Turf\Pre Vent\Pick up Guld
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Day
-                  opaque: false
-                Outside Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Faron Woods\Deep Woods\Initial Goddess Cube
-                Pumpkin Carrying: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Complete
-                      Hot Soup Delivery
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Day
-                  opaque: false
-                Start Kina's Quest: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Complete
-                      Hot Soup Delivery
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Day
-                  opaque: false
+                Crystal outside Lumpy Pumpkin: Night
+                Goddess Chest on the Roof: "\\Skyview\\Spring\\Goddess Cube in Skyview\
+                  \ Spring & Day"
+                Gossip Stone on Lumpy Pumpkin: 'True'
+                Kina's Crystals: "\\Eldin\\Mogma Turf\\Pre Vent\\Pick up Guld & Day"
+                Outside Goddess Chest: \Faron\Faron Woods\Deep Woods\Initial Goddess
+                  Cube
+                Pumpkin Carrying: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy Pumpkin\
+                  \ Building\\Complete Hot Soup Delivery & Day"
+                Start Kina's Quest: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy Pumpkin\
+                  \ Building\\Complete Hot Soup Delivery & Day"
               name: \Sky\South East\Lumpy Pumpkin
               sub_areas:
-                Lumpy Pumpkin Building: !!python/object:logic.logic_input.Area
+                Lumpy Pumpkin Building:
                   abstract: false
-                  allowed_time_of_day: *id002
+                  allowed_time_of_day: 3
                   can_save: false
                   can_sleep: true
                   entrances: !!set
@@ -7599,439 +4802,278 @@ areas: !!python/object:logic.logic_input.Area
                     Main Left Door Entrance: null
                     Main Right Door Entrance: null
                   exits:
-                    Back Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Main Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Main Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Back Door Exit: 'True'
+                    Main Left Door Exit: 'True'
+                    Main Right Door Exit: 'True'
                   hint_region: Sky
                   locations:
-                    Break the Chandelier: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Chandelier: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Break
-                        the Chandelier
-                    Complete Hot Soup Delivery: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyloft\Upper Skyloft\Sparring Hall\Delivered Hot Soup
-                    Crystal inside Lumpy Pumpkin: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Night
-                    Harp Minigame: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Play
-                        the Harp with Kina
-                    Pick up Levias' Soup: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Spiral Charge
-                    Play the Harp with Kina: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sky\South East\Lumpy Pumpkin\Pumpkin Carrying
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Goddess's Harp
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Night
-                      opaque: false
-                    Start Hot Soup Delivery: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Break
-                          the Chandelier
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bottle
-                      opaque: false
+                    Break the Chandelier: 'True'
+                    Chandelier: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Break
+                      the Chandelier
+                    Complete Hot Soup Delivery: \Skyloft\Upper Skyloft\Sparring Hall\Delivered
+                      Hot Soup
+                    Crystal inside Lumpy Pumpkin: Night
+                    Harp Minigame: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Play
+                      the Harp with Kina
+                    Pick up Levias' Soup: Spiral Charge
+                    Play the Harp with Kina: "\\Sky\\South East\\Lumpy Pumpkin\\Pumpkin\
+                      \ Carrying & Goddess's Harp & Night"
+                    Start Hot Soup Delivery: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy\
+                      \ Pumpkin Building\\Break the Chandelier & \\Bottle"
                   name: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
           toplevel_alias: null
-        South West: !!python/object:logic.logic_input.Area
+        South West:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
           exits:
-            \Sky\Around Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South East: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South West\Fun Fun Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South West\Lanayru Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South West\Orielle's Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South West\Triple Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\South West\Volcanic Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            \Sky\Around Skyloft: 'True'
+            \Sky\South East: 'True'
+            \Sky\South West\Fun Fun Island: 'True'
+            \Sky\South West\Lanayru Pillar: 'True'
+            \Sky\South West\Orielle's Island: 'True'
+            \Sky\South West\Triple Island: 'True'
+            \Sky\South West\Volcanic Island: 'True'
           hint_region: Sky
           locations:
-            Chest in Breakable Boulder near Fun Fun Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Spiral Charge
+            Chest in Breakable Boulder near Fun Fun Island: Spiral Charge
           name: \Sky\South West
           sub_areas:
-            Fun Fun Island: !!python/object:logic.logic_input.Area
+            Fun Fun Island:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                \Sky\South West: Day
               hint_region: Sky
               locations:
-                Dodoh's Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve Party
-                    Wheel
-                Fun Fun Island Minigame: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve Party
-                    Wheel
-                Fun Fun Island Minigame -- 500 Rupees: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky\South West\Fun Fun Island\Fun Fun Island Minigame
-                Goddess Chest under Fun Fun Island: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Lake Floria\Waterfall\Goddess Cube in Floria Waterfall
-                Start Dodoh's Quest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Dodoh's Crystals: \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve
+                  Party Wheel
+                Fun Fun Island Minigame: \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve
+                  Party Wheel
+                Fun Fun Island Minigame -- 500 Rupees: \Sky\South West\Fun Fun Island\Fun
+                  Fun Island Minigame
+                Goddess Chest under Fun Fun Island: \Faron\Lake Floria\Waterfall\Goddess
+                  Cube in Floria Waterfall
+                Start Dodoh's Quest: 'True'
               name: \Sky\South West\Fun Fun Island
               sub_areas: {}
               toplevel_alias: null
-            Lanayru Pillar: !!python/object:logic.logic_input.Area
+            Lanayru Pillar:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance: null
               exits:
-                Ancient Harbour Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Unlock Statue
-                  opaque: false
-                Desert Entrance Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\Entry\Unlock Statue
-                  opaque: false
-                Desert Gorge Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Temple of Time\South East\Unlock Statue
-                  opaque: false
-                First Time Dive: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Amber Tablet
-                Lanayru Gorge Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Gorge\Unlock Statue
-                  opaque: false
-                Lanayru Mine Entry Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Mine\Entry\Unlock Statue
-                  opaque: false
-                North Desert Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\North Part\Unlock Statue
-                  opaque: false
-                Pirate Stronghold Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Unlock Statue
-                  opaque: false
-                Shipyard Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Shipyard\Unlock Statue
-                  opaque: false
-                Skipper's Retreat Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Unlock Statue
-                  opaque: false
-                Stone Cache Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\East\Unlock Statue
-                  opaque: false
-                Temple of Time Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Temple of Time\Inside\Unlock Statue
-                  opaque: false
-                West Desert Statue Dive: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Amber Tablet
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Desert\West Part\Unlock Statue
-                  opaque: false
-                \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Ancient Harbour Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru Sand\
+                  \ Sea\\Ancient Harbour\\Unlock Statue"
+                Desert Entrance Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\Entry\\\
+                  Unlock Statue"
+                Desert Gorge Statue Dive: "Amber Tablet & \\Lanayru\\Temple of Time\\\
+                  South East\\Unlock Statue"
+                First Time Dive: Amber Tablet
+                Lanayru Gorge Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru Sand\
+                  \ Sea\\Gorge\\Unlock Statue"
+                Lanayru Mine Entry Statue Dive: "Amber Tablet & \\Lanayru\\Mine\\\
+                  Entry\\Unlock Statue"
+                North Desert Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\North\
+                  \ Part\\Unlock Statue"
+                Pirate Stronghold Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru\
+                  \ Sand Sea\\Pirate Stronghold\\Unlock Statue"
+                Shipyard Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru Sand Sea\\\
+                  Shipyard\\Unlock Statue"
+                Skipper's Retreat Statue Dive: "Amber Tablet & \\Lanayru\\Lanayru\
+                  \ Sand Sea\\Skipper's Retreat\\Unlock Statue"
+                Stone Cache Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\East\\\
+                  Unlock Statue"
+                Temple of Time Statue Dive: "Amber Tablet & \\Lanayru\\Temple of Time\\\
+                  Inside\\Unlock Statue"
+                West Desert Statue Dive: "Amber Tablet & \\Lanayru\\Desert\\West Part\\\
+                  Unlock Statue"
+                \Sky\South West: 'True'
               hint_region: Sky
               locations: {}
               name: \Sky\South West\Lanayru Pillar
               sub_areas: {}
               toplevel_alias: null
-            Orielle's Island: !!python/object:logic.logic_input.Area
+            Orielle's Island:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                \Sky\South West: Day
               hint_region: Sky
               locations:
-                Orielle's Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky\South West\Orielle's Island\Save Orielle
-                Save Orielle: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Bottle
-                Talk to Orielle: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Orielle's Crystals: \Sky\South West\Orielle's Island\Save Orielle
+                Save Orielle: \Bottle
+                Talk to Orielle: 'True'
               name: \Sky\South West\Orielle's Island
               sub_areas: {}
               toplevel_alias: null
-            Triple Island: !!python/object:logic.logic_input.Area
+            Triple Island:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                \Sky\South West: Day
               hint_region: Sky
               locations:
-                Southwest Triple Island Cage Goddess Chest: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Goddess
-                      Cube in Skipper's Retreat
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  opaque: false
-                Southwest Triple Island Lower Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\Near Caged Robot\Goddess Cube near Caged Robot
-                Southwest Triple Island Upper Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Entry\Goddess Cube at Eldin Entrance
+                Southwest Triple Island Cage Goddess Chest: "\\Lanayru\\Lanayru Sand\
+                  \ Sea\\Skipper's Retreat\\Past Rock\\Goddess Cube in Skipper's Retreat\
+                  \ & Clawshots"
+                Southwest Triple Island Lower Goddess Chest: \Lanayru\Desert\Near
+                  Caged Robot\Goddess Cube near Caged Robot
+                Southwest Triple Island Upper Goddess Chest: \Eldin\Volcano\Entry\Goddess
+                  Cube at Eldin Entrance
               name: \Sky\South West\Triple Island
               sub_areas: {}
               toplevel_alias: null
-            Volcanic Island: !!python/object:logic.logic_input.Area
+            Volcanic Island:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sky\South West: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                \Sky\South West: Day
               hint_region: Sky
               locations:
-                Goddess Chest inside Volcanic Island: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Faron Woods\Clawshot Target Branch\Goddess Cube on
-                      East Great Tree with Clawshots Target
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Sky - Volcanic Island Dive Trick
-                    opaque: false
-                  opaque: false
-                Goddess Chest outside Volcanic Island: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Desert\Sand Oasis\Goddess Cube in Sand Oasis
-                Gossip Stone on Volcanic Island: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Goddess Chest inside Volcanic Island: "\\Faron\\Faron Woods\\Clawshot\
+                  \ Target Branch\\Goddess Cube on East Great Tree with Clawshots\
+                  \ Target & (Clawshots | Sky - Volcanic Island Dive Trick)"
+                Goddess Chest outside Volcanic Island: \Lanayru\Desert\Sand Oasis\Goddess
+                  Cube in Sand Oasis
+                Gossip Stone on Volcanic Island: 'True'
               name: \Sky\South West\Volcanic Island
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
-        Thunderhead: !!python/object:logic.logic_input.Area
+        Thunderhead:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance: null
           exits:
-            Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\Thunderhead\Bug Heaven: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\Thunderhead\East Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\Thunderhead\Isle of Songs: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Sky\Thunderhead\Mogma Mitts Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit: 'True'
+            \Sky\Thunderhead\Bug Heaven: 'True'
+            \Sky\Thunderhead\East Island: 'True'
+            \Sky\Thunderhead\Isle of Songs: 'True'
+            \Sky\Thunderhead\Mogma Mitts Island: 'True'
           hint_region: Thunderhead
           locations:
-            Song from Levias: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Pick up
-                  Levias' Soup
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Spiral Charge
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Scrapper
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Sword
-              opaque: false
+            Song from Levias: "\\Sky\\South East\\Lumpy Pumpkin\\Lumpy Pumpkin Building\\\
+              Pick up Levias' Soup & Spiral Charge & Scrapper & \\Sword"
           name: \Sky\Thunderhead
           sub_areas:
-            Bug Heaven: !!python/object:logic.logic_input.Area
+            Bug Heaven:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sky\Thunderhead: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                \Sky\Thunderhead: Day
               hint_region: Thunderhead
               locations:
-                Bug Heaven -- 10 Bugs in 3 Minutes: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Bug Net
-                Bug Heaven Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano Summit\Waterfall\Goddess Cube in Summit Waterfall
-                Gossip Stone near Bug Heaven: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Bug Heaven -- 10 Bugs in 3 Minutes: \Bug Net
+                Bug Heaven Goddess Chest: \Eldin\Volcano Summit\Waterfall\Goddess
+                  Cube in Summit Waterfall
+                Gossip Stone near Bug Heaven: 'True'
               name: \Sky\Thunderhead\Bug Heaven
               sub_areas: {}
               toplevel_alias: null
-            East Island: !!python/object:logic.logic_input.Area
+            East Island:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sky\Thunderhead: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                \Sky\Thunderhead: Day
               hint_region: Thunderhead
               locations:
-                East Island Chest: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Digging Mitts
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Thunderhead - East Island Dive Trick
-                  opaque: false
-                East Island Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Faron Woods\Rope Branch\Goddess Cube on East Great
-                    Tree with Rope
+                East Island Chest: "\\Digging Mitts | Thunderhead - East Island Dive\
+                  \ Trick"
+                East Island Goddess Chest: \Faron\Faron Woods\Rope Branch\Goddess
+                  Cube on East Great Tree with Rope
               name: \Sky\Thunderhead\East Island
               sub_areas: {}
               toplevel_alias: null
-            Isle of Songs: !!python/object:logic.logic_input.Area
+            Isle of Songs:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Inside: null
               exits:
-                Exit to Inside: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky\Thunderhead\Isle of Songs\Puzzle Solved
-                \Sky\Thunderhead: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                Exit to Inside: \Sky\Thunderhead\Isle of Songs\Puzzle Solved
+                \Sky\Thunderhead: Day
               hint_region: Thunderhead
               locations:
-                Goddess Chest on top of Isle of Songs: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano Summit\Outside Fire Sanctuary\Goddess Cube
-                    near Fire Sanctuary Entrance
-                Goddess Chest outside Isle of Songs: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Mogma Turf\Pre Vent\Goddess Cube in Mogma Turf
-                Puzzle Solved: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Goddess Chest on top of Isle of Songs: \Eldin\Volcano Summit\Outside
+                  Fire Sanctuary\Goddess Cube near Fire Sanctuary Entrance
+                Goddess Chest outside Isle of Songs: \Eldin\Mogma Turf\Pre Vent\Goddess
+                  Cube in Mogma Turf
+                Puzzle Solved: 'True'
               name: \Sky\Thunderhead\Isle of Songs
               sub_areas:
-                Inside: !!python/object:logic.logic_input.Area
+                Inside:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Entrance: null
                   exits:
-                    Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Exit: 'True'
                   hint_region: Thunderhead
                   locations:
-                    Strike Crest with Goddess Sword: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Goddess Sword
-                    Strike Crest with Longsword: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Goddess Longsword
-                    Strike Crest with White Sword: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Goddess White Sword
+                    Strike Crest with Goddess Sword: \Goddess Sword
+                    Strike Crest with Longsword: \Goddess Longsword
+                    Strike Crest with White Sword: \Goddess White Sword
                   name: \Sky\Thunderhead\Isle of Songs\Inside
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Mogma Mitts Island: !!python/object:logic.logic_input.Area
+            Mogma Mitts Island:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sky\Thunderhead: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                \Sky\Thunderhead: Day
               hint_region: Thunderhead
               locations:
-                First Goddess Chest on Mogma Mitts Island: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Eldin\Volcano Summit\Goddess Cube inside Volcano Summit
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Mogma Mitts
-                  opaque: false
-                Second Goddess Chest on Mogma Mitts Island: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Goddess Cube
-                      in Lanayru Gorge
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Mogma Mitts
-                  opaque: false
+                First Goddess Chest on Mogma Mitts Island: "\\Eldin\\Volcano Summit\\\
+                  Goddess Cube inside Volcano Summit & \\Mogma Mitts"
+                Second Goddess Chest on Mogma Mitts Island: "\\Lanayru\\Lanayru Sand\
+                  \ Sea\\Gorge\\Beyond Bridge\\Goddess Cube in Lanayru Gorge & \\\
+                  Mogma Mitts"
               name: \Sky\Thunderhead\Mogma Mitts Island
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
       toplevel_alias: null
-    Sky Keep: !!python/object:logic.logic_input.Area
+    Sky Keep:
       abstract: false
-      allowed_time_of_day: *id001
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
@@ -8040,9 +5082,9 @@ areas: !!python/object:logic.logic_input.Area
       locations: {}
       name: \Sky Keep
       sub_areas:
-        Main: !!python/object:logic.logic_input.Area
+        Main:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -8051,96 +5093,76 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Sky Keep\Main
           sub_areas:
-            Ancient Cistern Room: !!python/object:logic.logic_input.Area
+            Ancient Cistern Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sky Keep\Main\Ancient Cistern Room\After Key: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky Keep\Main\Ancient Cistern Room\Unlock Key Door
-                \Sky Keep\Main\Ancient Cistern Room\Triforce Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Lever
+                \Sky Keep\Main\Ancient Cistern Room\After Key: \Sky Keep\Main\Ancient
+                  Cistern Room\Unlock Key Door
+                \Sky Keep\Main\Ancient Cistern Room\Triforce Room: \Sky Keep\Main\Ancient
+                  Cistern Room\Triforce Room\Lever
               hint_region: Sky Keep
               locations:
-                Bottom Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Right Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Unlock Key Door: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Sky Keep Small Key
+                Bottom Exit: 'True'
+                Right Exit: 'True'
+                Unlock Key Door: Sky Keep Small Key
               name: \Sky Keep\Main\Ancient Cistern Room
               sub_areas:
-                After Key: !!python/object:logic.logic_input.Area
+                After Key:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Ancient Cistern Room\Triforce Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Ancient Cistern Room\After Key\Beat Trial
+                    \Sky Keep\Main\Ancient Cistern Room\Triforce Room: \Sky Keep\Main\Ancient
+                      Cistern Room\After Key\Beat Trial
                   hint_region: Sky Keep
                   locations:
-                    Beat Trial: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Can Defeat Moblins
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Can Defeat Bokoblins
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Can Defeat Stalfos
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Can Defeat Cursed Bokoblins
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Can Defeat Stalmaster
-                      opaque: false
+                    Beat Trial: "\\Can Defeat Moblins & \\Can Defeat Bokoblins & \\\
+                      Can Defeat Stalfos & \\Bow & \\Can Defeat Cursed Bokoblins &\
+                      \ \\Can Defeat Stalmaster"
                   name: \Sky Keep\Main\Ancient Cistern Room\After Key
                   sub_areas: {}
                   toplevel_alias: null
-                Triforce Room: !!python/object:logic.logic_input.Area
+                Triforce Room:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Ancient Cistern Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Lever
-                    \Sky Keep\Main\Ancient Cistern Room\After Key: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Sky Keep\Main\Ancient Cistern Room: \Sky Keep\Main\Ancient Cistern
+                      Room\Triforce Room\Lever
+                    \Sky Keep\Main\Ancient Cistern Room\After Key: 'True'
                   hint_region: Sky Keep
                   locations:
-                    Lever: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Sacred Power of Farore: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Lever: 'True'
+                    Sacred Power of Farore: 'True'
                   name: \Sky Keep\Main\Ancient Cistern Room\Triforce Room
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Earth Temple Room: !!python/object:logic.logic_input.Area
+            Earth Temple Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits: {}
               hint_region: Sky Keep
               locations:
-                Right Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'False'
-                Top Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'False'
+                Right Exit: 'False'
+                Top Exit: 'False'
               name: \Sky Keep\Main\Earth Temple Room
               sub_areas: {}
               toplevel_alias: null
-            Fire Sanctuary Room: !!python/object:logic.logic_input.Area
+            Fire Sanctuary Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
@@ -8149,168 +5171,125 @@ areas: !!python/object:logic.logic_input.Area
               locations: {}
               name: \Sky Keep\Main\Fire Sanctuary Room
               sub_areas:
-                First Platform: !!python/object:logic.logic_input.Area
+                First Platform:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      opaque: false
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: "\\Beetle &\
+                      \ Clawshots"
                   hint_region: Sky Keep
                   locations:
-                    Lever: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Rupee in Fire Sanctuary Room in Alcove: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Beetle
+                    Lever: 'True'
+                    Rupee in Fire Sanctuary Room in Alcove: \Beetle
                   name: \Sky Keep\Main\Fire Sanctuary Room\First Platform
                   sub_areas: {}
                   toplevel_alias: null
-                From Left: !!python/object:logic.logic_input.Area
+                From Left:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Lower
-                        Lever
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: \Sky Keep\Main\Fire
+                      Sanctuary Room\Triforce Room\Lower Lever
                   hint_region: Sky Keep
                   locations:
-                    Left Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Left Exit: 'True'
                   name: \Sky Keep\Main\Fire Sanctuary Room\From Left
                   sub_areas: {}
                   toplevel_alias: null
-                From Right: !!python/object:logic.logic_input.Area
+                From Right:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Fire Sanctuary Room\First Platform: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sky Keep\Main\Fire Sanctuary Room\First Platform\Lever
-                      opaque: false
-                    \Sky Keep\Main\Fire Sanctuary Room\OoB: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Sky Keep - FS Room Clawshots Vine Clip Trick
-                      opaque: false
-                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Upper
-                        Lever
+                    \Sky Keep\Main\Fire Sanctuary Room\First Platform: "\\Beetle |\
+                      \ \\Sky Keep\\Main\\Fire Sanctuary Room\\First Platform\\Lever"
+                    \Sky Keep\Main\Fire Sanctuary Room\OoB: "Clawshots & Sky Keep\
+                      \ - FS Room Clawshots Vine Clip Trick"
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: \Sky Keep\Main\Fire
+                      Sanctuary Room\Triforce Room\Upper Lever
                   hint_region: Sky Keep
                   locations:
-                    Right Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Right Exit: 'True'
                   name: \Sky Keep\Main\Fire Sanctuary Room\From Right
                   sub_areas: {}
                   toplevel_alias: null
-                OoB: !!python/object:logic.logic_input.Area
+                OoB:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Clawshots
+                    \Sky Keep\Main\Fire Sanctuary Room\Triforce Room: Clawshots
                   hint_region: Sky Keep
                   locations: {}
                   name: \Sky Keep\Main\Fire Sanctuary Room\OoB
                   sub_areas: {}
                   toplevel_alias: null
-                Triforce Room: !!python/object:logic.logic_input.Area
+                Triforce Room:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Fire Sanctuary Room\From Left: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Lower
-                        Lever
-                    \Sky Keep\Main\Fire Sanctuary Room\From Right: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Upper
-                        Lever
+                    \Sky Keep\Main\Fire Sanctuary Room\From Left: \Sky Keep\Main\Fire
+                      Sanctuary Room\Triforce Room\Lower Lever
+                    \Sky Keep\Main\Fire Sanctuary Room\From Right: \Sky Keep\Main\Fire
+                      Sanctuary Room\Triforce Room\Upper Lever
                   hint_region: Sky Keep
                   locations:
-                    Lower Lever: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Sacred Power of Din: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Upper Lever: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Lower Lever: 'True'
+                    Sacred Power of Din: 'True'
+                    Upper Lever: 'True'
                   name: \Sky Keep\Main\Fire Sanctuary Room\Triforce Room
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            First Room: !!python/object:logic.logic_input.Area
+            First Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Bottom Entrance: null
               exits:
-                Bottom Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Sky Keep\Main\Puzzle Solving Meta Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Bottom Exit: 'True'
+                \Sky Keep\Main\Puzzle Solving Meta Room: 'True'
               hint_region: Sky Keep
               locations:
-                First Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Right Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                First Chest: 'True'
+                Right Exit: 'True'
               name: \Sky Keep\Main\First Room
               sub_areas: {}
               toplevel_alias: null
-            LMF Room: !!python/object:logic.logic_input.Area
+            LMF Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits: {}
               hint_region: Sky Keep
               locations:
-                Bottom Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Finish Room: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Gust Bellows
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Sky Keep - Shooting LMF Bow Switches in Present Trick
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  opaque: false
-                Top Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky Keep\Main\LMF Room\Finish Room
+                Bottom Exit: 'True'
+                Finish Room: "(Gust Bellows | Sky Keep - Shooting LMF Bow Switches\
+                  \ in Present Trick) & \\Bow"
+                Top Exit: \Sky Keep\Main\LMF Room\Finish Room
               name: \Sky Keep\Main\LMF Room
               sub_areas: {}
               toplevel_alias: null
-            Mini Boss Room: !!python/object:logic.logic_input.Area
+            Mini Boss Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
@@ -8319,139 +5298,113 @@ areas: !!python/object:logic.logic_input.Area
               locations: {}
               name: \Sky Keep\Main\Mini Boss Room
               sub_areas:
-                From Bottom: !!python/object:logic.logic_input.Area
+                From Bottom:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Mini Boss Room\Near Chest: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat Dreadfuse
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Clawshots
-                      opaque: false
+                    \Sky Keep\Main\Mini Boss Room\Near Chest: "\\Sky Keep\\Main\\\
+                      Mini Boss Room\\From Bottom\\Defeat Dreadfuse & Clawshots"
                   hint_region: Sky Keep
                   locations:
-                    Bottom Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat Dreadfuse
-                    Defeat Dreadfuse: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Can Defeat Scervo/Dreadfuse
+                    Bottom Exit: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat
+                      Dreadfuse
+                    Defeat Dreadfuse: \Can Defeat Scervo/Dreadfuse
                   name: \Sky Keep\Main\Mini Boss Room\From Bottom
                   sub_areas: {}
                   toplevel_alias: null
-                From Left: !!python/object:logic.logic_input.Area
+                From Left:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Mini Boss Room\Near Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Mini Boss Room\Near Chest\Unlock Door
+                    \Sky Keep\Main\Mini Boss Room\Near Chest: \Sky Keep\Main\Mini
+                      Boss Room\Near Chest\Unlock Door
                   hint_region: Sky Keep
                   locations:
-                    Left Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Left Exit: 'True'
                   name: \Sky Keep\Main\Mini Boss Room\From Left
                   sub_areas: {}
                   toplevel_alias: null
-                Near Chest: !!python/object:logic.logic_input.Area
+                Near Chest:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Mini Boss Room\From Left: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Mini Boss Room\Near Chest\Unlock Door
+                    \Sky Keep\Main\Mini Boss Room\From Left: \Sky Keep\Main\Mini Boss
+                      Room\Near Chest\Unlock Door
                   hint_region: Sky Keep
                   locations:
-                    Chest after Dreadfuse: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Unlock Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat Dreadfuse
+                    Chest after Dreadfuse: 'True'
+                    Unlock Door: \Sky Keep\Main\Mini Boss Room\From Bottom\Defeat
+                      Dreadfuse
                   name: \Sky Keep\Main\Mini Boss Room\Near Chest
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Puzzle Solving Meta Room: !!python/object:logic.logic_input.Area
+            Puzzle Solving Meta Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sky Keep\Main\Ancient Cistern Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky Keep\Main\LMF Room\Top Exit
-                \Sky Keep\Main\Earth Temple Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky Keep\Main\LMF Room\Top Exit
-                \Sky Keep\Main\Fire Sanctuary Room\From Right: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky Keep\Main\Ancient Cistern Room\Bottom Exit
-                \Sky Keep\Main\LMF Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky Keep\Main\Skyview Room\End\Top Exit
-                \Sky Keep\Main\Mini Boss Room\From Bottom: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky Keep\Main\Fire Sanctuary Room\From Left\Left Exit
-                \Sky Keep\Main\Sandship Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky Keep\Main\Fire Sanctuary Room\From Left\Left Exit
-                \Sky Keep\Main\Skyview Room\Beginning: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky Keep\Main\First Room\Right Exit
+                \Sky Keep\Main\Ancient Cistern Room: \Sky Keep\Main\LMF Room\Top Exit
+                \Sky Keep\Main\Earth Temple Room: \Sky Keep\Main\LMF Room\Top Exit
+                \Sky Keep\Main\Fire Sanctuary Room\From Right: \Sky Keep\Main\Ancient
+                  Cistern Room\Bottom Exit
+                \Sky Keep\Main\LMF Room: \Sky Keep\Main\Skyview Room\End\Top Exit
+                \Sky Keep\Main\Mini Boss Room\From Bottom: \Sky Keep\Main\Fire Sanctuary
+                  Room\From Left\Left Exit
+                \Sky Keep\Main\Sandship Room: \Sky Keep\Main\Fire Sanctuary Room\From
+                  Left\Left Exit
+                \Sky Keep\Main\Skyview Room\Beginning: \Sky Keep\Main\First Room\Right
+                  Exit
               hint_region: Sky Keep
               locations: {}
               name: \Sky Keep\Main\Puzzle Solving Meta Room
               sub_areas: {}
               toplevel_alias: null
-            Sandship Room: !!python/object:logic.logic_input.Area
+            Sandship Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Sky Keep\Main\Sandship Room\Triforce Area: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sky Keep\Main\Sandship Room\Lower Eye
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  opaque: false
+                \Sky Keep\Main\Sandship Room\Triforce Area: "\\Sky Keep\\Main\\Sandship\
+                  \ Room\\Lower Eye & Clawshots"
               hint_region: Sky Keep
               locations:
-                Higher Eye: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Bow
-                Left Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Lower Eye: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sky Keep\Main\Sandship Room\Higher Eye
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bow
-                  opaque: false
+                Higher Eye: \Bow
+                Left Exit: 'True'
+                Lower Eye: "\\Sky Keep\\Main\\Sandship Room\\Higher Eye & \\Bow"
               name: \Sky Keep\Main\Sandship Room
               sub_areas:
-                Triforce Area: !!python/object:logic.logic_input.Area
+                Triforce Area:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Sandship Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Sky Keep\Main\Sandship Room: 'True'
                   hint_region: Sky Keep
                   locations:
-                    Sacred Power of Nayru: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Sacred Power of Nayru: 'True'
                   name: \Sky Keep\Main\Sandship Room\Triforce Area
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Skyview Room: !!python/object:logic.logic_input.Area
+            Skyview Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
@@ -8460,78 +5413,47 @@ areas: !!python/object:logic.logic_input.Area
               locations: {}
               name: \Sky Keep\Main\Skyview Room
               sub_areas:
-                Beginning: !!python/object:logic.logic_input.Area
+                Beginning:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Skyview Room\End: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.AndCombination
-                        arguments:
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Whip
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Sky Keep\Main\Skyview Room\Beginning\Free Rope
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Clawshots
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Sky Keep\Main\Skyview Room\Beginning\Kill Pyrups
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Gust Bellows
-                        opaque: false
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sky Keep\Main\Skyview Room\End\Lever
-                      opaque: false
+                    \Sky Keep\Main\Skyview Room\End: "Whip & \\Sky Keep\\Main\\Skyview\
+                      \ Room\\Beginning\\Free Rope & Clawshots & \\Sky Keep\\Main\\\
+                      Skyview Room\\Beginning\\Kill Pyrups & Gust Bellows | \\Sky\
+                      \ Keep\\Main\\Skyview Room\\End\\Lever"
                   hint_region: Sky Keep
                   locations:
-                    Free Rope: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      opaque: false
-                    Kill Pyrups: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Hook Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      opaque: false
-                    Left Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Free Rope: "\\Beetle | \\Bow"
+                    Kill Pyrups: "Bomb Bag | \\Hook Beetle | \\Bow"
+                    Left Exit: 'True'
                   name: \Sky Keep\Main\Skyview Room\Beginning
                   sub_areas: {}
                   toplevel_alias: null
-                End: !!python/object:logic.logic_input.Area
+                End:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Sky Keep\Main\Skyview Room\Beginning: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Sky Keep\Main\Skyview Room\End\Lever
+                    \Sky Keep\Main\Skyview Room\Beginning: \Sky Keep\Main\Skyview
+                      Room\End\Lever
                   hint_region: Sky Keep
                   locations:
-                    Lever: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Top Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Lever: 'True'
+                    Top Exit: 'True'
                   name: \Sky Keep\Main\Skyview Room\End
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
           toplevel_alias: null
       toplevel_alias: null
-    Skyloft: !!python/object:logic.logic_input.Area
+    Skyloft:
       abstract: false
-      allowed_time_of_day: *id002
+      allowed_time_of_day: 3
       can_save: false
       can_sleep: false
       entrances: !!set {}
@@ -8540,78 +5462,51 @@ areas: !!python/object:logic.logic_input.Area
       locations: {}
       name: \Skyloft
       sub_areas:
-        Beedle's Shop: !!python/object:logic.logic_input.Area
+        Beedle's Shop:
           abstract: false
-          allowed_time_of_day: *id002
+          allowed_time_of_day: 3
           can_save: false
           can_sleep: true
           entrances: !!set
             Day Entrance: null
             Night Entrance: null
           exits:
-            Day Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Day
-            Night Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Night
-            \Skyloft\Beedle's Shop\Stall: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Day
+            Day Exit: Day
+            Night Exit: Night
+            \Skyloft\Beedle's Shop\Stall: Day
           hint_region: Beedle's Shop
           locations: {}
           name: \Skyloft\Beedle's Shop
           sub_areas:
-            Stall: !!python/object:logic.logic_input.Area
+            Stall:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Skyloft\Beedle's Shop: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Skyloft\Beedle's Shop: 'True'
               hint_region: Beedle's Shop
               locations:
-                1000 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Afford 1000 Rupees
-                1200 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Afford 1200 Rupees
-                1600 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Afford 1600 Rupees
-                300 Rupee Item: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Afford 300 Rupees
-                  - !!python/object:logic.logic_expression.OrCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Pouch
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Randomized Beedle option
-                    opaque: false
-                  opaque: false
-                50 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Afford 50 Rupees
-                600 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Afford 600 Rupees
-                800 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Afford 800 Rupees
-                First 100 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Afford 100 Rupees
-                Second 100 Rupee Item: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Can Afford 100 Rupees
-                Third 100 Rupee Item: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Afford 100 Rupees
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Medium Rupee Farm
-                  opaque: false
+                1000 Rupee Item: \Can Afford 1000 Rupees
+                1200 Rupee Item: \Can Afford 1200 Rupees
+                1600 Rupee Item: \Can Afford 1600 Rupees
+                300 Rupee Item: "\\Can Afford 300 Rupees & (\\Pouch | Randomized Beedle\
+                  \ option)"
+                50 Rupee Item: \Can Afford 50 Rupees
+                600 Rupee Item: \Can Afford 600 Rupees
+                800 Rupee Item: \Can Afford 800 Rupees
+                First 100 Rupee Item: \Can Afford 100 Rupees
+                Second 100 Rupee Item: \Can Afford 100 Rupees
+                Third 100 Rupee Item: "\\Can Afford 100 Rupees & \\Can Medium Rupee\
+                  \ Farm"
               name: \Skyloft\Beedle's Shop\Stall
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: Beedle
-        Central Skyloft: !!python/object:logic.logic_input.Area
+        Central Skyloft:
           abstract: false
-          allowed_time_of_day: *id002
+          allowed_time_of_day: 3
           can_save: false
           can_sleep: false
           entrances: !!set
@@ -8627,155 +5522,55 @@ areas: !!python/object:logic.logic_input.Area
             Waterfall Cave Upper Entrance: null
             Wryna's House Entrance: null
           exits:
-            Bazaar North Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Day
-            Bazaar South Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Day
-            Bazaar West Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Day
-            Exit to Beedle's Shop: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Day
-              - !!python/object:logic.logic_expression.OrCombination
-                arguments:
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Distance Activator
-                - !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Beedle's Shop With Bombs Trick
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  opaque: false
-                opaque: false
-              opaque: false
-            Exit to Sky: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Day
-            Orielle and Parrow's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Peatrice's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Piper's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Trial Gate Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Skyloft\Central Skyloft\Open Trial Gate
-            Waterfall Cave Upper Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Skyloft\Central Skyloft\Open Cave Entrance
-            Wryna's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Skyloft\Central Skyloft\Near Temple Entrance: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Day
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Clawshots
-              opaque: false
-            \Skyloft\Central Skyloft\Waterfall Island: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Clawshots
-            \Skyloft\Skyloft Village: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Skyloft\Upper Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Bazaar North Exit: Day
+            Bazaar South Exit: Day
+            Bazaar West Exit: Day
+            Exit to Beedle's Shop: "Day & (\\Distance Activator | Beedle's Shop With\
+              \ Bombs Trick & Bomb Bag)"
+            Exit to Sky: Day
+            Orielle and Parrow's House Exit: 'True'
+            Peatrice's House Exit: 'True'
+            Piper's House Exit: 'True'
+            Trial Gate Exit: \Skyloft\Central Skyloft\Open Trial Gate
+            Waterfall Cave Upper Exit: \Skyloft\Central Skyloft\Open Cave Entrance
+            Wryna's House Exit: 'True'
+            \Skyloft\Central Skyloft\Near Temple Entrance: "Day & Clawshots"
+            \Skyloft\Central Skyloft\Waterfall Island: Clawshots
+            \Skyloft\Skyloft Village: 'True'
+            \Skyloft\Upper Skyloft: 'True'
           hint_region: Central Skyloft
           locations:
-            Crystal between Wooden Planks: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Night
-            Crystal on Light Tower: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Night
-            Crystal on Waterfall Island: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Night
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Skyloft\Central Skyloft\Crystal on Waterfall Island from the
-                  ground
-              opaque: false
-            Crystal on Waterfall Island from the ground: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Quick Beetle
-            Crystal on West Cliff: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Night
-            Open Cave Entrance: !!python/object:logic.logic_expression.OrCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Sword
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Bomb Bag
-              opaque: false
-            Open Trial Gate: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Goddess's Harp
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Song of the Hero
-              opaque: false
-            Parrow's Crystals: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Sky\South West\Orielle's Island\Save Orielle
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Day
-              opaque: false
-            Parrow's Gift: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Sky\South West\Orielle's Island\Talk to Orielle
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Day
-              opaque: false
-            Shed Chest: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Water Dragon's Scale
-            Shed Goddess Chest: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Water Dragon's Scale
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Eldin\Volcano\Sand Slide\Goddess Cube on Sand Slide
-              opaque: false
-            Waterfall Cave Crystals from above: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Beetle
-            West Cliff Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Faron\Faron Woods\West Branch\Goddess Cube on West Great Tree
-                near Exit
-            \Can Collect Water: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Baby Rattle from Beedle's Shop Trick
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Day
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Distance Activator
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Gust Bellows
-              - !!python/object:logic.logic_expression.OrCombination
-                arguments:
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                - !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Whip
-                opaque: false
-              opaque: false
-            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Night
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Skyloft\Central Skyloft\Waterfall Cave Crystals from above
-              opaque: false
-            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Night
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Skyloft\Central Skyloft\Waterfall Cave Crystals from above
-              opaque: false
+            Crystal between Wooden Planks: Night
+            Crystal on Light Tower: Night
+            Crystal on Waterfall Island: "Night & \\Skyloft\\Central Skyloft\\Crystal\
+              \ on Waterfall Island from the ground"
+            Crystal on Waterfall Island from the ground: \Quick Beetle
+            Crystal on West Cliff: Night
+            Open Cave Entrance: "\\Sword | Bomb Bag"
+            Open Trial Gate: "Goddess's Harp & \\Song of the Hero"
+            Parrow's Crystals: "\\Sky\\South West\\Orielle's Island\\Save Orielle\
+              \ & Day"
+            Parrow's Gift: "\\Sky\\South West\\Orielle's Island\\Talk to Orielle &\
+              \ Day"
+            Shed Chest: Water Dragon's Scale
+            Shed Goddess Chest: "Water Dragon's Scale & \\Eldin\\Volcano\\Sand Slide\\\
+              Goddess Cube on Sand Slide"
+            Waterfall Cave Crystals from above: \Beetle
+            West Cliff Goddess Chest: \Faron\Faron Woods\West Branch\Goddess Cube
+              on West Great Tree near Exit
+            \Can Collect Water: 'True'
+            \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest: "Baby Rattle from\
+              \ Beedle's Shop Trick & Day & \\Distance Activator & Gust Bellows &\
+              \ (\\Beetle | Whip)"
+            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: "Night\
+              \ & \\Skyloft\\Central Skyloft\\Waterfall Cave Crystals from above"
+            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: "Night\
+              \ & \\Skyloft\\Central Skyloft\\Waterfall Cave Crystals from above"
           name: \Skyloft\Central Skyloft
           sub_areas:
-            Bazaar: !!python/object:logic.logic_input.Area
+            Bazaar:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
@@ -8783,305 +5578,222 @@ areas: !!python/object:logic.logic_input.Area
                 South Entrance: null
                 West Entrance: null
               exits:
-                North Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                South Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                West Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Gondo Upgrades On option
+                North Exit: 'True'
+                South Exit: 'True'
+                West Exit: 'True'
+                \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades: Gondo Upgrades On
+                  option
               hint_region: Central Skyloft
               locations:
-                Bazaar Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Goddess Cube in
-                    Ancient Harbour
-                Endurance Potion: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Bottle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Lanayru\Raise Lanayru Mining Facility
-                  opaque: false
-                Item Check Access: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Potion Lady's Gift: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Repair Gondo's Junk: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Ancient Flower Farming
-                Talk to Peatrice: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Bazaar Goddess Chest: \Lanayru\Lanayru Sand Sea\Ancient Harbour\Goddess
+                  Cube in Ancient Harbour
+                Endurance Potion: "\\Bottle & \\Lanayru\\Raise Lanayru Mining Facility"
+                Item Check Access: 'True'
+                Potion Lady's Gift: 'True'
+                Repair Gondo's Junk: \Ancient Flower Farming
+                Talk to Peatrice: 'True'
               name: \Skyloft\Central Skyloft\Bazaar
               sub_areas:
-                Gondo's Upgrades: !!python/object:logic.logic_input.Area
+                Gondo's Upgrades:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Skyloft\Central Skyloft\Bazaar: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Skyloft\Central Skyloft\Bazaar: 'True'
                   hint_region: Central Skyloft
                   locations:
-                    Upgrade to Quick Beetle: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Hook Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Faron\Faron Woods\Deep Woods\Entry\Hornet Larvae Farming
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Flower Farming
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sky\North East\Bamboo Island\Inside\Clean Cut Minigame
-                      opaque: true
-                    Upgrade to Tough Beetle: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Quick Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Faron\Faron Woods\Amber Relic Farming
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Ancient Flower Farming
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sky\North East\Bamboo Island\Inside\Clean Cut Minigame
-                      opaque: true
+                    Upgrade to Quick Beetle: "\\Hook Beetle & \\Faron\\Faron Woods\\\
+                      Deep Woods\\Entry\\Hornet Larvae Farming & \\Ancient Flower\
+                      \ Farming & \\Sky\\North East\\Bamboo Island\\Inside\\Clean\
+                      \ Cut Minigame"
+                    Upgrade to Tough Beetle: "\\Quick Beetle & \\Faron\\Faron Woods\\\
+                      Amber Relic Farming & \\Ancient Flower Farming & \\Sky\\North\
+                      \ East\\Bamboo Island\\Inside\\Clean Cut Minigame"
                   name: \Skyloft\Central Skyloft\Bazaar\Gondo's Upgrades
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Bird Nest: !!python/object:logic.logic_input.Area
+            Bird Nest:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Skyloft\Central Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Skyloft\Central Skyloft: 'True'
               hint_region: Central Skyloft
               locations:
-                Item in Bird Nest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Gust Bellows
+                Item in Bird Nest: Gust Bellows
               name: \Skyloft\Central Skyloft\Bird Nest
               sub_areas: {}
               toplevel_alias: null
-            Near Temple Entrance: !!python/object:logic.logic_input.Area
+            Near Temple Entrance:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance from Sky Keep: null
               exits:
-                Exit to Sky Keep: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Stone of Trials
-                \Skyloft\Central Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Clawshots
+                Exit to Sky Keep: Stone of Trials
+                \Skyloft\Central Skyloft: Clawshots
               hint_region: Central Skyloft
               locations: {}
               name: \Skyloft\Central Skyloft\Near Temple Entrance
               sub_areas: {}
               toplevel_alias: null
-            Orielle and Parrow's House: !!python/object:logic.logic_input.Area
+            Orielle and Parrow's House:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: true
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Central Skyloft
               locations:
-                Crystal in Orielle and Parrow's House: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Parrow's Crystals: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sky\South West\Orielle's Island\Save Orielle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Night
-                  opaque: false
-                Parrow's Gift: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Sky\South West\Orielle's Island\Talk to Orielle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Night
-                  opaque: false
+                Crystal in Orielle and Parrow's House: 'True'
+                Parrow's Crystals: "\\Sky\\South West\\Orielle's Island\\Save Orielle\
+                  \ & Night"
+                Parrow's Gift: "\\Sky\\South West\\Orielle's Island\\Talk to Orielle\
+                  \ & Night"
               name: \Skyloft\Central Skyloft\Orielle and Parrow's House
               sub_areas: {}
               toplevel_alias: null
-            Past Waterfall Cave: !!python/object:logic.logic_input.Area
+            Past Waterfall Cave:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: false
               entrances: !!set
                 Waterfall Cave Lower Entrance: null
               exits:
-                Waterfall Cave Lower Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Skyloft\Central Skyloft\Exit to Sky: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
+                Waterfall Cave Lower Exit: 'True'
+                \Skyloft\Central Skyloft\Exit to Sky: Day
               hint_region: Central Skyloft
               locations:
-                Crystal after Waterfall Cave: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Night
-                Crystal in Loftwing Prison: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Night
+                Crystal after Waterfall Cave: Night
+                Crystal in Loftwing Prison: Night
               name: \Skyloft\Central Skyloft\Past Waterfall Cave
               sub_areas: {}
               toplevel_alias: null
-            Peatrice's House: !!python/object:logic.logic_input.Area
+            Peatrice's House:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: true
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Central Skyloft
               locations:
-                Peater/Peatrice's Crystals: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyloft\Central Skyloft\Bazaar\Talk to Peatrice
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Night
-                  opaque: false
+                Peater/Peatrice's Crystals: "\\Skyloft\\Central Skyloft\\Bazaar\\\
+                  Talk to Peatrice & Night"
               name: \Skyloft\Central Skyloft\Peatrice's House
               sub_areas: {}
               toplevel_alias: null
-            Piper's House: !!python/object:logic.logic_input.Area
+            Piper's House:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: true
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Central Skyloft
               locations: {}
               name: \Skyloft\Central Skyloft\Piper's House
               sub_areas: {}
               toplevel_alias: null
-            Waterfall Cave: !!python/object:logic.logic_input.Area
+            Waterfall Cave:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: false
               entrances: !!set
                 Lower Entrance: null
                 Upper Entrance: null
               exits:
-                Lower Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Upper Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Lower Exit: 'True'
+                Upper Exit: 'True'
               hint_region: Central Skyloft
               locations:
-                Rupee Waterfall Cave Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Waterfall Cave First Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Waterfall Cave Second Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Rupee Waterfall Cave Crawlspace: 'True'
+                Waterfall Cave First Chest: 'True'
+                Waterfall Cave Second Chest: 'True'
               name: \Skyloft\Central Skyloft\Waterfall Cave
               sub_areas: {}
               toplevel_alias: null
-            Waterfall Island: !!python/object:logic.logic_input.Area
+            Waterfall Island:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Skyloft\Central Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Skyloft\Central Skyloft\Bird Nest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Skyloft\Skyloft Village: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                \Skyloft\Central Skyloft: 'True'
+                \Skyloft\Central Skyloft\Bird Nest: 'True'
+                \Skyloft\Skyloft Village: 'True'
               hint_region: Central Skyloft
               locations:
-                Crystal on Waterfall Island: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Night
-                Floating Island Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Lake Floria\Below Rock\Emerged Area\Goddess Cube in
-                    Lake Floria
-                Gossip Stone on Waterfall Island: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Waterfall Goddess Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark
-                    Head\Goddess Cube in Pirate Stronghold
+                Crystal on Waterfall Island: Night
+                Floating Island Goddess Chest: \Faron\Lake Floria\Below Rock\Emerged
+                  Area\Goddess Cube in Lake Floria
+                Gossip Stone on Waterfall Island: 'True'
+                Waterfall Goddess Chest: \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside
+                  the Shark Head\Goddess Cube in Pirate Stronghold
               name: \Skyloft\Central Skyloft\Waterfall Island
               sub_areas: {}
               toplevel_alias: null
-            Wryna's House: !!python/object:logic.logic_input.Area
+            Wryna's House:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: true
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Central Skyloft
               locations:
-                Wryna's Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Wryna's Crystals: 'True'
               name: \Skyloft\Central Skyloft\Wryna's House
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
-        Skyloft Silent Realm: !!python/object:logic.logic_input.Area
+        Skyloft Silent Realm:
           abstract: false
-          allowed_time_of_day: *id002
+          allowed_time_of_day: 3
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance: null
           exits:
-            Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit: 'True'
           hint_region: Skyloft Silent Realm
           locations:
-            Relic 1: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 10: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 2: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 3: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 4: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 5: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 6: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 7: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 8: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Relic 9: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Trial Reward: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Relic 1: 'True'
+            Relic 10: 'True'
+            Relic 2: 'True'
+            Relic 3: 'True'
+            Relic 4: 'True'
+            Relic 5: 'True'
+            Relic 6: 'True'
+            Relic 7: 'True'
+            Relic 8: 'True'
+            Relic 9: 'True'
+            Trial Reward: 'True'
           name: \Skyloft\Skyloft Silent Realm
           sub_areas: {}
           toplevel_alias: null
-        Skyloft Village: !!python/object:logic.logic_input.Area
+        Skyloft Village:
           abstract: false
-          allowed_time_of_day: *id002
+          allowed_time_of_day: 3
           can_save: false
           can_sleep: false
           entrances: !!set
@@ -9092,167 +5804,125 @@ areas: !!python/object:logic.logic_input.Area
             Rupin's House Entrance: null
             Sparrot's House Entrance: null
           exits:
-            Batreaux's House Exit: !!python/object:logic.logic_expression.OrCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Skyloft\Skyloft Village\Opened Shed
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Gravestone Jump Trick
-              opaque: false
-            Bertie's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Gondo's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Mallara's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Rupin's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Sparrot's House Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Skyloft\Central Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Skyloft\Central Skyloft\Exit to Sky: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Day
-            \Skyloft\Central Skyloft\Past Waterfall Cave: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Waterfall Cave Jump Trick
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Day
-              opaque: false
+            Batreaux's House Exit: "\\Skyloft\\Skyloft Village\\Opened Shed | Gravestone\
+              \ Jump Trick"
+            Bertie's House Exit: 'True'
+            Gondo's House Exit: 'True'
+            Mallara's House Exit: 'True'
+            Rupin's House Exit: 'True'
+            Sparrot's House Exit: 'True'
+            \Skyloft\Central Skyloft: 'True'
+            \Skyloft\Central Skyloft\Exit to Sky: Day
+            \Skyloft\Central Skyloft\Past Waterfall Cave: "Waterfall Cave Jump Trick\
+              \ & Day"
           hint_region: Skyloft Village
           locations:
-            Crystal near Pumpkin Patch: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Night
-            Opened Shed: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Night
+            Crystal near Pumpkin Patch: Night
+            Opened Shed: Night
           name: \Skyloft\Skyloft Village
           sub_areas:
-            Batreaux's House: !!python/object:logic.logic_input.Area
+            Batreaux's House:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Batreaux's House
               locations:
-                10 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \10 Gratitude Crystals
-                30 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \30 Gratitude Crystals
-                30 Crystals Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \30 Gratitude Crystals
-                40 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \40 Gratitude Crystals
-                5 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \5 Gratitude Crystals
-                50 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \50 Gratitude Crystals
-                70 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \70 Gratitude Crystals
-                70 Crystals Second Reward: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \70 Gratitude Crystals
-                80 Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \80 Gratitude Crystals
+                10 Crystals: \10 Gratitude Crystals
+                30 Crystals: \30 Gratitude Crystals
+                30 Crystals Chest: \30 Gratitude Crystals
+                40 Crystals: \40 Gratitude Crystals
+                5 Crystals: \5 Gratitude Crystals
+                50 Crystals: \50 Gratitude Crystals
+                70 Crystals: \70 Gratitude Crystals
+                70 Crystals Second Reward: \70 Gratitude Crystals
+                80 Crystals: \80 Gratitude Crystals
               name: \Skyloft\Skyloft Village\Batreaux's House
               sub_areas: {}
               toplevel_alias: null
-            Bertie's House: !!python/object:logic.logic_input.Area
+            Bertie's House:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: true
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Skyloft Village
               locations:
-                Bertie's Crystals: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Baby Rattle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Night
-                  opaque: false
+                Bertie's Crystals: "Baby Rattle & Night"
               name: \Skyloft\Skyloft Village\Bertie's House
               sub_areas: {}
               toplevel_alias: null
-            Gondo's House: !!python/object:logic.logic_input.Area
+            Gondo's House:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: true
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Skyloft Village
               locations: {}
               name: \Skyloft\Skyloft Village\Gondo's House
               sub_areas: {}
               toplevel_alias: null
-            Mallara's House: !!python/object:logic.logic_input.Area
+            Mallara's House:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: true
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Skyloft Village
               locations:
-                Mallara's Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Gust Bellows
+                Mallara's Crystals: Gust Bellows
               name: \Skyloft\Skyloft Village\Mallara's House
               sub_areas: {}
               toplevel_alias: null
-            Rupin's House: !!python/object:logic.logic_input.Area
+            Rupin's House:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: true
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Skyloft Village
               locations: {}
               name: \Skyloft\Skyloft Village\Rupin's House
               sub_areas: {}
               toplevel_alias: null
-            Sparrot's House: !!python/object:logic.logic_input.Area
+            Sparrot's House:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: true
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Skyloft Village
               locations:
-                Sparrot's Crystals: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Eldin\Volcano\Near Temple Entrance\Retrieve Crystal Ball
-                Start Sparrot's Quest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Sparrot's Crystals: \Eldin\Volcano\Near Temple Entrance\Retrieve Crystal
+                  Ball
+                Start Sparrot's Quest: 'True'
               name: \Skyloft\Skyloft Village\Sparrot's House
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
-        Upper Skyloft: !!python/object:logic.logic_input.Area
+        Upper Skyloft:
           abstract: false
-          allowed_time_of_day: *id002
+          allowed_time_of_day: 3
           can_save: false
           can_sleep: false
           entrances: !!set
@@ -9264,61 +5934,41 @@ areas: !!python/object:logic.logic_input.Area
             Sparring Hall Left Door Entrance: null
             Sparring Hall Right Door Entrance: null
           exits:
-            Goddess Statue Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Knight Academy Chimney Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Clawshots
-            Knight Academy Lower Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Day
-            Knight Academy Lower Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Day
-            Knight Academy Upper Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Knight Academy Upper Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Sparring Hall Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Sparring Hall Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            \Skyloft\Central Skyloft: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Goddess Statue Exit: 'True'
+            Knight Academy Chimney Entrance: Clawshots
+            Knight Academy Lower Left Door Exit: Day
+            Knight Academy Lower Right Door Exit: Day
+            Knight Academy Upper Left Door Exit: 'True'
+            Knight Academy Upper Right Door Exit: 'True'
+            Sparring Hall Left Door Exit: 'True'
+            Sparring Hall Right Door Exit: 'True'
+            \Skyloft\Central Skyloft: 'True'
           hint_region: Upper Skyloft
           locations:
-            Chest near Goddess Statue: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
-            Owlan's Gift: !!python/object:logic.logic_expression.BasicTextAtom
-              text: Day
-            Pumpkin Archery -- 600 Points: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Bow
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: Day
-              opaque: false
+            Chest near Goddess Statue: 'True'
+            Owlan's Gift: Day
+            Pumpkin Archery -- 600 Points: "\\Bow & Day"
           name: \Skyloft\Upper Skyloft
           sub_areas:
-            Goddess Statue: !!python/object:logic.logic_input.Area
+            Goddess Statue:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: false
               entrances: !!set
                 Entrance: null
               exits:
-                Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Exit: 'True'
               hint_region: Upper Skyloft
               locations:
-                First Goddess Sword Item in Goddess Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Second Goddess Sword Item in Goddess Statue: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                First Goddess Sword Item in Goddess Statue: 'True'
+                Second Goddess Sword Item in Goddess Statue: 'True'
               name: \Skyloft\Upper Skyloft\Goddess Statue
               sub_areas: {}
               toplevel_alias: null
-            Knight Academy: !!python/object:logic.logic_input.Area
+            Knight Academy:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: true
               entrances: !!set
@@ -9327,193 +5977,119 @@ areas: !!python/object:logic.logic_input.Area
                 Upper Left Door Entrance: null
                 Upper Right Door Entrance: null
               exits:
-                Lower Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
-                Lower Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Day
-                Upper Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Upper Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Skyloft\Upper Skyloft\Knight Academy\Link's Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Unlocked
-                    Zelda's Room
+                Lower Left Door Exit: Day
+                Lower Right Door Exit: Day
+                Upper Left Door Exit: 'True'
+                Upper Right Door Exit: 'True'
+                \Skyloft\Upper Skyloft\Knight Academy\Link's Room: 'True'
+                \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room: \Skyloft\Upper
+                  Skyloft\Knight Academy\Zelda's Room\Unlocked Zelda's Room
               hint_region: Upper Skyloft
               locations:
-                Crystal in Knight Academy Plant: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Night
-                Fledge's Crystals: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyloft\Central Skyloft\Bazaar\Endurance Potion
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Night
-                  opaque: false
-                Fledge's Gift: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Ghost/Pipit's Crystals: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Cawlin's Letter
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Day
-                  opaque: false
-                Item from Cawlin: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyloft\Upper Skyloft\Knight Academy\Knock on Toilet Door
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Day
-                  opaque: false
-                Knock on Toilet Door: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Goddess's Harp
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Night
-                  opaque: false
-                Owlan's Crystals: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Faron\Faron Woods\Behind the Crawlspace and Rope\Retrieve
-                      Oolo
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Day
-                  opaque: false
-                Start Owlan's Quest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Faron\Faron Woods\All Kikwis Saved
+                Crystal in Knight Academy Plant: Night
+                Fledge's Crystals: "\\Skyloft\\Central Skyloft\\Bazaar\\Endurance\
+                  \ Potion & Night"
+                Fledge's Gift: 'True'
+                Ghost/Pipit's Crystals: "Cawlin's Letter & Day"
+                Item from Cawlin: "\\Skyloft\\Upper Skyloft\\Knight Academy\\Knock\
+                  \ on Toilet Door & Day"
+                Knock on Toilet Door: "Goddess's Harp & Night"
+                Owlan's Crystals: "\\Faron\\Faron Woods\\Behind the Crawlspace and\
+                  \ Rope\\Retrieve Oolo & Day"
+                Start Owlan's Quest: \Faron\Faron Woods\All Kikwis Saved
               name: \Skyloft\Upper Skyloft\Knight Academy
               sub_areas:
-                Link's Room: !!python/object:logic.logic_input.Area
+                Link's Room:
                   abstract: false
-                  allowed_time_of_day: *id002
+                  allowed_time_of_day: 3
                   can_save: false
                   can_sleep: true
                   entrances: !!set
                     Start Entrance: null
                   exits:
-                    \Skyloft\Upper Skyloft\Knight Academy: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Skyloft\Upper Skyloft\Knight Academy: 'True'
                   hint_region: Upper Skyloft
                   locations:
-                    Crystal in Link's Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Night
+                    Crystal in Link's Room: Night
                   name: \Skyloft\Upper Skyloft\Knight Academy\Link's Room
                   sub_areas: {}
                   toplevel_alias: null
-                Zelda's Room: !!python/object:logic.logic_input.Area
+                Zelda's Room:
                   abstract: false
-                  allowed_time_of_day: *id002
+                  allowed_time_of_day: 3
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Chimney: null
                   exits:
-                    \Skyloft\Upper Skyloft\Knight Academy: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Skyloft\Upper Skyloft\Knight Academy: 'True'
                   hint_region: Upper Skyloft
                   locations:
-                    Crystal in Zelda's Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Night
-                    In Zelda's Closet: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Unlocked Zelda's Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Crystal in Zelda's Room: Night
+                    In Zelda's Closet: 'True'
+                    Unlocked Zelda's Room: 'True'
                   name: \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            Sparring Hall: !!python/object:logic.logic_input.Area
+            Sparring Hall:
               abstract: false
-              allowed_time_of_day: *id002
+              allowed_time_of_day: 3
               can_save: false
               can_sleep: false
               entrances: !!set
                 Left Door Entrance: null
                 Right Door Entrance: null
               exits:
-                Left Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                Right Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Left Door Exit: 'True'
+                Right Door Exit: 'True'
               hint_region: Upper Skyloft
               locations:
-                Crystal in Sparring Hall: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Beetle
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Night
-                  opaque: false
-                Delivered Hot Soup: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Start
-                    Hot Soup Delivery
-                Sparring Hall Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                Crystal in Sparring Hall: "\\Beetle & Night"
+                Delivered Hot Soup: \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Start
+                  Hot Soup Delivery
+                Sparring Hall Chest: 'True'
               name: \Skyloft\Upper Skyloft\Sparring Hall
               sub_areas: {}
               toplevel_alias: null
           toplevel_alias: null
       toplevel_alias: null
-    Skyview: !!python/object:logic.logic_input.Area
+    Skyview:
       abstract: true
-      allowed_time_of_day: *id001
+      allowed_time_of_day: 1
       can_save: false
       can_sleep: false
       entrances: !!set {}
       exits: {}
       hint_region: Skyview
       locations:
-        Can Cut Tree: !!python/object:logic.logic_expression.OrCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Sword
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: Bomb Bag
-          opaque: false
-        Can Hit High Skyview Switches: !!python/object:logic.logic_expression.OrCombination
-          arguments:
-          - !!python/object:logic.logic_expression.BasicTextAtom
-            text: \Distance Activator
-          - !!python/object:logic.logic_expression.AndCombination
-            arguments:
-            - !!python/object:logic.logic_expression.BasicTextAtom
-              text: Bomb Bag
-            - !!python/object:logic.logic_expression.BasicTextAtom
-              text: Bomb Throws Trick
-            opaque: false
-          opaque: false
-        Skyview 2: !!python/object:logic.logic_expression.BasicTextAtom
-          text: Water Dragon's Scale
+        Can Cut Tree: "\\Sword | Bomb Bag"
+        Can Hit High Skyview Switches: "\\Distance Activator | Bomb Bag & Bomb Throws\
+          \ Trick"
+        Skyview 2: Water Dragon's Scale
       name: \Skyview
       sub_areas:
-        Boss Room: !!python/object:logic.logic_input.Area
+        Boss Room:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance from Dungeon: null
             Entrance from Spring: null
           exits:
-            Exit to Dungeon: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Skyview\Boss Room\Beat Ghirahim
-            Exit to Spring: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Skyview\Boss Room\Beat Ghirahim
+            Exit to Dungeon: \Skyview\Boss Room\Beat Ghirahim
+            Exit to Spring: \Skyview\Boss Room\Beat Ghirahim
           hint_region: Skyview
           locations:
-            Beat Ghirahim: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Sword
-            Heart Container: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Skyview\Boss Room\Beat Ghirahim
+            Beat Ghirahim: \Sword
+            Heart Container: \Skyview\Boss Room\Beat Ghirahim
           name: \Skyview\Boss Room
           sub_areas: {}
           toplevel_alias: null
-        Main: !!python/object:logic.logic_input.Area
+        Main:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set {}
@@ -9522,140 +6098,76 @@ areas: !!python/object:logic.logic_input.Area
           locations: {}
           name: \Skyview\Main
           sub_areas:
-            Entry: !!python/object:logic.logic_input.Area
+            Entry:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set
                 Main Entrance: null
               exits:
-                Main Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
-                \Skyview\Main\First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\Entry\Cut Tree
+                Main Exit: 'True'
+                \Skyview\Main\First Room: \Skyview\Main\Entry\Cut Tree
               hint_region: Skyview
               locations:
-                Cut Tree: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Can Cut Tree
+                Cut Tree: \Skyview\Can Cut Tree
               name: \Skyview\Main\Entry
               sub_areas: {}
               toplevel_alias: null
-            First Hub: !!python/object:logic.logic_input.Area
+            First Hub:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Skyview\Main\First Hub\Left Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\First Hub\Switch to Left Room
-                \Skyview\Main\First Hub\Right Room\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\First Hub\Switch to Right Room
-                \Skyview\Main\First Hub\Right Room\Upper Area: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\First Hub\Left Room\Raise Water
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\First Hub\Right Room\After Crawlspace\Raise
-                        Water
-                    opaque: false
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Clawshots
-                  opaque: false
-                \Skyview\Main\First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\First Room\Destroy Barricade
-                \Skyview\Main\One Eye Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\One Eye Room\Unlock Door to First Hub
-                \Skyview\Main\Second Hub: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyview\Main\First Hub\One Water Raise
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Skyview Small Key
-                  opaque: false
+                \Skyview\Main\First Hub\Left Room: \Skyview\Main\First Hub\Switch
+                  to Left Room
+                \Skyview\Main\First Hub\Right Room\Lower Area: \Skyview\Main\First
+                  Hub\Switch to Right Room
+                \Skyview\Main\First Hub\Right Room\Upper Area: "\\Skyview\\Main\\\
+                  First Hub\\Left Room\\Raise Water & \\Skyview\\Main\\First Hub\\\
+                  Right Room\\After Crawlspace\\Raise Water | Clawshots"
+                \Skyview\Main\First Room: \Skyview\Main\First Room\Destroy Barricade
+                \Skyview\Main\One Eye Room: \Skyview\Main\One Eye Room\Unlock Door
+                  to First Hub
+                \Skyview\Main\Second Hub: "\\Skyview\\Main\\First Hub\\One Water Raise\
+                  \ & Skyview Small Key"
               hint_region: Skyview
               locations:
-                One Water Raise: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyview\Main\First Hub\Left Room\Raise Water
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyview\Main\First Hub\Right Room\After Crawlspace\Raise
-                      Water
-                  opaque: false
-                Switch to Left Room: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Can Hit Switch
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\First Hub\One Water Raise
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Water Dragon's Scale
-                    opaque: false
-                  opaque: false
-                Switch to Right Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Can Hit High Skyview Switches
-                \Skyview\Main\First Room\Destroy Barricade: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: 'True'
+                One Water Raise: "\\Skyview\\Main\\First Hub\\Left Room\\Raise Water\
+                  \ | \\Skyview\\Main\\First Hub\\Right Room\\After Crawlspace\\Raise\
+                  \ Water"
+                Switch to Left Room: "\\Can Hit Switch | \\Skyview\\Main\\First Hub\\\
+                  One Water Raise & Water Dragon's Scale"
+                Switch to Right Room: \Skyview\Can Hit High Skyview Switches
+                \Skyview\Main\First Room\Destroy Barricade: 'True'
               name: \Skyview\Main\First Hub
               sub_areas:
-                Left Room: !!python/object:logic.logic_input.Area
+                Left Room:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Skyview\Main\First Hub: 'True'
                   hint_region: Skyview
                   locations:
-                    Chest on Tree Branch: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Skyview\Main\First Hub\Left Room\Hit Vines
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Skyview\Main\First Hub\Left Room\Spider Roll
-                      opaque: false
-                    Hit Vines: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Skyview\Can Hit High Skyview Switches
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Goddess Sword
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Whip
-                      opaque: false
-                    Raise Water: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.AndCombination
-                        arguments:
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Skyview\Main\First Hub\Left Room\Hit Vines
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Can Hit Switch
-                        opaque: false
-                      - !!python/object:logic.logic_expression.AndCombination
-                        arguments:
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Skyview\Main\First Hub\Left Room\Spider Roll
-                        - !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Skyview\Can Hit High Skyview Switches
-                        opaque: false
-                      opaque: false
-                    Spider Roll: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Skyview - Spider Roll Trick
+                    Chest on Tree Branch: "\\Skyview\\Main\\First Hub\\Left Room\\\
+                      Hit Vines | \\Skyview\\Main\\First Hub\\Left Room\\Spider Roll"
+                    Hit Vines: "\\Skyview\\Can Hit High Skyview Switches | \\Goddess\
+                      \ Sword | Whip"
+                    Raise Water: "\\Skyview\\Main\\First Hub\\Left Room\\Hit Vines\
+                      \ & \\Can Hit Switch | \\Skyview\\Main\\First Hub\\Left Room\\\
+                      Spider Roll & \\Skyview\\Can Hit High Skyview Switches"
+                    Spider Roll: Skyview - Spider Roll Trick
                   name: \Skyview\Main\First Hub\Left Room
                   sub_areas: {}
                   toplevel_alias: null
-                Right Room: !!python/object:logic.logic_input.Area
+                Right Room:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
@@ -9664,118 +6176,93 @@ areas: !!python/object:logic.logic_input.Area
                   locations: {}
                   name: \Skyview\Main\First Hub\Right Room
                   sub_areas:
-                    After Crawlspace: !!python/object:logic.logic_input.Area
+                    After Crawlspace:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Skyview\Main\First Hub\Right Room\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
                       hint_region: Skyview
                       locations:
-                        Digging Spot in Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'False'
-                        Raise Water: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Skyview\Can Hit High Skyview Switches
+                        Digging Spot in Crawlspace: 'False'
+                        Raise Water: \Skyview\Can Hit High Skyview Switches
                       name: \Skyview\Main\First Hub\Right Room\After Crawlspace
                       sub_areas:
-                        With Water: !!python/object:logic.logic_input.Area
+                        With Water:
                           abstract: false
-                          allowed_time_of_day: *id001
+                          allowed_time_of_day: 1
                           can_save: false
                           can_sleep: false
                           entrances: !!set {}
                           exits:
-                            \Skyview\Main\First Hub\Right Room\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
-                              text: 'True'
+                            \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
                           hint_region: Skyview
                           locations:
-                            \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
-                              text: \Digging Mitts
+                            \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace: \Digging
+                              Mitts
                           name: \Skyview\Main\First Hub\Right Room\After Crawlspace\With
                             Water
                           sub_areas: {}
                           toplevel_alias: null
                       toplevel_alias: null
-                    Lower Area: !!python/object:logic.logic_input.Area
+                    Lower Area:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        \Skyview\Main\First Hub\Right Room\After Crawlspace: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        \Skyview\Main\First Hub\Right Room\After Crawlspace\With Water: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: Water Dragon's Scale
+                        \Skyview\Main\First Hub: 'True'
+                        \Skyview\Main\First Hub\Right Room\After Crawlspace: 'True'
+                        \Skyview\Main\First Hub\Right Room\After Crawlspace\With Water: Water
+                          Dragon's Scale
                       hint_region: Skyview
                       locations: {}
                       name: \Skyview\Main\First Hub\Right Room\Lower Area
                       sub_areas: {}
                       toplevel_alias: null
-                    Upper Area: !!python/object:logic.logic_input.Area
+                    Upper Area:
                       abstract: false
-                      allowed_time_of_day: *id001
+                      allowed_time_of_day: 1
                       can_save: false
                       can_sleep: false
                       entrances: !!set {}
                       exits:
-                        \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
-                        \Skyview\Main\First Hub\Right Room\Lower Area: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: 'True'
+                        \Skyview\Main\First Hub: 'True'
+                        \Skyview\Main\First Hub\Right Room\Lower Area: 'True'
                       hint_region: Skyview
                       locations:
-                        Chest behind Two Eyes: !!python/object:logic.logic_expression.BasicTextAtom
-                          text: \Sword
+                        Chest behind Two Eyes: \Sword
                       name: \Skyview\Main\First Hub\Right Room\Upper Area
                       sub_areas: {}
                       toplevel_alias: null
                   toplevel_alias: null
               toplevel_alias: null
-            First Room: !!python/object:logic.logic_input.Area
+            First Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Skyview\Main\Entry: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\Entry\Cut Tree
-                \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\First Room\Destroy Barricade
-                \Skyview\Main\One Eye Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\First Room\Switch to One Eye Room
+                \Skyview\Main\Entry: \Skyview\Main\Entry\Cut Tree
+                \Skyview\Main\First Hub: \Skyview\Main\First Room\Destroy Barricade
+                \Skyview\Main\One Eye Room: \Skyview\Main\First Room\Switch to One
+                  Eye Room
               hint_region: Skyview
               locations:
-                Destroy Barricade: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyview\Skyview 2
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Bomb Bag
-                  opaque: false
-                Goddess Wall Trigger: !!python/object:logic.logic_expression.AndCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Ballad of the Goddess
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Goddess's Harp
-                  opaque: false
-                Switch to One Eye Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Can Hit High Skyview Switches
-                \Skyview\Main\Entry\Cut Tree: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Can Cut Tree
+                Destroy Barricade: "\\Skyview\\Skyview 2 | Bomb Bag"
+                Goddess Wall Trigger: "Ballad of the Goddess & Goddess's Harp"
+                Switch to One Eye Room: \Skyview\Can Hit High Skyview Switches
+                \Skyview\Main\Entry\Cut Tree: \Skyview\Can Cut Tree
               name: \Skyview\Main\First Room
               sub_areas: {}
               toplevel_alias: null
-            Last Room: !!python/object:logic.logic_input.Area
+            Last Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
@@ -9784,3650 +6271,790 @@ areas: !!python/object:logic.logic_input.Area
               locations: {}
               name: \Skyview\Main\Last Room
               sub_areas:
-                After Rope: !!python/object:logic.logic_input.Area
+                After Rope:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set
                     Boss Door Entrance: null
                   exits:
-                    Boss Door Exit: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Skyview Boss Key
-                    \Skyview\Main\Last Room\Before Rope: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\Last Room\Before Rope\Deal with Archers
-                    \Skyview\Main\Last Room\Near Boss Key Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\Last Room\After Rope\Hit Vines
+                    Boss Door Exit: Skyview Boss Key
+                    \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Before
+                      Rope\Deal with Archers
+                    \Skyview\Main\Last Room\Near Boss Key Chest: \Skyview\Main\Last
+                      Room\After Rope\Hit Vines
                   hint_region: Skyview
                   locations:
-                    Chest near Boss Door: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
-                    Hit Vines: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Long Range Skyward Strike
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Distance Activator
-                      opaque: false
-                    \Skyview\Main\Last Room\Before Rope\Deal with Archers: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Can Defeat Bokoblins
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Hook Beetle
-                      opaque: false
+                    Chest near Boss Door: 'True'
+                    Hit Vines: "\\Long Range Skyward Strike | \\Distance Activator"
+                    \Skyview\Main\Last Room\Before Rope\Deal with Archers: "\\Can\
+                      \ Defeat Bokoblins | \\Hook Beetle"
                   name: \Skyview\Main\Last Room\After Rope
                   sub_areas: {}
                   toplevel_alias: null
-                Before Rope: !!python/object:logic.logic_input.Area
+                Before Rope:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Skyview\Main\Last Room\After Rope: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\Last Room\Before Rope\Deal with Archers
-                    \Skyview\Main\Last Room\Near East Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\Last Room\Near East Entrance\Deal with Hanging
-                        Skulltula
-                    \Skyview\Main\Second Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\Last Room\Before Rope\Unlock Shortcut to
-                        Second Hub
+                    \Skyview\Main\Last Room\After Rope: \Skyview\Main\Last Room\Before
+                      Rope\Deal with Archers
+                    \Skyview\Main\Last Room\Near East Entrance: \Skyview\Main\Last
+                      Room\Near East Entrance\Deal with Hanging Skulltula
+                    \Skyview\Main\Second Hub: \Skyview\Main\Last Room\Before Rope\Unlock
+                      Shortcut to Second Hub
                   hint_region: Skyview
                   locations:
-                    Deal with Archers: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Long Range Skyward Strike
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Hook Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      opaque: false
-                    Unlock Shortcut to Second Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Can Hit High Skyview Switches
-                    \Skyview\Main\Last Room\Near East Entrance\Deal with Hanging Skulltula: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Goddess Sword
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Skyview\Skyview 2
-                      opaque: false
+                    Deal with Archers: "\\Long Range Skyward Strike | \\Hook Beetle\
+                      \ | \\Bow"
+                    Unlock Shortcut to Second Hub: \Skyview\Can Hit High Skyview Switches
+                    \Skyview\Main\Last Room\Near East Entrance\Deal with Hanging Skulltula: "Bomb\
+                      \ Bag | \\Goddess Sword | \\Beetle | \\Bow | \\Skyview\\Skyview\
+                      \ 2"
                   name: \Skyview\Main\Last Room\Before Rope
                   sub_areas: {}
                   toplevel_alias: null
-                Near Boss Key Chest: !!python/object:logic.logic_input.Area
+                Near Boss Key Chest:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Skyview\Main\Last Room\After Rope: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\Last Room\After Rope\Hit Vines
-                    \Skyview\Main\Last Room\Before Rope: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Skyview\Main\Last Room\After Rope: \Skyview\Main\Last Room\After
+                      Rope\Hit Vines
+                    \Skyview\Main\Last Room\Before Rope: 'True'
                   hint_region: Skyview
                   locations:
-                    Boss Key Chest: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    Boss Key Chest: 'True'
                   name: \Skyview\Main\Last Room\Near Boss Key Chest
                   sub_areas: {}
                   toplevel_alias: null
-                Near East Entrance: !!python/object:logic.logic_input.Area
+                Near East Entrance:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Skyview\Main\Last Room\Before Rope: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\Last Room\Near East Entrance\Deal with Hanging
-                        Skulltula
-                    \Skyview\Main\Second Hub\Staldra Room: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Near
+                      East Entrance\Deal with Hanging Skulltula
+                    \Skyview\Main\Second Hub\Staldra Room: 'True'
                   hint_region: Skyview
                   locations:
-                    Deal with Hanging Skulltula: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Goddess Sword
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Bow
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Skyview\Skyview 2
-                      opaque: false
+                    Deal with Hanging Skulltula: "Bomb Bag | \\Goddess Sword | \\\
+                      Beetle | \\Bow | \\Skyview\\Skyview 2"
                   name: \Skyview\Main\Last Room\Near East Entrance
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
-            One Eye Room: !!python/object:logic.logic_input.Area
+            One Eye Room:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\One Eye Room\Unlock Door to First Hub
-                \Skyview\Main\First Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\First Room\Switch to One Eye Room
+                \Skyview\Main\First Hub: \Skyview\Main\One Eye Room\Unlock Door to
+                  First Hub
+                \Skyview\Main\First Room: \Skyview\Main\First Room\Switch to One Eye
+                  Room
               hint_region: Skyview
               locations:
-                Unlock Door to First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Sword
+                Unlock Door to First Hub: \Sword
               name: \Skyview\Main\One Eye Room
               sub_areas: {}
               toplevel_alias: null
-            Second Hub: !!python/object:logic.logic_input.Area
+            Second Hub:
               abstract: false
-              allowed_time_of_day: *id001
+              allowed_time_of_day: 1
               can_save: false
               can_sleep: false
               entrances: !!set {}
               exits:
-                \Skyview\Main\First Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Skyview Small Key x 2
-                \Skyview\Main\Last Room\Before Rope: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\Last Room\Before Rope\Unlock Shortcut to Second
-                    Hub
-                \Skyview\Main\Second Hub\Left Rooms: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\Second Hub\Switch to Left Room
-                \Skyview\Main\Second Hub\Miniboss Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Skyview\Main\Second Hub\Switch to Miniboss Room
-                \Skyview\Main\Second Hub\Staldra Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: Skyview Small Key x 2
+                \Skyview\Main\First Hub: Skyview Small Key x 2
+                \Skyview\Main\Last Room\Before Rope: \Skyview\Main\Last Room\Before
+                  Rope\Unlock Shortcut to Second Hub
+                \Skyview\Main\Second Hub\Left Rooms: \Skyview\Main\Second Hub\Switch
+                  to Left Room
+                \Skyview\Main\Second Hub\Miniboss Room: \Skyview\Main\Second Hub\Switch
+                  to Miniboss Room
+                \Skyview\Main\Second Hub\Staldra Room: Skyview Small Key x 2
               hint_region: Skyview
               locations:
-                Item behind Bars: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Skyview\Main\Second Hub\Switch for Bars
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: Whip
-                  opaque: false
-                Rupee in East Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Rupee in Southeast Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Rupee in Southwest Tunnel: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Switch for Bars: !!python/object:logic.logic_expression.OrCombination
-                  arguments:
-                  - !!python/object:logic.logic_expression.BasicTextAtom
-                    text: \Beetle
-                  - !!python/object:logic.logic_expression.AndCombination
-                    arguments:
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Slingshot
-                    - !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Skyview Slingshot Shot Trick
-                    opaque: false
-                  opaque: false
-                Switch to Left Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Beetle
-                Switch to Miniboss Room: !!python/object:logic.logic_expression.BasicTextAtom
-                  text: \Distance Activator
+                Item behind Bars: "\\Skyview\\Main\\Second Hub\\Switch for Bars |\
+                  \ Whip"
+                Rupee in East Tunnel: \Beetle
+                Rupee in Southeast Tunnel: \Beetle
+                Rupee in Southwest Tunnel: \Beetle
+                Switch for Bars: "\\Beetle | \\Slingshot & Skyview Slingshot Shot\
+                  \ Trick"
+                Switch to Left Room: \Beetle
+                Switch to Miniboss Room: \Distance Activator
               name: \Skyview\Main\Second Hub
               sub_areas:
-                Left Rooms: !!python/object:logic.logic_input.Area
+                Left Rooms:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Skyview\Main\Second Hub: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sword
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Projectile Item
-                      opaque: false
+                    \Skyview\Main\Second Hub: "\\Sword & \\Projectile Item"
                   hint_region: Skyview
                   locations:
-                    Chest behind Three Eyes: !!python/object:logic.logic_expression.AndCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Beetle
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sword
-                      opaque: false
+                    Chest behind Three Eyes: "\\Beetle & \\Sword"
                   name: \Skyview\Main\Second Hub\Left Rooms
                   sub_areas: {}
                   toplevel_alias: null
-                Miniboss Room: !!python/object:logic.logic_input.Area
+                Miniboss Room:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Skyview\Main\Second Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: 'True'
+                    \Skyview\Main\Second Hub: 'True'
                   hint_region: Skyview
                   locations:
-                    Chest after Stalfos Fight: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sword
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Skyview\Skyview 2
-                      opaque: false
+                    Chest after Stalfos Fight: "\\Sword | \\Skyview\\Skyview 2"
                   name: \Skyview\Main\Second Hub\Miniboss Room
                   sub_areas: {}
                   toplevel_alias: null
-                Staldra Room: !!python/object:logic.logic_input.Area
+                Staldra Room:
                   abstract: false
-                  allowed_time_of_day: *id001
+                  allowed_time_of_day: 1
                   can_save: false
                   can_sleep: false
                   entrances: !!set {}
                   exits:
-                    \Skyview\Main\Last Room\Near East Entrance: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: \Skyview\Main\Second Hub\Staldra Room\Can Defeat Staldra
-                    \Skyview\Main\Second Hub: !!python/object:logic.logic_expression.BasicTextAtom
-                      text: Skyview Small Key
+                    \Skyview\Main\Last Room\Near East Entrance: \Skyview\Main\Second
+                      Hub\Staldra Room\Can Defeat Staldra
+                    \Skyview\Main\Second Hub: Skyview Small Key
                   hint_region: Skyview
                   locations:
-                    Can Defeat Staldra: !!python/object:logic.logic_expression.OrCombination
-                      arguments:
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: \Sword
-                      - !!python/object:logic.logic_expression.BasicTextAtom
-                        text: Bomb Bag
-                      opaque: false
+                    Can Defeat Staldra: "\\Sword | Bomb Bag"
                   name: \Skyview\Main\Second Hub\Staldra Room
                   sub_areas: {}
                   toplevel_alias: null
               toplevel_alias: null
           toplevel_alias: null
-        Spring: !!python/object:logic.logic_input.Area
+        Spring:
           abstract: false
-          allowed_time_of_day: *id001
+          allowed_time_of_day: 1
           can_save: false
           can_sleep: false
           entrances: !!set
             Entrance: null
           exits:
-            Exit: !!python/object:logic.logic_expression.BasicTextAtom
-              text: 'True'
+            Exit: 'True'
           hint_region: Skyview
           locations:
-            Goddess Cube in Skyview Spring: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Goddess Sword
-            Rupee on Spring Pillar: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Beetle
-            Sacred Water: !!python/object:logic.logic_expression.AndCombination
-              arguments:
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Bottle
-              - !!python/object:logic.logic_expression.BasicTextAtom
-                text: \Skyview\Skyview 2
-              opaque: false
-            Strike Crest: !!python/object:logic.logic_expression.BasicTextAtom
-              text: \Goddess Sword
+            Goddess Cube in Skyview Spring: \Goddess Sword
+            Rupee on Spring Pillar: \Beetle
+            Sacred Water: "\\Bottle & \\Skyview\\Skyview 2"
+            Strike Crest: \Goddess Sword
           name: \Skyview\Spring
           sub_areas: {}
           toplevel_alias: Skyview Spring
       toplevel_alias: Skyview Temple
   toplevel_alias: null
 checks:
-  \Ancient Cistern\Boss Room\Heart Container:
-    Paths:
-    - stage/B101/r0/l1/HeartCo
-    - stage/B101/r0/l3/HeartCo
-    hint_region: Ancient Cistern
-    original item: Heart Container
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 756
-    short_name: Ancient Cistern - Heart Container
-    type: null
-  \Ancient Cistern\Flame Room\Farore's Flame:
-    Paths:
-    - event/202-ForestD2/give item after beating ancient cistern
-    - oarc/B101_1/l0
-    hint_region: Ancient Cistern
-    original item: Progressive Sword
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 757
-    short_name: Ancient Cistern - Farore's Flame
-    type: null
-  \Ancient Cistern\Main\Basement Gutters\Past Skulltula\Bokoblin:
-    Paths:
-    - stage/D101/r4/l0/EBc/0xFC00
-    hint_region: Ancient Cistern
-    original item: 'Ancient Cistern Small Key #1'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 748
-    short_name: Ancient Cistern - Bokoblin
-    type: null
-  \Ancient Cistern\Main\Basement\Under the Statue\Boss Key Chest:
-    Paths:
-    - stage/D101/r4/l0/TBox/68
-    hint_region: Ancient Cistern
-    original item: Ancient Cistern Boss Key
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 752
-    short_name: Ancient Cistern - Boss Key Chest
-    type: null
-  \Ancient Cistern\Main\East Part\Chest Ledge\Chest in East Part:
-    Paths:
-    - stage/D101/r1/l0/TBox/67
-    hint: sometimes
-    hint_region: Ancient Cistern
-    original item: 'Ancient Cistern Small Key #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 746
-    short_name: Ancient Cistern - Chest in East Part
-    text: the <r<lone east chest in the Ancient Cistern>> contains
-    type: null
-  \Ancient Cistern\Main\East Part\Second Room\First Rupee in East Part in Short Tunnel:
-    Paths:
-    - stage/D101/r2/l0/Item/65
-    hint_region: Ancient Cistern
-    original item: 'Green Rupee #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 742
-    short_name: Ancient Cistern - First Rupee in East Part in Short Tunnel
-    type: Rupees (No Quick Beetle)
-  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Cubby:
-    Paths:
-    - stage/D101/r2/l0/Item/68
-    hint_region: Ancient Cistern
-    original item: 'Red Rupee #41'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 741
-    short_name: Ancient Cistern - Rupee in East Part in Cubby
-    type: Rupees (No Quick Beetle)
-  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Main Tunnel:
-    Paths:
-    - stage/D101/r2/l0/Item/34
-    hint_region: Ancient Cistern
-    original item: 'Red Rupee #40'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 745
-    short_name: Ancient Cistern - Rupee in East Part in Main Tunnel
-    type: Rupees (No Quick Beetle)
-  \Ancient Cistern\Main\East Part\Second Room\Second Rupee in East Part in Short Tunnel:
-    Paths:
-    - stage/D101/r2/l0/Item/66
-    hint_region: Ancient Cistern
-    original item: 'Green Rupee #1'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 743
-    short_name: Ancient Cistern - Second Rupee in East Part in Short Tunnel
-    type: Rupees (No Quick Beetle)
-  \Ancient Cistern\Main\East Part\Second Room\Third Rupee in East Part in Short Tunnel:
-    Paths:
-    - stage/D101/r2/l0/Item/67
-    hint_region: Ancient Cistern
-    original item: 'Green Rupee #2'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 744
-    short_name: Ancient Cistern - Third Rupee in East Part in Short Tunnel
-    type: Rupees (No Quick Beetle)
-  \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest\Chest in Key Locked Room:
-    Paths:
-    - stage/D101/r7/l0/TBox/69
-    hint_region: Ancient Cistern
-    original item: Whip
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 754
-    short_name: Ancient Cistern - Chest in Key Locked Room
-    type: null
-  \Ancient Cistern\Main\Main Room\After Gutters\Rupee under Lilypad:
-    Paths:
-    - stage/D101/r5/l0/Item/13
-    hint_region: Ancient Cistern
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 733
-    short_name: Ancient Cistern - Rupee under Lilypad
-    type: Rupees (No Quick Beetle)
-  \Ancient Cistern\Main\Main Room\After Whip Hooks\Chest after Whip Hooks:
-    Paths:
-    - stage/D101/r0/l0/TBox/65
-    hint_region: Ancient Cistern
-    original item: Ancient Cistern Map
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 723
-    short_name: Ancient Cistern - Chest after Whip Hooks
-    type: null
-  \Ancient Cistern\Main\Main Room\Behind the Waterfall\Chest behind the Waterfall:
-    Paths:
-    - stage/D101/r3/l0/TBox/84
-    hint_region: Ancient Cistern
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 726
-    short_name: Ancient Cistern - Chest behind the Waterfall
-    type: null
-  \Ancient Cistern\Main\Main Room\Rupee in East Hand:
-    Paths:
-    - stage/D101/r0/l0/Item/92
-    hint_region: Ancient Cistern
-    original item: 'Silver Rupee #19'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 721
-    short_name: Ancient Cistern - Rupee in East Hand
-    type: Rupees (No Quick Beetle)
-  \Ancient Cistern\Main\Main Room\Rupee in West Hand:
-    Paths:
-    - stage/D101/r0/l0/Item/93
-    hint_region: Ancient Cistern
-    original item: 'Silver Rupee #20'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 722
-    short_name: Ancient Cistern - Rupee in West Hand
-    type: Rupees (No Quick Beetle)
-  \Ancient Cistern\Main\Main Room\Vines Area\Chest near Vines:
-    Paths:
-    - stage/D101/r0/l0/TBox/66
-    hint_region: Ancient Cistern
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 724
-    short_name: Ancient Cistern - Chest near Vines
-    type: null
-  \Earth Temple\Boss Room\Slope\Heart Container:
-    Paths:
-    - stage/B200/r10/l1/HeartCo
-    - stage/B200/r10/l2/HeartCo
-    hint_region: Earth Temple
-    original item: Heart Container
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 785
-    short_name: Earth Temple - Heart Container
-    type: null
-  \Earth Temple\Main\East Room\Chest after Double Lizalfos Fight:
-    Paths:
-    - stage/D200/r3/l0/TBox/65
-    hint_region: Earth Temple
-    original item: Bomb Bag
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 774
-    short_name: Earth Temple - Chest after Double Lizalfos Fight
-    text: a menacing <r<pair of Lizalfos>> protect
-    type: null
-  \Earth Temple\Main\First Room\Rupee above Drawbridge:
-    Paths:
-    - stage/D200/r1/l0/Item/25
-    hint_region: Earth Temple
-    original item: 'Red Rupee #39'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 759
-    short_name: Earth Temple - Rupee above Drawbridge
-    type: Rupees (No Quick Beetle)
-  \Earth Temple\Main\First Room\Vent Chest:
-    Paths:
-    - stage/D200/r1/l0/TBox/66
-    hint_region: Earth Temple
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 758
-    short_name: Earth Temple - Vent Chest
-    type: null
-  \Earth Temple\Main\Hub Room\Chest Left of Main Room Bridge:
-    Paths:
-    - stage/D200/r1/l0/TBox/70
-    hint_region: Earth Temple
-    original item: Golden Skull
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 764
-    short_name: Earth Temple - Chest Left of Main Room Bridge
-    type: null
-  \Earth Temple\Main\Hub Room\Chest behind Bombable Rock:
-    Paths:
-    - stage/D200/r1/l0/TBox/69
-    hint_region: Earth Temple
-    original item: Golden Skull
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 763
-    short_name: Earth Temple - Chest behind Bombable Rock
-    type: null
-  \Earth Temple\Main\Hub Room\Ledd's Gift:
-    Paths:
-    - event/301-MountainD1/16
-    - oarc/D200/l0
-    hint_region: Earth Temple
-    original item: 5 Bombs
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 765
-    short_name: Earth Temple - Ledd's Gift
-    type: null
-  \Earth Temple\Main\Hub Room\Past Lava Section\Chest Guarded by Lizalfos:
-    Paths:
-    - stage/D200/r1/l0/TBox/67
-    hint_region: Earth Temple
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 772
-    short_name: Earth Temple - Chest Guarded by Lizalfos
-    type: null
-  \Earth Temple\Main\Hub Room\Rupee in Lava Tunnel:
-    Paths:
-    - stage/D200/r2/l0/Item/21
-    hint_region: Earth Temple
-    original item: 'Silver Rupee #18'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 768
-    short_name: Earth Temple - Rupee in Lava Tunnel
-    text: hidden within the <r<neck of a dragon>> rests
-    type: Rupees (No Quick Beetle)
-  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Key Chest:
-    Paths:
-    - stage/D200/r4/l0/TBox/68
-    hint_region: Earth Temple
-    original item: Earth Temple Boss Key
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 778
-    short_name: Earth Temple - Boss Key Chest
-    type: null
-  \Earth Temple\Main\West Room\Chest in West Room:
-    Paths:
-    - stage/D200/r0/l0/TBox/64
-    hint: sometimes
-    hint_region: Earth Temple
-    original item: Earth Temple Map
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 775
-    short_name: Earth Temple - Chest in West Room
-    text: the <r<western wing in the Earth Temple>> holds
-    type: null
-  \Earth Temple\Spring\Strike Crest:
-    Paths:
-    - event/301-MountainD1/22
-    - oarc/B210/l0
-    hint_region: Earth Temple
-    original item: Amber Tablet
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 786
-    short_name: Earth Temple - Strike Crest
-    type: null
-  \Eldin\Bokoblin Base\Before Drawbridge\Chest near Drawbridge:
-    Paths:
-    - stage/F202/r2/l1/TBox/67
-    hint_region: Bokoblin Base
-    original item: Whip
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 867
-    short_name: Bokoblin Base - Chest near Drawbridge
-    type: null
-  \Eldin\Bokoblin Base\Bokoblin Base Summit\Chest in Volcano Summit Alcove:
-    Paths:
-    - stage/F201_2/r0/l0/TBox/71
-    - stage/F201_1/r0/l4/TBox/71
-    hint_region: Bokoblin Base
-    original item: Progressive Pouch
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 876
-    short_name: Bokoblin Base - Chest in Volcano Summit Alcove
-    type: null
-  \Eldin\Bokoblin Base\Bokoblin Base Summit\First Chest in Volcano Summit:
-    Paths:
-    - stage/F201_2/r0/l0/TBox/72
-    - stage/F201_1/r0/l4/TBox/72
-    hint_region: Bokoblin Base
-    original item: Blue Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 874
-    short_name: Bokoblin Base - First Chest in Volcano Summit
-    type: null
-  \Eldin\Bokoblin Base\Bokoblin Base Summit\Raised Chest in Volcano Summit:
-    Paths:
-    - stage/F201_2/r0/l0/TBox/73
-    - stage/F201_1/r0/l4/TBox/73
-    hint_region: Bokoblin Base
-    original item: Progressive Sword
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 875
-    short_name: Bokoblin Base - Raised Chest in Volcano Summit
-    type: null
-  \Eldin\Bokoblin Base\Fire Dragon's Lair\Fire Dragon's Reward:
-    Paths:
-    - event/305-MountainF3/Give item after Eldin SotH CS
-    - oarc/F221/l0
-    hint_region: Bokoblin Base
-    original item: Eldin Song of the Hero Part
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 879
-    short_name: Bokoblin Base - Fire Dragon's Reward
-    text: <r<hearing a song atop the great mountain>> is rewarded with
-    type: null
-  \Eldin\Bokoblin Base\Outside Earth Temple\Chest East of Earth Temple Entrance:
-    Paths:
-    - stage/F202/r4/l1/TBox/68
-    hint_region: Bokoblin Base
-    original item: Slingshot
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 869
-    short_name: Bokoblin Base - Chest East of Earth Temple Entrance
-    type: null
-  \Eldin\Bokoblin Base\Outside Earth Temple\Chest West of Earth Temple Entrance:
-    Paths:
-    - stage/F202/r4/l1/TBox/69
-    hint_region: Bokoblin Base
-    original item: Bombs
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 871
-    short_name: Bokoblin Base - Chest West of Earth Temple Entrance
-    type: null
-  \Eldin\Bokoblin Base\Prison\Plats' Gift:
-    Paths:
-    - event/305-MountainF3/Plats' Gift
-    - oarc/F202/l1
-    hint_region: Bokoblin Base
-    original item: Mogma Mitts
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 863
-    short_name: Bokoblin Base - Plats' Gift
-    text: a gift from an <r<imprisoned mogma>> has
-    type: null
-  \Eldin\Bokoblin Base\Volcano East\Chest near Bone Bridge:
-    Paths:
-    - stage/F202/r2/l1/TBox/70
-    hint_region: Bokoblin Base
-    original item: Gust Bellows
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 864
-    short_name: Bokoblin Base - Chest near Bone Bridge
-    type: null
-  \Eldin\Bokoblin Base\Volcano East\Chest on Cliff:
-    Paths:
-    - stage/F202/r2/l1/TBox/66
-    hint_region: Bokoblin Base
-    original item: Clawshots
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 865
-    short_name: Bokoblin Base - Chest on Cliff
-    type: null
-  \Eldin\Eldin Silent Realm\Relic 1:
-    Paths:
-    - stage/S200/r0/l2/Relic/102
-    hint_region: Eldin Silent Realm
-    original item: 'Dusk Relic #31'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 842
-    short_name: Eldin Silent Realm - Relic 1
-    type: eldin, silent realm
-  \Eldin\Eldin Silent Realm\Relic 10:
-    Paths:
-    - stage/S200/r0/l2/Relic/111
-    hint_region: Eldin Silent Realm
-    original item: 'Dusk Relic #40'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 851
-    short_name: Eldin Silent Realm - Relic 10
-    type: eldin, silent realm
-  \Eldin\Eldin Silent Realm\Relic 2:
-    Paths:
-    - stage/S200/r0/l2/Relic/103
-    hint_region: Eldin Silent Realm
-    original item: 'Dusk Relic #32'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 843
-    short_name: Eldin Silent Realm - Relic 2
-    type: eldin, silent realm
-  \Eldin\Eldin Silent Realm\Relic 3:
-    Paths:
-    - stage/S200/r0/l2/Relic/104
-    hint_region: Eldin Silent Realm
-    original item: 'Dusk Relic #33'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 844
-    short_name: Eldin Silent Realm - Relic 3
-    type: eldin, silent realm
-  \Eldin\Eldin Silent Realm\Relic 4:
-    Paths:
-    - stage/S200/r0/l2/Relic/105
-    hint_region: Eldin Silent Realm
-    original item: 'Dusk Relic #34'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 845
-    short_name: Eldin Silent Realm - Relic 4
-    type: eldin, silent realm
-  \Eldin\Eldin Silent Realm\Relic 5:
-    Paths:
-    - stage/S200/r0/l2/Relic/106
-    hint_region: Eldin Silent Realm
-    original item: 'Dusk Relic #35'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 846
-    short_name: Eldin Silent Realm - Relic 5
-    type: eldin, silent realm
-  \Eldin\Eldin Silent Realm\Relic 6:
-    Paths:
-    - stage/S200/r0/l2/Relic/107
-    hint_region: Eldin Silent Realm
-    original item: 'Dusk Relic #36'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 847
-    short_name: Eldin Silent Realm - Relic 6
-    type: eldin, silent realm
-  \Eldin\Eldin Silent Realm\Relic 7:
-    Paths:
-    - stage/S200/r0/l2/Relic/108
-    hint_region: Eldin Silent Realm
-    original item: 'Dusk Relic #37'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 848
-    short_name: Eldin Silent Realm - Relic 7
-    type: eldin, silent realm
-  \Eldin\Eldin Silent Realm\Relic 8:
-    Paths:
-    - stage/S200/r0/l2/Relic/109
-    hint_region: Eldin Silent Realm
-    original item: 'Dusk Relic #38'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 849
-    short_name: Eldin Silent Realm - Relic 8
-    type: eldin, silent realm
-  \Eldin\Eldin Silent Realm\Relic 9:
-    Paths:
-    - stage/S200/r0/l2/Relic/110
-    hint_region: Eldin Silent Realm
-    original item: 'Dusk Relic #39'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 850
-    short_name: Eldin Silent Realm - Relic 9
-    type: eldin, silent realm
-  \Eldin\Eldin Silent Realm\Trial Reward:
-    Paths:
-    - stage/S200/r2/l2/WarpObj
-    hint: sometimes
-    hint_region: Eldin Silent Realm
-    original item: Fireshield Earrings
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 841
-    short_name: Eldin Silent Realm - Trial Reward
-    text: a <r<trial of power>> grants
-    type: null
-  \Eldin\Mogma Turf\Past Vent\Chest behind Bombable Wall in Fire Maze:
-    Paths:
-    - stage/F210/r0/l0/TBox/70
-    hint_region: Mogma Turf
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 840
-    short_name: Mogma Turf - Chest behind Bombable Wall in Fire Maze
-    type: null
-  \Eldin\Mogma Turf\Pre Vent\Chest behind Bombable Wall at Entrance:
-    Paths:
-    - stage/F210/r0/l0/TBox/65
-    hint_region: Mogma Turf
-    original item: Golden Skull
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 835
-    short_name: Mogma Turf - Chest behind Bombable Wall at Entrance
-    type: null
-  \Eldin\Mogma Turf\Pre Vent\Defeat Bokoblins:
-    Paths:
-    - event/300-Mountain/6
-    - event/300-Mountain/135
-    - oarc/F210/l0
-    hint_region: Mogma Turf
-    original item: Progressive Mitts
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 837
-    short_name: Mogma Turf - Defeat Bokoblins
-    text: helping <r<reclaim the mogmas' territory>> rewards
-    type: Combat
-  \Eldin\Mogma Turf\Pre Vent\Free Fall Chest:
-    Paths:
-    - stage/F210/r0/l0/TBox/64
-    hint_region: Mogma Turf
-    original item: Eldin Ore
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 833
-    short_name: Mogma Turf - Free Fall Chest
-    type: null
-  \Eldin\Mogma Turf\Sand Slide Platform\Sand Slide Chest:
-    Paths:
-    - stage/F210/r0/l0/TBox/68
-    hint_region: Mogma Turf
-    original item: Eldin Ore
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 839
-    short_name: Mogma Turf - Sand Slide Chest
-    text: <r<behind>> a slide mogmas buried
-    type: null
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Item behind Digging:
-    Paths:
-    - stage/F201_3/r0/l0/Item/104
-    hint: sometimes
-    hint_region: Volcano Summit
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 860
-    short_name: Volcano Summit - Item behind Digging
-    text: <r<fairies at the summit>> dance with
-    type: null
-  \Eldin\Volcano Summit\Waterfall\Higher Area\Chest behind Bombable Wall in Waterfall Area:
-    Paths:
-    - stage/F201_4/r0/l0/TBox/95
-    hint_region: Volcano Summit
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 854
-    short_name: Volcano Summit - Chest behind Bombable Wall in Waterfall Area
-    text: atop a <r<volcanic waterfall>> hides
-    type: null
-  \Eldin\Volcano\Ascent\Chest behind Bombable Wall near Volcano Ascent:
-    Paths:
-    - stage/F200/r2/l0/TBox/71
-    hint_region: Eldin Volcano
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 808
-    short_name: Eldin Volcano - Chest behind Bombable Wall near Volcano Ascent
-    type: null
-  \Eldin\Volcano\East\Chest after Crawlspace:
-    Paths:
-    - stage/F200/r2/l0/TBox/66
-    hint_region: Eldin Volcano
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 797
-    short_name: Eldin Volcano - Chest after Crawlspace
-    type: null
-  \Eldin\Volcano\East\Chest behind Bombable Wall near Cliff:
-    Paths:
-    - stage/F200/r2/l0/TBox/73
-    hint_region: Eldin Volcano
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 798
-    short_name: Eldin Volcano - Chest behind Bombable Wall near Cliff
-    type: null
-  \Eldin\Volcano\East\Item on Cliff:
-    Paths:
-    - stage/F200/r2/l0/Item/102
-    hint_region: Eldin Volcano
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 799
-    short_name: Eldin Volcano - Item on Cliff
-    type: null
-  \Eldin\Volcano\East\North Rupee above Mogma Turf Entrance:
-    Paths:
-    - stage/F200/r2/l0/Item/123
-    hint_region: Eldin Volcano
-    original item: 'Red Rupee #31'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 802
-    short_name: Eldin Volcano - North Rupee above Mogma Turf Entrance
-    type: Rupees (No Quick Beetle)
-  \Eldin\Volcano\East\Southeast Rupee above Mogma Turf Entrance:
-    Paths:
-    - stage/F200/r2/l0/Item/125
-    hint_region: Eldin Volcano
-    original item: 'Blue Rupee #10'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 801
-    short_name: Eldin Volcano - Southeast Rupee above Mogma Turf Entrance
-    type: Rupees (No Quick Beetle)
-  \Eldin\Volcano\Entry\Rupee on Ledge before First Room:
-    Paths:
-    - stage/F200/r0/l0/Item/41
-    hint_region: Eldin Volcano
-    original item: 'Red Rupee #30'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 790
-    short_name: Eldin Volcano - Rupee on Ledge before First Room
-    type: Rupees (No Quick Beetle)
-  \Eldin\Volcano\First Room\Chest behind Bombable Wall in First Room:
-    Paths:
-    - stage/F200/r1/l0/TBox/72
-    hint_region: Eldin Volcano
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 791
-    short_name: Eldin Volcano - Chest behind Bombable Wall in First Room
-    type: null
-  \Eldin\Volcano\First Room\Rupee behind Bombable Wall in First Room:
-    Paths:
-    - stage/F200/r1/l0/Item/13
-    hint_region: Eldin Volcano
-    original item: 'Blue Rupee #8'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 792
-    short_name: Eldin Volcano - Rupee behind Bombable Wall in First Room
-    type: Rupees (No Quick Beetle)
-  \Eldin\Volcano\First Room\Rupee in Crawlspace in First Room:
-    Paths:
-    - stage/F200/r1/l0/Item/19
-    hint_region: Eldin Volcano
-    original item: 'Blue Rupee #9'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 793
-    short_name: Eldin Volcano - Rupee in Crawlspace in First Room
-    type: Rupees (No Quick Beetle)
-  \Eldin\Volcano\Near Temple Entrance\Digging Spot behind Boulder on Sandy Slope:
-    Paths:
-    - stage/F200/r4/l1/Soil/12
-    hint: sometimes
-    hint_region: Eldin Volcano
-    original item: Key Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 826
-    short_name: Eldin Volcano - Digging Spot behind Boulder on Sandy Slope
-    text: a <r<boulder on a sandy slope>> hides
-    type: null
-  \Eldin\Volcano\Near Temple Entrance\Digging Spot below Tower:
-    Paths:
-    - stage/F200/r4/l1/Soil/9
-    hint_region: Eldin Volcano
-    original item: Key Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 825
-    short_name: Eldin Volcano - Digging Spot below Tower
-    type: null
-  \Eldin\Volcano\Near Temple Entrance\Digging Spot in front of Earth Temple:
-    Paths:
-    - stage/F200/r4/l1/Soil/8
-    hint_region: Eldin Volcano
-    original item: Key Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 824
-    short_name: Eldin Volcano - Digging Spot in front of Earth Temple
-    type: null
-  \Eldin\Volcano\Near Thrill Digger Cave\Left Rupee behind Bombable Wall on First Slope:
-    Paths:
-    - stage/F200/r4/l0/Item/45
-    hint_region: Eldin Volcano
-    original item: 'Red Rupee #32'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 813
-    short_name: Eldin Volcano - Left Rupee behind Bombable Wall on First Slope
-    type: Rupees (No Quick Beetle)
-  \Eldin\Volcano\Near Thrill Digger Cave\Right Rupee behind Bombable Wall on First Slope:
-    Paths:
-    - stage/F200/r4/l0/Item/11
-    hint_region: Eldin Volcano
-    original item: 'Red Rupee #33'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 814
-    short_name: Eldin Volcano - Right Rupee behind Bombable Wall on First Slope
-    type: Rupees (No Quick Beetle)
-  \Eldin\Volcano\Past Slide\Digging Spot after Draining Lava:
-    Paths:
-    - stage/F200/r2/l1/Soil/64
-    hint_region: Eldin Volcano
-    original item: Key Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 830
-    short_name: Eldin Volcano - Digging Spot after Draining Lava
-    type: null
-  \Eldin\Volcano\Sand Slide\Digging Spot after Vents:
-    Paths:
-    - stage/F200/r6/l1/Soil/10
-    hint_region: Eldin Volcano
-    original item: Key Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 829
-    short_name: Eldin Volcano - Digging Spot after Vents
-    type: null
-  \Faron\Faron Silent Realm\Relic 1:
-    Paths:
-    - stage/S100/r0/l2/Relic/102
-    hint_region: Faron Silent Realm
-    original item: 'Dusk Relic #11'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 930
-    short_name: Faron Silent Realm - Relic 1
-    type: faron, silent realm
-  \Faron\Faron Silent Realm\Relic 10:
-    Paths:
-    - stage/S100/r0/l2/Relic/111
-    hint_region: Faron Silent Realm
-    original item: 'Dusk Relic #20'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 939
-    short_name: Faron Silent Realm - Relic 10
-    type: faron, silent realm
-  \Faron\Faron Silent Realm\Relic 2:
-    Paths:
-    - stage/S100/r0/l2/Relic/103
-    hint_region: Faron Silent Realm
-    original item: 'Dusk Relic #12'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 931
-    short_name: Faron Silent Realm - Relic 2
-    type: faron, silent realm
-  \Faron\Faron Silent Realm\Relic 3:
-    Paths:
-    - stage/S100/r0/l2/Relic/104
-    hint_region: Faron Silent Realm
-    original item: 'Dusk Relic #13'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 932
-    short_name: Faron Silent Realm - Relic 3
-    type: faron, silent realm
-  \Faron\Faron Silent Realm\Relic 4:
-    Paths:
-    - stage/S100/r0/l2/Relic/105
-    hint_region: Faron Silent Realm
-    original item: 'Dusk Relic #14'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 933
-    short_name: Faron Silent Realm - Relic 4
-    type: faron, silent realm
-  \Faron\Faron Silent Realm\Relic 5:
-    Paths:
-    - stage/S100/r0/l2/Relic/106
-    hint_region: Faron Silent Realm
-    original item: 'Dusk Relic #15'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 934
-    short_name: Faron Silent Realm - Relic 5
-    type: faron, silent realm
-  \Faron\Faron Silent Realm\Relic 6:
-    Paths:
-    - stage/S100/r0/l2/Relic/107
-    hint_region: Faron Silent Realm
-    original item: 'Dusk Relic #16'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 935
-    short_name: Faron Silent Realm - Relic 6
-    type: faron, silent realm
-  \Faron\Faron Silent Realm\Relic 7:
-    Paths:
-    - stage/S100/r0/l2/Relic/108
-    hint_region: Faron Silent Realm
-    original item: 'Dusk Relic #17'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 936
-    short_name: Faron Silent Realm - Relic 7
-    type: faron, silent realm
-  \Faron\Faron Silent Realm\Relic 8:
-    Paths:
-    - stage/S100/r0/l2/Relic/109
-    hint_region: Faron Silent Realm
-    original item: 'Dusk Relic #18'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 937
-    short_name: Faron Silent Realm - Relic 8
-    type: faron, silent realm
-  \Faron\Faron Silent Realm\Relic 9:
-    Paths:
-    - stage/S100/r0/l2/Relic/110
-    hint_region: Faron Silent Realm
-    original item: 'Dusk Relic #19'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 938
-    short_name: Faron Silent Realm - Relic 9
-    type: faron, silent realm
-  \Faron\Faron Silent Realm\Trial Reward:
-    Paths:
-    - stage/S100/r0/l2/WarpObj
-    hint: sometimes
-    hint_region: Faron Silent Realm
-    original item: Water Dragon's Scale
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 929
-    short_name: Faron Silent Realm - Trial Reward
-    text: a <r<trial of courage>> grants
-    type: null
-  \Faron\Faron Woods\Chest behind Upper Bombable Rock:
-    Paths:
-    - stage/F100/r0/l0/TBox/64
-    hint_region: Faron Woods
-    original item: Semi Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 906
-    short_name: Faron Woods - Chest behind Upper Bombable Rock
-    type: null
-  \Faron\Faron Woods\Deep Woods\Deep Woods Chest:
-    Paths:
-    - stage/F101/r0/l0/TBox/74
-    hint_region: Faron Woods
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 920
-    short_name: Faron Woods - Deep Woods Chest
-    type: null
-  \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest\Chest inside Great Tree:
-    Paths:
-    - stage/F100_1/r0/l0/TBox/84
-    hint: sometimes
-    hint_region: Faron Woods
-    original item: Gold Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 914
-    short_name: Faron Woods - Chest inside Great Tree
-    text: climbing inside an <r<old hermit's home>> rewards
-    type: null
-  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree North Branch:
-    Paths:
-    - stage/F100/r0/l0/Item/43
-    hint_region: Faron Woods
-    original item: 'Blue Rupee #4'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 917
-    short_name: Faron Woods - Rupee on Great Tree North Branch
-    type: Rupees (No Quick Beetle)
-  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree West Branch:
-    Paths:
-    - stage/F100/r0/l0/Item/44
-    hint_region: Faron Woods
-    original item: 'Blue Rupee #5'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 918
-    short_name: Faron Woods - Rupee on Great Tree West Branch
-    type: Rupees (No Quick Beetle)
-  \Faron\Faron Woods\Item behind Lower Bombable Rock:
-    Paths:
-    - stage/F100/r0/l0/Item/33
-    hint_region: Faron Woods
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 905
-    short_name: Faron Woods - Item behind Lower Bombable Rock
-    type: null
-  \Faron\Faron Woods\Item on Tree:
-    Paths:
-    - stage/F100/r0/l0/Item/68
-    hint_region: Faron Woods
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 904
-    short_name: Faron Woods - Item on Tree
-    type: null
-  \Faron\Faron Woods\Kikwi Elder's Reward:
-    Paths:
-    - event/200-Forest/595
-    - oarc/F100/l0
-    hint: sometimes
-    hint_region: Faron Woods
-    original item: Progressive Slingshot
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 903
-    short_name: Faron Woods - Kikwi Elder's Reward
-    text: the <r<Kikwi relic>> is
-    type: Combat
-  \Faron\Faron Woods\Rupee on Hollow Tree Branch:
-    Paths:
-    - stage/F100/r0/l0/Item/41
-    hint_region: Faron Woods
-    original item: 'Red Rupee #27'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 900
-    short_name: Faron Woods - Rupee on Hollow Tree Branch
-    type: Rupees (No Quick Beetle)
-  \Faron\Faron Woods\Rupee on Hollow Tree Root:
-    Paths:
-    - stage/F100/r0/l0/Item/42
-    hint_region: Faron Woods
-    original item: 'Blue Rupee #6'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 899
-    short_name: Faron Woods - Rupee on Hollow Tree Root
-    type: Rupees (No Quick Beetle)
-  \Faron\Faron Woods\Rupee on Platform near Floria Door:
-    Paths:
-    - stage/F100/r0/l0/Item/40
-    hint_region: Faron Woods
-    original item: 'Red Rupee #26'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 901
-    short_name: Faron Woods - Rupee on Platform near Floria Door
-    type: Rupees (No Quick Beetle)
-  \Faron\Flooded Faron Woods\16 Dark Blue Tadtones in the South West:
-    Paths:
-    - stage/F103/r0/l2/Clef/17
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #12'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 952
-    short_name: Flooded Faron Woods - 16 Dark Blue Tadtones in the South West
-    type: Tadtones
-  \Faron\Flooded Faron Woods\2 Dark Blue Tadtones in Grass West of Great Tree:
-    Paths:
-    - stage/F103/r0/l2/Clef/3
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #9'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 949
-    short_name: Flooded Faron Woods - 2 Dark Blue Tadtones in Grass West of Great
-      Tree
-    type: Tadtones
-  \Faron\Flooded Faron Woods\2 Red Tadtones in Grass near Lower Bombable Rock:
-    Paths:
-    - stage/F103/r0/l2/Clef/15
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #11'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 951
-    short_name: Flooded Faron Woods - 2 Red Tadtones in Grass near Lower Bombable
-      Rock
-    type: Tadtones
-  \Faron\Flooded Faron Woods\4 Light Blue Moving Tadtones under Kikwi Elder:
-    Paths:
-    - stage/F103/r0/l2/Clef/8
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #6'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 946
-    short_name: Flooded Faron Woods - 4 Light Blue Moving Tadtones under Kikwi Elder
-    type: Tadtones
-  \Faron\Flooded Faron Woods\4 Purple Moving Tadtones near Floria Gate:
-    Paths:
-    - stage/F103/r0/l2/Clef/16
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #13'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 953
-    short_name: Flooded Faron Woods - 4 Purple Moving Tadtones near Floria Gate
-    type: Tadtones
-  \Faron\Flooded Faron Woods\4 Purple Tadtones under Viewing Platform:
-    Paths:
-    - stage/F103/r0/l2/Clef/2
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #2'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 942
-    short_name: Flooded Faron Woods - 4 Purple Tadtones under Viewing Platform
-    type: Tadtones
-  \Faron\Flooded Faron Woods\4 Red Moving Tadtones North West of Great Tree:
-    Paths:
-    - stage/F103/r0/l2/Clef/11
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #7'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 947
-    short_name: Flooded Faron Woods - 4 Red Moving Tadtones North West of Great Tree
-    type: Tadtones
-  \Faron\Flooded Faron Woods\4 Yellow Tadtones under Small Hollow Tree:
-    Paths:
-    - stage/F103/r0/l2/Clef/14
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #15'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 955
-    short_name: Flooded Faron Woods - 4 Yellow Tadtones under Small Hollow Tree
-    type: Tadtones
-  \Faron\Flooded Faron Woods\8 Green Tadtones in West Tunnel:
-    Paths:
-    - stage/F103/r0/l2/Clef/9
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #10'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 950
-    short_name: Flooded Faron Woods - 8 Green Tadtones in West Tunnel
-    type: Tadtones
-  \Faron\Flooded Faron Woods\8 Light Blue Tadtones near Viewing Platform:
-    Paths:
-    - stage/F103/r0/l2/Clef/4
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #1'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 941
-    short_name: Flooded Faron Woods - 8 Light Blue Tadtones near Viewing Platform
-    type: Tadtones
-  \Faron\Flooded Faron Woods\8 Purple Tadtones in Clearing after Small Hollow Tree:
-    Paths:
-    - stage/F103/r0/l2/Clef/12
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #16'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 956
-    short_name: Flooded Faron Woods - 8 Purple Tadtones in Clearing after Small Hollow
-      Tree
-    type: Tadtones
-  \Faron\Flooded Faron Woods\8 Yellow Tadtones near Kikwi Elder:
-    Paths:
-    - stage/F103/r0/l2/Clef/6
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #5'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 945
-    short_name: Flooded Faron Woods - 8 Yellow Tadtones near Kikwi Elder
-    type: Tadtones
-  \Faron\Flooded Faron Woods\Dark Blue Moving Tadtone inside Small Hollow Tree:
-    Paths:
-    - stage/F103/r0/l2/Clef/7
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #14'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 954
-    short_name: Flooded Faron Woods - Dark Blue Moving Tadtone inside Small Hollow
-      Tree
-    type: Tadtones
-  \Faron\Flooded Faron Woods\Flooded Great Tree\Water Dragon's Reward:
-    Paths:
-    - event/204-ForestF3/Give item after Faron SotH CS
-    - oarc/F103_1/l0
-    hint: sometimes
-    hint_region: Flooded Faron Woods
-    original item: Faron Song of the Hero Part
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 958
-    short_name: Flooded Faron Woods - Water Dragon's Reward
-    text: completing a <r<watery song>> reveals
-    type: Tadtones
-  \Faron\Flooded Faron Woods\Green Tadtone behind Upper Bombable Rock:
-    Paths:
-    - stage/F103/r0/l2/Clef/5
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #8'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 948
-    short_name: Flooded Faron Woods - Green Tadtone behind Upper Bombable Rock
-    type: Tadtones
-  \Faron\Flooded Faron Woods\Light Blue Tadtone under Great Tree Root:
-    Paths:
-    - stage/F103/r0/l2/Clef/13
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #4'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 944
-    short_name: Flooded Faron Woods - Light Blue Tadtone under Great Tree Root
-    type: Tadtones
-  \Faron\Flooded Faron Woods\Red Moving Tadtone near Viewing Platform:
-    Paths:
-    - stage/F103/r0/l2/Clef/1
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #3'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 943
-    short_name: Flooded Faron Woods - Red Moving Tadtone near Viewing Platform
-    type: Tadtones
-  \Faron\Flooded Faron Woods\Yellow Tadtone under Lilypad:
-    Paths:
-    - stage/F103/r0/l2/Clef/10
-    hint_region: Flooded Faron Woods
-    original item: 'Group of Tadtones #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 940
-    short_name: Flooded Faron Woods - Yellow Tadtone under Lilypad
-    type: Tadtones
-  \Faron\Lake Floria\Above Rock\Left Rupee behind Northwest Boulder:
-    Paths:
-    - stage/F102/r2/l0/Item/62
-    hint_region: Lake Floria
-    original item: 'Red Rupee #29'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 960
-    short_name: Lake Floria - Left Rupee behind Northwest Boulder
-    type: Rupees (No Quick Beetle)
-  \Faron\Lake Floria\Above Rock\Right Rupee behind Northwest Boulder:
-    Paths:
-    - stage/F102/r2/l0/Item/61
-    hint_region: Lake Floria
-    original item: 'Red Rupee #28'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 961
-    short_name: Lake Floria - Right Rupee behind Northwest Boulder
-    type: Rupees (No Quick Beetle)
-  \Faron\Lake Floria\Above Rock\Rupee behind Southwest Boulder:
-    Paths:
-    - stage/F102/r2/l0/Item/63
-    hint_region: Lake Floria
-    original item: 'Blue Rupee #7'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 959
-    short_name: Lake Floria - Rupee behind Southwest Boulder
-    type: Rupees (No Quick Beetle)
-  \Faron\Lake Floria\Above Rock\Rupee under Central Boulder:
-    Paths:
-    - stage/F102/r2/l0/Item/60
-    hint_region: Lake Floria
-    original item: 'Silver Rupee #12'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 962
-    short_name: Lake Floria - Rupee under Central Boulder
-    type: Rupees (No Quick Beetle)
-  \Faron\Lake Floria\Below Rock\Emerged Area\Lake Floria Chest:
-    Paths:
-    - stage/F102/r3/l0/TBox/64
-    hint: sometimes
-    hint_region: Lake Floria
-    original item: Goddess Plume
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 964
-    short_name: Lake Floria - Lake Floria Chest
-    text: a <r<lonely chest in the lake>> contains
-    type: null
-  \Faron\Lake Floria\Farore's Lair\Dragon Lair East Chest:
-    Paths:
-    - stage/F102_2/r0/l0/TBox/85
-    hint_region: Lake Floria
-    original item: Semi Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 968
-    short_name: Lake Floria - Dragon Lair East Chest
-    type: null
-  \Faron\Lake Floria\Farore's Lair\Dragon Lair South Chest:
-    Paths:
-    - stage/F102_2/r0/l0/TBox/84
-    hint_region: Lake Floria
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 967
-    short_name: Lake Floria - Dragon Lair South Chest
-    type: null
-  \Faron\Lake Floria\Waterfall\Rupee on High Ledge outside Ancient Cistern Entrance:
-    Paths:
-    - stage/F102_1/r0/l0/Item/64
-    hint_region: Lake Floria
-    original item: 'Gold Rupee #10'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 973
-    short_name: Lake Floria - Rupee on High Ledge outside Ancient Cistern Entrance
-    type: Rupees (No Quick Beetle)
-  \Faron\Sealed Grounds\Behind the Temple\Gorko's Goddess Wall Reward:
-    Paths:
-    - event/503-Goron/630
-    - oarc/F400/l0
-    hint: sometimes
-    hint_region: Sealed Grounds
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 891
-    short_name: Sealed Grounds - Gorko's Goddess Wall Reward
-    text: <r<drawing upon a magical wall>> reveals
-    type: null
-  \Faron\Sealed Grounds\Hylia's Temple\Zelda's Blessing:
-    Paths:
-    - event/502-CenterFieldBack/17
-    - oarc/F404/l1
-    hint: sometimes
-    hint_region: Sealed Grounds
-    original item: Progressive Sword
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 887
-    short_name: Sealed Grounds - Zelda's Blessing
-    text: the <r<goddess blesses you>> with
-    type: null
-  \Faron\Sealed Grounds\Sealed Temple\Chest inside Sealed Temple:
-    Paths:
-    - stage/F402/r2/l0/TBox/64
-    hint_region: Sealed Grounds
-    original item: Revitalizing Potion
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 882
-    short_name: Sealed Grounds - Chest inside Sealed Temple
-    type: null
-  \Faron\Sealed Grounds\Sealed Temple\Song from Impa:
-    Paths:
-    - event/501-Inpa/267
-    - oarc/F402/l2
-    hint_region: Sealed Grounds
-    original item: Ballad of the Goddess
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 883
-    short_name: Sealed Grounds - Song from Impa
-    type: null
-  \Fire Sanctuary\Boss Room\Heart Container:
-    Paths:
-    - stage/B201/r0/l1/HeartCo
-    - stage/B201/r0/l2/HeartCo
-    hint_region: Fire Sanctuary
-    original item: Heart Container
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1015
-    short_name: Fire Sanctuary - Heart Container
-    type: null
-  \Fire Sanctuary\Flame Room\Din's Flame:
-    Paths:
-    - event/304-MountainD2/5
-    - oarc/B201_1/l0
-    hint_region: Fire Sanctuary
-    original item: Progressive Sword
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1016
-    short_name: Fire Sanctuary - Din's Flame
-    type: null
-  \Fire Sanctuary\Main\Boss Key Room\Boss Key Chest:
-    Paths:
-    - stage/D201/r4/l0/TBox/67
-    hint_region: Fire Sanctuary
-    original item: Fire Sanctuary Boss Key
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1013
-    short_name: Fire Sanctuary - Boss Key Chest
-    type: null
-  \Fire Sanctuary\Main\First Room\Past Water Plant\Chest in First Room:
-    Paths:
-    - stage/D201/r0/l0/TBox/64
-    hint_region: Fire Sanctuary
-    original item: 'Fire Sanctuary Small Key #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 976
-    short_name: Fire Sanctuary - Chest in First Room
-    type: null
-  \Fire Sanctuary\Main\First Trapped Mogma Room\Chest near First Trapped Mogma:
-    Paths:
-    - stage/D201_1/r5/l0/TBox/69
-    hint_region: Fire Sanctuary
-    original item: 'Fire Sanctuary Small Key #1'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 985
-    short_name: Fire Sanctuary - Chest near First Trapped Mogma
-    type: null
-  \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area\Rescue First Trapped Mogma:
-    Paths:
-    - stage/D201_1/r5/l0/TBox/68
-    hint_region: Fire Sanctuary
-    original item: Progressive Mitts
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 986
-    short_name: Fire Sanctuary - Rescue First Trapped Mogma
-    text: saving a <r<mogma>> from a <r<fiery fate>> rewards
-    type: null
-  \Fire Sanctuary\Main\Second Room\Balcony\Chest on Balcony:
-    Paths:
-    - stage/D201_1/r6/l0/TBox/70
-    - stage/D201/r6/l0/TBox/70
-    hint_region: Fire Sanctuary
-    original item: Bottle
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 980
-    short_name: Fire Sanctuary - Chest on Balcony
-    type: null
-  \Fire Sanctuary\Main\Second Room\Chest in Second Room:
-    Paths:
-    - stage/D201_1/r1/l0/TBox/74
-    - stage/D201/r1/l0/TBox/74
-    hint_region: Fire Sanctuary
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 977
-    short_name: Fire Sanctuary - Chest in Second Room
-    type: null
-  \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall\Chest after Bombable Wall:
-    Paths:
-    - stage/D201_1/r11/l0/TBox/71
-    hint: always
-    hint_region: Fire Sanctuary
-    original item: 'Fire Sanctuary Small Key #2'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1001
-    short_name: Fire Sanctuary - Chest after Bombable Wall
-    text: a <r<false wall in the Fire Sanctuary>> guards
-    type: null
-  \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Second Trapped Mogma:
-    Paths:
-    - stage/D201_1/r2/l0/TBox/65
-    - stage/D201/r2/l0/TBox/65
-    hint_region: Fire Sanctuary
-    original item: Fire Sanctuary Map
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 999
-    short_name: Fire Sanctuary - Rescue Second Trapped Mogma
-    type: null
-  \Fire Sanctuary\Main\Staircase Room\Chest in Staircase Room:
-    Paths:
-    - stage/D201/r9/l0/TBox/75
-    hint_region: Fire Sanctuary
-    original item: Semi Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1010
-    short_name: Fire Sanctuary - Chest in Staircase Room
-    text: exploring a <r<broken staircase>> reveals
-    type: null
-  \Fire Sanctuary\Main\Water Fruit Room\First Chest in Water Fruit Room:
-    Paths:
-    - stage/D201_1/r7/l0/TBox/73
-    hint_region: Fire Sanctuary
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 988
-    short_name: Fire Sanctuary - First Chest in Water Fruit Room
-    type: null
-  \Fire Sanctuary\Main\Water Fruit Room\Second Chest in Water Fruit Room:
-    Paths:
-    - stage/D201_1/r7/l0/TBox/72
-    hint_region: Fire Sanctuary
-    original item: Semi Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 989
-    short_name: Fire Sanctuary - Second Chest in Water Fruit Room
-    type: null
-  \Fire Sanctuary\Main\West of Boss Door\Plats' Chest:
-    Paths:
-    - stage/D201/r3/l0/TBox/66
-    hint_region: Fire Sanctuary
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1004
-    short_name: Fire Sanctuary - Plats' Chest
-    type: null
-  \Lanayru Mining Facility\Boss Room\After Sand Drain\Heart Container:
-    Paths:
-    - stage/B300/r0/l1/HeartCo
-    - stage/B300/r0/l3/HeartCo
-    hint_region: Lanayru Mining Facility
-    original item: Heart Container
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1054
-    short_name: Lanayru Mining Facility - Heart Container
-    type: null
-  \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit Hall of Ancient Robots:
-    Paths:
-    - event/400-Desert/286
-    - oarc/F300_5/l0
-    hint_region: Lanayru Mining Facility
-    original item: Goddess's Harp
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1056
-    short_name: Lanayru Mining Facility - Exit Hall of Ancient Robots
-    type: null
-  \Lanayru Mining Facility\Main\Armos Fight Room\Chest after Armos Fight:
-    Paths:
-    - stage/D300/r6/l0/TBox/69
-    hint_region: Lanayru Mining Facility
-    original item: Lanayru Mining Facility Map
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1033
-    short_name: Lanayru Mining Facility - Chest after Armos Fight
-    type: null
-  \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes\First Chest in Hub Room:
-    Paths:
-    - stage/D300_1/r5/l0/TBox/70
-    hint_region: Lanayru Mining Facility
-    original item: Lanayru Mining Facility Small Key
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1035
-    short_name: Lanayru Mining Facility - First Chest in Hub Room
-    type: null
-  \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Shortcut Chest in Main Hub:
-    Paths:
-    - stage/D300_1/r5/l0/TBox/74
-    hint_region: Lanayru Mining Facility
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1044
-    short_name: Lanayru Mining Facility - Shortcut Chest in Main Hub
-    type: null
-  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Chest behind First Crawlspace:
-    Paths:
-    - stage/D300_1/r9/l0/TBox/72
-    - stage/D300/r9/l0/TBox/72
-    hint_region: Lanayru Mining Facility
-    original item: Golden Skull
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1040
-    short_name: Lanayru Mining Facility - Chest behind First Crawlspace
-    type: null
-  \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Chest in Spike Maze:
-    Paths:
-    - stage/D300_1/r7/l0/TBox/73
-    - stage/D300/r7/l0/TBox/73
-    hint_region: Lanayru Mining Facility
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1042
-    short_name: Lanayru Mining Facility - Chest in Spike Maze
-    type: null
-  \Lanayru Mining Facility\Main\Boss Key Room\Boss Key Chest:
-    Paths:
-    - stage/D300_1/r8/l0/TBox/71
-    hint: always
-    hint_region: Lanayru Mining Facility
-    original item: Lanayru Mining Facility Boss Key
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1052
-    short_name: Lanayru Mining Facility - Boss Key Chest
-    text: deep inside <r<Lanayru Mining Facility, a pair of Armos>> guard
-    type: null
-  \Lanayru Mining Facility\Main\First Room\Chest behind Bars:
-    Paths:
-    - stage/D300/r0/l0/TBox/64
-    hint_region: Lanayru Mining Facility
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1020
-    short_name: Lanayru Mining Facility - Chest behind Bars
-    type: null
-  \Lanayru Mining Facility\Main\First West Room\Chest in First West Room:
-    Paths:
-    - stage/D300/r3/l0/TBox/66
-    hint_region: Lanayru Mining Facility
-    original item: Golden Skull
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1030
-    short_name: Lanayru Mining Facility - Chest in First West Room
-    type: null
-  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Lower Chest in Hop across Boxes Room:
-    Paths:
-    - stage/D300/r4/l0/TBox/76
-    hint_region: Lanayru Mining Facility
-    original item: Golden Skull
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1027
-    short_name: Lanayru Mining Facility - Lower Chest in Hop across Boxes Room
-    type: null
-  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Raised Chest in Hop across Boxes Room:
-    Paths:
-    - stage/D300/r4/l0/TBox/68
-    hint_region: Lanayru Mining Facility
-    original item: Gust Bellows
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1026
-    short_name: Lanayru Mining Facility - Raised Chest in Hop across Boxes Room
-    type: null
-  \Lanayru Mining Facility\Main\Key Locked Room\Chest in Key Locked Room:
-    Paths:
-    - stage/D300/r2/l0/TBox/65
-    hint_region: Lanayru Mining Facility
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1024
-    short_name: Lanayru Mining Facility - Chest in Key Locked Room
-    type: null
-  \Lanayru\Caves\Chest:
-    Paths:
-    - stage/F303/r0/l0/TBox/127
-    hint_region: Lanayru Caves
-    original item: Golden Skull
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1137
-    short_name: Lanayru Caves - Chest
-    type: null
-  \Lanayru\Caves\Golo's Gift:
-    Paths:
-    - event/404-DesertF3/127
-    - oarc/F303/l0
-    hint_region: Lanayru Caves
-    original item: Lanayru Caves Small Key
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1138
-    short_name: Lanayru Caves - Golo's Gift
-    type: null
-  \Lanayru\Desert\East\Chest on Platform near Fire Node:
-    Paths:
-    - stage/F300/r0/l0/TBox/73
-    hint_region: Lanayru Desert
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1107
-    short_name: Lanayru Desert - Chest on Platform near Fire Node
-    type: null
-  \Lanayru\Desert\East\Fire Node\Past after Grate\Left Ending Chest:
-    Paths:
-    - stage/F300_3/r0/l0/TBox/81
-    hint_region: Lanayru Desert
-    original item: Golden Skull
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1115
-    short_name: Lanayru Desert - Fire Node - Left Ending Chest
-    type: null
-  \Lanayru\Desert\East\Fire Node\Past after Grate\Right Ending Chest:
-    Paths:
-    - stage/F300_3/r0/l0/TBox/82
-    hint_region: Lanayru Desert
-    original item: Blue Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1116
-    short_name: Lanayru Desert - Fire Node - Right Ending Chest
-    type: null
-  \Lanayru\Desert\East\Fire Node\Past\First Small Chest:
-    Paths:
-    - stage/F300_3/r0/l0/TBox/78
-    hint_region: Lanayru Desert
-    original item: Blue Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1112
-    short_name: Lanayru Desert - Fire Node - First Small Chest
-    type: null
-  \Lanayru\Desert\East\Fire Node\Past\Second Small Chest:
-    Paths:
-    - stage/F300_3/r0/l0/TBox/80
-    hint_region: Lanayru Desert
-    original item: Blue Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1113
-    short_name: Lanayru Desert - Fire Node - Second Small Chest
-    type: null
-  \Lanayru\Desert\East\Fire Node\Present after Sand\Shortcut Chest:
-    Paths:
-    - stage/F300_3/r0/l0/TBox/79
-    hint: sometimes
-    hint_region: Lanayru Desert
-    original item: Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1110
-    short_name: Lanayru Desert - Fire Node - Shortcut Chest
-    text: a <r<raised chest in the Fire Node>> holds
-    type: null
-  \Lanayru\Desert\Entry\High Ledge after Vines\Chest near Party Wheel:
-    Paths:
-    - stage/F300/r0/l0/TBox/70
-    hint_region: Lanayru Desert
-    original item: Golden Skull
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1074
-    short_name: Lanayru Desert - Chest near Party Wheel
-    type: null
-  \Lanayru\Desert\Near Caged Robot\Chest near Caged Robot:
-    Paths:
-    - stage/F300/r0/l0/TBox/84
-    hint_region: Lanayru Desert
-    original item: Tumbleweed
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1075
-    short_name: Lanayru Desert - Chest near Caged Robot
-    type: null
-  \Lanayru\Desert\Near Caged Robot\Rescue Caged Robot:
-    Paths:
-    - event/400-Desert/8
-    - oarc/F300/l0
-    hint_region: Lanayru Desert
-    original item: Progressive Beetle
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1078
-    short_name: Lanayru Desert - Rescue Caged Robot
-    type: Combat
-  \Lanayru\Desert\North Part\Chest on Platform near Lightning Node:
-    Paths:
-    - stage/F300/r0/l0/TBox/72
-    hint_region: Lanayru Desert
-    original item: 'Dusk Relic #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1095
-    short_name: Lanayru Desert - Chest on Platform near Lightning Node
-    type: lanayru, miscellaneous
-  \Lanayru\Desert\North Part\Lightning Node\Past\First Chest:
-    Paths:
-    - stage/F300_2/r0/l0/TBox/75
-    hint_region: Lanayru Desert
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1101
-    short_name: Lanayru Desert - Lightning Node - First Chest
-    type: null
-  \Lanayru\Desert\North Part\Lightning Node\Past\Second Chest:
-    Paths:
-    - stage/F300_2/r0/l0/TBox/76
-    hint_region: Lanayru Desert
-    original item: Blue Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1102
-    short_name: Lanayru Desert - Lightning Node - Second Chest
-    type: null
-  \Lanayru\Desert\North Part\Lightning Node\Present from afar\Raised Chest near Generator:
-    Paths:
-    - stage/F300_2/r0/l0/TBox/77
-    hint_region: Lanayru Desert
-    original item: Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1104
-    short_name: Lanayru Desert - Lightning Node - Raised Chest near Generator
-    text: a <r<raised chest in the Lightning Node>> contains
-    type: null
-  \Lanayru\Desert\North Part\Secret Passageway\Secret Passageway Chest:
-    Paths:
-    - stage/F300/r0/l0/TBox/74
-    hint: sometimes
-    hint_region: Lanayru Desert
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1097
-    short_name: Lanayru Desert - Secret Passageway Chest
-    text: a <r<secret passage in the desert>> holds
-    type: null
-  \Lanayru\Desert\Top of LMF\Chest on top of Lanayru Mining Facility:
-    Paths:
-    - stage/F300/r0/l1/TBox/83
-    hint: sometimes
-    hint_region: Lanayru Desert
-    original item: Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1087
-    short_name: Lanayru Desert - Chest on top of Lanayru Mining Facility
-    text: the <r<midst of the desert>> holds
-    type: null
-  \Lanayru\Desert\Top of West Wall\Chest near Sand Oasis:
-    Paths:
-    - stage/F300/r0/l0/TBox/71
-    hint_region: Lanayru Desert
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1085
-    short_name: Lanayru Desert - Chest near Sand Oasis
-    type: null
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Left Rupee on Entrance Crown:
-    Paths:
-    - stage/F301/r0/l0/Item/91
-    hint_region: Lanayru Sand Sea
-    original item: 'Silver Rupee #13'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1145
-    short_name: Lanayru Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown
-    type: Rupees (Quick Beetle)
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Right Rupee on Entrance Crown:
-    Paths:
-    - stage/F301/r0/l0/Item/93
-    hint_region: Lanayru Sand Sea
-    original item: 'Silver Rupee #14'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1146
-    short_name: Lanayru Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown
-    type: Rupees (Quick Beetle)
-  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Rupee on First Pillar:
-    Paths:
-    - stage/F301/r0/l0/Item/92
-    hint_region: Lanayru Sand Sea
-    original item: 'Red Rupee #34'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1147
-    short_name: Lanayru Sand Sea - Ancient Harbour - Rupee on First Pillar
-    type: Rupees (No Quick Beetle)
-  \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Digging Spot:
-    Paths:
-    - stage/F302/r0/l0/Soil/30
-    hint_region: Lanayru Gorge
-    original item: Life Tree Seedling
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1178
-    short_name: Lanayru Gorge - Digging Spot
-    type: null
-  \Lanayru\Lanayru Sand Sea\Gorge\Item on Pillar:
-    Paths:
-    - stage/F302/r0/l0/Item/9
-    hint_region: Lanayru Gorge
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1171
-    short_name: Lanayru Gorge - Item on Pillar
-    type: null
-  \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward:
-    Paths:
-    - event/404-DesertF3/give item after Healing Thunderdragon
-    - oarc/F302/l0
-    hint: sometimes
-    hint_region: Lanayru Gorge
-    original item: Lanayru Song of the Hero Part
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1173
-    short_name: Lanayru Gorge - Thunder Dragon's Reward
-    text: <r<curing an ancient dragon>> is rewarded with
-    type: null
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Chest:
-    Paths:
-    - stage/F301_2/r4/l0/TBox/75
-    hint_region: Lanayru Sand Sea
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1166
-    short_name: Lanayru Sand Sea - Pirate Stronghold - First Chest
-    type: null
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Chest:
-    Paths:
-    - stage/F301_2/r5/l0/TBox/73
-    hint_region: Lanayru Sand Sea
-    original item: Semi Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1167
-    short_name: Lanayru Sand Sea - Pirate Stronghold - Second Chest
-    type: null
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Third Chest:
-    Paths:
-    - stage/F301_2/r6/l0/TBox/74
-    hint_region: Lanayru Sand Sea
-    original item: Semi Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1168
-    short_name: Lanayru Sand Sea - Pirate Stronghold - Third Chest
-    type: null
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose:
-    Paths:
-    - stage/F301_6/r0/l1/Item/13
-    - stage/F301_6/r0/l2/Item/13
-    hint_region: Lanayru Sand Sea
-    original item: 'Silver Rupee #17'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1164
-    short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar
-      or Nose
-    type: Rupees (No Quick Beetle)
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar:
-    Paths:
-    - stage/F301_6/r0/l0/Item/12
-    hint_region: Lanayru Sand Sea
-    original item: 'Silver Rupee #16'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1163
-    short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on East Sea Pillar
-    type: Rupees (Quick Beetle)
-  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar:
-    Paths:
-    - stage/F301_6/r0/l0/Item/11
-    hint_region: Lanayru Sand Sea
-    original item: 'Silver Rupee #15'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1162
-    short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on West Sea Pillar
-    type: Rupees (Quick Beetle)
-  \Lanayru\Lanayru Sand Sea\Shipyard\Rickety Coaster -- Heart Stopping Track in 1'05:
-    Paths:
-    - event/406-TrolleyRace/77
-    - oarc/F301_4/l0
-    hint: sometimes
-    hint_region: Lanayru Sand Sea
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1159
-    short_name: Lanayru Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05
-    text: a <r<fast minecart time>> is rewarded with
-    type: Minigames, Combat
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Chest after Moblin:
-    Paths:
-    - stage/F301_3/r0/l0/TBox/78
-    hint_region: Lanayru Sand Sea
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1150
-    short_name: Lanayru Sand Sea - Skipper's Retreat - Chest after Moblin
-    type: null
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Chest in Shack:
-    Paths:
-    - stage/F301_5/r0/l0/TBox/65
-    hint: sometimes
-    hint_region: Lanayru Sand Sea
-    original item: Sea Chart
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1155
-    short_name: Lanayru Sand Sea - Skipper's Retreat - Chest in Shack
-    text: a <r<chest atop a sandy retreat>> holds
-    type: null
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform\Skydive Chest:
-    Paths:
-    - stage/F301_3/r0/l0/TBox/77
-    hint_region: Lanayru Sand Sea
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1156
-    short_name: Lanayru Sand Sea - Skipper's Retreat - Skydive Chest
-    type: null
-  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Chest on top of Cacti Pillar:
-    Paths:
-    - stage/F301_3/r0/l0/TBox/76
-    hint_region: Lanayru Sand Sea
-    original item: Semi Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1154
-    short_name: Lanayru Sand Sea - Skipper's Retreat - Chest on top of Cacti Pillar
-    text: a <r<chest amongst cacti>> holds
-    type: null
-  \Lanayru\Lanayru Silent Realm\Relic 1:
-    Paths:
-    - stage/S300/r0/l2/Relic/102
-    hint_region: Lanayru Silent Realm
-    original item: 'Dusk Relic #21'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1127
-    short_name: Lanayru Silent Realm - Relic 1
-    type: lanayru, silent realm
-  \Lanayru\Lanayru Silent Realm\Relic 10:
-    Paths:
-    - stage/S300/r0/l2/Relic/111
-    hint_region: Lanayru Silent Realm
-    original item: 'Dusk Relic #30'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1136
-    short_name: Lanayru Silent Realm - Relic 10
-    type: lanayru, silent realm
-  \Lanayru\Lanayru Silent Realm\Relic 2:
-    Paths:
-    - stage/S300/r0/l2/Relic/103
-    hint_region: Lanayru Silent Realm
-    original item: 'Dusk Relic #22'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1128
-    short_name: Lanayru Silent Realm - Relic 2
-    type: lanayru, silent realm
-  \Lanayru\Lanayru Silent Realm\Relic 3:
-    Paths:
-    - stage/S300/r0/l2/Relic/104
-    hint_region: Lanayru Silent Realm
-    original item: 'Dusk Relic #23'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1129
-    short_name: Lanayru Silent Realm - Relic 3
-    type: lanayru, silent realm
-  \Lanayru\Lanayru Silent Realm\Relic 4:
-    Paths:
-    - stage/S300/r0/l2/Relic/105
-    hint_region: Lanayru Silent Realm
-    original item: 'Dusk Relic #24'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1130
-    short_name: Lanayru Silent Realm - Relic 4
-    type: lanayru, silent realm
-  \Lanayru\Lanayru Silent Realm\Relic 5:
-    Paths:
-    - stage/S300/r0/l2/Relic/106
-    hint_region: Lanayru Silent Realm
-    original item: 'Dusk Relic #25'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1131
-    short_name: Lanayru Silent Realm - Relic 5
-    type: lanayru, silent realm
-  \Lanayru\Lanayru Silent Realm\Relic 6:
-    Paths:
-    - stage/S300/r0/l2/Relic/107
-    hint_region: Lanayru Silent Realm
-    original item: 'Dusk Relic #26'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1132
-    short_name: Lanayru Silent Realm - Relic 6
-    type: lanayru, silent realm
-  \Lanayru\Lanayru Silent Realm\Relic 7:
-    Paths:
-    - stage/S300/r0/l2/Relic/108
-    hint_region: Lanayru Silent Realm
-    original item: 'Dusk Relic #27'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1133
-    short_name: Lanayru Silent Realm - Relic 7
-    type: lanayru, silent realm
-  \Lanayru\Lanayru Silent Realm\Relic 8:
-    Paths:
-    - stage/S300/r0/l2/Relic/109
-    hint_region: Lanayru Silent Realm
-    original item: 'Dusk Relic #28'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1134
-    short_name: Lanayru Silent Realm - Relic 8
-    type: lanayru, silent realm
-  \Lanayru\Lanayru Silent Realm\Relic 9:
-    Paths:
-    - stage/S300/r0/l2/Relic/110
-    hint_region: Lanayru Silent Realm
-    original item: 'Dusk Relic #29'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1135
-    short_name: Lanayru Silent Realm - Relic 9
-    type: lanayru, silent realm
-  \Lanayru\Lanayru Silent Realm\Trial Reward:
-    Paths:
-    - stage/S300/r0/l2/WarpObj
-    hint: sometimes
-    hint_region: Lanayru Silent Realm
-    original item: Clawshots
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1126
-    short_name: Lanayru Silent Realm - Trial Reward
-    text: a <r<trial of wisdom>> grants
-    type: null
-  \Lanayru\Mine\End\Chest at the End of Mine:
-    Paths:
-    - stage/F300_1/r2/l0/TBox/66
-    hint_region: Lanayru Mine
-    original item: Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1068
-    short_name: Lanayru Mine - Chest at the End of Mine
-    type: null
-  \Lanayru\Mine\Entry\Chest near First Timeshift Stone:
-    Paths:
-    - stage/F300_1/r1/l0/TBox/65
-    hint_region: Lanayru Mine
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1063
-    short_name: Lanayru Mine - Chest near First Timeshift Stone
-    type: null
-  \Lanayru\Mine\Entry\Higher Area\Chest behind First Landing:
-    Paths:
-    - stage/F300_1/r0/l0/TBox/64
-    hint_region: Lanayru Mine
-    original item: Evil Crystal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1064
-    short_name: Lanayru Mine - Chest behind First Landing
-    type: null
-  \Lanayru\Mine\Statues Area\Chest behind Statue:
-    Paths:
-    - stage/F300_1/r2/l0/TBox/67
-    hint_region: Lanayru Mine
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1066
-    short_name: Lanayru Mine - Chest behind Statue
-    type: null
-  \Sandship\Boss Room\Heart Container:
-    Paths:
-    - stage/B301/r0/l1/HeartCo
-    - stage/D301/r0/l1/HeartCo
-    hint: sometimes
-    hint_region: Sandship
-    original item: Heart Container
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1204
-    short_name: Sandship - Heart Container
-    text: the <r<heart of an ancient sea creature>> holds
-    type: null
-  \Sandship\Boss Room\Nayru's Flame:
-    Paths:
-    - event/401-DesertD2/45
-    - oarc/B301/l1
-    - oarc/D301/l1
-    hint_region: Sandship
-    original item: Progressive Sword
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1205
-    short_name: Sandship - Nayru's Flame
-    type: null
-  \Sandship\Main\Before Boss Door\Chest behind Combination Lock:
-    Paths:
-    - stage/D301/r10/l0/TBox/69
-    hint_region: Sandship
-    original item: 'Sandship Small Key #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1195
-    short_name: Sandship - Chest behind Combination Lock
-    type: null
-  \Sandship\Main\Before Ship's Bow\Chest before 4-Door Corridor:
-    Paths:
-    - stage/D301/r3/l0/TBox/71
-    hint_region: Sandship
-    original item: Sandship Map
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1188
-    short_name: Sandship - Chest before 4-Door Corridor
-    type: null
-  \Sandship\Main\Brig Prison\Robot in Brig's Reward:
-    Paths:
-    - event/401-DesertD2/14
-    - oarc/D301/l4
-    hint: sometimes
-    hint_region: Sandship
-    original item: 'Sandship Small Key #1'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1202
-    short_name: Sandship - Robot in Brig's Reward
-    text: the <r<gratitude of a freed crew>> reveals
-    type: null
-  \Sandship\Main\Deck\Captain's Cabin\Boss Key Chest:
-    Paths:
-    - stage/D301/r14/l3/TBox/73
-    hint: sometimes
-    hint_region: Sandship
-    original item: Sandship Boss Key
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1187
-    short_name: Sandship - Boss Key Chest
-    text: the <r<secret treasure of the Sandship's captain>> is
-    type: null
-  \Sandship\Main\Deck\Stern\Chest at the Stern:
-    Paths:
-    - stage/D301/r0/l0/TBox/127
-    hint_region: Sandship
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1184
-    short_name: Sandship - Chest at the Stern
-    type: null
-  \Sandship\Main\Ship's Bow\Chest after Scervo Fight:
-    Paths:
-    - stage/D301/r15/l0/TBox/72
-    hint: sometimes
-    hint_region: Sandship
-    original item: Progressive Bow
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1189
-    short_name: Sandship - Chest after Scervo Fight
-    text: a <r<robot upon the Sandship's bow>> guards
-    type: null
-  \Sandship\Main\Treasure Room\Treasure Room Fifth Chest:
-    Paths:
-    - stage/D301/r9/l0/TBox/68
-    hint_region: Sandship
-    original item: Semi Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1201
-    short_name: Sandship - Treasure Room Fifth Chest
-    type: null
-  \Sandship\Main\Treasure Room\Treasure Room First Chest:
-    Paths:
-    - stage/D301/r9/l0/TBox/64
-    hint_region: Sandship
-    original item: Semi Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1197
-    short_name: Sandship - Treasure Room First Chest
-    type: null
-  \Sandship\Main\Treasure Room\Treasure Room Fourth Chest:
-    Paths:
-    - stage/D301/r9/l0/TBox/67
-    hint_region: Sandship
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1200
-    short_name: Sandship - Treasure Room Fourth Chest
-    type: null
-  \Sandship\Main\Treasure Room\Treasure Room Second Chest:
-    Paths:
-    - stage/D301/r9/l0/TBox/65
-    hint_region: Sandship
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1198
-    short_name: Sandship - Treasure Room Second Chest
-    type: null
-  \Sandship\Main\Treasure Room\Treasure Room Third Chest:
-    Paths:
-    - stage/D301/r9/l0/TBox/66
-    hint_region: Sandship
-    original item: Semi Rare Treasure
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1199
-    short_name: Sandship - Treasure Room Third Chest
-    type: null
-  \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Sacred Power of Farore:
-    Paths:
-    - stage/D003_8/r0/l3/Item/64
-    hint_region: Sky Keep
-    original item: Triforce of Courage
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1227
-    short_name: Sky Keep - Sacred Power of Farore
-    type: null
-  \Sky Keep\Main\Fire Sanctuary Room\First Platform\Rupee in Fire Sanctuary Room in Alcove:
-    Paths:
-    - stage/D003_2/r0/l0/Item/36
-    hint_region: Sky Keep
-    original item: 'Silver Rupee #21'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1231
-    short_name: Sky Keep - Rupee in Fire Sanctuary Room in Alcove
-    type: Rupees (No Quick Beetle)
-  \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Sacred Power of Din:
-    Paths:
-    - stage/D003_8/r0/l2/Item/61
-    hint_region: Sky Keep
-    original item: Triforce of Power
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1232
-    short_name: Sky Keep - Sacred Power of Din
-    type: null
-  \Sky Keep\Main\First Room\First Chest:
-    Paths:
-    - stage/D003_7/r0/l0/TBox/64
-    hint_region: Sky Keep
-    original item: Sky Keep Map
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1206
-    short_name: Sky Keep - First Chest
-    type: null
-  \Sky Keep\Main\Mini Boss Room\Near Chest\Chest after Dreadfuse:
-    Paths:
-    - stage/D003_6/r0/l0/TBox/65
-    hint_region: Sky Keep
-    original item: Sky Keep Small Key
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1220
-    short_name: Sky Keep - Chest after Dreadfuse
-    type: null
-  \Sky Keep\Main\Sandship Room\Triforce Area\Sacred Power of Nayru:
-    Paths:
-    - stage/D003_8/r0/l1/Item/62
-    hint_region: Sky Keep
-    original item: Triforce of Wisdom
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1239
-    short_name: Sky Keep - Sacred Power of Nayru
-    type: null
-  \Sky\North East\Bamboo Island\Bamboo Island Goddess Chest:
-    Paths:
-    - stage/F020/r0/l0/TBox/82
-    cube_region: Eldin Volcano
-    hint_region: Sky
-    original item: Gold Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1244
-    short_name: Sky - Bamboo Island Goddess Chest
-    type: goddess, Eldin Volcano Goddess Chests
-  \Sky\North East\Beedle's Island\Beedle's Crystals:
-    Paths:
-    - event/105-Terry/115
-    - oarc/F020/l0
-    hint: sometimes
-    hint_region: Sky
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1248
-    short_name: Sky - Beedle's Crystals
-    text: <r<reuniting two Beedles>> is rewarded with
-    type: Gratitude Crystal Sidequests
-  \Sky\North East\Beedle's Island\Cage\Beedle's Island Cage Goddess Chest:
-    Paths:
-    - stage/F020/r0/l0/TBox/81
-    cube_region: Faron Woods
-    hint_region: Sky
-    original item: Rupee Medal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1250
-    short_name: Sky - Beedle's Island Cage Goddess Chest
-    type: goddess, Faron Woods Goddess Chests
-  \Sky\North East\Beedle's Island\Crystal on Beedle's Ship:
-    hint_region: Sky
-    original item: 'Gratitude Crystal #14'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1247
-    short_name: Sky - Crystal on Beedle's Ship
-    type: Loose Crystals
-  \Sky\North East\Beedle's Island\Top\Beedle's Island Goddess Chest:
-    Paths:
-    - stage/F020/r0/l0/TBox/89
-    cube_region: Lanayru Desert
-    hint: sometimes
-    hint_region: Sky
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1249
-    short_name: Sky - Beedle's Island Goddess Chest
-    text: a <s<goddess cube>> at the <r<monument to time>> reveals
-    type: goddess, Lanayru Desert Goddess Chests, Combat
-  \Sky\North East\Goddess Chest in Cave on Island next to Bamboo Island:
-    Paths:
-    - stage/F020/r0/l0/TBox/83
-    cube_region: Lanayru Desert
-    hint_region: Sky
-    original item: Heart Medal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1241
-    short_name: Sky - Goddess Chest in Cave on Island next to Bamboo Island
-    type: goddess, Lanayru Desert Goddess Chests
-  \Sky\North East\Goddess Chest on Island next to Bamboo Island:
-    Paths:
-    - stage/F020/r0/l0/TBox/71
-    cube_region: Eldin Volcano
-    hint_region: Sky
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1240
-    short_name: Sky - Goddess Chest on Island next to Bamboo Island
-    type: goddess, Eldin Volcano Goddess Chests
-  \Sky\North East\Northeast Island Cage Goddess Chest:
-    Paths:
-    - stage/F020/r0/l0/TBox/74
-    cube_region: Eldin Volcano
-    hint_region: Sky
-    original item: Treasure Medal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1243
-    short_name: Sky - Northeast Island Cage Goddess Chest
-    type: goddess, Eldin Volcano Goddess Chests
-  \Sky\North East\Northeast Island Goddess Chest behind Bombable Rocks:
-    Paths:
-    - stage/F020/r0/l0/TBox/72
-    cube_region: Lanayru Mine
-    hint_region: Sky
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1242
-    short_name: Sky - Northeast Island Goddess Chest behind Bombable Rocks
-    type: goddess, Lanayru Desert Goddess Chests
-  \Sky\South East\Chest in Breakable Boulder near Lumpy Pumpkin:
-    Paths:
-    - stage/F020/r0/l0/TBox/69
-    hint_region: Sky
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1251
-    short_name: Sky - Chest in Breakable Boulder near Lumpy Pumpkin
-    type: null
-  \Sky\South East\Goddess Chest on Island Closest to Faron Pillar:
-    Paths:
-    - stage/F020/r0/l0/TBox/65
-    cube_region: Faron Woods
-    hint_region: Sky
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1252
-    short_name: Sky - Goddess Chest on Island Closest to Faron Pillar
-    type: goddess, Faron Woods Goddess Chests
-  \Sky\South East\Lumpy Pumpkin\Crystal outside Lumpy Pumpkin:
-    hint_region: Sky
-    original item: 'Gratitude Crystal #12'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1253
-    short_name: Sky - Crystal outside Lumpy Pumpkin
-    type: Loose Crystals
-  \Sky\South East\Lumpy Pumpkin\Goddess Chest on the Roof:
-    Paths:
-    - stage/F020/r0/l0/TBox/87
-    cube_region: Skyview
-    hint_region: Sky
-    original item: Gold Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1255
-    short_name: Sky - Lumpy Pumpkin - Goddess Chest on the Roof
-    type: goddess, Faron Woods Goddess Chests
-  \Sky\South East\Lumpy Pumpkin\Kina's Crystals:
-    Paths:
-    - event/117-Pumpkin/386
-    - oarc/F020/l0
-    hint: sometimes
-    hint_region: Sky
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1257
-    short_name: Sky - Kina's Crystals
-    text: <r<delivering a mogma to the sky>> is rewarded with
-    type: Scrapper Deliveries, Gratitude Crystal Sidequests
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Chandelier:
-    Paths:
-    - stage/F011r/r0/l0/Chandel
-    hint_region: Sky
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1260
-    short_name: Sky - Lumpy Pumpkin - Chandelier
-    text: <r<angering a bartender>> dislodges
-    type: null
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Crystal inside Lumpy Pumpkin:
-    hint_region: Sky
-    original item: 'Gratitude Crystal #13'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1261
-    short_name: Sky - Crystal inside Lumpy Pumpkin
-    type: Loose Crystals
-  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Harp Minigame:
-    Paths:
-    - event/117-Pumpkin/305
-    - oarc/F011r/l0
-    hint: sometimes
-    hint_region: Sky
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1266
-    short_name: Sky - Lumpy Pumpkin - Harp Minigame
-    text: the <r<bartender>> holds
-    type: Minigames
-  \Sky\South East\Lumpy Pumpkin\Outside Goddess Chest:
-    Paths:
-    - stage/F020/r0/l0/TBox/64
-    cube_region: Faron Woods
-    hint_region: Sky
-    original item: Progressive Pouch
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1254
-    short_name: Sky - Lumpy Pumpkin - Outside Goddess Chest
-    type: goddess, Faron Woods Goddess Chests
-  \Sky\South West\Chest in Breakable Boulder near Fun Fun Island:
-    Paths:
-    - stage/F020/r0/l0/TBox/70
-    hint_region: Sky
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1268
-    short_name: Sky - Chest in Breakable Boulder near Fun Fun Island
-    type: null
-  \Sky\South West\Fun Fun Island\Dodoh's Crystals:
-    Paths:
-    - event/110-DivingGame/60
-    - oarc/F020/l0
-    hint_region: Sky
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1276
-    short_name: Sky - Dodoh's Crystals
-    text: delivering a <r<colorful wheel>> is rewarded with
-    type: Scrapper Deliveries
-  \Sky\South West\Fun Fun Island\Fun Fun Island Minigame -- 500 Rupees:
-    Paths:
-    - event/110-DivingGame/19
-    - oarc/F020/l2
-    hint: sometimes
-    hint_region: Sky
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1277
-    short_name: Sky - Fun Fun Island Minigame -- 500 Rupees
-    text: <r<diving through 5 rings>> yields
-    type: Minigames, Scrapper Deliveries
-  \Sky\South West\Fun Fun Island\Goddess Chest under Fun Fun Island:
-    Paths:
-    - stage/F020/r0/l0/TBox/86
-    cube_region: Lake Floria
-    hint_region: Sky
-    original item: Gold Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1278
-    short_name: Sky - Goddess Chest under Fun Fun Island
-    type: goddess, Lake Floria Goddess Chests
-  \Sky\South West\Orielle's Island\Orielle's Crystals:
-    Paths:
-    - event/115-Town2/225
-    - oarc/F020/l0
-    hint_region: Sky
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1274
-    short_name: Sky - Orielle's Crystals
-    text: saving a <r<sick loftwing>> is rewarded with
-    type: Gratitude Crystal Sidequests
-  \Sky\South West\Triple Island\Southwest Triple Island Cage Goddess Chest:
-    Paths:
-    - stage/F020/r0/l0/TBox/75
-    cube_region: Lanayru Sand Sea
-    hint_region: Sky
-    original item: Potion Medal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1282
-    short_name: Sky - Southwest Triple Island Cage Goddess Chest
-    type: goddess, Sand Sea Goddess Chests
-  \Sky\South West\Triple Island\Southwest Triple Island Lower Goddess Chest:
-    Paths:
-    - stage/F020/r0/l0/TBox/84
-    cube_region: Lanayru Desert
-    hint_region: Sky
-    original item: Life Medal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1281
-    short_name: Sky - Southwest Triple Island Lower Goddess Chest
-    type: goddess, Lanayru Desert Goddess Chests
-  \Sky\South West\Triple Island\Southwest Triple Island Upper Goddess Chest:
-    Paths:
-    - stage/F020/r0/l0/TBox/66
-    cube_region: Eldin Volcano
-    hint_region: Sky
-    original item: Small Seed Satchel
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1280
-    short_name: Sky - Southwest Triple Island Upper Goddess Chest
-    type: goddess, Eldin Volcano Goddess Chests
-  \Sky\South West\Volcanic Island\Goddess Chest inside Volcanic Island:
-    Paths:
-    - stage/F020/r0/l0/TBox/68
-    cube_region: Faron Woods
-    hint_region: Sky
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1270
-    short_name: Sky - Goddess Chest inside Volcanic Island
-    type: goddess, Faron Woods Goddess Chests
-  \Sky\South West\Volcanic Island\Goddess Chest outside Volcanic Island:
-    Paths:
-    - stage/F020/r0/l0/TBox/67
-    cube_region: Lanayru Desert
-    hint_region: Sky
-    original item: Heart Medal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1269
-    short_name: Sky - Goddess Chest outside Volcanic Island
-    type: goddess, Lanayru Desert Goddess Chests
-  \Sky\Thunderhead\Bug Heaven\Bug Heaven -- 10 Bugs in 3 Minutes:
-    Paths:
-    - event/116-InsectGame/69
-    - oarc/F023/l0
-    hint: sometimes
-    hint_region: Thunderhead
-    original item: Horned Colossus Beetle
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1294
-    short_name: Thunderhead - Bug Heaven -- 10 Bugs in 3 Minutes
-    text: <r<true bug catchers>> can find
-    type: Minigames
-  \Sky\Thunderhead\Bug Heaven\Bug Heaven Goddess Chest:
-    Paths:
-    - stage/F023/r0/l0/TBox/88
-    cube_region: Volcano Summit
-    hint_region: Thunderhead
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1295
-    short_name: Thunderhead - Bug Heaven Goddess Chest
-    type: goddess, Volcano Summit Goddess Chests
-  \Sky\Thunderhead\East Island\East Island Chest:
-    Paths:
-    - stage/F023/r0/l0/TBox/94
-    hint_region: Thunderhead
-    original item: Evil Crystal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1291
-    short_name: Thunderhead - East Island Chest
-    type: null
-  \Sky\Thunderhead\East Island\East Island Goddess Chest:
-    Paths:
-    - stage/F023/r0/l0/TBox/73
-    cube_region: Faron Woods
-    hint_region: Thunderhead
-    original item: Rupee Medal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1290
-    short_name: Thunderhead - East Island Goddess Chest
-    type: goddess, Faron Woods Goddess Chests
-  \Sky\Thunderhead\Isle of Songs\Goddess Chest on top of Isle of Songs:
-    Paths:
-    - stage/F023/r0/l0/TBox/85
-    cube_region: Volcano Summit
-    hint_region: Thunderhead
-    original item: Small Bomb Bag
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1285
-    short_name: Thunderhead - Goddess Chest on top of Isle of Songs
-    type: goddess, Volcano Summit Goddess Chests
-  \Sky\Thunderhead\Isle of Songs\Goddess Chest outside Isle of Songs:
-    Paths:
-    - stage/F023/r0/l0/TBox/92
-    cube_region: Mogma Turf
-    hint_region: Thunderhead
-    original item: Gold Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1284
-    short_name: Thunderhead - Goddess Chest outside Isle of Songs
-    type: goddess, Eldin Volcano Goddess Chests
-  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Goddess Sword:
-    Paths:
-    - stage/F010r/r0/l0/SwSB/0
-    hint_region: Thunderhead
-    original item: Farore's Courage
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1287
-    short_name: Thunderhead - Isle of Songs - Strike Crest with Goddess Sword
-    text: the <r<goddess' blade>> reveals
-    type: null
-  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Longsword:
-    Paths:
-    - stage/F010r/r0/l0/SwSB/1
-    hint_region: Thunderhead
-    original item: Nayru's Wisdom
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1288
-    short_name: Thunderhead - Isle of Songs - Strike Crest with Longsword
-    text: a <r<longsword>> reveals
-    type: null
-  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with White Sword:
-    Paths:
-    - stage/F010r/r0/l0/SwSB/2
-    hint: sometimes
-    hint_region: Thunderhead
-    original item: Din's Power
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1289
-    short_name: Thunderhead - Isle of Songs - Strike Crest with White Sword
-    text: a <r<blade of white>> reveals
-    type: null
-  \Sky\Thunderhead\Mogma Mitts Island\First Goddess Chest on Mogma Mitts Island:
-    Paths:
-    - stage/F023/r0/l0/TBox/77
-    cube_region: Volcano Summit
-    hint_region: Thunderhead
-    original item: Bottle
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1292
-    short_name: Thunderhead - First Goddess Chest on Mogma Mitts Island
-    type: goddess, Volcano Summit Goddess Chests
-  \Sky\Thunderhead\Mogma Mitts Island\Second Goddess Chest on Mogma Mitts Island:
-    Paths:
-    - stage/F023/r0/l0/TBox/76
-    cube_region: Lanayru Gorge
-    hint_region: Thunderhead
-    original item: Small Quiver
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1293
-    short_name: Thunderhead - Second Goddess Chest on Mogma Mitts Island
-    type: goddess, Sand Sea Goddess Chests
-  \Sky\Thunderhead\Song from Levias:
-    Paths:
-    - event/120-Nushi/give item after levias
-    - oarc/F023/l0
-    hint: always
-    hint_region: Thunderhead
-    original item: Song of the Hero
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1283
-    short_name: Thunderhead - Song from Levias
-    text: the <r<ancient whale within a raging storm>> bellows out
-    type: Scrapper Deliveries, Combat
-  \Skyloft\Beedle's Shop\Stall\1000 Rupee Item:
-    Paths:
-    - ShpSmpl/27
-    hint_region: Beedle's Shop
-    original item: Bug Medal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1388
-    short_name: Beedle's Shop - 1000 Rupee Item
-    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
-  \Skyloft\Beedle's Shop\Stall\1200 Rupee Item:
-    Paths:
-    - ShpSmpl/22
-    hint: always
-    hint_region: Beedle's Shop
-    original item: 'Progressive Pouch #3'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1381
-    short_name: Beedle's Shop - 1200 Rupee Item
-    text: for <g+<1200 rupees>> <r<Beedle>> sells
-    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
-  \Skyloft\Beedle's Shop\Stall\1600 Rupee Item:
-    Paths:
-    - ShpSmpl/23
-    hint: always
-    hint_region: Beedle's Shop
-    original item: 'Heart Piece #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1383
-    short_name: Beedle's Shop - 1600 Rupee Item
-    text: for <g+<1600 rupees>> <r<Beedle>> sells
-    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
-  \Skyloft\Beedle's Shop\Stall\300 Rupee Item:
-    Paths:
-    - ShpSmpl/20
-    hint_region: Beedle's Shop
-    original item: 'Progressive Pouch #1'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1379
-    short_name: Beedle's Shop - 300 Rupee Item
-    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
-  \Skyloft\Beedle's Shop\Stall\50 Rupee Item:
-    Paths:
-    - ShpSmpl/25
-    hint_region: Beedle's Shop
-    original item: 'Progressive Bug Net #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1387
-    short_name: Beedle's Shop - 50 Rupee Item
-    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
-  \Skyloft\Beedle's Shop\Stall\600 Rupee Item:
-    Paths:
-    - ShpSmpl/21
-    hint_region: Beedle's Shop
-    original item: 'Progressive Pouch #2'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1380
-    short_name: Beedle's Shop - 600 Rupee Item
-    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
-  \Skyloft\Beedle's Shop\Stall\800 Rupee Item:
-    Paths:
-    - ShpSmpl/26
-    hint_region: Beedle's Shop
-    original item: 'Life Medal #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1382
-    short_name: Beedle's Shop - 800 Rupee Item
-    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
-  \Skyloft\Beedle's Shop\Stall\First 100 Rupee Item:
-    Paths:
-    - ShpSmpl/24
-    hint_region: Beedle's Shop
-    original item: 'Extra Wallet #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1384
-    short_name: Beedle's Shop - First 100 Rupee Item
-    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
-  \Skyloft\Beedle's Shop\Stall\Second 100 Rupee Item:
-    Paths:
-    - ShpSmpl/17
-    hint_region: Beedle's Shop
-    original item: 'Extra Wallet #1'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1385
-    short_name: Beedle's Shop - Second 100 Rupee Item
-    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
-  \Skyloft\Beedle's Shop\Stall\Third 100 Rupee Item:
-    Paths:
-    - ShpSmpl/18
-    hint_region: Beedle's Shop
-    original item: 'Extra Wallet #2'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1386
-    short_name: Beedle's Shop - Third 100 Rupee Item
-    type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
-  \Skyloft\Central Skyloft\Bazaar\Bazaar Goddess Chest:
-    Paths:
-    - stage/F004r/r0/l0/TBox/93
-    cube_region: Lanayru Sand Sea
-    hint_region: Central Skyloft
-    original item: Gold Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1333
-    short_name: Central Skyloft - Bazaar Goddess Chest
-    type: goddess, Sand Sea Goddess Chests
-  \Skyloft\Central Skyloft\Bazaar\Potion Lady's Gift:
-    Paths:
-    - event/106-DrugStore/44
-    - oarc/F004r/l0
-    hint_region: Central Skyloft
-    original item: Bottle
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1331
-    short_name: Central Skyloft - Potion Lady's Gift
-    type: null
-  \Skyloft\Central Skyloft\Bazaar\Repair Gondo's Junk:
-    Paths:
-    - event/113-RemodelStore/Give Repair Gondo Junk item
-    - oarc/F004r/l0
-    hint_region: Central Skyloft
-    original item: Scrapper
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1332
-    short_name: Central Skyloft - Repair Gondo's Junk
-    type: null
-  \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest:
-    Paths:
-    - stage/F000/r0/l0/Item/13
-    hint_region: Central Skyloft
-    original item: Baby's Rattle
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1330
-    short_name: Central Skyloft - Item in Bird Nest
-    type: null
-  \Skyloft\Central Skyloft\Crystal between Wooden Planks:
-    hint_region: Central Skyloft
-    original item: 'Gratitude Crystal #4'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1317
-    short_name: Central Skyloft - Crystal between Wooden Planks
-    type: Loose Crystals
-  \Skyloft\Central Skyloft\Crystal on Light Tower:
-    hint_region: Central Skyloft
-    original item: 'Gratitude Crystal #1'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1319
-    short_name: Central Skyloft - Crystal on Light Tower
-    type: Loose Crystals
-  \Skyloft\Central Skyloft\Crystal on Waterfall Island:
-    hint_region: Central Skyloft
-    original item: 'Gratitude Crystal #10'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1328
-    short_name: Central Skyloft - Crystal on Waterfall Island
-    type: Loose Crystals
-  \Skyloft\Central Skyloft\Crystal on West Cliff:
-    hint_region: Central Skyloft
-    original item: 'Gratitude Crystal #6'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1318
-    short_name: Central Skyloft - Crystal on West Cliff
-    type: Loose Crystals
-  \Skyloft\Central Skyloft\Orielle and Parrow's House\Crystal in Orielle and Parrow's House:
-    hint_region: Central Skyloft
-    original item: 'Gratitude Crystal #3'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1339
-    short_name: Central Skyloft - Crystal in Orielle and Parrow's House
-    type: Loose Crystals
-  \Skyloft\Central Skyloft\Parrow's Crystals:
-    Paths:
-    - event/115-Town2/814
-    - oarc/F000/l4
-    - oarc/F000/l6
-    - oarc/F005r/l0
-    hint_region: Central Skyloft
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1322
-    short_name: Central Skyloft - Parrow's Crystals
-    type: Gratitude Crystal Sidequests
-  \Skyloft\Central Skyloft\Parrow's Gift:
-    Paths:
-    - event/115-Town2/230
-    - event/115-Town2/733
-    - oarc/F000/l4
-    - oarc/F000/l6
-    - oarc/F005r/l0
-    hint_region: Central Skyloft
-    original item: Bottle
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1321
-    short_name: Central Skyloft - Parrow's Gift
-    type: null
-  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave:
-    hint_region: Central Skyloft
-    original item: 'Gratitude Crystal #7'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1351
-    short_name: Central Skyloft - Crystal after Waterfall Cave
-    type: Loose Crystals
-  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison:
-    hint_region: Central Skyloft
-    original item: 'Gratitude Crystal #8'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1352
-    short_name: Central Skyloft - Crystal in Loftwing Prison
-    type: Loose Crystals
-  \Skyloft\Central Skyloft\Peatrice's House\Peater/Peatrice's Crystals:
-    Paths:
-    - event/109-TakeGoron/79
-    - event/123-Town5/316
-    - oarc/F018r/l0
-    - oarc/F019r/l0
-    hint: always
-    hint_region: Central Skyloft
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1342
-    short_name: Central Skyloft - Peater/Peatrice's Crystals
-    text: the <r<item check girl>> hides
-    type: Gratitude Crystal Sidequests
-  \Skyloft\Central Skyloft\Shed Chest:
-    Paths:
-    - stage/F000/r0/l0/TBox/70
-    hint_region: Central Skyloft
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1323
-    short_name: Central Skyloft - Shed Chest
-    type: null
-  \Skyloft\Central Skyloft\Shed Goddess Chest:
-    Paths:
-    - stage/F000/r0/l0/TBox/79
-    cube_region: Eldin Volcano
-    hint_region: Central Skyloft
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1324
-    short_name: Central Skyloft - Shed Goddess Chest
-    type: goddess, Eldin Volcano Goddess Chests
-  \Skyloft\Central Skyloft\Waterfall Cave\Rupee Waterfall Cave Crawlspace:
-    Paths:
-    - stage/D000/r0/l0/Item/88
-    hint_region: Central Skyloft
-    original item: 'Red Rupee #25'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1350
-    short_name: Central Skyloft - Rupee Waterfall Cave Crawlspace
-    type: Rupees (No Quick Beetle)
-  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave First Chest:
-    Paths:
-    - stage/D000/r0/l0/TBox/67
-    hint_region: Central Skyloft
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1348
-    short_name: Central Skyloft - Waterfall Cave First Chest
-    type: null
-  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave Second Chest:
-    Paths:
-    - stage/D000/r0/l0/TBox/68
-    hint_region: Central Skyloft
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1349
-    short_name: Central Skyloft - Waterfall Cave Second Chest
-    type: null
-  \Skyloft\Central Skyloft\Waterfall Island\Floating Island Goddess Chest:
-    Paths:
-    - stage/F000/r0/l0/TBox/91
-    cube_region: Lake Floria
-    hint_region: Central Skyloft
-    original item: Gold Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1346
-    short_name: Central Skyloft - Floating Island Goddess Chest
-    type: goddess, Lake Floria Goddess Chests
-  \Skyloft\Central Skyloft\Waterfall Island\Waterfall Goddess Chest:
-    Paths:
-    - stage/F000/r0/l0/TBox/80
-    cube_region: Lanayru Sand Sea
-    hint: sometimes
-    hint_region: Central Skyloft
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1345
-    short_name: Central Skyloft - Waterfall Goddess Chest
-    text: a <s<goddess cube>> <r<amongst the pirates>> reveals
-    type: goddess, Sand Sea Goddess Chests
-  \Skyloft\Central Skyloft\West Cliff Goddess Chest:
-    Paths:
-    - stage/F000/r0/l0/TBox/78
-    cube_region: Faron Woods
-    hint_region: Central Skyloft
-    original item: Silver Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1320
-    short_name: Central Skyloft - West Cliff Goddess Chest
-    type: goddess, Faron Woods Goddess Chests
-  \Skyloft\Central Skyloft\Wryna's House\Wryna's Crystals:
-    Paths:
-    - event/118-Town3/144
-    - oarc/F006r/l0
-    hint_region: Central Skyloft
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1343
-    short_name: Central Skyloft - Wryna's Crystals
-    type: Gratitude Crystal Sidequests
-  \Skyloft\Skyloft Silent Realm\Relic 1:
-    Paths:
-    - stage/S000/r0/l2/Relic/102
-    hint_region: Skyloft Silent Realm
-    original item: 'Dusk Relic #1'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1354
-    short_name: Skyloft Silent Realm - Relic 1
-    type: skyloft, silent realm
-  \Skyloft\Skyloft Silent Realm\Relic 10:
-    Paths:
-    - stage/S000/r0/l2/Relic/111
-    hint_region: Skyloft Silent Realm
-    original item: 'Dusk Relic #10'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1363
-    short_name: Skyloft Silent Realm - Relic 10
-    type: skyloft, silent realm
-  \Skyloft\Skyloft Silent Realm\Relic 2:
-    Paths:
-    - stage/S000/r0/l2/Relic/103
-    hint_region: Skyloft Silent Realm
-    original item: 'Dusk Relic #2'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1355
-    short_name: Skyloft Silent Realm - Relic 2
-    type: skyloft, silent realm
-  \Skyloft\Skyloft Silent Realm\Relic 3:
-    Paths:
-    - stage/S000/r0/l2/Relic/104
-    hint_region: Skyloft Silent Realm
-    original item: 'Dusk Relic #3'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1356
-    short_name: Skyloft Silent Realm - Relic 3
-    type: skyloft, silent realm
-  \Skyloft\Skyloft Silent Realm\Relic 4:
-    Paths:
-    - stage/S000/r0/l2/Relic/105
-    hint_region: Skyloft Silent Realm
-    original item: 'Dusk Relic #4'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1357
-    short_name: Skyloft Silent Realm - Relic 4
-    type: skyloft, silent realm
-  \Skyloft\Skyloft Silent Realm\Relic 5:
-    Paths:
-    - stage/S000/r0/l2/Relic/106
-    hint_region: Skyloft Silent Realm
-    original item: 'Dusk Relic #5'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1358
-    short_name: Skyloft Silent Realm - Relic 5
-    type: skyloft, silent realm
-  \Skyloft\Skyloft Silent Realm\Relic 6:
-    Paths:
-    - stage/S000/r0/l2/Relic/107
-    hint_region: Skyloft Silent Realm
-    original item: 'Dusk Relic #6'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1359
-    short_name: Skyloft Silent Realm - Relic 6
-    type: skyloft, silent realm
-  \Skyloft\Skyloft Silent Realm\Relic 7:
-    Paths:
-    - stage/S000/r0/l2/Relic/108
-    hint_region: Skyloft Silent Realm
-    original item: 'Dusk Relic #7'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1360
-    short_name: Skyloft Silent Realm - Relic 7
-    type: skyloft, silent realm
-  \Skyloft\Skyloft Silent Realm\Relic 8:
-    Paths:
-    - stage/S000/r0/l2/Relic/109
-    hint_region: Skyloft Silent Realm
-    original item: 'Dusk Relic #8'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1361
-    short_name: Skyloft Silent Realm - Relic 8
-    type: skyloft, silent realm
-  \Skyloft\Skyloft Silent Realm\Relic 9:
-    Paths:
-    - stage/S000/r0/l2/Relic/110
-    hint_region: Skyloft Silent Realm
-    original item: 'Dusk Relic #9'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1362
-    short_name: Skyloft Silent Realm - Relic 9
-    type: skyloft, silent realm
-  \Skyloft\Skyloft Silent Realm\Trial Reward:
-    Paths:
-    - stage/S000/r0/l2/WarpObj
-    hint: sometimes
-    hint_region: Skyloft Silent Realm
-    original item: Stone of Trials
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1353
-    short_name: Skyloft Silent Realm - Trial Reward
-    text: the <r<goddess's final trial>> grants
-    type: null
-  \Skyloft\Skyloft Village\Batreaux's House\10 Crystals:
-    Paths:
-    - event/121-AkumaKun/42
-    - oarc/F012r/l0
-    hint_region: Batreaux's House
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1371
-    short_name: Batreaux's House - 10 Crystals
-    type: Batreaux's Rewards
-  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals:
-    Paths:
-    - event/121-AkumaKun/24
-    - oarc/F012r/l0
-    hint_region: Batreaux's House
-    original item: Progressive Wallet
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1372
-    short_name: Batreaux's House - 30 Crystals
-    type: Batreaux's Rewards
-  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals Chest:
-    Paths:
-    - stage/F012r/r0/l0/TBox/69
-    hint_region: Batreaux's House
-    original item: Cursed Medal
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1373
-    short_name: Batreaux's House - 30 Crystals Chest
-    type: Batreaux's Rewards
-  \Skyloft\Skyloft Village\Batreaux's House\40 Crystals:
-    Paths:
-    - event/121-AkumaKun/49
-    - oarc/F012r/l0
-    hint_region: Batreaux's House
-    original item: Gold Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1374
-    short_name: Batreaux's House - 40 Crystals
-    type: Batreaux's Rewards
-  \Skyloft\Skyloft Village\Batreaux's House\5 Crystals:
-    Paths:
-    - event/121-AkumaKun/21
-    - oarc/F012r/l0
-    hint_region: Batreaux's House
-    original item: Progressive Wallet
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1370
-    short_name: Batreaux's House - 5 Crystals
-    type: Batreaux's Rewards
-  \Skyloft\Skyloft Village\Batreaux's House\50 Crystals:
-    Paths:
-    - event/121-AkumaKun/27
-    - oarc/F012r/l0
-    hint: sometimes
-    hint_region: Batreaux's House
-    original item: Progressive Wallet
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1375
-    short_name: Batreaux's House - 50 Crystals
-    text: <ye<50>> <r<pieces of gratitude>> can be exchanged for
-    type: Batreaux's Rewards
-  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals:
-    Paths:
-    - event/121-AkumaKun/161
-    - oarc/F012r/l0
-    hint: sometimes
-    hint_region: Batreaux's House
-    original item: Gold Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1376
-    short_name: Batreaux's House - 70 Crystals
-    text: the <r<demon's penultimate reward>> is
-    type: Batreaux's Rewards
-  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals Second Reward:
-    Paths:
-    - event/121-AkumaKun/163
-    - oarc/F012r/l0
-    hint: sometimes
-    hint_region: Batreaux's House
-    original item: Gold Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1377
-    short_name: Batreaux's House - 70 Crystals Second Reward
-    text: the <r<demon's penultimate reward>> is
-    type: Batreaux's Rewards
-  \Skyloft\Skyloft Village\Batreaux's House\80 Crystals:
-    Paths:
-    - event/121-AkumaKun/37
-    - oarc/F012r/l0
-    hint: always
-    hint_region: Batreaux's House
-    original item: Progressive Wallet
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1378
-    short_name: Batreaux's House - 80 Crystals
-    text: a <r<demon in human form>> grants
-    type: Batreaux's Rewards
-  \Skyloft\Skyloft Village\Bertie's House\Bertie's Crystals:
-    Paths:
-    - event/115-Town2/125
-    - oarc/F014r/l0
-    hint_region: Skyloft Village
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1366
-    short_name: Skyloft Village - Bertie's Crystals
-    text: helping an <r<exhausted parent>> rewards
-    type: Gratitude Crystal Sidequests
-  \Skyloft\Skyloft Village\Crystal near Pumpkin Patch:
-    hint_region: Skyloft Village
-    original item: 'Gratitude Crystal #2'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1364
-    short_name: Skyloft Village - Crystal near Pumpkin Patch
-    type: Loose Crystals
-  \Skyloft\Skyloft Village\Mallara's House\Mallara's Crystals:
-    Paths:
-    - event/123-Town5/186
-    - oarc/F016r/l0
-    hint_region: Skyloft Village
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1369
-    short_name: Skyloft Village - Mallara's Crystals
-    type: Gratitude Crystal Sidequests
-  \Skyloft\Skyloft Village\Sparrot's House\Sparrot's Crystals:
-    Paths:
-    - event/118-Town3/141
-    - oarc/F013r/l0
-    hint: sometimes
-    hint_region: Skyloft Village
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1368
-    short_name: Skyloft Village - Sparrot's Crystals
-    text: delivering a <r<fortune telling device>> reveals
-    type: Scrapper Deliveries, Gratitude Crystal Sidequests
-  \Skyloft\Upper Skyloft\Chest near Goddess Statue:
-    Paths:
-    - stage/F000/r0/l0/TBox/71
-    hint_region: Upper Skyloft
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1298
-    short_name: Upper Skyloft - Chest near Goddess Statue
-    type: null
-  \Skyloft\Upper Skyloft\Goddess Statue\First Goddess Sword Item in Goddess Statue:
-    Paths:
-    - event/107-Kanban/Fi give Goddess Statue item 1
-    - oarc/F008r/l1
-    hint_region: Upper Skyloft
-    original item: Progressive Sword
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1315
-    short_name: Upper Skyloft - First Goddess Sword Item in Goddess Statue
-    type: null
-  \Skyloft\Upper Skyloft\Goddess Statue\Second Goddess Sword Item in Goddess Statue:
-    Paths:
-    - event/107-Kanban/Fi give Goddess Statue item 2
-    - oarc/F008r/l1
-    hint_region: Upper Skyloft
-    original item: Emerald Tablet
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1316
-    short_name: Upper Skyloft - Second Goddess Sword Item in Goddess Statue
-    type: null
-  \Skyloft\Upper Skyloft\Knight Academy\Crystal in Knight Academy Plant:
-    hint_region: Upper Skyloft
-    original item: 'Gratitude Crystal #5'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1301
-    short_name: Upper Skyloft - Crystal in Knight Academy Plant
-    type: Loose Crystals
-  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Crystals:
-    Paths:
-    - event/115-Town2/325
-    - oarc/F001r/l0
-    hint_region: Upper Skyloft
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1307
-    short_name: Upper Skyloft - Fledge's Crystals
-    text: <r<lending strength to a friend>> yields
-    type: Gratitude Crystal Sidequests
-  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Gift:
-    Paths:
-    - event/114-Friend/16
-    - oarc/F001r/l3
-    - oarc/F001r/l4
-    hint_region: Upper Skyloft
-    original item: Progressive Pouch
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1300
-    short_name: Upper Skyloft - Fledge's Gift
-    type: null
-  \Skyloft\Upper Skyloft\Knight Academy\Ghost/Pipit's Crystals:
-    Paths:
-    - event/115-Town2/522
-    - event/115-Town2/641
-    - oarc/F001r/l0
-    hint_region: Upper Skyloft
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1306
-    short_name: Upper Skyloft - Ghost/Pipit's Crystals
-    type: Gratitude Crystal Sidequests
-  \Skyloft\Upper Skyloft\Knight Academy\Item from Cawlin:
-    Paths:
-    - event/115-Town2/166
-    - oarc/F001r/l0
-    hint_region: Upper Skyloft
-    original item: Cawlin's Letter
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1305
-    short_name: Upper Skyloft - Item from Cawlin
-    type: null
-  \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Crystal in Link's Room:
-    hint_region: Upper Skyloft
-    original item: 'Gratitude Crystal #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1308
-    short_name: Upper Skyloft - Crystal in Link's Room
-    type: Loose Crystals
-  \Skyloft\Upper Skyloft\Knight Academy\Owlan's Crystals:
-    Paths:
-    - event/118-Town3/157
-    - oarc/F001r/l0
-    hint: sometimes
-    hint_region: Upper Skyloft
-    original item: Gratitude Crystal Pack
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1303
-    short_name: Upper Skyloft - Owlan's Crystals
-    text: delivering a <r<Kikwi>> reveals
-    type: Scrapper Deliveries, Gratitude Crystal Sidequests, Combat
-  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Crystal in Zelda's Room:
-    hint_region: Upper Skyloft
-    original item: 'Gratitude Crystal #11'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1310
-    short_name: Upper Skyloft - Crystal in Zelda's Room
-    type: Loose Crystals
-  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\In Zelda's Closet:
-    Paths:
-    - stage/F001r/r6/l0/chest/32
-    hint_region: Upper Skyloft
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1311
-    short_name: Upper Skyloft - In Zelda's Closet
-    type: null
-  \Skyloft\Upper Skyloft\Owlan's Gift:
-    Paths:
-    - event/108-ShinkanA/169
-    - oarc/F000/l4
-    - oarc/F000/l6
-    hint_region: Upper Skyloft
-    original item: Wooden Shield
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1297
-    short_name: Upper Skyloft - Owlan's Gift
-    type: null
-  \Skyloft\Upper Skyloft\Pumpkin Archery -- 600 Points:
-    Paths:
-    - event/114-Friend/99
-    - oarc/F000/l4
-    - oarc/F000/l6
-    hint: sometimes
-    hint_region: Upper Skyloft
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1299
-    short_name: Upper Skyloft - Pumpkin Archery -- 600 Points
-    text: <r<shooting pumpkings>> is rewarded with
-    type: Minigames
-  \Skyloft\Upper Skyloft\Sparring Hall\Crystal in Sparring Hall:
-    hint_region: Upper Skyloft
-    original item: 'Gratitude Crystal #9'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1312
-    short_name: Upper Skyloft - Crystal in Sparring Hall
-    type: Loose Crystals
-  \Skyloft\Upper Skyloft\Sparring Hall\Sparring Hall Chest:
-    Paths:
-    - stage/F009r/r0/l0/TBox/66
-    hint_region: Upper Skyloft
-    original item: Progressive Sword
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1313
-    short_name: Upper Skyloft - Sparring Hall Chest
-    type: null
-  \Skyview\Boss Room\Heart Container:
-    Paths:
-    - stage/B100/r0/l1/HeartCo
-    - stage/B100/r0/l2/HeartCo
-    - stage/B100/r0/l3/HeartCo
-    - stage/B100/r0/l4/HeartCo
-    hint_region: Skyview
-    original item: Heart Container
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1424
-    short_name: Skyview - Heart Container
-    type: null
-  \Skyview\Main\First Hub\Left Room\Chest on Tree Branch:
-    Paths:
-    - stage/D100/r2/l0/TBox/64
-    hint_region: Skyview
-    original item: Skyview Map
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1403
-    short_name: Skyview - Chest on Tree Branch
-    type: null
-  \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace:
-    Paths:
-    - stage/D100/r4/l0/Soil/15
-    hint_region: Skyview
-    hints: sometimes
-    original item: Skyview Small Key
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1405
-    short_name: Skyview - Digging Spot in Crawlspace
-    text: in a <r<temple in the forest>> a mogma <r<buried>>
-    type: null
-  \Skyview\Main\First Hub\Right Room\Upper Area\Chest behind Two Eyes:
-    Paths:
-    - stage/D100/r4/l0/TBox/67
-    hint_region: Skyview
-    original item: 'Skyview Small Key #0'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1406
-    short_name: Skyview - Chest behind Two Eyes
-    text: <r<two watchful eyes>> guard
-    type: null
-  \Skyview\Main\Last Room\After Rope\Chest near Boss Door:
-    Paths:
-    - stage/D100/r9/l0/TBox/70
-    hint_region: Skyview
-    original item: Red Rupee
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1420
-    short_name: Skyview - Chest near Boss Door
-    type: null
-  \Skyview\Main\Last Room\Near Boss Key Chest\Boss Key Chest:
-    Paths:
-    - stage/D100/r9/l0/TBox/66
-    hint_region: Skyview
-    original item: Skyview Boss Key
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1422
-    short_name: Skyview - Boss Key Chest
-    type: null
-  \Skyview\Main\Second Hub\Item behind Bars:
-    Paths:
-    - stage/D100/r5/l0/Item/103
-    hint_region: Skyview
-    original item: Heart Piece
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1413
-    short_name: Skyview - Item behind Bars
-    type: null
-  \Skyview\Main\Second Hub\Left Rooms\Chest behind Three Eyes:
-    Paths:
-    - stage/D100/r7/l0/TBox/68
-    hint: sometimes
-    hint_region: Skyview
-    original item: 'Skyview Small Key #1'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1415
-    short_name: Skyview - Chest behind Three Eyes
-    text: <r<three watchful eyes>> guard
-    type: null
-  \Skyview\Main\Second Hub\Miniboss Room\Chest after Stalfos Fight:
-    Paths:
-    - stage/D100/r10/l1/TBox/65
-    - stage/D100/r10/l2/TBox/65
-    hint_region: Skyview
-    original item: Progressive Beetle
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1414
-    short_name: Skyview - Chest after Stalfos Fight
-    type: null
-  \Skyview\Main\Second Hub\Rupee in East Tunnel:
-    Paths:
-    - stage/D100/r5/l0/Item/66
-    hint_region: Skyview
-    original item: 'Red Rupee #37'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1409
-    short_name: Skyview - Rupee in East Tunnel
-    type: Rupees (No Quick Beetle)
-  \Skyview\Main\Second Hub\Rupee in Southeast Tunnel:
-    Paths:
-    - stage/D100/r5/l0/Item/65
-    hint_region: Skyview
-    original item: 'Red Rupee #35'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1407
-    short_name: Skyview - Rupee in Southeast Tunnel
-    type: Rupees (No Quick Beetle)
-  \Skyview\Main\Second Hub\Rupee in Southwest Tunnel:
-    Paths:
-    - stage/D100/r5/l0/Item/67
-    hint_region: Skyview
-    original item: 'Red Rupee #36'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1408
-    short_name: Skyview - Rupee in Southwest Tunnel
-    type: Rupees (No Quick Beetle)
-  \Skyview\Spring\Rupee on Spring Pillar:
-    Paths:
-    - stage/B100_1/r0/l0/Item/109
-    hint_region: Skyview
-    original item: 'Red Rupee #38'
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1425
-    short_name: Skyview - Rupee on Spring Pillar
-    type: Rupees (No Quick Beetle)
-  \Skyview\Spring\Strike Crest:
-    Paths:
-    - event/201-ForestD1/6
-    - oarc/B100_1/l0
-    hint_region: Skyview
-    original item: Ruby Tablet
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1426
-    short_name: Skyview - Strike Crest
-    type: null
+  \Ancient Cistern\Boss Room\Heart Container: Ancient Cistern - Heart Container
+  \Ancient Cistern\Flame Room\Farore's Flame: Ancient Cistern - Farore's Flame
+  \Ancient Cistern\Main\Basement Gutters\Past Skulltula\Bokoblin: Ancient Cistern
+    - Bokoblin
+  \Ancient Cistern\Main\Basement\Under the Statue\Boss Key Chest: Ancient Cistern
+    - Boss Key Chest
+  \Ancient Cistern\Main\East Part\Chest Ledge\Chest in East Part: Ancient Cistern
+    - Chest in East Part
+  \Ancient Cistern\Main\East Part\Second Room\First Rupee in East Part in Short Tunnel: Ancient
+    Cistern - First Rupee in East Part in Short Tunnel
+  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Cubby: Ancient
+    Cistern - Rupee in East Part in Cubby
+  \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Main Tunnel: Ancient
+    Cistern - Rupee in East Part in Main Tunnel
+  \Ancient Cistern\Main\East Part\Second Room\Second Rupee in East Part in Short Tunnel: Ancient
+    Cistern - Second Rupee in East Part in Short Tunnel
+  \Ancient Cistern\Main\East Part\Second Room\Third Rupee in East Part in Short Tunnel: Ancient
+    Cistern - Third Rupee in East Part in Short Tunnel
+  \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest\Chest in Key Locked Room: Ancient
+    Cistern - Chest in Key Locked Room
+  \Ancient Cistern\Main\Main Room\After Gutters\Rupee under Lilypad: Ancient Cistern
+    - Rupee under Lilypad
+  \Ancient Cistern\Main\Main Room\After Whip Hooks\Chest after Whip Hooks: Ancient
+    Cistern - Chest after Whip Hooks
+  \Ancient Cistern\Main\Main Room\Behind the Waterfall\Chest behind the Waterfall: Ancient
+    Cistern - Chest behind the Waterfall
+  \Ancient Cistern\Main\Main Room\Rupee in East Hand: Ancient Cistern - Rupee in East
+    Hand
+  \Ancient Cistern\Main\Main Room\Rupee in West Hand: Ancient Cistern - Rupee in West
+    Hand
+  \Ancient Cistern\Main\Main Room\Vines Area\Chest near Vines: Ancient Cistern - Chest
+    near Vines
+  \Earth Temple\Boss Room\Slope\Heart Container: Earth Temple - Heart Container
+  \Earth Temple\Main\East Room\Chest after Double Lizalfos Fight: Earth Temple - Chest
+    after Double Lizalfos Fight
+  \Earth Temple\Main\First Room\Rupee above Drawbridge: Earth Temple - Rupee above
+    Drawbridge
+  \Earth Temple\Main\First Room\Vent Chest: Earth Temple - Vent Chest
+  \Earth Temple\Main\Hub Room\Chest Left of Main Room Bridge: Earth Temple - Chest
+    Left of Main Room Bridge
+  \Earth Temple\Main\Hub Room\Chest behind Bombable Rock: Earth Temple - Chest behind
+    Bombable Rock
+  \Earth Temple\Main\Hub Room\Ledd's Gift: Earth Temple - Ledd's Gift
+  \Earth Temple\Main\Hub Room\Past Lava Section\Chest Guarded by Lizalfos: Earth Temple
+    - Chest Guarded by Lizalfos
+  \Earth Temple\Main\Hub Room\Rupee in Lava Tunnel: Earth Temple - Rupee in Lava Tunnel
+  \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Key Chest: Earth Temple
+    - Boss Key Chest
+  \Earth Temple\Main\West Room\Chest in West Room: Earth Temple - Chest in West Room
+  \Earth Temple\Spring\Strike Crest: Earth Temple - Strike Crest
+  \Eldin\Bokoblin Base\Before Drawbridge\Chest near Drawbridge: Bokoblin Base - Chest
+    near Drawbridge
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\Chest in Volcano Summit Alcove: Bokoblin
+    Base - Chest in Volcano Summit Alcove
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\First Chest in Volcano Summit: Bokoblin
+    Base - First Chest in Volcano Summit
+  \Eldin\Bokoblin Base\Bokoblin Base Summit\Raised Chest in Volcano Summit: Bokoblin
+    Base - Raised Chest in Volcano Summit
+  \Eldin\Bokoblin Base\Fire Dragon's Lair\Fire Dragon's Reward: Bokoblin Base - Fire
+    Dragon's Reward
+  \Eldin\Bokoblin Base\Outside Earth Temple\Chest East of Earth Temple Entrance: Bokoblin
+    Base - Chest East of Earth Temple Entrance
+  \Eldin\Bokoblin Base\Outside Earth Temple\Chest West of Earth Temple Entrance: Bokoblin
+    Base - Chest West of Earth Temple Entrance
+  \Eldin\Bokoblin Base\Prison\Plats' Gift: Bokoblin Base - Plats' Gift
+  \Eldin\Bokoblin Base\Volcano East\Chest near Bone Bridge: Bokoblin Base - Chest
+    near Bone Bridge
+  \Eldin\Bokoblin Base\Volcano East\Chest on Cliff: Bokoblin Base - Chest on Cliff
+  \Eldin\Eldin Silent Realm\Relic 1: Eldin Silent Realm - Relic 1
+  \Eldin\Eldin Silent Realm\Relic 10: Eldin Silent Realm - Relic 10
+  \Eldin\Eldin Silent Realm\Relic 2: Eldin Silent Realm - Relic 2
+  \Eldin\Eldin Silent Realm\Relic 3: Eldin Silent Realm - Relic 3
+  \Eldin\Eldin Silent Realm\Relic 4: Eldin Silent Realm - Relic 4
+  \Eldin\Eldin Silent Realm\Relic 5: Eldin Silent Realm - Relic 5
+  \Eldin\Eldin Silent Realm\Relic 6: Eldin Silent Realm - Relic 6
+  \Eldin\Eldin Silent Realm\Relic 7: Eldin Silent Realm - Relic 7
+  \Eldin\Eldin Silent Realm\Relic 8: Eldin Silent Realm - Relic 8
+  \Eldin\Eldin Silent Realm\Relic 9: Eldin Silent Realm - Relic 9
+  \Eldin\Eldin Silent Realm\Trial Reward: Eldin Silent Realm - Trial Reward
+  \Eldin\Mogma Turf\Past Vent\Chest behind Bombable Wall in Fire Maze: Mogma Turf
+    - Chest behind Bombable Wall in Fire Maze
+  \Eldin\Mogma Turf\Pre Vent\Chest behind Bombable Wall at Entrance: Mogma Turf -
+    Chest behind Bombable Wall at Entrance
+  \Eldin\Mogma Turf\Pre Vent\Defeat Bokoblins: Mogma Turf - Defeat Bokoblins
+  \Eldin\Mogma Turf\Pre Vent\Free Fall Chest: Mogma Turf - Free Fall Chest
+  \Eldin\Mogma Turf\Sand Slide Platform\Sand Slide Chest: Mogma Turf - Sand Slide
+    Chest
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Item behind Digging: Volcano
+    Summit - Item behind Digging
+  \Eldin\Volcano Summit\Waterfall\Higher Area\Chest behind Bombable Wall in Waterfall Area: Volcano
+    Summit - Chest behind Bombable Wall in Waterfall Area
+  \Eldin\Volcano\Ascent\Chest behind Bombable Wall near Volcano Ascent: Eldin Volcano
+    - Chest behind Bombable Wall near Volcano Ascent
+  \Eldin\Volcano\East\Chest after Crawlspace: Eldin Volcano - Chest after Crawlspace
+  \Eldin\Volcano\East\Chest behind Bombable Wall near Cliff: Eldin Volcano - Chest
+    behind Bombable Wall near Cliff
+  \Eldin\Volcano\East\Item on Cliff: Eldin Volcano - Item on Cliff
+  \Eldin\Volcano\East\North Rupee above Mogma Turf Entrance: Eldin Volcano - North
+    Rupee above Mogma Turf Entrance
+  \Eldin\Volcano\East\Southeast Rupee above Mogma Turf Entrance: Eldin Volcano - Southeast
+    Rupee above Mogma Turf Entrance
+  \Eldin\Volcano\Entry\Rupee on Ledge before First Room: Eldin Volcano - Rupee on
+    Ledge before First Room
+  \Eldin\Volcano\First Room\Chest behind Bombable Wall in First Room: Eldin Volcano
+    - Chest behind Bombable Wall in First Room
+  \Eldin\Volcano\First Room\Rupee behind Bombable Wall in First Room: Eldin Volcano
+    - Rupee behind Bombable Wall in First Room
+  \Eldin\Volcano\First Room\Rupee in Crawlspace in First Room: Eldin Volcano - Rupee
+    in Crawlspace in First Room
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot behind Boulder on Sandy Slope: Eldin
+    Volcano - Digging Spot behind Boulder on Sandy Slope
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot below Tower: Eldin Volcano - Digging
+    Spot below Tower
+  \Eldin\Volcano\Near Temple Entrance\Digging Spot in front of Earth Temple: Eldin
+    Volcano - Digging Spot in front of Earth Temple
+  \Eldin\Volcano\Near Thrill Digger Cave\Left Rupee behind Bombable Wall on First Slope: Eldin
+    Volcano - Left Rupee behind Bombable Wall on First Slope
+  \Eldin\Volcano\Near Thrill Digger Cave\Right Rupee behind Bombable Wall on First Slope: Eldin
+    Volcano - Right Rupee behind Bombable Wall on First Slope
+  \Eldin\Volcano\Past Slide\Digging Spot after Draining Lava: Eldin Volcano - Digging
+    Spot after Draining Lava
+  \Eldin\Volcano\Sand Slide\Digging Spot after Vents: Eldin Volcano - Digging Spot
+    after Vents
+  \Faron\Faron Silent Realm\Relic 1: Faron Silent Realm - Relic 1
+  \Faron\Faron Silent Realm\Relic 10: Faron Silent Realm - Relic 10
+  \Faron\Faron Silent Realm\Relic 2: Faron Silent Realm - Relic 2
+  \Faron\Faron Silent Realm\Relic 3: Faron Silent Realm - Relic 3
+  \Faron\Faron Silent Realm\Relic 4: Faron Silent Realm - Relic 4
+  \Faron\Faron Silent Realm\Relic 5: Faron Silent Realm - Relic 5
+  \Faron\Faron Silent Realm\Relic 6: Faron Silent Realm - Relic 6
+  \Faron\Faron Silent Realm\Relic 7: Faron Silent Realm - Relic 7
+  \Faron\Faron Silent Realm\Relic 8: Faron Silent Realm - Relic 8
+  \Faron\Faron Silent Realm\Relic 9: Faron Silent Realm - Relic 9
+  \Faron\Faron Silent Realm\Trial Reward: Faron Silent Realm - Trial Reward
+  \Faron\Faron Woods\Chest behind Upper Bombable Rock: Faron Woods - Chest behind
+    Upper Bombable Rock
+  \Faron\Faron Woods\Deep Woods\Deep Woods Chest: Faron Woods - Deep Woods Chest
+  \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest\Chest inside Great Tree: Faron
+    Woods - Chest inside Great Tree
+  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree North Branch: Faron Woods
+    - Rupee on Great Tree North Branch
+  \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree West Branch: Faron Woods -
+    Rupee on Great Tree West Branch
+  \Faron\Faron Woods\Item behind Lower Bombable Rock: Faron Woods - Item behind Lower
+    Bombable Rock
+  \Faron\Faron Woods\Item on Tree: Faron Woods - Item on Tree
+  \Faron\Faron Woods\Kikwi Elder's Reward: Faron Woods - Kikwi Elder's Reward
+  \Faron\Faron Woods\Rupee on Hollow Tree Branch: Faron Woods - Rupee on Hollow Tree
+    Branch
+  \Faron\Faron Woods\Rupee on Hollow Tree Root: Faron Woods - Rupee on Hollow Tree
+    Root
+  \Faron\Faron Woods\Rupee on Platform near Floria Door: Faron Woods - Rupee on Platform
+    near Floria Door
+  \Faron\Flooded Faron Woods\16 Dark Blue Tadtones in the South West: Flooded Faron
+    Woods - 16 Dark Blue Tadtones in the South West
+  \Faron\Flooded Faron Woods\2 Dark Blue Tadtones in Grass West of Great Tree: Flooded
+    Faron Woods - 2 Dark Blue Tadtones in Grass West of Great Tree
+  \Faron\Flooded Faron Woods\2 Red Tadtones in Grass near Lower Bombable Rock: Flooded
+    Faron Woods - 2 Red Tadtones in Grass near Lower Bombable Rock
+  \Faron\Flooded Faron Woods\4 Light Blue Moving Tadtones under Kikwi Elder: Flooded
+    Faron Woods - 4 Light Blue Moving Tadtones under Kikwi Elder
+  \Faron\Flooded Faron Woods\4 Purple Moving Tadtones near Floria Gate: Flooded Faron
+    Woods - 4 Purple Moving Tadtones near Floria Gate
+  \Faron\Flooded Faron Woods\4 Purple Tadtones under Viewing Platform: Flooded Faron
+    Woods - 4 Purple Tadtones under Viewing Platform
+  \Faron\Flooded Faron Woods\4 Red Moving Tadtones North West of Great Tree: Flooded
+    Faron Woods - 4 Red Moving Tadtones North West of Great Tree
+  \Faron\Flooded Faron Woods\4 Yellow Tadtones under Small Hollow Tree: Flooded Faron
+    Woods - 4 Yellow Tadtones under Small Hollow Tree
+  \Faron\Flooded Faron Woods\8 Green Tadtones in West Tunnel: Flooded Faron Woods
+    - 8 Green Tadtones in West Tunnel
+  \Faron\Flooded Faron Woods\8 Light Blue Tadtones near Viewing Platform: Flooded
+    Faron Woods - 8 Light Blue Tadtones near Viewing Platform
+  \Faron\Flooded Faron Woods\8 Purple Tadtones in Clearing after Small Hollow Tree: Flooded
+    Faron Woods - 8 Purple Tadtones in Clearing after Small Hollow Tree
+  \Faron\Flooded Faron Woods\8 Yellow Tadtones near Kikwi Elder: Flooded Faron Woods
+    - 8 Yellow Tadtones near Kikwi Elder
+  \Faron\Flooded Faron Woods\Dark Blue Moving Tadtone inside Small Hollow Tree: Flooded
+    Faron Woods - Dark Blue Moving Tadtone inside Small Hollow Tree
+  \Faron\Flooded Faron Woods\Flooded Great Tree\Water Dragon's Reward: Flooded Faron
+    Woods - Water Dragon's Reward
+  \Faron\Flooded Faron Woods\Green Tadtone behind Upper Bombable Rock: Flooded Faron
+    Woods - Green Tadtone behind Upper Bombable Rock
+  \Faron\Flooded Faron Woods\Light Blue Tadtone under Great Tree Root: Flooded Faron
+    Woods - Light Blue Tadtone under Great Tree Root
+  \Faron\Flooded Faron Woods\Red Moving Tadtone near Viewing Platform: Flooded Faron
+    Woods - Red Moving Tadtone near Viewing Platform
+  \Faron\Flooded Faron Woods\Yellow Tadtone under Lilypad: Flooded Faron Woods - Yellow
+    Tadtone under Lilypad
+  \Faron\Lake Floria\Above Rock\Left Rupee behind Northwest Boulder: Lake Floria -
+    Left Rupee behind Northwest Boulder
+  \Faron\Lake Floria\Above Rock\Right Rupee behind Northwest Boulder: Lake Floria
+    - Right Rupee behind Northwest Boulder
+  \Faron\Lake Floria\Above Rock\Rupee behind Southwest Boulder: Lake Floria - Rupee
+    behind Southwest Boulder
+  \Faron\Lake Floria\Above Rock\Rupee under Central Boulder: Lake Floria - Rupee under
+    Central Boulder
+  \Faron\Lake Floria\Below Rock\Emerged Area\Lake Floria Chest: Lake Floria - Lake
+    Floria Chest
+  \Faron\Lake Floria\Farore's Lair\Dragon Lair East Chest: Lake Floria - Dragon Lair
+    East Chest
+  \Faron\Lake Floria\Farore's Lair\Dragon Lair South Chest: Lake Floria - Dragon Lair
+    South Chest
+  \Faron\Lake Floria\Waterfall\Rupee on High Ledge outside Ancient Cistern Entrance: Lake
+    Floria - Rupee on High Ledge outside Ancient Cistern Entrance
+  \Faron\Sealed Grounds\Behind the Temple\Gorko's Goddess Wall Reward: Sealed Grounds
+    - Gorko's Goddess Wall Reward
+  \Faron\Sealed Grounds\Hylia's Temple\Zelda's Blessing: Sealed Grounds - Zelda's
+    Blessing
+  \Faron\Sealed Grounds\Sealed Temple\Chest inside Sealed Temple: Sealed Grounds -
+    Chest inside Sealed Temple
+  \Faron\Sealed Grounds\Sealed Temple\Song from Impa: Sealed Grounds - Song from Impa
+  \Fire Sanctuary\Boss Room\Heart Container: Fire Sanctuary - Heart Container
+  \Fire Sanctuary\Flame Room\Din's Flame: Fire Sanctuary - Din's Flame
+  \Fire Sanctuary\Main\Boss Key Room\Boss Key Chest: Fire Sanctuary - Boss Key Chest
+  \Fire Sanctuary\Main\First Room\Past Water Plant\Chest in First Room: Fire Sanctuary
+    - Chest in First Room
+  \Fire Sanctuary\Main\First Trapped Mogma Room\Chest near First Trapped Mogma: Fire
+    Sanctuary - Chest near First Trapped Mogma
+  \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area\Rescue First Trapped Mogma: Fire
+    Sanctuary - Rescue First Trapped Mogma
+  \Fire Sanctuary\Main\Second Room\Balcony\Chest on Balcony: Fire Sanctuary - Chest
+    on Balcony
+  \Fire Sanctuary\Main\Second Room\Chest in Second Room: Fire Sanctuary - Chest in
+    Second Room
+  \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall\Chest after Bombable Wall: Fire
+    Sanctuary - Chest after Bombable Wall
+  \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Second Trapped Mogma: Fire
+    Sanctuary - Rescue Second Trapped Mogma
+  \Fire Sanctuary\Main\Staircase Room\Chest in Staircase Room: Fire Sanctuary - Chest
+    in Staircase Room
+  \Fire Sanctuary\Main\Water Fruit Room\First Chest in Water Fruit Room: Fire Sanctuary
+    - First Chest in Water Fruit Room
+  \Fire Sanctuary\Main\Water Fruit Room\Second Chest in Water Fruit Room: Fire Sanctuary
+    - Second Chest in Water Fruit Room
+  \Fire Sanctuary\Main\West of Boss Door\Plats' Chest: Fire Sanctuary - Plats' Chest
+  \Lanayru Mining Facility\Boss Room\After Sand Drain\Heart Container: Lanayru Mining
+    Facility - Heart Container
+  \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit Hall of Ancient Robots: Lanayru
+    Mining Facility - Exit Hall of Ancient Robots
+  \Lanayru Mining Facility\Main\Armos Fight Room\Chest after Armos Fight: Lanayru
+    Mining Facility - Chest after Armos Fight
+  \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes\First Chest in Hub Room: Lanayru
+    Mining Facility - First Chest in Hub Room
+  \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Shortcut Chest in Main Hub: Lanayru
+    Mining Facility - Shortcut Chest in Main Hub
+  \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Chest behind First Crawlspace: Lanayru
+    Mining Facility - Chest behind First Crawlspace
+  \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Chest in Spike Maze: Lanayru
+    Mining Facility - Chest in Spike Maze
+  \Lanayru Mining Facility\Main\Boss Key Room\Boss Key Chest: Lanayru Mining Facility
+    - Boss Key Chest
+  \Lanayru Mining Facility\Main\First Room\Chest behind Bars: Lanayru Mining Facility
+    - Chest behind Bars
+  \Lanayru Mining Facility\Main\First West Room\Chest in First West Room: Lanayru
+    Mining Facility - Chest in First West Room
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Lower Chest in Hop across Boxes Room: Lanayru
+    Mining Facility - Lower Chest in Hop across Boxes Room
+  \Lanayru Mining Facility\Main\Hop Across Boxes Room\Raised Chest in Hop across Boxes Room: Lanayru
+    Mining Facility - Raised Chest in Hop across Boxes Room
+  \Lanayru Mining Facility\Main\Key Locked Room\Chest in Key Locked Room: Lanayru
+    Mining Facility - Chest in Key Locked Room
+  \Lanayru\Caves\Chest: Lanayru Caves - Chest
+  \Lanayru\Caves\Golo's Gift: Lanayru Caves - Golo's Gift
+  \Lanayru\Desert\East\Chest on Platform near Fire Node: Lanayru Desert - Chest on
+    Platform near Fire Node
+  \Lanayru\Desert\East\Fire Node\Past after Grate\Left Ending Chest: Lanayru Desert
+    - Fire Node - Left Ending Chest
+  \Lanayru\Desert\East\Fire Node\Past after Grate\Right Ending Chest: Lanayru Desert
+    - Fire Node - Right Ending Chest
+  \Lanayru\Desert\East\Fire Node\Past\First Small Chest: Lanayru Desert - Fire Node
+    - First Small Chest
+  \Lanayru\Desert\East\Fire Node\Past\Second Small Chest: Lanayru Desert - Fire Node
+    - Second Small Chest
+  \Lanayru\Desert\East\Fire Node\Present after Sand\Shortcut Chest: Lanayru Desert
+    - Fire Node - Shortcut Chest
+  \Lanayru\Desert\Entry\High Ledge after Vines\Chest near Party Wheel: Lanayru Desert
+    - Chest near Party Wheel
+  \Lanayru\Desert\Near Caged Robot\Chest near Caged Robot: Lanayru Desert - Chest
+    near Caged Robot
+  \Lanayru\Desert\Near Caged Robot\Rescue Caged Robot: Lanayru Desert - Rescue Caged
+    Robot
+  \Lanayru\Desert\North Part\Chest on Platform near Lightning Node: Lanayru Desert
+    - Chest on Platform near Lightning Node
+  \Lanayru\Desert\North Part\Lightning Node\Past\First Chest: Lanayru Desert - Lightning
+    Node - First Chest
+  \Lanayru\Desert\North Part\Lightning Node\Past\Second Chest: Lanayru Desert - Lightning
+    Node - Second Chest
+  \Lanayru\Desert\North Part\Lightning Node\Present from afar\Raised Chest near Generator: Lanayru
+    Desert - Lightning Node - Raised Chest near Generator
+  \Lanayru\Desert\North Part\Secret Passageway\Secret Passageway Chest: Lanayru Desert
+    - Secret Passageway Chest
+  \Lanayru\Desert\Top of LMF\Chest on top of Lanayru Mining Facility: Lanayru Desert
+    - Chest on top of Lanayru Mining Facility
+  \Lanayru\Desert\Top of West Wall\Chest near Sand Oasis: Lanayru Desert - Chest near
+    Sand Oasis
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Left Rupee on Entrance Crown: Lanayru
+    Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Right Rupee on Entrance Crown: Lanayru
+    Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown
+  \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Rupee on First Pillar: Lanayru
+    Sand Sea - Ancient Harbour - Rupee on First Pillar
+  \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Digging Spot: Lanayru Gorge - Digging
+    Spot
+  \Lanayru\Lanayru Sand Sea\Gorge\Item on Pillar: Lanayru Gorge - Item on Pillar
+  \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward: Lanayru Gorge - Thunder
+    Dragon's Reward
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Chest: Lanayru Sand Sea
+    - Pirate Stronghold - First Chest
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Chest: Lanayru Sand Sea
+    - Pirate Stronghold - Second Chest
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Third Chest: Lanayru Sand Sea
+    - Pirate Stronghold - Third Chest
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose: Lanayru
+    Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar or Nose
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar: Lanayru Sand
+    Sea - Pirate Stronghold - Rupee on East Sea Pillar
+  \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar: Lanayru Sand
+    Sea - Pirate Stronghold - Rupee on West Sea Pillar
+  \Lanayru\Lanayru Sand Sea\Shipyard\Rickety Coaster -- Heart Stopping Track in 1'05: Lanayru
+    Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Chest after Moblin: Lanayru
+    Sand Sea - Skipper's Retreat - Chest after Moblin
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Chest in Shack: Lanayru Sand Sea
+    - Skipper's Retreat - Chest in Shack
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform\Skydive Chest: Lanayru
+    Sand Sea - Skipper's Retreat - Skydive Chest
+  \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Chest on top of Cacti Pillar: Lanayru
+    Sand Sea - Skipper's Retreat - Chest on top of Cacti Pillar
+  \Lanayru\Lanayru Silent Realm\Relic 1: Lanayru Silent Realm - Relic 1
+  \Lanayru\Lanayru Silent Realm\Relic 10: Lanayru Silent Realm - Relic 10
+  \Lanayru\Lanayru Silent Realm\Relic 2: Lanayru Silent Realm - Relic 2
+  \Lanayru\Lanayru Silent Realm\Relic 3: Lanayru Silent Realm - Relic 3
+  \Lanayru\Lanayru Silent Realm\Relic 4: Lanayru Silent Realm - Relic 4
+  \Lanayru\Lanayru Silent Realm\Relic 5: Lanayru Silent Realm - Relic 5
+  \Lanayru\Lanayru Silent Realm\Relic 6: Lanayru Silent Realm - Relic 6
+  \Lanayru\Lanayru Silent Realm\Relic 7: Lanayru Silent Realm - Relic 7
+  \Lanayru\Lanayru Silent Realm\Relic 8: Lanayru Silent Realm - Relic 8
+  \Lanayru\Lanayru Silent Realm\Relic 9: Lanayru Silent Realm - Relic 9
+  \Lanayru\Lanayru Silent Realm\Trial Reward: Lanayru Silent Realm - Trial Reward
+  \Lanayru\Mine\End\Chest at the End of Mine: Lanayru Mine - Chest at the End of Mine
+  \Lanayru\Mine\Entry\Chest near First Timeshift Stone: Lanayru Mine - Chest near
+    First Timeshift Stone
+  \Lanayru\Mine\Entry\Higher Area\Chest behind First Landing: Lanayru Mine - Chest
+    behind First Landing
+  \Lanayru\Mine\Statues Area\Chest behind Statue: Lanayru Mine - Chest behind Statue
+  \Sandship\Boss Room\Heart Container: Sandship - Heart Container
+  \Sandship\Boss Room\Nayru's Flame: Sandship - Nayru's Flame
+  \Sandship\Main\Before Boss Door\Chest behind Combination Lock: Sandship - Chest
+    behind Combination Lock
+  \Sandship\Main\Before Ship's Bow\Chest before 4-Door Corridor: Sandship - Chest
+    before 4-Door Corridor
+  \Sandship\Main\Brig Prison\Robot in Brig's Reward: Sandship - Robot in Brig's Reward
+  \Sandship\Main\Deck\Captain's Cabin\Boss Key Chest: Sandship - Boss Key Chest
+  \Sandship\Main\Deck\Stern\Chest at the Stern: Sandship - Chest at the Stern
+  \Sandship\Main\Ship's Bow\Chest after Scervo Fight: Sandship - Chest after Scervo
+    Fight
+  \Sandship\Main\Treasure Room\Treasure Room Fifth Chest: Sandship - Treasure Room
+    Fifth Chest
+  \Sandship\Main\Treasure Room\Treasure Room First Chest: Sandship - Treasure Room
+    First Chest
+  \Sandship\Main\Treasure Room\Treasure Room Fourth Chest: Sandship - Treasure Room
+    Fourth Chest
+  \Sandship\Main\Treasure Room\Treasure Room Second Chest: Sandship - Treasure Room
+    Second Chest
+  \Sandship\Main\Treasure Room\Treasure Room Third Chest: Sandship - Treasure Room
+    Third Chest
+  \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Sacred Power of Farore: Sky Keep
+    - Sacred Power of Farore
+  \Sky Keep\Main\Fire Sanctuary Room\First Platform\Rupee in Fire Sanctuary Room in Alcove: Sky
+    Keep - Rupee in Fire Sanctuary Room in Alcove
+  \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Sacred Power of Din: Sky Keep -
+    Sacred Power of Din
+  \Sky Keep\Main\First Room\First Chest: Sky Keep - First Chest
+  \Sky Keep\Main\Mini Boss Room\Near Chest\Chest after Dreadfuse: Sky Keep - Chest
+    after Dreadfuse
+  \Sky Keep\Main\Sandship Room\Triforce Area\Sacred Power of Nayru: Sky Keep - Sacred
+    Power of Nayru
+  \Sky\North East\Bamboo Island\Bamboo Island Goddess Chest: Sky - Bamboo Island Goddess
+    Chest
+  \Sky\North East\Beedle's Island\Beedle's Crystals: Sky - Beedle's Crystals
+  \Sky\North East\Beedle's Island\Cage\Beedle's Island Cage Goddess Chest: Sky - Beedle's
+    Island Cage Goddess Chest
+  \Sky\North East\Beedle's Island\Crystal on Beedle's Ship: Sky - Crystal on Beedle's
+    Ship
+  \Sky\North East\Beedle's Island\Top\Beedle's Island Goddess Chest: Sky - Beedle's
+    Island Goddess Chest
+  \Sky\North East\Goddess Chest in Cave on Island next to Bamboo Island: Sky - Goddess
+    Chest in Cave on Island next to Bamboo Island
+  \Sky\North East\Goddess Chest on Island next to Bamboo Island: Sky - Goddess Chest
+    on Island next to Bamboo Island
+  \Sky\North East\Northeast Island Cage Goddess Chest: Sky - Northeast Island Cage
+    Goddess Chest
+  \Sky\North East\Northeast Island Goddess Chest behind Bombable Rocks: Sky - Northeast
+    Island Goddess Chest behind Bombable Rocks
+  \Sky\South East\Chest in Breakable Boulder near Lumpy Pumpkin: Sky - Chest in Breakable
+    Boulder near Lumpy Pumpkin
+  \Sky\South East\Goddess Chest on Island Closest to Faron Pillar: Sky - Goddess Chest
+    on Island Closest to Faron Pillar
+  \Sky\South East\Lumpy Pumpkin\Crystal outside Lumpy Pumpkin: Sky - Crystal outside
+    Lumpy Pumpkin
+  \Sky\South East\Lumpy Pumpkin\Goddess Chest on the Roof: Sky - Lumpy Pumpkin - Goddess
+    Chest on the Roof
+  \Sky\South East\Lumpy Pumpkin\Kina's Crystals: Sky - Kina's Crystals
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Chandelier: Sky - Lumpy Pumpkin
+    - Chandelier
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Crystal inside Lumpy Pumpkin: Sky
+    - Crystal inside Lumpy Pumpkin
+  \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Harp Minigame: Sky - Lumpy
+    Pumpkin - Harp Minigame
+  \Sky\South East\Lumpy Pumpkin\Outside Goddess Chest: Sky - Lumpy Pumpkin - Outside
+    Goddess Chest
+  \Sky\South West\Chest in Breakable Boulder near Fun Fun Island: Sky - Chest in Breakable
+    Boulder near Fun Fun Island
+  \Sky\South West\Fun Fun Island\Dodoh's Crystals: Sky - Dodoh's Crystals
+  \Sky\South West\Fun Fun Island\Fun Fun Island Minigame -- 500 Rupees: Sky - Fun
+    Fun Island Minigame -- 500 Rupees
+  \Sky\South West\Fun Fun Island\Goddess Chest under Fun Fun Island: Sky - Goddess
+    Chest under Fun Fun Island
+  \Sky\South West\Orielle's Island\Orielle's Crystals: Sky - Orielle's Crystals
+  \Sky\South West\Triple Island\Southwest Triple Island Cage Goddess Chest: Sky -
+    Southwest Triple Island Cage Goddess Chest
+  \Sky\South West\Triple Island\Southwest Triple Island Lower Goddess Chest: Sky -
+    Southwest Triple Island Lower Goddess Chest
+  \Sky\South West\Triple Island\Southwest Triple Island Upper Goddess Chest: Sky -
+    Southwest Triple Island Upper Goddess Chest
+  \Sky\South West\Volcanic Island\Goddess Chest inside Volcanic Island: Sky - Goddess
+    Chest inside Volcanic Island
+  \Sky\South West\Volcanic Island\Goddess Chest outside Volcanic Island: Sky - Goddess
+    Chest outside Volcanic Island
+  \Sky\Thunderhead\Bug Heaven\Bug Heaven -- 10 Bugs in 3 Minutes: Thunderhead - Bug
+    Heaven -- 10 Bugs in 3 Minutes
+  \Sky\Thunderhead\Bug Heaven\Bug Heaven Goddess Chest: Thunderhead - Bug Heaven Goddess
+    Chest
+  \Sky\Thunderhead\East Island\East Island Chest: Thunderhead - East Island Chest
+  \Sky\Thunderhead\East Island\East Island Goddess Chest: Thunderhead - East Island
+    Goddess Chest
+  \Sky\Thunderhead\Isle of Songs\Goddess Chest on top of Isle of Songs: Thunderhead
+    - Goddess Chest on top of Isle of Songs
+  \Sky\Thunderhead\Isle of Songs\Goddess Chest outside Isle of Songs: Thunderhead
+    - Goddess Chest outside Isle of Songs
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Goddess Sword: Thunderhead
+    - Isle of Songs - Strike Crest with Goddess Sword
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Longsword: Thunderhead -
+    Isle of Songs - Strike Crest with Longsword
+  \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with White Sword: Thunderhead
+    - Isle of Songs - Strike Crest with White Sword
+  \Sky\Thunderhead\Mogma Mitts Island\First Goddess Chest on Mogma Mitts Island: Thunderhead
+    - First Goddess Chest on Mogma Mitts Island
+  \Sky\Thunderhead\Mogma Mitts Island\Second Goddess Chest on Mogma Mitts Island: Thunderhead
+    - Second Goddess Chest on Mogma Mitts Island
+  \Sky\Thunderhead\Song from Levias: Thunderhead - Song from Levias
+  \Skyloft\Beedle's Shop\Stall\1000 Rupee Item: Beedle's Shop - 1000 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\1200 Rupee Item: Beedle's Shop - 1200 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\1600 Rupee Item: Beedle's Shop - 1600 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\300 Rupee Item: Beedle's Shop - 300 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\50 Rupee Item: Beedle's Shop - 50 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\600 Rupee Item: Beedle's Shop - 600 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\800 Rupee Item: Beedle's Shop - 800 Rupee Item
+  \Skyloft\Beedle's Shop\Stall\First 100 Rupee Item: Beedle's Shop - First 100 Rupee
+    Item
+  \Skyloft\Beedle's Shop\Stall\Second 100 Rupee Item: Beedle's Shop - Second 100 Rupee
+    Item
+  \Skyloft\Beedle's Shop\Stall\Third 100 Rupee Item: Beedle's Shop - Third 100 Rupee
+    Item
+  \Skyloft\Central Skyloft\Bazaar\Bazaar Goddess Chest: Central Skyloft - Bazaar Goddess
+    Chest
+  \Skyloft\Central Skyloft\Bazaar\Potion Lady's Gift: Central Skyloft - Potion Lady's
+    Gift
+  \Skyloft\Central Skyloft\Bazaar\Repair Gondo's Junk: Central Skyloft - Repair Gondo's
+    Junk
+  \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest: Central Skyloft - Item in
+    Bird Nest
+  \Skyloft\Central Skyloft\Crystal between Wooden Planks: Central Skyloft - Crystal
+    between Wooden Planks
+  \Skyloft\Central Skyloft\Crystal on Light Tower: Central Skyloft - Crystal on Light
+    Tower
+  \Skyloft\Central Skyloft\Crystal on Waterfall Island: Central Skyloft - Crystal
+    on Waterfall Island
+  \Skyloft\Central Skyloft\Crystal on West Cliff: Central Skyloft - Crystal on West
+    Cliff
+  \Skyloft\Central Skyloft\Orielle and Parrow's House\Crystal in Orielle and Parrow's House: Central
+    Skyloft - Crystal in Orielle and Parrow's House
+  \Skyloft\Central Skyloft\Parrow's Crystals: Central Skyloft - Parrow's Crystals
+  \Skyloft\Central Skyloft\Parrow's Gift: Central Skyloft - Parrow's Gift
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: Central
+    Skyloft - Crystal after Waterfall Cave
+  \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: Central
+    Skyloft - Crystal in Loftwing Prison
+  \Skyloft\Central Skyloft\Peatrice's House\Peater/Peatrice's Crystals: Central Skyloft
+    - Peater/Peatrice's Crystals
+  \Skyloft\Central Skyloft\Shed Chest: Central Skyloft - Shed Chest
+  \Skyloft\Central Skyloft\Shed Goddess Chest: Central Skyloft - Shed Goddess Chest
+  \Skyloft\Central Skyloft\Waterfall Cave\Rupee Waterfall Cave Crawlspace: Central
+    Skyloft - Rupee Waterfall Cave Crawlspace
+  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave First Chest: Central Skyloft
+    - Waterfall Cave First Chest
+  \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave Second Chest: Central Skyloft
+    - Waterfall Cave Second Chest
+  \Skyloft\Central Skyloft\Waterfall Island\Floating Island Goddess Chest: Central
+    Skyloft - Floating Island Goddess Chest
+  \Skyloft\Central Skyloft\Waterfall Island\Waterfall Goddess Chest: Central Skyloft
+    - Waterfall Goddess Chest
+  \Skyloft\Central Skyloft\West Cliff Goddess Chest: Central Skyloft - West Cliff
+    Goddess Chest
+  \Skyloft\Central Skyloft\Wryna's House\Wryna's Crystals: Central Skyloft - Wryna's
+    Crystals
+  \Skyloft\Skyloft Silent Realm\Relic 1: Skyloft Silent Realm - Relic 1
+  \Skyloft\Skyloft Silent Realm\Relic 10: Skyloft Silent Realm - Relic 10
+  \Skyloft\Skyloft Silent Realm\Relic 2: Skyloft Silent Realm - Relic 2
+  \Skyloft\Skyloft Silent Realm\Relic 3: Skyloft Silent Realm - Relic 3
+  \Skyloft\Skyloft Silent Realm\Relic 4: Skyloft Silent Realm - Relic 4
+  \Skyloft\Skyloft Silent Realm\Relic 5: Skyloft Silent Realm - Relic 5
+  \Skyloft\Skyloft Silent Realm\Relic 6: Skyloft Silent Realm - Relic 6
+  \Skyloft\Skyloft Silent Realm\Relic 7: Skyloft Silent Realm - Relic 7
+  \Skyloft\Skyloft Silent Realm\Relic 8: Skyloft Silent Realm - Relic 8
+  \Skyloft\Skyloft Silent Realm\Relic 9: Skyloft Silent Realm - Relic 9
+  \Skyloft\Skyloft Silent Realm\Trial Reward: Skyloft Silent Realm - Trial Reward
+  \Skyloft\Skyloft Village\Batreaux's House\10 Crystals: Batreaux's House - 10 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals: Batreaux's House - 30 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\30 Crystals Chest: Batreaux's House -
+    30 Crystals Chest
+  \Skyloft\Skyloft Village\Batreaux's House\40 Crystals: Batreaux's House - 40 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\5 Crystals: Batreaux's House - 5 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\50 Crystals: Batreaux's House - 50 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals: Batreaux's House - 70 Crystals
+  \Skyloft\Skyloft Village\Batreaux's House\70 Crystals Second Reward: Batreaux's
+    House - 70 Crystals Second Reward
+  \Skyloft\Skyloft Village\Batreaux's House\80 Crystals: Batreaux's House - 80 Crystals
+  \Skyloft\Skyloft Village\Bertie's House\Bertie's Crystals: Skyloft Village - Bertie's
+    Crystals
+  \Skyloft\Skyloft Village\Crystal near Pumpkin Patch: Skyloft Village - Crystal near
+    Pumpkin Patch
+  \Skyloft\Skyloft Village\Mallara's House\Mallara's Crystals: Skyloft Village - Mallara's
+    Crystals
+  \Skyloft\Skyloft Village\Sparrot's House\Sparrot's Crystals: Skyloft Village - Sparrot's
+    Crystals
+  \Skyloft\Upper Skyloft\Chest near Goddess Statue: Upper Skyloft - Chest near Goddess
+    Statue
+  \Skyloft\Upper Skyloft\Goddess Statue\First Goddess Sword Item in Goddess Statue: Upper
+    Skyloft - First Goddess Sword Item in Goddess Statue
+  \Skyloft\Upper Skyloft\Goddess Statue\Second Goddess Sword Item in Goddess Statue: Upper
+    Skyloft - Second Goddess Sword Item in Goddess Statue
+  \Skyloft\Upper Skyloft\Knight Academy\Crystal in Knight Academy Plant: Upper Skyloft
+    - Crystal in Knight Academy Plant
+  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Crystals: Upper Skyloft - Fledge's
+    Crystals
+  \Skyloft\Upper Skyloft\Knight Academy\Fledge's Gift: Upper Skyloft - Fledge's Gift
+  \Skyloft\Upper Skyloft\Knight Academy\Ghost/Pipit's Crystals: Upper Skyloft - Ghost/Pipit's
+    Crystals
+  \Skyloft\Upper Skyloft\Knight Academy\Item from Cawlin: Upper Skyloft - Item from
+    Cawlin
+  \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Crystal in Link's Room: Upper
+    Skyloft - Crystal in Link's Room
+  \Skyloft\Upper Skyloft\Knight Academy\Owlan's Crystals: Upper Skyloft - Owlan's
+    Crystals
+  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Crystal in Zelda's Room: Upper
+    Skyloft - Crystal in Zelda's Room
+  \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\In Zelda's Closet: Upper Skyloft
+    - In Zelda's Closet
+  \Skyloft\Upper Skyloft\Owlan's Gift: Upper Skyloft - Owlan's Gift
+  \Skyloft\Upper Skyloft\Pumpkin Archery -- 600 Points: Upper Skyloft - Pumpkin Archery
+    -- 600 Points
+  \Skyloft\Upper Skyloft\Sparring Hall\Crystal in Sparring Hall: Upper Skyloft - Crystal
+    in Sparring Hall
+  \Skyloft\Upper Skyloft\Sparring Hall\Sparring Hall Chest: Upper Skyloft - Sparring
+    Hall Chest
+  \Skyview\Boss Room\Heart Container: Skyview - Heart Container
+  \Skyview\Main\First Hub\Left Room\Chest on Tree Branch: Skyview - Chest on Tree
+    Branch
+  \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace: Skyview
+    - Digging Spot in Crawlspace
+  \Skyview\Main\First Hub\Right Room\Upper Area\Chest behind Two Eyes: Skyview - Chest
+    behind Two Eyes
+  \Skyview\Main\Last Room\After Rope\Chest near Boss Door: Skyview - Chest near Boss
+    Door
+  \Skyview\Main\Last Room\Near Boss Key Chest\Boss Key Chest: Skyview - Boss Key Chest
+  \Skyview\Main\Second Hub\Item behind Bars: Skyview - Item behind Bars
+  \Skyview\Main\Second Hub\Left Rooms\Chest behind Three Eyes: Skyview - Chest behind
+    Three Eyes
+  \Skyview\Main\Second Hub\Miniboss Room\Chest after Stalfos Fight: Skyview - Chest
+    after Stalfos Fight
+  \Skyview\Main\Second Hub\Rupee in East Tunnel: Skyview - Rupee in East Tunnel
+  \Skyview\Main\Second Hub\Rupee in Southeast Tunnel: Skyview - Rupee in Southeast
+    Tunnel
+  \Skyview\Main\Second Hub\Rupee in Southwest Tunnel: Skyview - Rupee in Southwest
+    Tunnel
+  \Skyview\Spring\Rupee on Spring Pillar: Skyview - Rupee on Spring Pillar
+  \Skyview\Spring\Strike Crest: Skyview - Strike Crest
 entrances:
   \Ancient Cistern\Boss Room\Entrance from Dungeon:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2232
@@ -13435,7 +7062,7 @@ entrances:
     tod: 2
     type: entrance
   \Ancient Cistern\Boss Room\Entrance from Flame Room:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2233
@@ -13443,7 +7070,7 @@ entrances:
     tod: 2
     type: entrance
   \Ancient Cistern\Flame Room\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2234
@@ -13451,7 +7078,7 @@ entrances:
     tod: 2
     type: entrance
   \Ancient Cistern\Main\Inside Statue\Boss Door Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2231
@@ -13459,7 +7086,7 @@ entrances:
     tod: 2
     type: entrance
   \Ancient Cistern\Main\Main Room\Main Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -13471,7 +7098,7 @@ entrances:
     tod: 2
     type: entrance
   \Earth Temple\Boss Room\Entry\Entrance from Dungeon:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2261
@@ -13479,7 +7106,7 @@ entrances:
     tod: 2
     type: entrance
   \Earth Temple\Boss Room\Slope\Entrance from Spring:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2262
@@ -13487,7 +7114,7 @@ entrances:
     tod: 2
     type: entrance
   \Earth Temple\Main\First Room\Main Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -13499,7 +7126,7 @@ entrances:
     tod: 2
     type: entrance
   \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2260
@@ -13507,7 +7134,7 @@ entrances:
     tod: 2
     type: entrance
   \Earth Temple\Spring\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2263
@@ -13515,7 +7142,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Bokoblin Base\Prison\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 1
     province: Eldin Province
@@ -13526,7 +7153,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Eldin Silent Realm\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2251
@@ -13534,7 +7161,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Mogma Turf\Pre Vent\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Eldin Province
@@ -13545,7 +7172,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano Summit\Entrance from Eldin Volcano:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 4
     layer: 0
@@ -13557,7 +7184,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano Summit\Entrance from Outside Fire Sanctuary:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 1
     layer: 0
@@ -13569,7 +7196,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano Summit\Entrance from Waterfall:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 2
     layer: 0
@@ -13581,7 +7208,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Entrance from Summit:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -13593,7 +7220,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Entrance from Fire Sanctuary:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 1
     layer: 0
@@ -13605,7 +7232,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 3
     layer: 0
     province: Eldin Province
@@ -13618,7 +7245,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano Summit\Waterfall\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -13630,7 +7257,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Ascent\Trial Gate Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2245
@@ -13638,7 +7265,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Ascent\Volcano Ascent Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 7
     layer: 0
     province: Eldin Province
@@ -13651,7 +7278,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\East\Entrance from Bokoblin Base:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 5
     layer: 1
     province: Eldin Province
@@ -13662,7 +7289,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\East\First Vent from Mogma Turf:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Eldin Province
@@ -13673,7 +7300,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\East\Volcano East Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 6
     layer: 0
     province: Eldin Province
@@ -13686,7 +7313,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Entry\First Time Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Eldin Province
@@ -13697,7 +7324,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Entry\Volcano Entrance Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: Eldin Province
@@ -13710,7 +7337,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Hot Cave\Entrance from Summit:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 2
     layer: 0
@@ -13722,7 +7349,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Hot Cave\Vent Entrance near Hot Cave:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2246
@@ -13730,7 +7357,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Near Temple Entrance\Entrance from Earth Temple:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Eldin Province
@@ -13741,7 +7368,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 7
     layer: 0
     province: Eldin Province
@@ -13754,7 +7381,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: Eldin Province
@@ -13765,7 +7392,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Past Mogma Turf\Second Vent from Mogma Turf:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: Eldin Province
@@ -13776,7 +7403,7 @@ entrances:
     tod: 2
     type: entrance
   \Eldin\Volcano\Thrill Digger Cave\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 1
     province: Eldin Province
@@ -13787,7 +7414,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Silent Realm\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2197
@@ -13795,7 +7422,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Deep Woods\Deep Woods Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 14
     layer: 0
     province: Faron Province
@@ -13808,7 +7435,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Deep Woods\Entrance from Skyview Temple:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 1
     layer: 0
@@ -13820,7 +7447,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Deep Woods\Entry\Entrance from Faron Woods:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Faron Province
@@ -13831,7 +7458,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Deep Woods\Forest Temple Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 13
     layer: 0
     province: Faron Province
@@ -13844,7 +7471,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Entry\Entrance from Behind the Temple:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Faron Province
@@ -13855,7 +7482,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Entry\Faron Woods Entry Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 50
     layer: 0
     province: Faron Province
@@ -13868,7 +7495,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Entrance from Platforms:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Faron Province
@@ -13879,7 +7506,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 4
     layer: 0
@@ -13891,7 +7518,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 7
     layer: 0
@@ -13903,7 +7530,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Great Tree\Platforms\Lower Entrance from Great Tree:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 4
     layer: 0
     province: Faron Province
@@ -13914,7 +7541,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Great Tree\Platforms\Upper Entrance from Great Tree:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 5
     layer: 0
     province: Faron Province
@@ -13925,7 +7552,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Great Tree\Top\The Great Tree Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 53
     layer: 0
     province: Faron Province
@@ -13938,7 +7565,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Great Tree\Top\Top Entrance from Great Tree:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 6
     layer: 0
     province: Faron Province
@@ -13949,7 +7576,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Flooded Great Tree:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2206
@@ -13957,7 +7584,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Top:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 3
     layer: 0
     province: Faron Province
@@ -13968,7 +7595,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Great Tree\Upper Area\Upper Entrance from Platforms:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: Faron Province
@@ -13979,7 +7606,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\In the Woods Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 51
     layer: 0
     province: Faron Province
@@ -13992,7 +7619,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Ledge To Deep Woods\Entrance from Deep Woods:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 45
     layer: 0
     province: Faron Province
@@ -14003,7 +7630,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Entrance from Floria Waterfall:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 17
     layer: 0
     province: Faron Province
@@ -14014,7 +7641,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Trial Gate Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2196
@@ -14022,7 +7649,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Faron Woods\Viewing Platform Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 52
     layer: 0
     province: Faron Province
@@ -14035,7 +7662,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Flooded Faron Woods\Entrance from Lower Flooded Great Tree:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2211
@@ -14043,27 +7670,27 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Flooded Faron Woods\Entrance from Upper Flooded Great Tree:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     req_index: 2210
     short_name: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
     type: entrance
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     req_index: 2207
     short_name: Flooded Great Tree - Entrance
     type: entrance
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Lower Flooded Faron Woods:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     req_index: 2209
     short_name: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
     type: entrance
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Upper Flooded Faron Woods:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     req_index: 2208
     short_name: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
     type: entrance
   \Faron\Lake Floria\Above Rock\Dive from Faron Woods:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -14075,7 +7702,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Lake Floria\Below Rock\Emerged Area\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: Faron Province
@@ -14088,7 +7715,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Lake Floria\Below Rock\Entrance from Farore's Lair:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 1
     layer: 0
@@ -14100,7 +7727,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Lake Floria\Farore's Lair\Entrance from Lake Floria:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -14112,7 +7739,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Lake Floria\Farore's Lair\Entrance from Waterfall:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Faron Province
@@ -14123,7 +7750,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Lake Floria\Waterfall\Entrance from Ancient Cistern:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Faron Province
@@ -14135,7 +7762,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Lake Floria\Waterfall\Entrance from Faron Woods:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: Faron Province
@@ -14146,7 +7773,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Lake Floria\Waterfall\Entrance from Farore's Lair:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Faron Province
@@ -14157,7 +7784,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Lake Floria\Waterfall\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 5
     layer: 0
     province: Faron Province
@@ -14170,7 +7797,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Behind the Temple\Door Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Faron Province
@@ -14181,7 +7808,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Behind the Temple\Entrance from Faron Woods:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 3
     layer: 0
     province: Faron Province
@@ -14192,7 +7819,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Behind the Temple\Shortcut Entrance from Spiral:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 2
     layer: 0
@@ -14204,7 +7831,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Behind the Temple\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 10
     layer: 0
     province: Faron Province
@@ -14217,7 +7844,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 1
     layer: 0
@@ -14229,7 +7856,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Sealed Temple\Gate of Time Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 11
     layer: 0
@@ -14241,7 +7868,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Sealed Temple\Main Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Faron Province
@@ -14252,7 +7879,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Sealed Temple\Side Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Faron Province
@@ -14263,7 +7890,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Spiral\Door Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: Faron Province
@@ -14274,7 +7901,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Entrance from Behind the Temple:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Faron Province
@@ -14285,7 +7912,7 @@ entrances:
     tod: 2
     type: entrance
   \Faron\Sealed Grounds\Spiral\Upper Part\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 8
     layer: 0
     province: Faron Province
@@ -14298,7 +7925,7 @@ entrances:
     tod: 2
     type: entrance
   \Fire Sanctuary\Boss Room\Entrance from Dungeon:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2271
@@ -14306,7 +7933,7 @@ entrances:
     tod: 2
     type: entrance
   \Fire Sanctuary\Boss Room\Entrance from Flame Room:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2272
@@ -14314,7 +7941,7 @@ entrances:
     tod: 2
     type: entrance
   \Fire Sanctuary\Flame Room\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2273
@@ -14322,7 +7949,7 @@ entrances:
     tod: 2
     type: entrance
   \Fire Sanctuary\Main\First Room\Main Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -14334,7 +7961,7 @@ entrances:
     tod: 2
     type: entrance
   \Fire Sanctuary\Main\First Room\Past Water Plant\Entrance from Second Room:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2266
@@ -14342,7 +7969,7 @@ entrances:
     tod: 2
     type: entrance
   \Fire Sanctuary\Main\Front of Boss Door\Boss Door Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2270
@@ -14350,7 +7977,7 @@ entrances:
     tod: 2
     type: entrance
   \Fire Sanctuary\Main\Front of Boss Door\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 2
     layer: 0
@@ -14364,7 +7991,7 @@ entrances:
     tod: 2
     type: entrance
   \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Entrance from West of Boss Door:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2268
@@ -14373,7 +8000,7 @@ entrances:
     tod: 2
     type: entrance
   \Fire Sanctuary\Main\Second Room\Outside Section\Entrance from First Room:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2267
@@ -14381,7 +8008,7 @@ entrances:
     tod: 2
     type: entrance
   \Fire Sanctuary\Main\West of Boss Door\Entry\Entrance from Magmanos Fight Room:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Eldin Province
     req_index: 2269
@@ -14390,7 +8017,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Boss Room\After Sand Drain\Entrance from Hall of Ancient Robots:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2337
@@ -14399,7 +8026,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Boss Room\Entrance from Dungeon:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2336
@@ -14407,7 +8034,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Hall of Ancient Robots\End\Entrance from Temple of Time:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 1
     layer: 0
@@ -14421,7 +8048,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Entrance from Boss Room:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2338
@@ -14430,7 +8057,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Main\Armos Fight Room\Entrance from Big Hub:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2331
@@ -14438,7 +8065,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Main\Big Hub\Entry\Entrance from First Hub:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2332
@@ -14446,7 +8073,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Entrance from Hop Across Boxes Room:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2333
@@ -14455,7 +8082,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Entrance from Armos Fight Room:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2334
@@ -14463,7 +8090,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Main\First Hub\Entrance from Big Hub:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2329
@@ -14471,7 +8098,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Main\First Room\Main Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -14483,7 +8110,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Entrance from Big Hub:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2330
@@ -14492,7 +8119,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2335
@@ -14500,7 +8127,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Caves\Entrance from Desert:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Lanayru Province
@@ -14511,7 +8138,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Caves\Entrance from Mine:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -14522,7 +8149,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Caves\Past Crawlspace\Entrance from Gorge:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 3
     layer: 0
     province: Lanayru Province
@@ -14533,7 +8160,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Caves\Past Door to Lanayru Sand Sea\Entrance from Lanayru Sand Sea:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 2
     layer: 0
@@ -14545,7 +8172,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\East\Fire Node Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 3
     layer: 0
     province: Lanayru Province
@@ -14556,7 +8183,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\East\Fire Node\Present\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -14567,7 +8194,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\East\Stone Cache Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 18
     layer: 0
     province: Lanayru Province
@@ -14580,7 +8207,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\Entry\Desert Entrance Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 15
     layer: 0
     province: Lanayru Province
@@ -14593,7 +8220,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\Entry\Entrance from Mine:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: Lanayru Province
@@ -14604,7 +8231,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Entrance from Caves:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 6
     layer: 0
     province: Lanayru Province
@@ -14615,7 +8242,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\Near South Exit to Temple of Time\South Entrance from Temple of Time:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -14626,7 +8253,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\North Part\Lightning Node Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 7
     layer: 0
     province: Lanayru Province
@@ -14637,7 +8264,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\North Part\Lightning Node\Present\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -14648,7 +8275,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\North Part\North Desert Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 17
     layer: 0
     province: Lanayru Province
@@ -14661,7 +8288,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\North Part\North Entrance from Temple of Time:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Lanayru Province
@@ -14672,7 +8299,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\North Part\Trial Gate Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2289
@@ -14680,7 +8307,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\Top of LMF\Entrance from Lanayru Mining Facility:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 5
     layer: 0
@@ -14692,7 +8319,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Desert\West Part\West Desert Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 16
     layer: 0
     province: Lanayru Province
@@ -14705,7 +8332,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -14716,7 +8343,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Lanayru Province
@@ -14727,7 +8354,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Entrance from Caves:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -14739,7 +8366,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 10
     layer: 0
     province: Lanayru Province
@@ -14752,7 +8379,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Gorge\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 2
     province: Lanayru Province
@@ -14763,7 +8390,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Gorge\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 12
     layer: 0
     province: Lanayru Province
@@ -14776,7 +8403,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 3
     layer: 0
     province: Lanayru Province
@@ -14787,7 +8414,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -14798,7 +8425,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 2
     layer: 0
@@ -14810,7 +8437,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -14821,7 +8448,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 1
     layer: 0
@@ -14833,7 +8460,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Lanayru Province
@@ -14844,7 +8471,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 10
     layer: 0
     province: Lanayru Province
@@ -14857,7 +8484,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Sandship Dock Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 4
     layer: 0
@@ -14869,7 +8496,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Shipyard Dock Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: Lanayru Province
@@ -14880,7 +8507,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 1
     layer: 0
@@ -14892,7 +8519,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 4
     layer: 0
@@ -14904,7 +8531,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 1
     layer: 0
@@ -14916,7 +8543,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -14928,7 +8555,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Dock Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -14939,7 +8566,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 10
     layer: 0
     province: Lanayru Province
@@ -14952,7 +8579,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Lanayru Province
@@ -14963,7 +8590,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -14974,7 +8601,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -14985,7 +8612,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 10
     layer: 0
     province: Lanayru Province
@@ -14998,7 +8625,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Lanayru Province
@@ -15009,7 +8636,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Lanayru Silent Realm\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2290
@@ -15017,7 +8644,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Mine\End\In Minecart\Entrance from Desert:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Lanayru Province
@@ -15028,7 +8655,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Mine\Entry\Caves Entrance\Entrance from Caves:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Lanayru Province
@@ -15039,7 +8666,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Mine\Entry\First Time Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -15050,7 +8677,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Mine\Entry\Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: Lanayru Province
@@ -15063,7 +8690,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Temple of Time\Inside\Entrance from Lanayru Mining Facility:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 5
     layer: 2
@@ -15076,7 +8703,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Temple of Time\Inside\Temple of Time Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 17
     layer: 0
     province: Lanayru Province
@@ -15089,7 +8716,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Temple of Time\North East\North Entrance from Desert:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: Lanayru Province
@@ -15100,7 +8727,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Temple of Time\South East\Desert Gorge Statue Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 16
     layer: 0
     province: Lanayru Province
@@ -15113,7 +8740,7 @@ entrances:
     tod: 2
     type: entrance
   \Lanayru\Temple of Time\South East\South Entrance from Desert:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: Lanayru Province
@@ -15124,7 +8751,7 @@ entrances:
     tod: 2
     type: entrance
   \Sandship\Boss Room\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Lanayru Province
     req_index: 2341
@@ -15132,7 +8759,7 @@ entrances:
     tod: 2
     type: entrance
   \Sandship\Main\Deck\Main Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 1
@@ -15144,7 +8771,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky Keep\Main\First Room\Bottom Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 4
     layer: 0
@@ -15156,7 +8783,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\Around Skyloft\Entrance from Skyloft:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: The Sky
     req_index: 2155
@@ -15164,7 +8791,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\Around Skyloft\Entrance from Thunderhead:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 28
     layer: 0
@@ -15176,7 +8803,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\North East\Bamboo Island\Entrance from Inside:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 11
     layer: 0
     province: The Sky
@@ -15187,7 +8814,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\North East\Bamboo Island\Inside\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 1
     province: The Sky
@@ -15199,8 +8826,7 @@ entrances:
     type: entrance
   \Sky\North East\Beedle's Island\Beedle's Ship Entrance:
     allowed-time-of-day: NightOnly
-    allowed_time_of_day: &id003 !!python/object/apply:logic.logic_input.AllowedTimeOfDay
-    - 2
+    allowed_time_of_day: 2
     entrance: 0
     layer: 4
     province: The Sky
@@ -15211,7 +8837,7 @@ entrances:
     tod: 1
     type: entrance
   \Sky\North East\Eldin Pillar\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 13
     layer: 0
     province: The Sky
@@ -15223,7 +8849,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\South East\Faron Pillar\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 12
     layer: 0
     province: The Sky
@@ -15235,7 +8861,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\South East\Lumpy Pumpkin\Back Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 24
     layer: 0
     province: The Sky
@@ -15246,7 +8872,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 3
     layer: 0
     province: The Sky
@@ -15257,7 +8883,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 2
     layer: 0
     province: The Sky
@@ -15268,7 +8894,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15279,7 +8905,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\South East\Lumpy Pumpkin\Main Left Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 22
     layer: 0
     province: The Sky
@@ -15290,7 +8916,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\South East\Lumpy Pumpkin\Main Right Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 23
     layer: 0
     province: The Sky
@@ -15301,7 +8927,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\South West\Lanayru Pillar\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 14
     layer: 0
     province: The Sky
@@ -15312,7 +8938,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\Thunderhead\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 1
     layer: 0
@@ -15324,7 +8950,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\Thunderhead\Isle of Songs\Entrance from Inside:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 4
     layer: 0
@@ -15336,7 +8962,7 @@ entrances:
     tod: 2
     type: entrance
   \Sky\Thunderhead\Isle of Songs\Inside\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -15348,7 +8974,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Beedle's Shop\Day Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 0
     layer: 0
     province: The Sky
@@ -15360,7 +8986,7 @@ entrances:
     type: entrance
   \Skyloft\Beedle's Shop\Night Entrance:
     allowed-time-of-day: NightOnly
-    allowed_time_of_day: *id003
+    allowed_time_of_day: 2
     entrance: 0
     layer: 0
     province: The Sky
@@ -15371,7 +8997,7 @@ entrances:
     tod: 1
     type: entrance
   \Skyloft\Central Skyloft\Bazaar North Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 2
     layer: 0
     province: The Sky
@@ -15382,7 +9008,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Bazaar South Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 3
     layer: 0
     province: The Sky
@@ -15393,7 +9019,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Bazaar West Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 20
     layer: 0
     province: The Sky
@@ -15404,7 +9030,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Bazaar\North Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 0
     layer: 0
     province: The Sky
@@ -15415,7 +9041,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Bazaar\South Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 1
     layer: 0
     province: The Sky
@@ -15426,7 +9052,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Bazaar\West Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 2
     layer: 0
     province: The Sky
@@ -15437,7 +9063,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Entrance from Beedle's Shop:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 0
     layer: 0
     province: The Sky
@@ -15448,7 +9074,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Entrance from Sky:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     can-start-at: false
     province: The Sky
     req_index: 2153
@@ -15456,7 +9082,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Near Temple Entrance\Entrance from Sky Keep:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 53
     layer: 0
@@ -15468,7 +9094,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Orielle and Parrow's House Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 30
     layer: 0
     province: The Sky
@@ -15479,7 +9105,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Orielle and Parrow's House\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15490,7 +9116,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 8
     layer: 0
     province: The Sky
@@ -15501,7 +9127,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Peatrice's House Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 38
     layer: 0
     province: The Sky
@@ -15512,7 +9138,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Peatrice's House\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15523,7 +9149,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Piper's House Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 32
     layer: 0
     province: The Sky
@@ -15534,7 +9160,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Piper's House\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15545,7 +9171,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Trial Gate Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     can-start-at: false
     province: The Sky
     req_index: 2110
@@ -15553,7 +9179,7 @@ entrances:
     tod: 0
     type: entrance
   \Skyloft\Central Skyloft\Waterfall Cave Upper Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 7
     layer: 0
     province: The Sky
@@ -15564,7 +9190,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Waterfall Cave\Lower Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15575,7 +9201,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Waterfall Cave\Upper Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 0
     layer: 0
     province: The Sky
@@ -15586,7 +9212,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Wryna's House Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 31
     layer: 0
     province: The Sky
@@ -15597,7 +9223,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Central Skyloft\Wryna's House\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15608,7 +9234,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Silent Realm\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     can-start-at: false
     province: The Sky
     req_index: 2108
@@ -15616,7 +9242,7 @@ entrances:
     tod: 0
     type: entrance
   \Skyloft\Skyloft Village\Batreaux's House Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 29
     layer: 0
     province: The Sky
@@ -15627,7 +9253,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Batreaux's House\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 0
     layer: 0
     province: The Sky
@@ -15638,7 +9264,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Bertie's House Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 34
     layer: 0
     province: The Sky
@@ -15649,7 +9275,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Bertie's House\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15660,7 +9286,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Gondo's House Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 35
     layer: 0
     province: The Sky
@@ -15671,7 +9297,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Gondo's House\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15682,7 +9308,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Mallara's House Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 36
     layer: 0
     province: The Sky
@@ -15693,7 +9319,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Mallara's House\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15704,7 +9330,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Rupin's House Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 37
     layer: 0
     province: The Sky
@@ -15715,7 +9341,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Rupin's House\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15726,7 +9352,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Sparrot's House Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 33
     layer: 0
     province: The Sky
@@ -15737,7 +9363,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Skyloft Village\Sparrot's House\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15748,7 +9374,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Goddess Statue Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 6
     layer: 0
     province: The Sky
@@ -15759,7 +9385,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Goddess Statue\Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 0
     layer: 0
     province: The Sky
@@ -15770,7 +9396,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 5
     layer: 0
     province: The Sky
@@ -15781,7 +9407,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 4
     layer: 0
     province: The Sky
@@ -15792,7 +9418,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 23
     layer: 0
     province: The Sky
@@ -15803,7 +9429,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 24
     layer: 0
     province: The Sky
@@ -15815,7 +9441,7 @@ entrances:
     type: entrance
   \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Start Entrance:
     allowed-time-of-day: DayOnly
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     entrance: 5
     layer: 0
     province: The Sky
@@ -15827,7 +9453,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 2
     layer: 0
     province: The Sky
@@ -15838,7 +9464,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15849,7 +9475,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 4
     layer: 0
     province: The Sky
@@ -15860,7 +9486,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 3
     layer: 0
     province: The Sky
@@ -15871,7 +9497,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Chimney:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15882,7 +9508,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Sparring Hall Left Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 21
     layer: 0
     province: The Sky
@@ -15893,7 +9519,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Sparring Hall Right Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 26
     layer: 0
     province: The Sky
@@ -15904,7 +9530,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Left Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 2
     layer: 0
     province: The Sky
@@ -15915,7 +9541,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Right Door Entrance:
-    allowed_time_of_day: *id002
+    allowed_time_of_day: 3
     entrance: 1
     layer: 0
     province: The Sky
@@ -15926,7 +9552,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyview\Boss Room\Entrance from Dungeon:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2227
@@ -15934,7 +9560,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyview\Boss Room\Entrance from Spring:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2228
@@ -15942,7 +9568,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyview\Main\Entry\Main Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     entrance: 0
     layer: 0
@@ -15954,7 +9580,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyview\Main\Last Room\After Rope\Boss Door Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2226
@@ -15962,7 +9588,7 @@ entrances:
     tod: 2
     type: entrance
   \Skyview\Spring\Entrance:
-    allowed_time_of_day: *id001
+    allowed_time_of_day: 1
     can-start-at: false
     province: Faron Province
     req_index: 2229
@@ -17817,114 +11443,41 @@ exits:
     type: exit
     vanilla: Skyloft - Knight Academy - Start Entrance
 gossip_stones:
-  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Gossip Stone near Second Thirsty Frog:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 861
-    short_name: Volcano Summit - Gossip Stone near Second Thirsty Frog
-    textfile: 004-Object
-    textindex: 31
-  \Eldin\Volcano Summit\Waterfall\Higher Area\Gossip Stone in Waterfall Area:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 855
-    short_name: Volcano Summit - Gossip Stone in Waterfall Area
-    textfile: 004-Object
-    textindex: 26
-  \Eldin\Volcano\Lower Platform Cave\Gossip Stone in Lower Platform Cave:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 832
-    short_name: Eldin Volcano - Gossip Stone in Lower Platform Cave
-    textfile: 004-Object
-    textindex: 17
-  \Eldin\Volcano\Near Temple Entrance\Gossip Stone next to Earth Temple:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 822
-    short_name: Eldin Volcano - Gossip Stone next to Earth Temple
-    textfile: 004-Object
-    textindex: 14
-  \Eldin\Volcano\Thrill Digger Cave\Gossip Stone in Thrill Digger Cave:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 817
-    short_name: Eldin Volcano - Gossip Stone in Thrill Digger Cave
-    textfile: 004-Object
-    textindex: 16
-  \Eldin\Volcano\Upper Platform Cave\Gossip Stone in Upper Platform Cave:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 827
-    short_name: Eldin Volcano - Gossip Stone in Upper Platform Cave
-    textfile: 004-Object
-    textindex: 21
-  \Faron\Faron Woods\Deep Woods\Gossip Stone in Deep Woods:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 924
-    short_name: Faron Woods - Gossip Stone in Deep Woods
-    textfile: 004-Object
-    textindex: 15
-  \Faron\Lake Floria\Waterfall\Gossip Stone outside Ancient Cistern:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 971
-    short_name: Lake Floria - Gossip Stone outside Ancient Cistern
-    textfile: 004-Object
-    textindex: 28
-  \Faron\Sealed Grounds\Behind the Temple\Gossip Stone behind the Temple:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 890
-    short_name: Sealed Grounds - Gossip Stone behind the Temple
-    textfile: 004-Object
-    textindex: 13
-  \Lanayru\Caves\Gossip Stone in Center:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1139
-    short_name: Lanayru Caves - Gossip Stone in Center
-    textfile: 004-Object
-    textindex: 24
-  \Lanayru\Caves\Past Crawlspace\Gossip Stone towards Lanayru Gorge:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1140
-    short_name: Lanayru Caves - Gossip Stone towards Lanayru Gorge
-    textfile: 004-Object
-    textindex: 29
-  \Lanayru\Lanayru Sand Sea\Shipyard\Gossip Stone in Shipyard:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1158
-    short_name: Lanayru Sand Sea - Gossip Stone in Shipyard
-    textfile: 004-Object
-    textindex: 23
-  \Lanayru\Temple of Time\Front\Gossip Stone in Temple of Time Area:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1119
-    short_name: Temple of Time - Gossip Stone in Temple of Time Area
-    textfile: 004-Object
-    textindex: 25
-  \Sky\North East\Bamboo Island\Inside\Gossip Stone on Bamboo Island:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1246
-    short_name: Sky - Gossip Stone on Bamboo Island
-    textfile: 004-Object
-    textindex: 11
-  \Sky\South East\Lumpy Pumpkin\Gossip Stone on Lumpy Pumpkin:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1258
-    short_name: Sky - Gossip Stone on Lumpy Pumpkin
-    textfile: 004-Object
-    textindex: 27
-  \Sky\South West\Volcanic Island\Gossip Stone on Volcanic Island:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1271
-    short_name: Sky - Gossip Stone on Volcanic Island
-    textfile: 004-Object
-    textindex: 30
-  \Sky\Thunderhead\Bug Heaven\Gossip Stone near Bug Heaven:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1296
-    short_name: Thunderhead - Gossip Stone near Bug Heaven
-    textfile: 004-Object
-    textindex: 12
-  \Skyloft\Central Skyloft\Waterfall Island\Gossip Stone on Waterfall Island:
-    req_index: !!python/object/new:logic.inventory.EXTENDED_ITEM
-    - 1347
-    short_name: Central Skyloft - Gossip Stone on Waterfall Island
-    textfile: 124-Town6
-    textindex: 18
+  \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Gossip Stone near Second Thirsty Frog: Volcano
+    Summit - Gossip Stone near Second Thirsty Frog
+  \Eldin\Volcano Summit\Waterfall\Higher Area\Gossip Stone in Waterfall Area: Volcano
+    Summit - Gossip Stone in Waterfall Area
+  \Eldin\Volcano\Lower Platform Cave\Gossip Stone in Lower Platform Cave: Eldin Volcano
+    - Gossip Stone in Lower Platform Cave
+  \Eldin\Volcano\Near Temple Entrance\Gossip Stone next to Earth Temple: Eldin Volcano
+    - Gossip Stone next to Earth Temple
+  \Eldin\Volcano\Thrill Digger Cave\Gossip Stone in Thrill Digger Cave: Eldin Volcano
+    - Gossip Stone in Thrill Digger Cave
+  \Eldin\Volcano\Upper Platform Cave\Gossip Stone in Upper Platform Cave: Eldin Volcano
+    - Gossip Stone in Upper Platform Cave
+  \Faron\Faron Woods\Deep Woods\Gossip Stone in Deep Woods: Faron Woods - Gossip Stone
+    in Deep Woods
+  \Faron\Lake Floria\Waterfall\Gossip Stone outside Ancient Cistern: Lake Floria -
+    Gossip Stone outside Ancient Cistern
+  \Faron\Sealed Grounds\Behind the Temple\Gossip Stone behind the Temple: Sealed Grounds
+    - Gossip Stone behind the Temple
+  \Lanayru\Caves\Gossip Stone in Center: Lanayru Caves - Gossip Stone in Center
+  \Lanayru\Caves\Past Crawlspace\Gossip Stone towards Lanayru Gorge: Lanayru Caves
+    - Gossip Stone towards Lanayru Gorge
+  \Lanayru\Lanayru Sand Sea\Shipyard\Gossip Stone in Shipyard: Lanayru Sand Sea -
+    Gossip Stone in Shipyard
+  \Lanayru\Temple of Time\Front\Gossip Stone in Temple of Time Area: Temple of Time
+    - Gossip Stone in Temple of Time Area
+  \Sky\North East\Bamboo Island\Inside\Gossip Stone on Bamboo Island: Sky - Gossip
+    Stone on Bamboo Island
+  \Sky\South East\Lumpy Pumpkin\Gossip Stone on Lumpy Pumpkin: Sky - Gossip Stone
+    on Lumpy Pumpkin
+  \Sky\South West\Volcanic Island\Gossip Stone on Volcanic Island: Sky - Gossip Stone
+    on Volcanic Island
+  \Sky\Thunderhead\Bug Heaven\Gossip Stone near Bug Heaven: Thunderhead - Gossip Stone
+    near Bug Heaven
+  \Skyloft\Central Skyloft\Waterfall Island\Gossip Stone on Waterfall Island: Central
+    Skyloft - Gossip Stone on Waterfall Island
 items:
 - Day
 - Night
@@ -20300,4 +13853,3 @@ items:
 - \Sandship\Main\Deck\Main Entrance
 - \Sandship\Boss Room\Entrance
 - \Sky Keep\Main\First Room\Bottom Entrance
-

--- a/logic/dump.py
+++ b/logic/dump.py
@@ -10,11 +10,16 @@ def dump_constants(short_to_full):
 
     return {
         "linked_entrances": {
-            "silent_realms": { p: silent_realm(p, short_to_full) for p in ALL_SILENT_REALMS },
-            "dungeons": { p: dungeon(p, short_to_full) for p in ALL_DUNGEONS },
+            "silent_realms": {
+                p: silent_realm(p, short_to_full) for p in ALL_SILENT_REALMS
+            },
+            "dungeons": {p: dungeon(p, short_to_full) for p in ALL_DUNGEONS},
         },
-        "dungeon_completion_requirements": { k: short_to_full(v) for k, v in DUNGEON_FINAL_CHECK.items() },
+        "dungeon_completion_requirements": {
+            k: short_to_full(v) for k, v in DUNGEON_FINAL_CHECK.items()
+        },
     }
+
 
 def silent_realm(pool, short_to_full):
     return {
@@ -22,12 +27,15 @@ def silent_realm(pool, short_to_full):
         "exit_from_inside": short_to_full(SILENT_REALM_EXITS[pool]),
     }
 
+
 def dungeon(pool, short_to_full):
     entrance = DUNGEON_OVERWORLD_ENTRANCES[pool]
     exit_to_dungeon = DUNGEON_ENTRANCE_EXITS[entrance]
     exit_from_dungeon = DUNGEON_MAIN_EXITS[pool]
 
     return {
-        "exit_from_outside": [short_to_full(e) for e in exit_to_dungeon] if len(exit_to_dungeon) > 1 else short_to_full(exit_to_dungeon[0]),
+        "exit_from_outside": [short_to_full(e) for e in exit_to_dungeon]
+        if len(exit_to_dungeon) > 1
+        else short_to_full(exit_to_dungeon[0]),
         "exit_from_inside": short_to_full(exit_from_dungeon),
     }

--- a/logic/dump.py
+++ b/logic/dump.py
@@ -9,8 +9,10 @@ def dump_constants(short_to_full):
     """
 
     return {
-        "silent_realms": { p: silent_realm(p, short_to_full) for p in ALL_SILENT_REALMS },
-        "dungeons": { p: dungeon(p, short_to_full) for p in ALL_DUNGEONS },
+        "linked_entrances": {
+            "silent_realms": { p: silent_realm(p, short_to_full) for p in ALL_SILENT_REALMS },
+            "dungeons": { p: dungeon(p, short_to_full) for p in ALL_DUNGEONS },
+        },
         "dungeon_completion_requirements": { k: short_to_full(v) for k, v in DUNGEON_FINAL_CHECK.items() },
     }
 

--- a/logic/dump.py
+++ b/logic/dump.py
@@ -1,0 +1,30 @@
+from logic.constants import *
+
+
+def dump_constants(short_to_full):
+    # dungeons = [SV, ET, LMF, AC, SSH, FS, SK]
+
+    return {
+        "silent_realms": { p: silent_realm(p, short_to_full) for p in ALL_SILENT_REALMS },
+        "dungeons": { p: dungeon(p, short_to_full) for p in ALL_DUNGEONS }
+    }
+
+def silent_realm(pool, short_to_full):
+    return {
+        "exit_from_outside": short_to_full(TRIAL_GATE_EXITS[SILENT_REALM_GATES[pool]]),
+        # "entrance_from_outside": short_to_full(entrance_of_exit(SILENT_REALM_EXITS[pool])),
+        "exit_from_inside": short_to_full(SILENT_REALM_EXITS[pool]),
+        # "entrance_from_inside": short_to_full(entrance_of_exit(TRIAL_GATE_EXITS[SILENT_REALM_GATES[pool]])),
+    }
+
+def dungeon(pool, short_to_full):
+    entrance = DUNGEON_OVERWORLD_ENTRANCES[pool]
+    exit_to_dungeon = DUNGEON_ENTRANCE_EXITS[entrance]
+    exit_from_dungeon = DUNGEON_MAIN_EXITS[pool]
+
+    return {
+        "exit_from_outside": [short_to_full(e) for e in exit_to_dungeon] if len(exit_to_dungeon) > 1 else short_to_full(exit_to_dungeon[0]),
+        # "entrance_from_outside": short_to_full(entrance_of_exit(exit_from_dungeon)),
+        "exit_from_inside": short_to_full(exit_from_dungeon),
+        # "entrance_from_inside": short_to_full(entrance_of_exit(exit_to_dungeon[0])),
+    }

--- a/logic/dump.py
+++ b/logic/dump.py
@@ -2,19 +2,22 @@ from logic.constants import *
 
 
 def dump_constants(short_to_full):
-    # dungeons = [SV, ET, LMF, AC, SSH, FS, SK]
+    """
+    Some things aren't defined in the YAML files but instead hardcoded in the rando source files.
+    Add these constants to the dump so that consumers of the dump don't have to hardcode
+    as much.
+    """
 
     return {
         "silent_realms": { p: silent_realm(p, short_to_full) for p in ALL_SILENT_REALMS },
-        "dungeons": { p: dungeon(p, short_to_full) for p in ALL_DUNGEONS }
+        "dungeons": { p: dungeon(p, short_to_full) for p in ALL_DUNGEONS },
+        "dungeon_completion_requirements": { k: short_to_full(v) for k, v in DUNGEON_FINAL_CHECK.items() },
     }
 
 def silent_realm(pool, short_to_full):
     return {
         "exit_from_outside": short_to_full(TRIAL_GATE_EXITS[SILENT_REALM_GATES[pool]]),
-        # "entrance_from_outside": short_to_full(entrance_of_exit(SILENT_REALM_EXITS[pool])),
         "exit_from_inside": short_to_full(SILENT_REALM_EXITS[pool]),
-        # "entrance_from_inside": short_to_full(entrance_of_exit(TRIAL_GATE_EXITS[SILENT_REALM_GATES[pool]])),
     }
 
 def dungeon(pool, short_to_full):
@@ -24,7 +27,5 @@ def dungeon(pool, short_to_full):
 
     return {
         "exit_from_outside": [short_to_full(e) for e in exit_to_dungeon] if len(exit_to_dungeon) > 1 else short_to_full(exit_to_dungeon[0]),
-        # "entrance_from_outside": short_to_full(entrance_of_exit(exit_from_dungeon)),
         "exit_from_inside": short_to_full(exit_from_dungeon),
-        # "entrance_from_inside": short_to_full(entrance_of_exit(exit_to_dungeon[0])),
     }

--- a/logic/logic_expression.py
+++ b/logic/logic_expression.py
@@ -262,7 +262,12 @@ class OrCombination(LogicExpression):
         )
 
     def __str__(self):
-        return " | ".join([str(expr) for expr in self.arguments])
+        return " | ".join(
+            [
+                f"({str(expr)})" if isinstance(expr, AndCombination) else str(expr)
+                for expr in self.arguments
+            ]
+        )
 
 
 # Parsing

--- a/logic/logic_expression.py
+++ b/logic/logic_expression.py
@@ -338,7 +338,7 @@ def text_atom_representer(dumper, data):
 
 
 def combination_representer(dumper, data):
-    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data), 'folded')
+    return dumper.represent_scalar("tag:yaml.org,2002:str", str(data), "folded")
 
 
 yaml.add_representer(BasicTextAtom, text_atom_representer)

--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -490,3 +490,6 @@ class Areas:
                         area_bit = EXTENDED_ITEM[area_name]
                     self.opaque[area_bit] = False
                     reqs[area_bit] |= DNFInv(entrance)
+
+    def __str__(self):
+        return f"{EXTENDED_ITEM.items_list}\n{self.parent_area}\n{self.checks}\n{self.gossip_stones}\n{self.map_exits}\n{self.map_entrances}\n"

--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -521,7 +521,7 @@ yaml.add_representer(
             "allowed_time_of_day": data.allowed_time_of_day,
             "can_save": data.can_save,
             "can_sleep": data.can_sleep,
-            "entrances": data.entrances,
+            "entrances": list(data.entrances),
             "exits": data.exits,
             "hint_region": data.hint_region,
             "locations": data.locations,

--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -45,7 +45,7 @@ class Area(Generic[LE]):
     sub_areas: Dict[str, Area[LE]] = field(default_factory=dict)
     locations: Dict[str, LE] = field(default_factory=dict)
     exits: Dict[str, LE] = field(default_factory=dict)
-    entrances: Set[str] = field(default_factory=set)
+    entrances: Dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def of_dict(cls, args):
@@ -122,14 +122,14 @@ class Area(Generic[LE]):
         new_self.locations = d
 
         new_exits = {}
-        entrances = set()
+        entrances = dict()
         for k, v in self.exits.items():
             exit, entrance = fexit(self.name, k, v)
             if exit is not None:
                 exit, req = exit
                 new_exits[exit] = req
             if entrance is not None:
-                entrances.add(entrance)
+                entrances[entrance] = entrance
 
         new_self.exits = new_exits
         new_self.entrances = entrances
@@ -476,7 +476,7 @@ class Areas:
                     else:
                         assert False
 
-            for entrance in area.entrances:
+            for entrance in area.entrances.keys():
                 entrance = with_sep_full(area_name, entrance)
                 allowed_time_of_day = self.entrance_allowed_time_of_day[entrance]
                 if allowed_time_of_day == Both:
@@ -521,7 +521,7 @@ yaml.add_representer(
             "allowed_time_of_day": data.allowed_time_of_day,
             "can_save": data.can_save,
             "can_sleep": data.can_sleep,
-            "entrances": list(data.entrances),
+            "entrances": list(data.entrances.keys()),
             "exits": data.exits,
             "hint_region": data.hint_region,
             "locations": data.locations,

--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -501,7 +501,14 @@ class Areas:
         return {
             "items": EXTENDED_ITEM.items_list,
             "areas": self.parent_area,
-            "checks": dict({id: dict({k: v for k, v in check.items() if k in ['short_name', 'type']}) for id, check in self.checks.items()}),
+            "checks": dict(
+                {
+                    id: dict(
+                        {k: v for k, v in check.items() if k in ["short_name", "type"]}
+                    )
+                    for id, check in self.checks.items()
+                }
+            ),
             "gossip_stones": dict(
                 {k: v["short_name"] for k, v in self.gossip_stones.items()}
             ),

--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -8,11 +8,17 @@ from .logic_expression import DNFInventory, LogicExpression
 from .inventory import EXTENDED_ITEM, Inventory
 from .constants import *
 
+import yaml
+
 
 AllowedTimeOfDay = Enum("AllowedTimeOfDay", ("DayOnly", "NightOnly", "Both"))
 DayOnly = AllowedTimeOfDay.DayOnly
 NightOnly = AllowedTimeOfDay.NightOnly
 Both = AllowedTimeOfDay.Both
+
+yaml.add_representer(
+    AllowedTimeOfDay, lambda dumper, data: dumper.represent_int(data.value)
+)
 
 
 class defaultfactorydict(dict):
@@ -495,11 +501,33 @@ class Areas:
         return {
             "items": EXTENDED_ITEM.items_list,
             "areas": self.parent_area,
-            "checks": self.checks,
-            "gossip_stones": self.gossip_stones,
+            "checks": dict({k: v["short_name"] for k, v in self.checks.items()}),
+            "gossip_stones": dict(
+                {k: v["short_name"] for k, v in self.gossip_stones.items()}
+            ),
             "exits": self.map_exits,
             "entrances": self.map_entrances,
         }
 
     def __str__(self):
         return f"{EXTENDED_ITEM.items_list}\n{self.parent_area}\n{self.checks}\n{self.gossip_stones}\n{self.map_exits}\n{self.map_entrances}\n"
+
+
+yaml.add_representer(
+    Area,
+    lambda dumper, data: dumper.represent_dict(
+        {
+            "abstract": data.abstract,
+            "allowed_time_of_day": data.allowed_time_of_day,
+            "can_save": data.can_save,
+            "can_sleep": data.can_sleep,
+            "entrances": data.entrances,
+            "exits": data.exits,
+            "hint_region": data.hint_region,
+            "locations": data.locations,
+            "name": data.name,
+            "sub_areas": data.sub_areas,
+            "toplevel_alias": data.toplevel_alias,
+        }
+    ),
+)

--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -491,5 +491,15 @@ class Areas:
                     self.opaque[area_bit] = False
                     reqs[area_bit] |= DNFInv(entrance)
 
+    def to_dict(self):
+        return {
+            "items": EXTENDED_ITEM.items_list,
+            "areas": self.parent_area,
+            "checks": self.checks,
+            "gossip_stones": self.gossip_stones,
+            "exits": self.map_exits,
+            "entrances": self.map_entrances,
+        }
+
     def __str__(self):
         return f"{EXTENDED_ITEM.items_list}\n{self.parent_area}\n{self.checks}\n{self.gossip_stones}\n{self.map_exits}\n{self.map_entrances}\n"

--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -501,7 +501,7 @@ class Areas:
         return {
             "items": EXTENDED_ITEM.items_list,
             "areas": self.parent_area,
-            "checks": dict({k: v["short_name"] for k, v in self.checks.items()}),
+            "checks": dict({id: dict({k: v for k, v in check.items() if k in ['short_name', 'type']}) for id, check in self.checks.items()}),
             "gossip_stones": dict(
                 {k: v["short_name"] for k, v in self.gossip_stones.items()}
             ),

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -314,6 +314,7 @@ Temple of Time:
     exits:
       South East: Distance Activator
       North Exit to Desert: Nothing
+    locations:
       General - Ancient Flower Farming: Distance Activator # for timeshift stone
 
 Lanayru Silent Realm:

--- a/randoscript.py
+++ b/randoscript.py
@@ -34,6 +34,12 @@ def main():
         help="Specify the location of a placement file json that is used directly as a plandomizer, overrides all other options",
     )
     parser.add_argument(
+        "--dump-graph",
+        help="Dumps the graph used for logic and exits",
+        const=True,
+        nargs="?",
+    )
+    parser.add_argument(
         "--version",
         help="Prints the version and exits",
         action="store_true",
@@ -110,6 +116,18 @@ def main():
         for err in all_errors:
             print(err)
         exit(1)
+
+    if dest := parsed_args.dump_graph:
+        import logic
+
+        logic.logic_expression.GLOBAL_DUMP_MODE = True
+        areas = Areas(requirements, checks, hints, map_exits)
+        if dest is True:
+            print(areas)
+            exit(0)
+        with open(dest, mode="w") as f:
+            print(areas, file=f)
+            exit(0)
 
     areas = Areas(requirements, checks, hints, map_exits)
 

--- a/randoscript.py
+++ b/randoscript.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 import sys
 import argparse
 import yaml
+import json
 from logic.logic_input import Areas
 from yaml_files import requirements, checks, hints, map_exits
 
@@ -120,6 +121,7 @@ def main():
 
     if dest := parsed_args.dump_graph:
         import logic
+        from logic.logic_input import Area
 
         logic.logic_expression.GLOBAL_DUMP_MODE = True
         areas = Areas(requirements, checks, hints, map_exits)
@@ -127,7 +129,8 @@ def main():
             print(areas)
             exit(0)
         with open(dest, mode="w") as f:
-            print(yaml.dump(areas.to_dict()), file=f)
+            yaml.Dumper.ignore_aliases = lambda *args: True
+            yaml.dump(areas.to_dict(), f)
             exit(0)
 
     areas = Areas(requirements, checks, hints, map_exits)

--- a/randoscript.py
+++ b/randoscript.py
@@ -3,6 +3,7 @@ import sys
 import argparse
 import yaml
 import json
+from logic.dump import dump_constants
 from logic.logic_input import Areas
 from yaml_files import requirements, checks, hints, map_exits
 
@@ -130,7 +131,7 @@ def main():
             exit(0)
         with open(dest, mode="w") as f:
             yaml.Dumper.ignore_aliases = lambda *args: True
-            yaml.dump(areas.to_dict(), f, sort_keys=False)
+            yaml.dump({ **areas.to_dict(), "linked_entrances": dump_constants(areas.short_to_full) }, f, sort_keys=False)
             exit(0)
 
     areas = Areas(requirements, checks, hints, map_exits)

--- a/randoscript.py
+++ b/randoscript.py
@@ -131,7 +131,11 @@ def main():
             exit(0)
         with open(dest, mode="w") as f:
             yaml.Dumper.ignore_aliases = lambda *args: True
-            yaml.dump({ **areas.to_dict(), **dump_constants(areas.short_to_full) }, f, sort_keys=False)
+            yaml.dump(
+                {**areas.to_dict(), **dump_constants(areas.short_to_full)},
+                f,
+                sort_keys=False,
+            )
             exit(0)
 
     areas = Areas(requirements, checks, hints, map_exits)

--- a/randoscript.py
+++ b/randoscript.py
@@ -130,7 +130,7 @@ def main():
             exit(0)
         with open(dest, mode="w") as f:
             yaml.Dumper.ignore_aliases = lambda *args: True
-            yaml.dump(areas.to_dict(), f)
+            yaml.dump(areas.to_dict(), f, sort_keys=False)
             exit(0)
 
     areas = Areas(requirements, checks, hints, map_exits)

--- a/randoscript.py
+++ b/randoscript.py
@@ -131,7 +131,7 @@ def main():
             exit(0)
         with open(dest, mode="w") as f:
             yaml.Dumper.ignore_aliases = lambda *args: True
-            yaml.dump({ **areas.to_dict(), "linked_entrances": dump_constants(areas.short_to_full) }, f, sort_keys=False)
+            yaml.dump({ **areas.to_dict(), **dump_constants(areas.short_to_full) }, f, sort_keys=False)
             exit(0)
 
     areas = Areas(requirements, checks, hints, map_exits)

--- a/randoscript.py
+++ b/randoscript.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import sys
 import argparse
+import yaml
 from logic.logic_input import Areas
 from yaml_files import requirements, checks, hints, map_exits
 
@@ -126,7 +127,7 @@ def main():
             print(areas)
             exit(0)
         with open(dest, mode="w") as f:
-            print(areas, file=f)
+            print(yaml.dump(areas.to_dict()), file=f)
             exit(0)
 
     areas = Areas(requirements, checks, hints, map_exits)


### PR DESCRIPTION
A rebase and continuation of #504.

> Adds dump mode and an automated action to check if the dump file contents in the repository match the contents generated by the randomizer. Failing the dump check does not prevent builds from completing. Dump mode dumps to yaml format.

This dump is currently being used by the [WIP new-logic tracker](https://robojumper.github.io/SS-Randomizer-Tracker/) and it seems to be reasonably complete (with some hardcoding needed for special requirements and logical rules).

The main concern for the future is compatibility - mainly, should this dump format be able to change in an incompatible way due to rando changes or evolutions of the dump format, and if so, when? Should we emit a "spec version" in the dump so that consumers can handle breaking changes? Should the eventual release of the new-logic tracker only support the latest version of the dump, with legacy versions of the tracker for older rando versions with incompatible dumps hosted separately? Until these questions are resolved, I think it's fine to advertise this dump as unstable and likely to change in the near future.