### PR TITLE
Non-cryptic hints by default

### DIFF
--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -238,9 +238,9 @@
              <item>
               <layout class="QVBoxLayout" name="vlay_cosmetics">
                <item>
-                <widget class="QCheckBox" name="option_clear_location_hints">
+                <widget class="QCheckBox" name="option_cryptic_location_hints">
                  <property name="text">
-                  <string>Clear Location Hints</string>
+                  <string>Cryptic Location Hints</string>
                  </property>
                 </widget>
                </item>

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -179,10 +179,10 @@ class Ui_MainWindow(object):
         self.verticalLayout_24.setObjectName(u"verticalLayout_24")
         self.vlay_cosmetics = QVBoxLayout()
         self.vlay_cosmetics.setObjectName(u"vlay_cosmetics")
-        self.option_clear_location_hints = QCheckBox(self.box_cosmetics)
-        self.option_clear_location_hints.setObjectName(u"option_clear_location_hints")
+        self.option_cryptic_location_hints = QCheckBox(self.box_cosmetics)
+        self.option_cryptic_location_hints.setObjectName(u"option_cryptic_location_hints")
 
-        self.vlay_cosmetics.addWidget(self.option_clear_location_hints)
+        self.vlay_cosmetics.addWidget(self.option_cryptic_location_hints)
 
         self.option_lightning_skyward_strike = QCheckBox(self.box_cosmetics)
         self.option_lightning_skyward_strike.setObjectName(u"option_lightning_skyward_strike")
@@ -2033,7 +2033,7 @@ class Ui_MainWindow(object):
         self.box_advanced.setTitle(QCoreApplication.translate("MainWindow", u"Advanced Options", None))
         self.option_dry_run.setText(QCoreApplication.translate("MainWindow", u"Dry Run", None))
         self.box_cosmetics.setTitle(QCoreApplication.translate("MainWindow", u"Cosmetics", None))
-        self.option_clear_location_hints.setText(QCoreApplication.translate("MainWindow", u"Clear Location Hints", None))
+        self.option_cryptic_location_hints.setText(QCoreApplication.translate("MainWindow", u"Cryptic Location Hints", None))
         self.option_lightning_skyward_strike.setText(QCoreApplication.translate("MainWindow", u"Lightning Skyward Strike", None))
         self.option_starry_skies.setText(QCoreApplication.translate("MainWindow", u"Starry Skies", None))
         self.label_for_option_star_count.setText(QCoreApplication.translate("MainWindow", u"Number of stars", None))

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -307,7 +307,7 @@ class HintDistribution:
 
         loc = self.always_hints.pop()
         item = self.logic.placement.locations[loc]
-        if self.options["clear-location-hints"]:
+        if not self.options["cryptic-location-hints"]:
             text = None
         else:
             text = self.areas.checks[loc].get("text")
@@ -334,7 +334,7 @@ class HintDistribution:
 
         loc = self.sometimes_hints.pop()
         item = self.logic.placement.locations[loc]
-        if self.options["clear-location-hints"]:
+        if not self.options["cryptic-location-hints"]:
             text = None
         else:
             text = self.areas.checks[loc].get("text")
@@ -351,7 +351,7 @@ class HintDistribution:
 
         item = self.required_boss_keys.pop()
         loc = self.logic.placement.items[item]
-        if self.options["clear-location-hints"]:
+        if not self.options["cryptic-location-hints"]:
             text = None
         else:
             text = self.areas.checks[loc].get("text")
@@ -395,7 +395,7 @@ class HintDistribution:
 
         loc = self.rng.choice(all_locations_without_hint)
         item = self.logic.placement.locations[loc]
-        if self.options["clear-location-hints"]:
+        if not self.options["cryptic-location-hints"]:
             text = None
         else:
             text = self.areas.checks[loc].get("text")

--- a/options.yaml
+++ b/options.yaml
@@ -1098,12 +1098,12 @@
   bits: 4
   help: How many treasures per Silent Realm you want to randomize.
   ui: option_trial_treasure_amount
-- name: Clear Location Hints
-  command: clear-location-hints
+- name: Cryptic Location Hints
+  command: cryptic-location-hints
   type: boolean
   default: false
   permalink: false
   cosmetic: true
-  help: If enabled, location hints (always, sometimes, & random hints) that normally have flavor text
-        will just appear as their location name, like other locations.
-  ui: option_clear_location_hints
+  help: If enabled, location hints (always, sometimes, & random hints) will display special flavor text
+        if they have it (such as "drawing on a magical wall" instead of Gorko's Goddess Wall Reward).
+  ui: option_cryptic_location_hints


### PR DESCRIPTION
Flips the clear location hints option to cryptic location hints. Default remains false, meaning hints will be clear by default.