### PR TITLE
FS logic: allow reaching Plat's Chest from Front of Boss Door

### DIFF
--- a/logic/requirements/Fire Sanctuary.yaml
+++ b/logic/requirements/Fire Sanctuary.yaml
@@ -189,6 +189,7 @@ Main:
     exits:
       Statue: Unlock Statue
       Boss Door: Fire Sanctuary Boss Key
+      West of Boss Door: Nothing
       Lizalfos Fight Room: Nothing
       Past Bars: Past Bars - Unlock Way to Front
     locations:


### PR DESCRIPTION
If an experimental ER setting gives you access to the FS statue, you can simply walk up the stairs, turn left at the boss door, and hop down the ledge. Then all you need to get the Plat's Chest check is Mogma Mitts.