### PR TITLE
Remove some ac and ssh cutscenes

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -130,6 +130,7 @@ global:
       - 55 # First time landing cutscene
     Ancient Cistern:
       - 62 # Ancient Cistern Intro Cutscene
+      - 59 # Lilypad over tunnel after gutters flipped cutscene
     Eldin Volcano:
       - 2  # gets rid of first digging mitts mogma text
       - 16 # First time landing cutscene
@@ -170,6 +171,15 @@ global:
     Lanayru Gorge:
       - 10 # Minecart at end of Track
       - 16 # Lanayru Gorge Intro Cutscene
+    Sandship:
+      - 9  # Press switch cutscene in south generator room
+      - 10 # Release switch cutscene in south generator room
+      - 33 # Press switch cutscene in BK room
+      - 34 # Release switch cutscene in BK room
+      - 43 # Press switch cutscene in north generator room
+      - 44 # Release switch cutscene in north generator room
+      - 62 # South generator activation cutscene
+      - 63 # North generator activation cutscene
     Fire Sanctuary:
       - 83 # Cutscene showing the outside of the Fire Sanctuary
       - onlyif: Option "fs-lava-flow" Enabled


### PR DESCRIPTION
Removes the following cutscenes
- Flip over lilypad after gutters in AC (more relevant now with the Rupee Under Lilypad check)
- All Sandship floor switch first-time raise/lower cutscenes
- Sandship generator activation cutscenes

I've verified that all these cutscenes are actually removed