### PR TITLE
Mark AC Lilypad rupee as a Rupee check

### DIFF
--- a/logic/constants.py
+++ b/logic/constants.py
@@ -735,7 +735,7 @@ RUPEE_CHECKS = [
     "Ancient Cistern - First Rupee in East Part in Short Tunnel",
     "Ancient Cistern - Second Rupee in East Part in Short Tunnel",
     "Ancient Cistern - Third Rupee in East Part in Short Tunnel",
-    # "Ancient Cistern - Rupee under Lilypad",
+    "Ancient Cistern - Rupee under Lilypad",
     "Ancient Cistern - Rupee in East Hand",
     "Ancient Cistern - Rupee in West Hand",
     "Sky Keep - Rupee in Fire Sanctuary Room in Alcove",


### PR DESCRIPTION
Looks like this was missed in #483, resulting in the check being randomized even with Rupeesanity off.