### PR TITLE
Explicitly filter dumped entrance and exit data

### DIFF
--- a/dump.yaml
+++ b/dump.yaml
@@ -8836,1055 +8836,1404 @@ areas:
   toplevel_alias: null
 checks:
   \Skyloft\Upper Skyloft\Knight Academy\Fledge's Gift:
+    original item: Progressive Pouch
     type: null
     short_name: Upper Skyloft - Fledge's Gift
   \Skyloft\Upper Skyloft\Owlan's Gift:
+    original item: Wooden Shield
     type: null
     short_name: Upper Skyloft - Owlan's Gift
   \Skyloft\Upper Skyloft\Sparring Hall\Sparring Hall Chest:
+    original item: Progressive Sword
     type: null
     short_name: Upper Skyloft - Sparring Hall Chest
   \Skyloft\Upper Skyloft\Chest near Goddess Statue:
+    original item: Red Rupee
     type: null
     short_name: Upper Skyloft - Chest near Goddess Statue
   \Skyloft\Upper Skyloft\Goddess Statue\First Goddess Sword Item in Goddess Statue:
+    original item: Progressive Sword
     type: null
     short_name: Upper Skyloft - First Goddess Sword Item in Goddess Statue
   \Skyloft\Upper Skyloft\Goddess Statue\Second Goddess Sword Item in Goddess Statue:
+    original item: Emerald Tablet
     type: null
     short_name: Upper Skyloft - Second Goddess Sword Item in Goddess Statue
   \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\In Zelda's Closet:
+    original item: Heart Piece
     type: null
     short_name: Upper Skyloft - In Zelda's Closet
   \Skyloft\Upper Skyloft\Knight Academy\Owlan's Crystals:
+    original item: Gratitude Crystal Pack
     type: Scrapper Deliveries, Gratitude Crystal Sidequests, Combat
     short_name: Upper Skyloft - Owlan's Crystals
   \Skyloft\Upper Skyloft\Knight Academy\Fledge's Crystals:
+    original item: Gratitude Crystal Pack
     type: Gratitude Crystal Sidequests
     short_name: Upper Skyloft - Fledge's Crystals
   \Skyloft\Upper Skyloft\Knight Academy\Item from Cawlin:
+    original item: Cawlin's Letter
     type: null
     short_name: Upper Skyloft - Item from Cawlin
   \Skyloft\Upper Skyloft\Knight Academy\Ghost/Pipit's Crystals:
+    original item: Gratitude Crystal Pack
     type: Gratitude Crystal Sidequests
     short_name: Upper Skyloft - Ghost/Pipit's Crystals
   \Skyloft\Upper Skyloft\Pumpkin Archery -- 600 Points:
+    original item: Heart Piece
     type: Minigames
     short_name: Upper Skyloft - Pumpkin Archery -- 600 Points
   \Skyloft\Central Skyloft\Bazaar\Potion Lady's Gift:
+    original item: Bottle
     type: null
     short_name: Central Skyloft - Potion Lady's Gift
   \Skyloft\Central Skyloft\Bazaar\Repair Gondo's Junk:
+    original item: Scrapper
     type: null
     short_name: Central Skyloft - Repair Gondo's Junk
   \Skyloft\Central Skyloft\Wryna's House\Wryna's Crystals:
+    original item: Gratitude Crystal Pack
     type: Gratitude Crystal Sidequests
     short_name: Central Skyloft - Wryna's Crystals
   \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave First Chest:
+    original item: Red Rupee
     type: null
     short_name: Central Skyloft - Waterfall Cave First Chest
   \Skyloft\Central Skyloft\Waterfall Cave\Waterfall Cave Second Chest:
+    original item: Red Rupee
     type: null
     short_name: Central Skyloft - Waterfall Cave Second Chest
   \Skyloft\Central Skyloft\Waterfall Cave\Rupee Waterfall Cave Crawlspace:
+    original item: 'Red Rupee #25'
     type: Rupees (No Quick Beetle)
     short_name: Central Skyloft - Rupee Waterfall Cave Crawlspace
   \Skyloft\Central Skyloft\Parrow's Gift:
+    original item: Bottle
     type: null
     short_name: Central Skyloft - Parrow's Gift
   \Skyloft\Central Skyloft\Parrow's Crystals:
+    original item: Gratitude Crystal Pack
     type: Gratitude Crystal Sidequests
     short_name: Central Skyloft - Parrow's Crystals
   \Skyloft\Central Skyloft\Peatrice's House\Peater/Peatrice's Crystals:
+    original item: Gratitude Crystal Pack
     type: Gratitude Crystal Sidequests
     short_name: Central Skyloft - Peater/Peatrice's Crystals
   \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest:
+    original item: Baby's Rattle
     type: null
     short_name: Central Skyloft - Item in Bird Nest
   \Skyloft\Central Skyloft\Shed Chest:
+    original item: Silver Rupee
     type: null
     short_name: Central Skyloft - Shed Chest
   \Skyloft\Central Skyloft\West Cliff Goddess Chest:
+    original item: Silver Rupee
     type: goddess, Faron Woods Goddess Chests
     short_name: Central Skyloft - West Cliff Goddess Chest
   \Skyloft\Central Skyloft\Bazaar\Bazaar Goddess Chest:
+    original item: Gold Rupee
     type: goddess, Sand Sea Goddess Chests
     short_name: Central Skyloft - Bazaar Goddess Chest
   \Skyloft\Central Skyloft\Shed Goddess Chest:
+    original item: Heart Piece
     type: goddess, Eldin Volcano Goddess Chests
     short_name: Central Skyloft - Shed Goddess Chest
   \Skyloft\Central Skyloft\Waterfall Island\Floating Island Goddess Chest:
+    original item: Gold Rupee
     type: goddess, Lake Floria Goddess Chests
     short_name: Central Skyloft - Floating Island Goddess Chest
   \Skyloft\Central Skyloft\Waterfall Island\Waterfall Goddess Chest:
+    original item: Heart Piece
     type: goddess, Sand Sea Goddess Chests
     short_name: Central Skyloft - Waterfall Goddess Chest
   \Skyloft\Skyloft Village\Mallara's House\Mallara's Crystals:
+    original item: Gratitude Crystal Pack
     type: Gratitude Crystal Sidequests
     short_name: Skyloft Village - Mallara's Crystals
   \Skyloft\Skyloft Village\Bertie's House\Bertie's Crystals:
+    original item: Gratitude Crystal Pack
     type: Gratitude Crystal Sidequests
     short_name: Skyloft Village - Bertie's Crystals
   \Skyloft\Skyloft Village\Sparrot's House\Sparrot's Crystals:
+    original item: Gratitude Crystal Pack
     type: Scrapper Deliveries, Gratitude Crystal Sidequests
     short_name: Skyloft Village - Sparrot's Crystals
   \Skyloft\Skyloft Village\Batreaux's House\5 Crystals:
+    original item: Progressive Wallet
     type: Batreaux's Rewards
     short_name: Batreaux's House - 5 Crystals
   \Skyloft\Skyloft Village\Batreaux's House\10 Crystals:
+    original item: Heart Piece
     type: Batreaux's Rewards
     short_name: Batreaux's House - 10 Crystals
   \Skyloft\Skyloft Village\Batreaux's House\30 Crystals:
+    original item: Progressive Wallet
     type: Batreaux's Rewards
     short_name: Batreaux's House - 30 Crystals
   \Skyloft\Skyloft Village\Batreaux's House\30 Crystals Chest:
+    original item: Cursed Medal
     type: Batreaux's Rewards
     short_name: Batreaux's House - 30 Crystals Chest
   \Skyloft\Skyloft Village\Batreaux's House\40 Crystals:
+    original item: Gold Rupee
     type: Batreaux's Rewards
     short_name: Batreaux's House - 40 Crystals
   \Skyloft\Skyloft Village\Batreaux's House\50 Crystals:
+    original item: Progressive Wallet
     type: Batreaux's Rewards
     short_name: Batreaux's House - 50 Crystals
   \Skyloft\Skyloft Village\Batreaux's House\70 Crystals:
+    original item: Gold Rupee
     type: Batreaux's Rewards
     short_name: Batreaux's House - 70 Crystals
   \Skyloft\Skyloft Village\Batreaux's House\70 Crystals Second Reward:
+    original item: Gold Rupee
     type: Batreaux's Rewards
     short_name: Batreaux's House - 70 Crystals Second Reward
   \Skyloft\Skyloft Village\Batreaux's House\80 Crystals:
+    original item: Progressive Wallet
     type: Batreaux's Rewards
     short_name: Batreaux's House - 80 Crystals
   \Skyloft\Beedle's Shop\Stall\300 Rupee Item:
+    original item: 'Progressive Pouch #1'
     type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
     short_name: Beedle's Shop - 300 Rupee Item
   \Skyloft\Beedle's Shop\Stall\600 Rupee Item:
+    original item: 'Progressive Pouch #2'
     type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
     short_name: Beedle's Shop - 600 Rupee Item
   \Skyloft\Beedle's Shop\Stall\1200 Rupee Item:
+    original item: 'Progressive Pouch #3'
     type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
     short_name: Beedle's Shop - 1200 Rupee Item
   \Skyloft\Beedle's Shop\Stall\800 Rupee Item:
+    original item: 'Life Medal #0'
     type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
     short_name: Beedle's Shop - 800 Rupee Item
   \Skyloft\Beedle's Shop\Stall\1600 Rupee Item:
+    original item: 'Heart Piece #0'
     type: Beedle's Shop Purchases, Beedle's Shop Purchase (Expensive)
     short_name: Beedle's Shop - 1600 Rupee Item
   \Skyloft\Beedle's Shop\Stall\First 100 Rupee Item:
+    original item: 'Extra Wallet #0'
     type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
     short_name: Beedle's Shop - First 100 Rupee Item
   \Skyloft\Beedle's Shop\Stall\Second 100 Rupee Item:
+    original item: 'Extra Wallet #1'
     type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
     short_name: Beedle's Shop - Second 100 Rupee Item
   \Skyloft\Beedle's Shop\Stall\Third 100 Rupee Item:
+    original item: 'Extra Wallet #2'
     type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
     short_name: Beedle's Shop - Third 100 Rupee Item
   \Skyloft\Beedle's Shop\Stall\50 Rupee Item:
+    original item: 'Progressive Bug Net #0'
     type: Beedle's Shop Purchases, Beedle's Shop Purchase (Cheap)
     short_name: Beedle's Shop - 50 Rupee Item
   \Skyloft\Beedle's Shop\Stall\1000 Rupee Item:
+    original item: Bug Medal
     type: Beedle's Shop Purchases, Beedle's Shop Purchase (Medium)
     short_name: Beedle's Shop - 1000 Rupee Item
   \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Crystal in Link's Room:
+    original item: 'Gratitude Crystal #0'
     type: Loose Crystals
     short_name: Upper Skyloft - Crystal in Link's Room
   \Skyloft\Upper Skyloft\Knight Academy\Crystal in Knight Academy Plant:
+    original item: 'Gratitude Crystal #5'
     type: Loose Crystals
     short_name: Upper Skyloft - Crystal in Knight Academy Plant
   \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Crystal in Zelda's Room:
+    original item: 'Gratitude Crystal #11'
     type: Loose Crystals
     short_name: Upper Skyloft - Crystal in Zelda's Room
   \Skyloft\Upper Skyloft\Sparring Hall\Crystal in Sparring Hall:
+    original item: 'Gratitude Crystal #9'
     type: Loose Crystals
     short_name: Upper Skyloft - Crystal in Sparring Hall
   \Skyloft\Central Skyloft\Orielle and Parrow's House\Crystal in Orielle and Parrow's House:
+    original item: 'Gratitude Crystal #3'
     type: Loose Crystals
     short_name: Central Skyloft - Crystal in Orielle and Parrow's House
   \Skyloft\Central Skyloft\Crystal on West Cliff:
+    original item: 'Gratitude Crystal #6'
     type: Loose Crystals
     short_name: Central Skyloft - Crystal on West Cliff
   \Skyloft\Central Skyloft\Crystal between Wooden Planks:
+    original item: 'Gratitude Crystal #4'
     type: Loose Crystals
     short_name: Central Skyloft - Crystal between Wooden Planks
   \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave:
+    original item: 'Gratitude Crystal #7'
     type: Loose Crystals
     short_name: Central Skyloft - Crystal after Waterfall Cave
   \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison:
+    original item: 'Gratitude Crystal #8'
     type: Loose Crystals
     short_name: Central Skyloft - Crystal in Loftwing Prison
   \Skyloft\Central Skyloft\Waterfall Island\Crystal on Waterfall Island:
+    original item: 'Gratitude Crystal #10'
     type: Loose Crystals
     short_name: Central Skyloft - Crystal on Waterfall Island
   \Skyloft\Central Skyloft\Crystal on Light Tower:
+    original item: 'Gratitude Crystal #1'
     type: Loose Crystals
     short_name: Central Skyloft - Crystal on Light Tower
   \Skyloft\Skyloft Village\Crystal near Pumpkin Patch:
+    original item: 'Gratitude Crystal #2'
     type: Loose Crystals
     short_name: Skyloft Village - Crystal near Pumpkin Patch
   \Sky\South East\Lumpy Pumpkin\Crystal outside Lumpy Pumpkin:
+    original item: 'Gratitude Crystal #12'
     type: Loose Crystals
     short_name: Sky - Crystal outside Lumpy Pumpkin
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Crystal inside Lumpy Pumpkin:
+    original item: 'Gratitude Crystal #13'
     type: Loose Crystals
     short_name: Sky - Crystal inside Lumpy Pumpkin
   \Sky\North East\Beedle's Island\Crystal on Beedle's Ship:
+    original item: 'Gratitude Crystal #14'
     type: Loose Crystals
     short_name: Sky - Crystal on Beedle's Ship
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Chandelier:
+    original item: Heart Piece
     type: null
     short_name: Sky - Lumpy Pumpkin - Chandelier
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Harp Minigame:
+    original item: Heart Piece
     type: Minigames
     short_name: Sky - Lumpy Pumpkin - Harp Minigame
   \Sky\South East\Lumpy Pumpkin\Kina's Crystals:
+    original item: Gratitude Crystal Pack
     type: Scrapper Deliveries, Gratitude Crystal Sidequests
     short_name: Sky - Kina's Crystals
   \Sky\South West\Orielle's Island\Orielle's Crystals:
+    original item: Gratitude Crystal Pack
     type: Gratitude Crystal Sidequests
     short_name: Sky - Orielle's Crystals
   \Sky\North East\Beedle's Island\Beedle's Crystals:
+    original item: Gratitude Crystal Pack
     type: Gratitude Crystal Sidequests
     short_name: Sky - Beedle's Crystals
   \Sky\South West\Fun Fun Island\Dodoh's Crystals:
+    original item: Gratitude Crystal Pack
     type: Scrapper Deliveries
     short_name: Sky - Dodoh's Crystals
   \Sky\South West\Fun Fun Island\Fun Fun Island Minigame -- 500 Rupees:
+    original item: Heart Piece
     type: Minigames, Scrapper Deliveries
     short_name: Sky - Fun Fun Island Minigame -- 500 Rupees
   \Sky\South West\Chest in Breakable Boulder near Fun Fun Island:
+    original item: Silver Rupee
     type: null
     short_name: Sky - Chest in Breakable Boulder near Fun Fun Island
   \Sky\South East\Chest in Breakable Boulder near Lumpy Pumpkin:
+    original item: Silver Rupee
     type: null
     short_name: Sky - Chest in Breakable Boulder near Lumpy Pumpkin
   \Sky\North East\Bamboo Island\Bamboo Island Goddess Chest:
+    original item: Gold Rupee
     type: goddess, Eldin Volcano Goddess Chests
     short_name: Sky - Bamboo Island Goddess Chest
   \Sky\North East\Goddess Chest on Island next to Bamboo Island:
+    original item: Silver Rupee
     type: goddess, Eldin Volcano Goddess Chests
     short_name: Sky - Goddess Chest on Island next to Bamboo Island
   \Sky\North East\Goddess Chest in Cave on Island next to Bamboo Island:
+    original item: Heart Medal
     type: goddess, Lanayru Desert Goddess Chests
     short_name: Sky - Goddess Chest in Cave on Island next to Bamboo Island
   \Sky\North East\Beedle's Island\Top\Beedle's Island Goddess Chest:
+    original item: Heart Piece
     type: goddess, Lanayru Desert Goddess Chests, Combat
     short_name: Sky - Beedle's Island Goddess Chest
   \Sky\North East\Beedle's Island\Cage\Beedle's Island Cage Goddess Chest:
+    original item: Rupee Medal
     type: goddess, Faron Woods Goddess Chests
     short_name: Sky - Beedle's Island Cage Goddess Chest
   \Sky\North East\Northeast Island Goddess Chest behind Bombable Rocks:
+    original item: Silver Rupee
     type: goddess, Lanayru Desert Goddess Chests
     short_name: Sky - Northeast Island Goddess Chest behind Bombable Rocks
   \Sky\North East\Northeast Island Cage Goddess Chest:
+    original item: Treasure Medal
     type: goddess, Eldin Volcano Goddess Chests
     short_name: Sky - Northeast Island Cage Goddess Chest
   \Sky\South East\Lumpy Pumpkin\Goddess Chest on the Roof:
+    original item: Gold Rupee
     type: goddess, Faron Woods Goddess Chests
     short_name: Sky - Lumpy Pumpkin - Goddess Chest on the Roof
   \Sky\South East\Lumpy Pumpkin\Outside Goddess Chest:
+    original item: Progressive Pouch
     type: goddess, Faron Woods Goddess Chests
     short_name: Sky - Lumpy Pumpkin - Outside Goddess Chest
   \Sky\South East\Goddess Chest on Island Closest to Faron Pillar:
+    original item: Heart Piece
     type: goddess, Faron Woods Goddess Chests
     short_name: Sky - Goddess Chest on Island Closest to Faron Pillar
   \Sky\South West\Volcanic Island\Goddess Chest outside Volcanic Island:
+    original item: Heart Medal
     type: goddess, Lanayru Desert Goddess Chests
     short_name: Sky - Goddess Chest outside Volcanic Island
   \Sky\South West\Volcanic Island\Goddess Chest inside Volcanic Island:
+    original item: Heart Piece
     type: goddess, Faron Woods Goddess Chests
     short_name: Sky - Goddess Chest inside Volcanic Island
   \Sky\South West\Fun Fun Island\Goddess Chest under Fun Fun Island:
+    original item: Gold Rupee
     type: goddess, Lake Floria Goddess Chests
     short_name: Sky - Goddess Chest under Fun Fun Island
   \Sky\South West\Triple Island\Southwest Triple Island Upper Goddess Chest:
+    original item: Small Seed Satchel
     type: goddess, Eldin Volcano Goddess Chests
     short_name: Sky - Southwest Triple Island Upper Goddess Chest
   \Sky\South West\Triple Island\Southwest Triple Island Lower Goddess Chest:
+    original item: Life Medal
     type: goddess, Lanayru Desert Goddess Chests
     short_name: Sky - Southwest Triple Island Lower Goddess Chest
   \Sky\South West\Triple Island\Southwest Triple Island Cage Goddess Chest:
+    original item: Potion Medal
     type: goddess, Sand Sea Goddess Chests
     short_name: Sky - Southwest Triple Island Cage Goddess Chest
   \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Goddess Sword:
+    original item: Farore's Courage
     type: null
     short_name: Thunderhead - Isle of Songs - Strike Crest with Goddess Sword
   \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with Longsword:
+    original item: Nayru's Wisdom
     type: null
     short_name: Thunderhead - Isle of Songs - Strike Crest with Longsword
   \Sky\Thunderhead\Isle of Songs\Inside\Strike Crest with White Sword:
+    original item: Din's Power
     type: null
     short_name: Thunderhead - Isle of Songs - Strike Crest with White Sword
   \Sky\Thunderhead\Song from Levias:
+    original item: Song of the Hero
     type: Scrapper Deliveries, Combat
     short_name: Thunderhead - Song from Levias
   \Sky\Thunderhead\Bug Heaven\Bug Heaven -- 10 Bugs in 3 Minutes:
+    original item: Horned Colossus Beetle
     type: Minigames
     short_name: Thunderhead - Bug Heaven -- 10 Bugs in 3 Minutes
   \Sky\Thunderhead\East Island\East Island Chest:
+    original item: Evil Crystal
     type: null
     short_name: Thunderhead - East Island Chest
   \Sky\Thunderhead\East Island\East Island Goddess Chest:
+    original item: Rupee Medal
     type: goddess, Faron Woods Goddess Chests
     short_name: Thunderhead - East Island Goddess Chest
   \Sky\Thunderhead\Isle of Songs\Goddess Chest on top of Isle of Songs:
+    original item: Small Bomb Bag
     type: goddess, Volcano Summit Goddess Chests
     short_name: Thunderhead - Goddess Chest on top of Isle of Songs
   \Sky\Thunderhead\Isle of Songs\Goddess Chest outside Isle of Songs:
+    original item: Gold Rupee
     type: goddess, Eldin Volcano Goddess Chests
     short_name: Thunderhead - Goddess Chest outside Isle of Songs
   \Sky\Thunderhead\Mogma Mitts Island\First Goddess Chest on Mogma Mitts Island:
+    original item: Bottle
     type: goddess, Volcano Summit Goddess Chests
     short_name: Thunderhead - First Goddess Chest on Mogma Mitts Island
   \Sky\Thunderhead\Mogma Mitts Island\Second Goddess Chest on Mogma Mitts Island:
+    original item: Small Quiver
     type: goddess, Sand Sea Goddess Chests
     short_name: Thunderhead - Second Goddess Chest on Mogma Mitts Island
   \Sky\Thunderhead\Bug Heaven\Bug Heaven Goddess Chest:
+    original item: Heart Piece
     type: goddess, Volcano Summit Goddess Chests
     short_name: Thunderhead - Bug Heaven Goddess Chest
   \Faron\Sealed Grounds\Sealed Temple\Chest inside Sealed Temple:
+    original item: Revitalizing Potion
     type: null
     short_name: Sealed Grounds - Chest inside Sealed Temple
   \Faron\Sealed Grounds\Sealed Temple\Song from Impa:
+    original item: Ballad of the Goddess
     type: null
     short_name: Sealed Grounds - Song from Impa
   \Faron\Sealed Grounds\Behind the Temple\Gorko's Goddess Wall Reward:
     type: null
+    original item: Heart Piece
     short_name: Sealed Grounds - Gorko's Goddess Wall Reward
   \Faron\Sealed Grounds\Hylia's Temple\Zelda's Blessing:
+    original item: Progressive Sword
     type: null
     short_name: Sealed Grounds - Zelda's Blessing
   \Faron\Faron Woods\Item behind Lower Bombable Rock:
+    original item: Heart Piece
     type: null
     short_name: Faron Woods - Item behind Lower Bombable Rock
   \Faron\Faron Woods\Item on Tree:
+    original item: Heart Piece
     type: null
     short_name: Faron Woods - Item on Tree
   \Faron\Faron Woods\Kikwi Elder's Reward:
+    original item: Progressive Slingshot
     type: Combat
     short_name: Faron Woods - Kikwi Elder's Reward
   \Faron\Faron Woods\Rupee on Hollow Tree Root:
+    original item: 'Blue Rupee #6'
     type: Rupees (No Quick Beetle)
     short_name: Faron Woods - Rupee on Hollow Tree Root
   \Faron\Faron Woods\Rupee on Hollow Tree Branch:
+    original item: 'Red Rupee #27'
     type: Rupees (No Quick Beetle)
     short_name: Faron Woods - Rupee on Hollow Tree Branch
   \Faron\Faron Woods\Rupee on Platform near Floria Door:
+    original item: 'Red Rupee #26'
     type: Rupees (No Quick Beetle)
     short_name: Faron Woods - Rupee on Platform near Floria Door
   \Faron\Faron Woods\Deep Woods\Deep Woods Chest:
+    original item: Red Rupee
     type: null
     short_name: Faron Woods - Deep Woods Chest
   \Faron\Faron Woods\Chest behind Upper Bombable Rock:
+    original item: Semi Rare Treasure
     type: null
     short_name: Faron Woods - Chest behind Upper Bombable Rock
   \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest\Chest inside Great Tree:
+    original item: Gold Rupee
     type: null
     short_name: Faron Woods - Chest inside Great Tree
   \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree North Branch:
+    original item: 'Blue Rupee #4'
     type: Rupees (No Quick Beetle)
     short_name: Faron Woods - Rupee on Great Tree North Branch
   \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree West Branch:
+    original item: 'Blue Rupee #5'
     type: Rupees (No Quick Beetle)
     short_name: Faron Woods - Rupee on Great Tree West Branch
   \Faron\Lake Floria\Above Rock\Rupee under Central Boulder:
+    original item: 'Silver Rupee #12'
     type: Rupees (No Quick Beetle)
     short_name: Lake Floria - Rupee under Central Boulder
   \Faron\Lake Floria\Above Rock\Rupee behind Southwest Boulder:
+    original item: 'Blue Rupee #7'
     type: Rupees (No Quick Beetle)
     short_name: Lake Floria - Rupee behind Southwest Boulder
   \Faron\Lake Floria\Above Rock\Left Rupee behind Northwest Boulder:
+    original item: 'Red Rupee #29'
     type: Rupees (No Quick Beetle)
     short_name: Lake Floria - Left Rupee behind Northwest Boulder
   \Faron\Lake Floria\Above Rock\Right Rupee behind Northwest Boulder:
+    original item: 'Red Rupee #28'
     type: Rupees (No Quick Beetle)
     short_name: Lake Floria - Right Rupee behind Northwest Boulder
   \Faron\Lake Floria\Below Rock\Emerged Area\Lake Floria Chest:
+    original item: Goddess Plume
     type: null
     short_name: Lake Floria - Lake Floria Chest
   \Faron\Lake Floria\Farore's Lair\Dragon Lair South Chest:
+    original item: Silver Rupee
     type: null
     short_name: Lake Floria - Dragon Lair South Chest
   \Faron\Lake Floria\Farore's Lair\Dragon Lair East Chest:
+    original item: Semi Rare Treasure
     type: null
     short_name: Lake Floria - Dragon Lair East Chest
   \Faron\Lake Floria\Waterfall\Rupee on High Ledge outside Ancient Cistern Entrance:
+    original item: 'Gold Rupee #10'
     type: Rupees (No Quick Beetle)
     short_name: Lake Floria - Rupee on High Ledge outside Ancient Cistern Entrance
   \Faron\Flooded Faron Woods\Yellow Tadtone under Lilypad:
+    original item: 'Group of Tadtones #0'
     type: Tadtones
     short_name: Flooded Faron Woods - Yellow Tadtone under Lilypad
   \Faron\Flooded Faron Woods\8 Light Blue Tadtones near Viewing Platform:
+    original item: 'Group of Tadtones #1'
     type: Tadtones
     short_name: Flooded Faron Woods - 8 Light Blue Tadtones near Viewing Platform
   \Faron\Flooded Faron Woods\4 Purple Tadtones under Viewing Platform:
+    original item: 'Group of Tadtones #2'
     type: Tadtones
     short_name: Flooded Faron Woods - 4 Purple Tadtones under Viewing Platform
   \Faron\Flooded Faron Woods\Red Moving Tadtone near Viewing Platform:
+    original item: 'Group of Tadtones #3'
     type: Tadtones
     short_name: Flooded Faron Woods - Red Moving Tadtone near Viewing Platform
   \Faron\Flooded Faron Woods\Light Blue Tadtone under Great Tree Root:
+    original item: 'Group of Tadtones #4'
     type: Tadtones
     short_name: Flooded Faron Woods - Light Blue Tadtone under Great Tree Root
   \Faron\Flooded Faron Woods\8 Yellow Tadtones near Kikwi Elder:
+    original item: 'Group of Tadtones #5'
     type: Tadtones
     short_name: Flooded Faron Woods - 8 Yellow Tadtones near Kikwi Elder
   \Faron\Flooded Faron Woods\4 Light Blue Moving Tadtones under Kikwi Elder:
+    original item: 'Group of Tadtones #6'
     type: Tadtones
     short_name: Flooded Faron Woods - 4 Light Blue Moving Tadtones under Kikwi Elder
   \Faron\Flooded Faron Woods\4 Red Moving Tadtones North West of Great Tree:
+    original item: 'Group of Tadtones #7'
     type: Tadtones
     short_name: Flooded Faron Woods - 4 Red Moving Tadtones North West of Great Tree
   \Faron\Flooded Faron Woods\Green Tadtone behind Upper Bombable Rock:
+    original item: 'Group of Tadtones #8'
     type: Tadtones
     short_name: Flooded Faron Woods - Green Tadtone behind Upper Bombable Rock
   \Faron\Flooded Faron Woods\2 Dark Blue Tadtones in Grass West of Great Tree:
+    original item: 'Group of Tadtones #9'
     type: Tadtones
     short_name: Flooded Faron Woods - 2 Dark Blue Tadtones in Grass West of Great
       Tree
   \Faron\Flooded Faron Woods\8 Green Tadtones in West Tunnel:
+    original item: 'Group of Tadtones #10'
     type: Tadtones
     short_name: Flooded Faron Woods - 8 Green Tadtones in West Tunnel
   \Faron\Flooded Faron Woods\2 Red Tadtones in Grass near Lower Bombable Rock:
+    original item: 'Group of Tadtones #11'
     type: Tadtones
     short_name: Flooded Faron Woods - 2 Red Tadtones in Grass near Lower Bombable
       Rock
   \Faron\Flooded Faron Woods\16 Dark Blue Tadtones in the South West:
+    original item: 'Group of Tadtones #12'
     type: Tadtones
     short_name: Flooded Faron Woods - 16 Dark Blue Tadtones in the South West
   \Faron\Flooded Faron Woods\4 Purple Moving Tadtones near Floria Gate:
+    original item: 'Group of Tadtones #13'
     type: Tadtones
     short_name: Flooded Faron Woods - 4 Purple Moving Tadtones near Floria Gate
   \Faron\Flooded Faron Woods\Dark Blue Moving Tadtone inside Small Hollow Tree:
+    original item: 'Group of Tadtones #14'
     type: Tadtones
     short_name: Flooded Faron Woods - Dark Blue Moving Tadtone inside Small Hollow
       Tree
   \Faron\Flooded Faron Woods\4 Yellow Tadtones under Small Hollow Tree:
+    original item: 'Group of Tadtones #15'
     type: Tadtones
     short_name: Flooded Faron Woods - 4 Yellow Tadtones under Small Hollow Tree
   \Faron\Flooded Faron Woods\8 Purple Tadtones in Clearing after Small Hollow Tree:
+    original item: 'Group of Tadtones #16'
     type: Tadtones
     short_name: Flooded Faron Woods - 8 Purple Tadtones in Clearing after Small Hollow
       Tree
   \Faron\Flooded Faron Woods\Flooded Great Tree\Water Dragon's Reward:
+    original item: Faron Song of the Hero Part
     type: Tadtones
     short_name: Flooded Faron Woods - Water Dragon's Reward
   \Eldin\Volcano\Entry\Rupee on Ledge before First Room:
+    original item: 'Red Rupee #30'
     type: Rupees (No Quick Beetle)
     short_name: Eldin Volcano - Rupee on Ledge before First Room
   \Eldin\Volcano\First Room\Chest behind Bombable Wall in First Room:
+    original item: Red Rupee
     type: null
     short_name: Eldin Volcano - Chest behind Bombable Wall in First Room
   \Eldin\Volcano\First Room\Rupee behind Bombable Wall in First Room:
+    original item: 'Blue Rupee #8'
     type: Rupees (No Quick Beetle)
     short_name: Eldin Volcano - Rupee behind Bombable Wall in First Room
   \Eldin\Volcano\First Room\Rupee in Crawlspace in First Room:
+    original item: 'Blue Rupee #9'
     type: Rupees (No Quick Beetle)
     short_name: Eldin Volcano - Rupee in Crawlspace in First Room
   \Eldin\Volcano\East\Chest after Crawlspace:
+    original item: Red Rupee
     type: null
     short_name: Eldin Volcano - Chest after Crawlspace
   \Eldin\Volcano\East\Southeast Rupee above Mogma Turf Entrance:
+    original item: 'Blue Rupee #10'
     type: Rupees (No Quick Beetle)
     short_name: Eldin Volcano - Southeast Rupee above Mogma Turf Entrance
   \Eldin\Volcano\East\North Rupee above Mogma Turf Entrance:
+    original item: 'Red Rupee #31'
     type: Rupees (No Quick Beetle)
     short_name: Eldin Volcano - North Rupee above Mogma Turf Entrance
   \Eldin\Volcano\East\Chest behind Bombable Wall near Cliff:
+    original item: Red Rupee
     type: null
     short_name: Eldin Volcano - Chest behind Bombable Wall near Cliff
   \Eldin\Volcano\East\Item on Cliff:
+    original item: Heart Piece
     type: null
     short_name: Eldin Volcano - Item on Cliff
   \Eldin\Volcano\Ascent\Chest behind Bombable Wall near Volcano Ascent:
+    original item: Red Rupee
     type: null
     short_name: Eldin Volcano - Chest behind Bombable Wall near Volcano Ascent
   \Eldin\Volcano\Near Thrill Digger Cave\Left Rupee behind Bombable Wall on First Slope:
+    original item: 'Red Rupee #32'
     type: Rupees (No Quick Beetle)
     short_name: Eldin Volcano - Left Rupee behind Bombable Wall on First Slope
   \Eldin\Volcano\Near Thrill Digger Cave\Right Rupee behind Bombable Wall on First Slope:
+    original item: 'Red Rupee #33'
     type: Rupees (No Quick Beetle)
     short_name: Eldin Volcano - Right Rupee behind Bombable Wall on First Slope
   \Eldin\Volcano\Near Temple Entrance\Digging Spot in front of Earth Temple:
+    original item: Key Piece
     type: null
     short_name: Eldin Volcano - Digging Spot in front of Earth Temple
   \Eldin\Volcano\Near Temple Entrance\Digging Spot below Tower:
+    original item: Key Piece
     type: null
     short_name: Eldin Volcano - Digging Spot below Tower
   \Eldin\Volcano\Near Temple Entrance\Digging Spot behind Boulder on Sandy Slope:
+    original item: Key Piece
     type: null
     short_name: Eldin Volcano - Digging Spot behind Boulder on Sandy Slope
   \Eldin\Volcano\Sand Slide\Digging Spot after Vents:
+    original item: Key Piece
     type: null
     short_name: Eldin Volcano - Digging Spot after Vents
   \Eldin\Volcano\Past Slide\Digging Spot after Draining Lava:
+    original item: Key Piece
     type: null
     short_name: Eldin Volcano - Digging Spot after Draining Lava
   \Eldin\Mogma Turf\Pre Vent\Free Fall Chest:
+    original item: Eldin Ore
     type: null
     short_name: Mogma Turf - Free Fall Chest
   \Eldin\Mogma Turf\Pre Vent\Chest behind Bombable Wall at Entrance:
+    original item: Golden Skull
     type: null
     short_name: Mogma Turf - Chest behind Bombable Wall at Entrance
   \Eldin\Mogma Turf\Pre Vent\Defeat Bokoblins:
+    original item: Progressive Mitts
     type: Combat
     short_name: Mogma Turf - Defeat Bokoblins
   \Eldin\Mogma Turf\Sand Slide Platform\Sand Slide Chest:
+    original item: Eldin Ore
     type: null
     short_name: Mogma Turf - Sand Slide Chest
   \Eldin\Mogma Turf\Past Vent\Chest behind Bombable Wall in Fire Maze:
+    original item: Silver Rupee
     type: null
     short_name: Mogma Turf - Chest behind Bombable Wall in Fire Maze
   \Eldin\Volcano Summit\Waterfall\Higher Area\Chest behind Bombable Wall in Waterfall Area:
+    original item: Silver Rupee
     type: null
     short_name: Volcano Summit - Chest behind Bombable Wall in Waterfall Area
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Between Thirsty Frogs\Item behind Digging:
+    original item: Heart Piece
     type: null
     short_name: Volcano Summit - Item behind Digging
   \Eldin\Bokoblin Base\Prison\Plats' Gift:
+    original item: Mogma Mitts
     type: null
     short_name: Bokoblin Base - Plats' Gift
   \Eldin\Bokoblin Base\Volcano East\Chest near Bone Bridge:
+    original item: Gust Bellows
     type: null
     short_name: Bokoblin Base - Chest near Bone Bridge
   \Eldin\Bokoblin Base\Volcano East\Chest on Cliff:
+    original item: Clawshots
     type: null
     short_name: Bokoblin Base - Chest on Cliff
   \Eldin\Bokoblin Base\Before Drawbridge\Chest near Drawbridge:
+    original item: Whip
     type: null
     short_name: Bokoblin Base - Chest near Drawbridge
   \Eldin\Bokoblin Base\Outside Earth Temple\Chest East of Earth Temple Entrance:
+    original item: Slingshot
     type: null
     short_name: Bokoblin Base - Chest East of Earth Temple Entrance
   \Eldin\Bokoblin Base\Outside Earth Temple\Chest West of Earth Temple Entrance:
+    original item: Bombs
     type: null
     short_name: Bokoblin Base - Chest West of Earth Temple Entrance
   \Eldin\Bokoblin Base\Bokoblin Base Summit\First Chest in Volcano Summit:
+    original item: Blue Rupee
     type: null
     short_name: Bokoblin Base - First Chest in Volcano Summit
   \Eldin\Bokoblin Base\Bokoblin Base Summit\Raised Chest in Volcano Summit:
+    original item: Progressive Sword
     type: null
     short_name: Bokoblin Base - Raised Chest in Volcano Summit
   \Eldin\Bokoblin Base\Bokoblin Base Summit\Chest in Volcano Summit Alcove:
+    original item: Progressive Pouch
     type: null
     short_name: Bokoblin Base - Chest in Volcano Summit Alcove
   \Eldin\Bokoblin Base\Fire Dragon's Lair\Fire Dragon's Reward:
+    original item: Eldin Song of the Hero Part
     type: null
     short_name: Bokoblin Base - Fire Dragon's Reward
   \Lanayru\Mine\Entry\Higher Area\Chest behind First Landing:
+    original item: Evil Crystal
     type: null
     short_name: Lanayru Mine - Chest behind First Landing
   \Lanayru\Mine\Entry\Chest near First Timeshift Stone:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Mine - Chest near First Timeshift Stone
   \Lanayru\Mine\Statues Area\Chest behind Statue:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Mine - Chest behind Statue
   \Lanayru\Mine\End\Chest at the End of Mine:
+    original item: Rare Treasure
     type: null
     short_name: Lanayru Mine - Chest at the End of Mine
   \Lanayru\Desert\Entry\High Ledge after Vines\Chest near Party Wheel:
+    original item: Golden Skull
     type: null
     short_name: Lanayru Desert - Chest near Party Wheel
   \Lanayru\Desert\Near Caged Robot\Chest near Caged Robot:
+    original item: Tumbleweed
     type: null
     short_name: Lanayru Desert - Chest near Caged Robot
   \Lanayru\Desert\Near Caged Robot\Rescue Caged Robot:
+    original item: Progressive Beetle
     type: Combat
     short_name: Lanayru Desert - Rescue Caged Robot
   \Lanayru\Desert\East\Chest on Platform near Fire Node:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Desert - Chest on Platform near Fire Node
   \Lanayru\Desert\North Part\Chest on Platform near Lightning Node:
+    original item: 'Dusk Relic #0'
     type: lanayru, miscellaneous
     short_name: Lanayru Desert - Chest on Platform near Lightning Node
   \Lanayru\Desert\Top of West Wall\Chest near Sand Oasis:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Desert - Chest near Sand Oasis
   \Lanayru\Desert\Top of LMF\Chest on top of Lanayru Mining Facility:
+    original item: Rare Treasure
     type: null
     short_name: Lanayru Desert - Chest on top of Lanayru Mining Facility
   \Lanayru\Desert\North Part\Secret Passageway\Secret Passageway Chest:
+    original item: Heart Piece
     type: null
     short_name: Lanayru Desert - Secret Passageway Chest
   \Lanayru\Desert\East\Fire Node\Present after Sand\Shortcut Chest:
+    original item: Rare Treasure
     type: null
     short_name: Lanayru Desert - Fire Node - Shortcut Chest
   \Lanayru\Desert\East\Fire Node\Past\First Small Chest:
+    original item: Blue Rupee
     type: null
     short_name: Lanayru Desert - Fire Node - First Small Chest
   \Lanayru\Desert\East\Fire Node\Past\Second Small Chest:
+    original item: Blue Rupee
     type: null
     short_name: Lanayru Desert - Fire Node - Second Small Chest
   \Lanayru\Desert\East\Fire Node\Past after Grate\Left Ending Chest:
+    original item: Golden Skull
     type: null
     short_name: Lanayru Desert - Fire Node - Left Ending Chest
   \Lanayru\Desert\East\Fire Node\Past after Grate\Right Ending Chest:
+    original item: Blue Rupee
     type: null
     short_name: Lanayru Desert - Fire Node - Right Ending Chest
   \Lanayru\Desert\North Part\Lightning Node\Past\First Chest:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Desert - Lightning Node - First Chest
   \Lanayru\Desert\North Part\Lightning Node\Past\Second Chest:
+    original item: Blue Rupee
     type: null
     short_name: Lanayru Desert - Lightning Node - Second Chest
   \Lanayru\Desert\North Part\Lightning Node\Present from afar\Raised Chest near Generator:
+    original item: Rare Treasure
     type: null
     short_name: Lanayru Desert - Lightning Node - Raised Chest near Generator
   \Lanayru\Caves\Chest:
+    original item: Golden Skull
     type: null
     short_name: Lanayru Caves - Chest
   \Lanayru\Caves\Golo's Gift:
+    original item: Lanayru Caves Small Key
     type: null
     short_name: Lanayru Caves - Golo's Gift
   \Lanayru\Lanayru Sand Sea\Gorge\Thunder Dragon's Reward:
+    original item: Lanayru Song of the Hero Part
     type: null
     short_name: Lanayru Gorge - Thunder Dragon's Reward
   \Lanayru\Lanayru Sand Sea\Gorge\Item on Pillar:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Gorge - Item on Pillar
   \Lanayru\Lanayru Sand Sea\Gorge\Beyond Bridge\Digging Spot:
+    original item: Life Tree Seedling
     type: null
     short_name: Lanayru Gorge - Digging Spot
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Rupee on First Pillar:
+    original item: 'Red Rupee #34'
     type: Rupees (No Quick Beetle)
     short_name: Lanayru Sand Sea - Ancient Harbour - Rupee on First Pillar
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Left Rupee on Entrance Crown:
+    original item: 'Silver Rupee #13'
     type: Rupees (Quick Beetle)
     short_name: Lanayru Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Right Rupee on Entrance Crown:
+    original item: 'Silver Rupee #14'
     type: Rupees (Quick Beetle)
     short_name: Lanayru Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Past Rock\Chest after Moblin:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Sand Sea - Skipper's Retreat - Chest after Moblin
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Chest on top of Cacti Pillar:
+    original item: Semi Rare Treasure
     type: null
     short_name: Lanayru Sand Sea - Skipper's Retreat - Chest on top of Cacti Pillar
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Chest in Shack:
+    original item: Sea Chart
     type: null
     short_name: Lanayru Sand Sea - Skipper's Retreat - Chest in Shack
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Skydive Platform\Skydive Chest:
+    original item: Silver Rupee
     type: null
     short_name: Lanayru Sand Sea - Skipper's Retreat - Skydive Chest
   \Lanayru\Lanayru Sand Sea\Shipyard\Rickety Coaster -- Heart Stopping Track in 1'05:
+    original item: Heart Piece
     type: Minigames, Combat
     short_name: Lanayru Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on East Sea Pillar:
+    original item: 'Silver Rupee #16'
     type: Rupees (Quick Beetle)
     short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on East Sea Pillar
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on West Sea Pillar:
+    original item: 'Silver Rupee #15'
     type: Rupees (Quick Beetle)
     short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on West Sea Pillar
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Rupee on Bird Statue Pillar or Nose:
+    original item: 'Silver Rupee #17'
     type: Rupees (No Quick Beetle)
     short_name: Lanayru Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar
       or Nose
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Chest:
+    original item: Silver Rupee
     type: null
     short_name: Lanayru Sand Sea - Pirate Stronghold - First Chest
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Chest:
+    original item: Semi Rare Treasure
     type: null
     short_name: Lanayru Sand Sea - Pirate Stronghold - Second Chest
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Third Chest:
+    original item: Semi Rare Treasure
     type: null
     short_name: Lanayru Sand Sea - Pirate Stronghold - Third Chest
   \Skyview\Main\First Hub\Left Room\Chest on Tree Branch:
+    original item: Skyview Map
     type: null
     short_name: Skyview - Chest on Tree Branch
   \Skyview\Main\First Hub\Right Room\After Crawlspace\Digging Spot in Crawlspace:
+    original item: Skyview Small Key
     type: null
     short_name: Skyview - Digging Spot in Crawlspace
   \Skyview\Main\First Hub\Right Room\Upper Area\Chest behind Two Eyes:
+    original item: 'Skyview Small Key #0'
     type: null
     short_name: Skyview - Chest behind Two Eyes
   \Skyview\Main\Second Hub\Miniboss Room\Chest after Stalfos Fight:
+    original item: Progressive Beetle
     type: null
     short_name: Skyview - Chest after Stalfos Fight
   \Skyview\Main\Second Hub\Item behind Bars:
+    original item: Heart Piece
     type: null
     short_name: Skyview - Item behind Bars
   \Skyview\Main\Second Hub\Rupee in Southeast Tunnel:
+    original item: 'Red Rupee #35'
     type: Rupees (No Quick Beetle)
     short_name: Skyview - Rupee in Southeast Tunnel
   \Skyview\Main\Second Hub\Rupee in Southwest Tunnel:
+    original item: 'Red Rupee #36'
     type: Rupees (No Quick Beetle)
     short_name: Skyview - Rupee in Southwest Tunnel
   \Skyview\Main\Second Hub\Rupee in East Tunnel:
+    original item: 'Red Rupee #37'
     type: Rupees (No Quick Beetle)
     short_name: Skyview - Rupee in East Tunnel
   \Skyview\Main\Second Hub\Left Rooms\Chest behind Three Eyes:
+    original item: 'Skyview Small Key #1'
     type: null
     short_name: Skyview - Chest behind Three Eyes
   \Skyview\Main\Last Room\After Rope\Chest near Boss Door:
+    original item: Red Rupee
     type: null
     short_name: Skyview - Chest near Boss Door
   \Skyview\Main\Last Room\Near Boss Key Chest\Boss Key Chest:
+    original item: Skyview Boss Key
     type: null
     short_name: Skyview - Boss Key Chest
   \Skyview\Boss Room\Heart Container:
+    original item: Heart Container
     type: null
     short_name: Skyview - Heart Container
   \Skyview\Spring\Rupee on Spring Pillar:
+    original item: 'Red Rupee #38'
     type: Rupees (No Quick Beetle)
     short_name: Skyview - Rupee on Spring Pillar
   \Skyview\Spring\Strike Crest:
+    original item: Ruby Tablet
     type: null
     short_name: Skyview - Strike Crest
   \Earth Temple\Main\First Room\Vent Chest:
+    original item: Red Rupee
     type: null
     short_name: Earth Temple - Vent Chest
   \Earth Temple\Main\First Room\Rupee above Drawbridge:
+    original item: 'Red Rupee #39'
     type: Rupees (No Quick Beetle)
     short_name: Earth Temple - Rupee above Drawbridge
   \Earth Temple\Main\Hub Room\Chest behind Bombable Rock:
+    original item: Golden Skull
     type: null
     short_name: Earth Temple - Chest behind Bombable Rock
   \Earth Temple\Main\Hub Room\Chest Left of Main Room Bridge:
+    original item: Golden Skull
     type: null
     short_name: Earth Temple - Chest Left of Main Room Bridge
   \Earth Temple\Main\West Room\Chest in West Room:
+    original item: Earth Temple Map
     type: null
     short_name: Earth Temple - Chest in West Room
   \Earth Temple\Main\East Room\Chest after Double Lizalfos Fight:
+    original item: Bomb Bag
     type: null
     short_name: Earth Temple - Chest after Double Lizalfos Fight
   \Earth Temple\Main\Hub Room\Ledd's Gift:
+    original item: 5 Bombs
     type: null
     short_name: Earth Temple - Ledd's Gift
   \Earth Temple\Main\Hub Room\Rupee in Lava Tunnel:
+    original item: 'Silver Rupee #18'
     type: Rupees (No Quick Beetle)
     short_name: Earth Temple - Rupee in Lava Tunnel
   \Earth Temple\Main\Hub Room\Past Lava Section\Chest Guarded by Lizalfos:
+    original item: Red Rupee
     type: null
     short_name: Earth Temple - Chest Guarded by Lizalfos
   \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Key Chest:
+    original item: Earth Temple Boss Key
     type: null
     short_name: Earth Temple - Boss Key Chest
   \Earth Temple\Boss Room\Slope\Heart Container:
+    original item: Heart Container
     type: null
     short_name: Earth Temple - Heart Container
   \Earth Temple\Spring\Strike Crest:
+    original item: Amber Tablet
     type: null
     short_name: Earth Temple - Strike Crest
   \Lanayru Mining Facility\Main\First Room\Chest behind Bars:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Mining Facility - Chest behind Bars
   \Lanayru Mining Facility\Main\Big Hub\After Wooden Boxes\First Chest in Hub Room:
+    original item: Lanayru Mining Facility Small Key
     type: null
     short_name: Lanayru Mining Facility - First Chest in Hub Room
   \Lanayru Mining Facility\Main\First West Room\Chest in First West Room:
+    original item: Golden Skull
     type: null
     short_name: Lanayru Mining Facility - Chest in First West Room
   \Lanayru Mining Facility\Main\Armos Fight Room\Chest after Armos Fight:
+    original item: Lanayru Mining Facility Map
     type: null
     short_name: Lanayru Mining Facility - Chest after Armos Fight
   \Lanayru Mining Facility\Main\Key Locked Room\Chest in Key Locked Room:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Mining Facility - Chest in Key Locked Room
   \Lanayru Mining Facility\Main\Hop Across Boxes Room\Raised Chest in Hop across Boxes Room:
+    original item: Gust Bellows
     type: null
     short_name: Lanayru Mining Facility - Raised Chest in Hop across Boxes Room
   \Lanayru Mining Facility\Main\Hop Across Boxes Room\Lower Chest in Hop across Boxes Room:
+    original item: Golden Skull
     type: null
     short_name: Lanayru Mining Facility - Lower Chest in Hop across Boxes Room
   \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Chest behind First Crawlspace:
+    original item: Golden Skull
     type: null
     short_name: Lanayru Mining Facility - Chest behind First Crawlspace
   \Lanayru Mining Facility\Main\Big Hub\Sand Spike Maze\Chest in Spike Maze:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Mining Facility - Chest in Spike Maze
   \Lanayru Mining Facility\Main\Boss Key Room\Boss Key Chest:
+    original item: Lanayru Mining Facility Boss Key
     type: null
     short_name: Lanayru Mining Facility - Boss Key Chest
   \Lanayru Mining Facility\Main\Big Hub\Near Boss Key Room Second Exit\Shortcut Chest in Main Hub:
+    original item: Red Rupee
     type: null
     short_name: Lanayru Mining Facility - Shortcut Chest in Main Hub
   \Lanayru Mining Facility\Boss Room\After Sand Drain\Heart Container:
+    original item: Heart Container
     type: null
     short_name: Lanayru Mining Facility - Heart Container
   \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit Hall of Ancient Robots:
+    original item: Goddess's Harp
     type: null
     short_name: Lanayru Mining Facility - Exit Hall of Ancient Robots
   \Ancient Cistern\Main\Main Room\Rupee in West Hand:
+    original item: 'Silver Rupee #20'
     type: Rupees (No Quick Beetle)
     short_name: Ancient Cistern - Rupee in West Hand
   \Ancient Cistern\Main\Main Room\Rupee in East Hand:
+    original item: 'Silver Rupee #19'
     type: Rupees (No Quick Beetle)
     short_name: Ancient Cistern - Rupee in East Hand
   \Ancient Cistern\Main\East Part\Second Room\First Rupee in East Part in Short Tunnel:
+    original item: 'Green Rupee #0'
     type: Rupees (No Quick Beetle)
     short_name: Ancient Cistern - First Rupee in East Part in Short Tunnel
   \Ancient Cistern\Main\East Part\Second Room\Second Rupee in East Part in Short Tunnel:
+    original item: 'Green Rupee #1'
     type: Rupees (No Quick Beetle)
     short_name: Ancient Cistern - Second Rupee in East Part in Short Tunnel
   \Ancient Cistern\Main\East Part\Second Room\Third Rupee in East Part in Short Tunnel:
+    original item: 'Green Rupee #2'
     type: Rupees (No Quick Beetle)
     short_name: Ancient Cistern - Third Rupee in East Part in Short Tunnel
   \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Cubby:
+    original item: 'Red Rupee #41'
     type: Rupees (No Quick Beetle)
     short_name: Ancient Cistern - Rupee in East Part in Cubby
   \Ancient Cistern\Main\East Part\Second Room\Rupee in East Part in Main Tunnel:
+    original item: 'Red Rupee #40'
     type: Rupees (No Quick Beetle)
     short_name: Ancient Cistern - Rupee in East Part in Main Tunnel
   \Ancient Cistern\Main\East Part\Chest Ledge\Chest in East Part:
+    original item: 'Ancient Cistern Small Key #0'
     type: null
     short_name: Ancient Cistern - Chest in East Part
   \Ancient Cistern\Main\Main Room\After Whip Hooks\Chest after Whip Hooks:
+    original item: Ancient Cistern Map
     type: null
     short_name: Ancient Cistern - Chest after Whip Hooks
   \Ancient Cistern\Main\Main Room\Vines Area\Chest near Vines:
+    original item: Red Rupee
     type: null
     short_name: Ancient Cistern - Chest near Vines
   \Ancient Cistern\Main\Main Room\Behind the Waterfall\Chest behind the Waterfall:
+    original item: Red Rupee
     type: null
     short_name: Ancient Cistern - Chest behind the Waterfall
   \Ancient Cistern\Main\Basement Gutters\Past Skulltula\Bokoblin:
+    original item: 'Ancient Cistern Small Key #1'
     type: null
     short_name: Ancient Cistern - Bokoblin
   \Ancient Cistern\Main\Main Room\After Gutters\Rupee under Lilypad:
+    original item: Red Rupee
     type: Rupees (No Quick Beetle)
     short_name: Ancient Cistern - Rupee under Lilypad
   \Ancient Cistern\Main\Inside Statue\Key Locked Room with Chest\Chest in Key Locked Room:
+    original item: Whip
     type: null
     short_name: Ancient Cistern - Chest in Key Locked Room
   \Ancient Cistern\Main\Basement\Under the Statue\Boss Key Chest:
+    original item: Ancient Cistern Boss Key
     type: null
     short_name: Ancient Cistern - Boss Key Chest
   \Ancient Cistern\Boss Room\Heart Container:
+    original item: Heart Container
     type: null
     short_name: Ancient Cistern - Heart Container
   \Ancient Cistern\Flame Room\Farore's Flame:
+    original item: Progressive Sword
     type: null
     short_name: Ancient Cistern - Farore's Flame
   \Sandship\Main\Deck\Stern\Chest at the Stern:
+    original item: Heart Piece
     type: null
     short_name: Sandship - Chest at the Stern
   \Sandship\Main\Before Ship's Bow\Chest before 4-Door Corridor:
+    original item: Sandship Map
     type: null
     short_name: Sandship - Chest before 4-Door Corridor
   \Sandship\Main\Before Boss Door\Chest behind Combination Lock:
+    original item: 'Sandship Small Key #0'
     type: null
     short_name: Sandship - Chest behind Combination Lock
   \Sandship\Main\Treasure Room\Treasure Room First Chest:
+    original item: Semi Rare Treasure
     type: null
     short_name: Sandship - Treasure Room First Chest
   \Sandship\Main\Treasure Room\Treasure Room Second Chest:
+    original item: Silver Rupee
     type: null
     short_name: Sandship - Treasure Room Second Chest
   \Sandship\Main\Treasure Room\Treasure Room Third Chest:
+    original item: Semi Rare Treasure
     type: null
     short_name: Sandship - Treasure Room Third Chest
   \Sandship\Main\Treasure Room\Treasure Room Fourth Chest:
+    original item: Silver Rupee
     type: null
     short_name: Sandship - Treasure Room Fourth Chest
   \Sandship\Main\Treasure Room\Treasure Room Fifth Chest:
+    original item: Semi Rare Treasure
     type: null
     short_name: Sandship - Treasure Room Fifth Chest
   \Sandship\Main\Brig Prison\Robot in Brig's Reward:
+    original item: 'Sandship Small Key #1'
     type: null
     short_name: Sandship - Robot in Brig's Reward
   \Sandship\Main\Ship's Bow\Chest after Scervo Fight:
+    original item: Progressive Bow
     type: null
     short_name: Sandship - Chest after Scervo Fight
   \Sandship\Main\Deck\Captain's Cabin\Boss Key Chest:
+    original item: Sandship Boss Key
     type: null
     short_name: Sandship - Boss Key Chest
   \Sandship\Boss Room\Heart Container:
+    original item: Heart Container
     type: null
     short_name: Sandship - Heart Container
   \Sandship\Boss Room\Nayru's Flame:
+    original item: Progressive Sword
     type: null
     short_name: Sandship - Nayru's Flame
   \Fire Sanctuary\Main\First Room\Past Water Plant\Chest in First Room:
+    original item: 'Fire Sanctuary Small Key #0'
     type: null
     short_name: Fire Sanctuary - Chest in First Room
   \Fire Sanctuary\Main\Second Room\Chest in Second Room:
+    original item: Red Rupee
     type: null
     short_name: Fire Sanctuary - Chest in Second Room
   \Fire Sanctuary\Main\Second Room\Balcony\Chest on Balcony:
+    original item: Bottle
     type: null
     short_name: Fire Sanctuary - Chest on Balcony
   \Fire Sanctuary\Main\First Trapped Mogma Room\Chest near First Trapped Mogma:
+    original item: 'Fire Sanctuary Small Key #1'
     type: null
     short_name: Fire Sanctuary - Chest near First Trapped Mogma
   \Fire Sanctuary\Main\Water Fruit Room\First Chest in Water Fruit Room:
+    original item: Red Rupee
     type: null
     short_name: Fire Sanctuary - First Chest in Water Fruit Room
   \Fire Sanctuary\Main\Water Fruit Room\Second Chest in Water Fruit Room:
+    original item: Semi Rare Treasure
     type: null
     short_name: Fire Sanctuary - Second Chest in Water Fruit Room
   \Fire Sanctuary\Main\First Trapped Mogma Room\Lower Area\Rescue First Trapped Mogma:
+    original item: Progressive Mitts
     type: null
     short_name: Fire Sanctuary - Rescue First Trapped Mogma
   \Fire Sanctuary\Main\Second Trapped Mogma Room\Rescue Second Trapped Mogma:
+    original item: Fire Sanctuary Map
     type: null
     short_name: Fire Sanctuary - Rescue Second Trapped Mogma
   \Fire Sanctuary\Main\Second Trapped Mogma Room\Past Bombable Wall\Chest after Bombable Wall:
+    original item: 'Fire Sanctuary Small Key #2'
     type: null
     short_name: Fire Sanctuary - Chest after Bombable Wall
   \Fire Sanctuary\Main\West of Boss Door\Plats' Chest:
+    original item: Heart Piece
     type: null
     short_name: Fire Sanctuary - Plats' Chest
   \Fire Sanctuary\Main\Staircase Room\Chest in Staircase Room:
+    original item: Semi Rare Treasure
     type: null
     short_name: Fire Sanctuary - Chest in Staircase Room
   \Fire Sanctuary\Main\Boss Key Room\Boss Key Chest:
+    original item: Fire Sanctuary Boss Key
     type: null
     short_name: Fire Sanctuary - Boss Key Chest
   \Fire Sanctuary\Boss Room\Heart Container:
+    original item: Heart Container
     type: null
     short_name: Fire Sanctuary - Heart Container
   \Fire Sanctuary\Flame Room\Din's Flame:
+    original item: Progressive Sword
     type: null
     short_name: Fire Sanctuary - Din's Flame
   \Sky Keep\Main\First Room\First Chest:
+    original item: Sky Keep Map
     type: null
     short_name: Sky Keep - First Chest
   \Sky Keep\Main\Mini Boss Room\Near Chest\Chest after Dreadfuse:
+    original item: Sky Keep Small Key
     type: null
     short_name: Sky Keep - Chest after Dreadfuse
   \Sky Keep\Main\Fire Sanctuary Room\First Platform\Rupee in Fire Sanctuary Room in Alcove:
+    original item: 'Silver Rupee #21'
     type: Rupees (No Quick Beetle)
     short_name: Sky Keep - Rupee in Fire Sanctuary Room in Alcove
   \Sky Keep\Main\Fire Sanctuary Room\Triforce Room\Sacred Power of Din:
+    original item: Triforce of Power
     type: null
     short_name: Sky Keep - Sacred Power of Din
   \Sky Keep\Main\Sandship Room\Triforce Area\Sacred Power of Nayru:
+    original item: Triforce of Wisdom
     type: null
     short_name: Sky Keep - Sacred Power of Nayru
   \Sky Keep\Main\Ancient Cistern Room\Triforce Room\Sacred Power of Farore:
+    original item: Triforce of Courage
     type: null
     short_name: Sky Keep - Sacred Power of Farore
   \Skyloft\Skyloft Silent Realm\Trial Reward:
+    original item: Stone of Trials
     type: null
     short_name: Skyloft Silent Realm - Trial Reward
   \Skyloft\Skyloft Silent Realm\Relic 1:
+    original item: 'Dusk Relic #1'
     type: skyloft, silent realm
     short_name: Skyloft Silent Realm - Relic 1
   \Skyloft\Skyloft Silent Realm\Relic 2:
+    original item: 'Dusk Relic #2'
     type: skyloft, silent realm
     short_name: Skyloft Silent Realm - Relic 2
   \Skyloft\Skyloft Silent Realm\Relic 3:
+    original item: 'Dusk Relic #3'
     type: skyloft, silent realm
     short_name: Skyloft Silent Realm - Relic 3
   \Skyloft\Skyloft Silent Realm\Relic 4:
+    original item: 'Dusk Relic #4'
     type: skyloft, silent realm
     short_name: Skyloft Silent Realm - Relic 4
   \Skyloft\Skyloft Silent Realm\Relic 5:
+    original item: 'Dusk Relic #5'
     type: skyloft, silent realm
     short_name: Skyloft Silent Realm - Relic 5
   \Skyloft\Skyloft Silent Realm\Relic 6:
+    original item: 'Dusk Relic #6'
     type: skyloft, silent realm
     short_name: Skyloft Silent Realm - Relic 6
   \Skyloft\Skyloft Silent Realm\Relic 7:
+    original item: 'Dusk Relic #7'
     type: skyloft, silent realm
     short_name: Skyloft Silent Realm - Relic 7
   \Skyloft\Skyloft Silent Realm\Relic 8:
+    original item: 'Dusk Relic #8'
     type: skyloft, silent realm
     short_name: Skyloft Silent Realm - Relic 8
   \Skyloft\Skyloft Silent Realm\Relic 9:
+    original item: 'Dusk Relic #9'
     type: skyloft, silent realm
     short_name: Skyloft Silent Realm - Relic 9
   \Skyloft\Skyloft Silent Realm\Relic 10:
+    original item: 'Dusk Relic #10'
     type: skyloft, silent realm
     short_name: Skyloft Silent Realm - Relic 10
   \Faron\Faron Silent Realm\Trial Reward:
+    original item: Water Dragon's Scale
     type: null
     short_name: Faron Silent Realm - Trial Reward
   \Faron\Faron Silent Realm\Relic 1:
+    original item: 'Dusk Relic #11'
     type: faron, silent realm
     short_name: Faron Silent Realm - Relic 1
   \Faron\Faron Silent Realm\Relic 2:
+    original item: 'Dusk Relic #12'
     type: faron, silent realm
     short_name: Faron Silent Realm - Relic 2
   \Faron\Faron Silent Realm\Relic 3:
+    original item: 'Dusk Relic #13'
     type: faron, silent realm
     short_name: Faron Silent Realm - Relic 3
   \Faron\Faron Silent Realm\Relic 4:
+    original item: 'Dusk Relic #14'
     type: faron, silent realm
     short_name: Faron Silent Realm - Relic 4
   \Faron\Faron Silent Realm\Relic 5:
+    original item: 'Dusk Relic #15'
     type: faron, silent realm
     short_name: Faron Silent Realm - Relic 5
   \Faron\Faron Silent Realm\Relic 6:
+    original item: 'Dusk Relic #16'
     type: faron, silent realm
     short_name: Faron Silent Realm - Relic 6
   \Faron\Faron Silent Realm\Relic 7:
+    original item: 'Dusk Relic #17'
     type: faron, silent realm
     short_name: Faron Silent Realm - Relic 7
   \Faron\Faron Silent Realm\Relic 8:
+    original item: 'Dusk Relic #18'
     type: faron, silent realm
     short_name: Faron Silent Realm - Relic 8
   \Faron\Faron Silent Realm\Relic 9:
+    original item: 'Dusk Relic #19'
     type: faron, silent realm
     short_name: Faron Silent Realm - Relic 9
   \Faron\Faron Silent Realm\Relic 10:
+    original item: 'Dusk Relic #20'
     type: faron, silent realm
     short_name: Faron Silent Realm - Relic 10
   \Lanayru\Lanayru Silent Realm\Trial Reward:
+    original item: Clawshots
     type: null
     short_name: Lanayru Silent Realm - Trial Reward
   \Lanayru\Lanayru Silent Realm\Relic 1:
+    original item: 'Dusk Relic #21'
     type: lanayru, silent realm
     short_name: Lanayru Silent Realm - Relic 1
   \Lanayru\Lanayru Silent Realm\Relic 2:
+    original item: 'Dusk Relic #22'
     type: lanayru, silent realm
     short_name: Lanayru Silent Realm - Relic 2
   \Lanayru\Lanayru Silent Realm\Relic 3:
+    original item: 'Dusk Relic #23'
     type: lanayru, silent realm
     short_name: Lanayru Silent Realm - Relic 3
   \Lanayru\Lanayru Silent Realm\Relic 4:
+    original item: 'Dusk Relic #24'
     type: lanayru, silent realm
     short_name: Lanayru Silent Realm - Relic 4
   \Lanayru\Lanayru Silent Realm\Relic 5:
+    original item: 'Dusk Relic #25'
     type: lanayru, silent realm
     short_name: Lanayru Silent Realm - Relic 5
   \Lanayru\Lanayru Silent Realm\Relic 6:
+    original item: 'Dusk Relic #26'
     type: lanayru, silent realm
     short_name: Lanayru Silent Realm - Relic 6
   \Lanayru\Lanayru Silent Realm\Relic 7:
+    original item: 'Dusk Relic #27'
     type: lanayru, silent realm
     short_name: Lanayru Silent Realm - Relic 7
   \Lanayru\Lanayru Silent Realm\Relic 8:
+    original item: 'Dusk Relic #28'
     type: lanayru, silent realm
     short_name: Lanayru Silent Realm - Relic 8
   \Lanayru\Lanayru Silent Realm\Relic 9:
+    original item: 'Dusk Relic #29'
     type: lanayru, silent realm
     short_name: Lanayru Silent Realm - Relic 9
   \Lanayru\Lanayru Silent Realm\Relic 10:
+    original item: 'Dusk Relic #30'
     type: lanayru, silent realm
     short_name: Lanayru Silent Realm - Relic 10
   \Eldin\Eldin Silent Realm\Trial Reward:
+    original item: Fireshield Earrings
     type: null
     short_name: Eldin Silent Realm - Trial Reward
   \Eldin\Eldin Silent Realm\Relic 1:
+    original item: 'Dusk Relic #31'
     type: eldin, silent realm
     short_name: Eldin Silent Realm - Relic 1
   \Eldin\Eldin Silent Realm\Relic 2:
+    original item: 'Dusk Relic #32'
     type: eldin, silent realm
     short_name: Eldin Silent Realm - Relic 2
   \Eldin\Eldin Silent Realm\Relic 3:
+    original item: 'Dusk Relic #33'
     type: eldin, silent realm
     short_name: Eldin Silent Realm - Relic 3
   \Eldin\Eldin Silent Realm\Relic 4:
+    original item: 'Dusk Relic #34'
     type: eldin, silent realm
     short_name: Eldin Silent Realm - Relic 4
   \Eldin\Eldin Silent Realm\Relic 5:
+    original item: 'Dusk Relic #35'
     type: eldin, silent realm
     short_name: Eldin Silent Realm - Relic 5
   \Eldin\Eldin Silent Realm\Relic 6:
+    original item: 'Dusk Relic #36'
     type: eldin, silent realm
     short_name: Eldin Silent Realm - Relic 6
   \Eldin\Eldin Silent Realm\Relic 7:
+    original item: 'Dusk Relic #37'
     type: eldin, silent realm
     short_name: Eldin Silent Realm - Relic 7
   \Eldin\Eldin Silent Realm\Relic 8:
+    original item: 'Dusk Relic #38'
     type: eldin, silent realm
     short_name: Eldin Silent Realm - Relic 8
   \Eldin\Eldin Silent Realm\Relic 9:
+    original item: 'Dusk Relic #39'
     type: eldin, silent realm
     short_name: Eldin Silent Realm - Relic 9
   \Eldin\Eldin Silent Realm\Relic 10:
+    original item: 'Dusk Relic #40'
     type: eldin, silent realm
     short_name: Eldin Silent Realm - Relic 10
 gossip_stones:
@@ -9928,3934 +10277,2390 @@ exits:
     type: exit
     vanilla: Skyloft - Knight Academy - Start Entrance
     stage: F001r
-    room: 1
-    index: 2
-    req_index: 1790
     short_name: Start
   \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Exit:
     type: exit
     vanilla: Skyloft - Knight Academy Lower Right Door Entrance
     stage: F001r
-    room: 0
-    index: 0
-    req_index: 1791
     short_name: Skyloft - Knight Academy - Lower Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Exit:
     type: exit
     vanilla: Skyloft - Knight Academy Lower Left Door Entrance
     stage: F001r
-    room: 0
-    index: 1
-    req_index: 1792
     short_name: Skyloft - Knight Academy - Lower Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Exit:
     type: exit
     vanilla: Skyloft - Knight Academy Upper Left Door Entrance
     stage: F001r
-    room: 0
-    index: 2
-    req_index: 1793
     short_name: Skyloft - Knight Academy - Upper Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Exit:
     type: exit
     vanilla: Skyloft - Knight Academy Upper Right Door Entrance
     stage: F001r
-    room: 0
-    index: 3
-    req_index: 1794
     short_name: Skyloft - Knight Academy - Upper Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Exit:
     type: exit
     vanilla: Skyloft - Knight Academy - Lower Left Door Entrance
     stage: F000
-    room: 0
-    index: 3
-    req_index: 1795
     short_name: Skyloft - Knight Academy Lower Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Exit:
     type: exit
     vanilla: Skyloft - Knight Academy - Lower Right Door Entrance
     stage: F000
-    room: 0
-    index: 4
-    req_index: 1796
     short_name: Skyloft - Knight Academy Lower Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Exit:
     type: exit
     vanilla: Skyloft - Knight Academy - Upper Right Door Entrance
     stage: F000
-    room: 0
-    index: 23
-    req_index: 1797
     short_name: Skyloft - Knight Academy Upper Left Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Exit:
     type: exit
     vanilla: Skyloft - Knight Academy - Upper Left Door Entrance
     stage: F000
-    room: 0
-    index: 24
-    req_index: 1798
     short_name: Skyloft - Knight Academy Upper Right Door Exit
   \Skyloft\Upper Skyloft\Knight Academy Chimney Entrance:
     type: exit
     vanilla: Skyloft - Knight Academy - Chimney
     stage: F000
-    room: 0
-    index: 57
-    req_index: 1799
     short_name: Skyloft - Knight Academy Chimney Entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Right Door Exit:
     type: exit
     vanilla: Skyloft - Sparring Hall Left Door Entrance
     stage: F009r
-    room: 0
-    index: 0
-    req_index: 1800
     short_name: Sparring Hall - Right Door Exit
   \Skyloft\Upper Skyloft\Sparring Hall\Left Door Exit:
     type: exit
     vanilla: Skyloft - Sparring Hall Right Door Entrance
     stage: F009r
-    room: 0
-    index: 1
-    req_index: 1801
     short_name: Sparring Hall - Left Door Exit
   \Skyloft\Upper Skyloft\Sparring Hall Left Door Exit:
     type: exit
     vanilla: Sparring Hall - Right Door Entrance
     stage: F000
-    room: 0
-    index: 20
-    req_index: 1802
     short_name: Skyloft - Sparring Hall Left Door Exit
   \Skyloft\Upper Skyloft\Sparring Hall Right Door Exit:
     type: exit
     vanilla: Sparring Hall - Left Door Entrance
     stage: F000
-    room: 0
-    index: 27
-    req_index: 1803
     short_name: Skyloft - Sparring Hall Right Door Exit
   \Skyloft\Upper Skyloft\Goddess Statue\Exit:
     type: exit
     vanilla: Goddess Statue Entrance
     stage: F008r
-    room: 0
-    index: 0
-    req_index: 1804
     short_name: Goddess Statue - Exit
   \Skyloft\Upper Skyloft\Goddess Statue Exit:
     type: exit
     vanilla: Goddess Statue - Entrance
     stage: F000
-    room: 0
-    index: 5
-    req_index: 1805
     short_name: Goddess Statue Exit
   \Skyloft\Central Skyloft\Waterfall Cave\Upper Exit:
     type: exit
     vanilla: Waterfall Cave Upper Entrance
     stage: D000
-    room: 0
-    index: 0
-    req_index: 1806
     short_name: Waterfall Cave - Upper Exit
   \Skyloft\Central Skyloft\Waterfall Cave\Lower Exit:
     type: exit
     vanilla: Waterfall Cave Lower Entrance
     stage: D000
-    room: 0
-    index: 1
-    req_index: 1807
     short_name: Waterfall Cave - Lower Exit
   \Skyloft\Central Skyloft\Waterfall Cave Upper Exit:
     type: exit
     vanilla: Waterfall Cave - Upper Entrance
     stage: F000
-    room: 0
-    index: 6
-    req_index: 1808
     short_name: Waterfall Cave Upper Exit
   \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Exit:
     type: exit
     vanilla: Waterfall Cave - Lower Entrance
     stage: F000
-    room: 0
-    index: 7
-    req_index: 1809
     short_name: Waterfall Cave Lower Exit
   \Skyloft\Central Skyloft\Bazaar\North Exit:
     type: exit
     vanilla: Bazaar North Entrance
     stage: F004r
-    room: 0
-    index: 0
-    req_index: 1810
     short_name: Bazaar - North Exit
   \Skyloft\Central Skyloft\Bazaar\South Exit:
     type: exit
     vanilla: Bazaar South Entrance
     stage: F004r
-    room: 0
-    index: 1
-    req_index: 1811
     short_name: Bazaar - South Exit
   \Skyloft\Central Skyloft\Bazaar\West Exit:
     type: exit
     vanilla: Bazaar West Entrance
     stage: F004r
-    room: 0
-    index: 2
-    req_index: 1812
     short_name: Bazaar - West Exit
   \Skyloft\Central Skyloft\Bazaar North Exit:
     type: exit
     vanilla: Bazaar - North Entrance
     stage: F000
-    room: 0
-    index: 1
-    req_index: 1813
     short_name: Bazaar North Exit
   \Skyloft\Central Skyloft\Bazaar South Exit:
     type: exit
     vanilla: Bazaar - South Entrance
     stage: F000
-    room: 0
-    index: 2
-    req_index: 1814
     short_name: Bazaar South Exit
   \Skyloft\Central Skyloft\Bazaar West Exit:
     type: exit
     vanilla: Bazaar - West Entrance
     stage: F000
-    room: 0
-    index: 19
-    req_index: 1815
     short_name: Bazaar West Exit
   \Skyloft\Beedle's Shop\Day Exit:
     type: exit
     vanilla: Skyloft - Entrance from Beedle's Shop
     stage: F002r
-    room: 0
-    index: 0
-    req_index: 1816
     short_name: Beedle's Shop - Day Exit
   \Skyloft\Beedle's Shop\Night Exit:
     type: exit
     vanilla: Sky - Beedle's Island - Beedle's Ship Entrance
-    allowed-time-of-day: NightOnly
     stage: F002r
-    room: 0
-    index: 2
-    req_index: 1817
     short_name: Beedle's Shop - Night Exit
   \Skyloft\Central Skyloft\Exit to Beedle's Shop:
     type: exit
     vanilla: Beedle's Shop - Day Entrance
     stage: F000
-    room: 0
-    index: 26
-    req_index: 1818
     short_name: Skyloft - Exit to Beedle's Shop
   \Skyloft\Skyloft Silent Realm\Exit:
     type: exit
     vanilla: Skyloft - Trial Gate Entrance
-    req_index: 1819
     short_name: Skyloft Silent Realm - Exit
   \Skyloft\Central Skyloft\Trial Gate Exit:
     type: exit
     vanilla: Skyloft Silent Realm - Entrance
-    req_index: 1820
     short_name: Skyloft - Trial Gate Exit
   \Skyloft\Central Skyloft\Near Temple Entrance\Exit to Sky Keep:
     type: exit
     vanilla: Sky Keep - First Room - Bottom Entrance
     stage: F000
-    room: 0
-    index: 48
-    req_index: 1821
     short_name: Skyloft - Exit to Sky Keep
   \Skyloft\Central Skyloft\Orielle and Parrow's House\Exit:
     type: exit
     vanilla: Orielle and Parrow's House Entrance
     stage: F005r
-    room: 0
-    index: 0
-    req_index: 1822
     short_name: Orielle and Parrow's House - Exit
   \Skyloft\Central Skyloft\Orielle and Parrow's House Exit:
     type: exit
     vanilla: Orielle and Parrow's House - Entrance
     stage: F000
-    room: 0
-    index: 31
-    req_index: 1823
     short_name: Orielle and Parrow's House Exit
   \Skyloft\Central Skyloft\Peatrice's House\Exit:
     type: exit
     vanilla: Peatrice's House Entrance
     stage: F018r
-    room: 0
-    index: 0
-    req_index: 1824
     short_name: Peatrice's House - Exit
   \Skyloft\Central Skyloft\Peatrice's House Exit:
     type: exit
     vanilla: Peatrice's House - Entrance
     stage: F000
-    room: 0
-    index: 38
-    req_index: 1825
     short_name: Peatrice's House Exit
   \Skyloft\Central Skyloft\Wryna's House\Exit:
     type: exit
     vanilla: Wryna's House Entrance
     stage: F006r
-    room: 0
-    index: 0
-    req_index: 1826
     short_name: Wryna's House - Exit
   \Skyloft\Central Skyloft\Wryna's House Exit:
     type: exit
     vanilla: Wryna's House - Entrance
     stage: F000
-    room: 0
-    index: 10
-    req_index: 1827
     short_name: Wryna's House Exit
   \Skyloft\Skyloft Village\Bertie's House\Exit:
     type: exit
     vanilla: Bertie's House Entrance
     stage: F014r
-    room: 0
-    index: 0
-    req_index: 1828
     short_name: Bertie's House - Exit
   \Skyloft\Skyloft Village\Bertie's House Exit:
     type: exit
     vanilla: Bertie's House - Entrance
     stage: F000
-    room: 0
-    index: 34
-    req_index: 1829
     short_name: Bertie's House Exit
   \Skyloft\Skyloft Village\Sparrot's House\Exit:
     type: exit
     vanilla: Sparrot's House Entrance
     stage: F013r
-    room: 0
-    index: 0
-    req_index: 1830
     short_name: Sparrot's House - Exit
   \Skyloft\Skyloft Village\Sparrot's House Exit:
     type: exit
     vanilla: Sparrot's House - Entrance
     stage: F000
-    room: 0
-    index: 33
-    req_index: 1831
     short_name: Sparrot's House Exit
   \Skyloft\Skyloft Village\Mallara's House Exit:
     type: exit
     vanilla: Mallara's House - Entrance
     stage: F000
-    room: 0
-    index: 36
-    req_index: 1832
     short_name: Skyloft - Mallara's House Exit
   \Skyloft\Skyloft Village\Mallara's House\Exit:
     type: exit
     vanilla: Mallara's House Entrance
     stage: F016r
-    room: 0
-    index: 0
-    req_index: 1833
     short_name: Mallara's House - Exit
   \Skyloft\Skyloft Village\Batreaux's House\Exit:
     type: exit
     vanilla: Batreaux's House Entrance
     stage: F012r
-    room: 0
-    index: 0
-    req_index: 1834
     short_name: Batreaux's House - Exit
   \Skyloft\Skyloft Village\Batreaux's House Exit:
     type: exit
     vanilla: Batreaux's House - Entrance
     stage: F000
-    room: 0
-    index: 30
-    req_index: 1835
     short_name: Batreaux's House Exit
   \Skyloft\Skyloft Village\Gondo's House\Exit:
     type: exit
     vanilla: Gondo's House Entrance
     stage: F015r
-    room: 0
-    index: 0
-    req_index: 1836
     short_name: Gondo's House - Exit
   \Skyloft\Skyloft Village\Gondo's House Exit:
     type: exit
     vanilla: Gondo's House - Entrance
     stage: F000
-    room: 0
-    index: 35
-    req_index: 1837
     short_name: Gondo's House Exit
   \Skyloft\Skyloft Village\Rupin's House\Exit:
     type: exit
     vanilla: Rupin's House Entrance
     stage: F017r
-    room: 0
-    index: 1
-    req_index: 1838
     short_name: Rupin's House - Exit
   \Skyloft\Skyloft Village\Rupin's House Exit:
     type: exit
     vanilla: Rupin's House - Entrance
     stage: F000
-    room: 0
-    index: 37
-    req_index: 1839
     short_name: Rupin's House Exit
   \Skyloft\Central Skyloft\Piper's House\Exit:
     type: exit
     vanilla: Piper's House Entrance
     stage: F007r
-    room: 0
-    index: 0
-    req_index: 1840
     short_name: Piper's House - Exit
   \Skyloft\Central Skyloft\Piper's House Exit:
     type: exit
     vanilla: Piper's House - Entrance
     stage: F000
-    room: 0
-    index: 32
-    req_index: 1841
     short_name: Piper's House Exit
   \Skyloft\Central Skyloft\Exit to Sky:
     type: exit
     vanilla: Sky - Entrance from Skyloft
-    req_index: 1842
     short_name: Skyloft - Exit to Sky
   \Sky\Around Skyloft\Exit to Skyloft:
     type: exit
     vanilla: Skyloft - Entrance from Sky
-    req_index: 1843
     short_name: Sky - Exit to Skyloft
   \Sky\North East\Bamboo Island\Inside\Exit:
     type: exit
     vanilla: Bamboo Island - Entrance from Inside
     stage: F019r
-    room: 0
-    index: 2
-    req_index: 1844
     short_name: Bamboo Island - Inside - Exit
   \Sky\North East\Bamboo Island\Exit to Inside:
     type: exit
     vanilla: Bamboo Island - Inside - Entrance
     stage: F020
-    room: 0
-    index: 13
-    req_index: 1845
     short_name: Bamboo Island - Exit to Inside
   \Sky\North East\Beedle's Island\Beedle's Ship Exit:
     type: exit
     vanilla: Beedle's Shop - Night Entrance
-    allowed-time-of-day: NightOnly
     stage: F020
-    room: 0
-    index: 14
-    req_index: 1846
     short_name: Sky - Beedle's Island - Beedle's Ship Exit
   \Sky\North East\Eldin Pillar\First Time Dive:
     type: exit
     vanilla: Eldin Volcano - First Time Entrance
     stage: F020
-    room: 0
-    index: 1
     pillar-province: Eldin Province
-    req_index: 1847
     short_name: Sky - Eldin Pillar - First Time Dive
   \Sky\North East\Eldin Pillar\Temple Entrance Statue Dive:
     type: exit
     vanilla: Eldin Volcano - Temple Entrance Statue Entrance
     stage: F020
-    room: 0
-    index: 29
-    req_index: 1848
     short_name: Sky - Eldin Pillar - Temple Entrance Statue Dive
   \Sky\North East\Eldin Pillar\Inside the Volcano Statue Dive:
     type: exit
     vanilla: Outside Fire Sanctuary - Statue Entrance
     stage: F020
-    room: 0
-    index: 30
-    req_index: 1849
     short_name: Sky - Eldin Pillar - Inside the Volcano Statue Dive
   \Sky\North East\Eldin Pillar\Volcano Entrance Statue Dive:
     type: exit
     vanilla: Eldin Volcano - Volcano Entrance Statue Entrance
     stage: F020
-    room: 0
-    index: 50
-    req_index: 1850
     short_name: Sky - Eldin Pillar - Volcano Entrance Statue Dive
   \Sky\North East\Eldin Pillar\Volcano East Statue Dive:
     type: exit
     vanilla: Eldin Volcano - Volcano East Statue Entrance
     stage: F020
-    room: 0
-    index: 51
-    req_index: 1851
     short_name: Sky - Eldin Pillar - Volcano East Statue Dive
   \Sky\North East\Eldin Pillar\Volcano Ascent Statue Dive:
     type: exit
     vanilla: Eldin Volcano - Volcano Ascent Statue Entrance
     stage: F020
-    room: 0
-    index: 52
-    req_index: 1852
     short_name: Sky - Eldin Pillar - Volcano Ascent Statue Dive
   \Sky\North East\Eldin Pillar\Fire Sanctuary Statue Dive:
     type: exit
     vanilla: Fire Sanctuary - Statue Entrance
     stage: F020
-    room: 0
-    index: 55
-    req_index: 1853
     short_name: Sky - Eldin Pillar - Fire Sanctuary Statue Dive
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Exit:
     type: exit
     vanilla: Lumpy Pumpkin - Main Left Door Entrance
     stage: F011r
-    room: 0
-    index: 0
-    req_index: 1854
     short_name: Lumpy Pumpkin Building - Main Right Door Exit
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Exit:
     type: exit
     vanilla: Lumpy Pumpkin - Main Right Door Entrance
     stage: F011r
-    room: 0
-    index: 1
-    req_index: 1855
     short_name: Lumpy Pumpkin Building - Main Left Door Exit
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Exit:
     type: exit
     vanilla: Lumpy Pumpkin - Back Door Entrance
     stage: F011r
-    room: 0
-    index: 2
-    req_index: 1856
     short_name: Lumpy Pumpkin Building - Back Door Exit
   \Sky\South East\Lumpy Pumpkin\Main Right Door Exit:
     type: exit
     vanilla: Lumpy Pumpkin Building - Main Left Door Entrance
     stage: F020
-    room: 0
-    index: 18
-    req_index: 1857
     short_name: Lumpy Pumpkin - Main Right Door Exit
   \Sky\South East\Lumpy Pumpkin\Main Left Door Exit:
     type: exit
     vanilla: Lumpy Pumpkin Building - Main Right Door Entrance
     stage: F020
-    room: 0
-    index: 19
-    req_index: 1858
     short_name: Lumpy Pumpkin - Main Left Door Exit
   \Sky\South East\Lumpy Pumpkin\Back Door Exit:
     type: exit
     vanilla: Lumpy Pumpkin Building - Back Door Entrance
     stage: F020
-    room: 0
-    index: 20
-    req_index: 1859
     short_name: Lumpy Pumpkin - Back Door Exit
   \Sky\South East\Faron Pillar\First Time Dive:
     type: exit
     vanilla: Sealed Grounds Spiral - Statue Entrance
     stage: F020
-    room: 0
-    index: 0
     pillar-province: Faron Province
-    req_index: 1860
     short_name: Sky - Faron Pillar - First Time Dive
   \Sky\South East\Faron Pillar\Sealed Grounds Statue Dive:
     type: exit
     vanilla: Sealed Grounds Spiral - Statue Entrance
     stage: F020
-    room: 0
-    index: 68
-    req_index: 1861
     short_name: Sky - Faron Pillar - Sealed Grounds Statue Dive
   \Sky\South East\Faron Pillar\Forest Temple Statue Dive:
     type: exit
     vanilla: Deep Woods - Forest Temple Statue Entrance
     stage: F020
-    room: 0
-    index: 27
-    req_index: 1862
     short_name: Sky - Faron Pillar - Forest Temple Statue Dive
   \Sky\South East\Faron Pillar\Behind the Temple Statue Dive:
     type: exit
     vanilla: Behind the Temple - Statue Entrance
     stage: F020
-    room: 0
-    index: 40
-    req_index: 1863
     short_name: Sky - Faron Pillar - Behind the Temple Statue Dive
   \Sky\South East\Faron Pillar\Faron Woods Entry Statue Dive:
     type: exit
     vanilla: Faron Woods - Faron Woods Entry Statue Entrance
     stage: F020
-    room: 0
-    index: 41
-    req_index: 1864
     short_name: Sky - Faron Pillar - Faron Woods Entry Statue Dive
   \Sky\South East\Faron Pillar\In the Woods Statue Dive:
     type: exit
     vanilla: Faron Woods - In the Woods Statue Entrance
     stage: F020
-    room: 0
-    index: 42
-    req_index: 1865
     short_name: Sky - Faron Pillar - In the Woods Statue Dive
   \Sky\South East\Faron Pillar\Viewing Platform Statue Dive:
     type: exit
     vanilla: Faron Woods - Viewing Platform Statue Entrance
     stage: F020
-    room: 0
-    index: 43
-    req_index: 1866
     short_name: Sky - Faron Pillar - Viewing Platform Statue Dive
   \Sky\South East\Faron Pillar\The Great Tree Statue Dive:
     type: exit
     vanilla: Great Tree - The Great Tree Statue Entrance
     stage: F020
-    room: 0
-    index: 44
-    req_index: 1867
     short_name: Sky - Faron Pillar - The Great Tree Statue Dive
   \Sky\South East\Faron Pillar\Deep Woods Statue Dive:
     type: exit
     vanilla: Deep Woods - Deep Woods Statue Entrance
     stage: F020
-    room: 0
-    index: 46
-    req_index: 1868
     short_name: Sky - Faron Pillar - Deep Woods Statue Dive
   \Sky\South East\Faron Pillar\Lake Floria Statue Dive:
     type: exit
     vanilla: Lake Floria - Below Rock - Statue Entrance
     stage: F020
-    room: 0
-    index: 47
-    req_index: 1869
     short_name: Sky - Faron Pillar - Lake Floria Statue Dive
   \Sky\South East\Faron Pillar\Floria Waterfall Statue Dive:
     type: exit
     vanilla: Floria Waterfall - Statue Entrance
     stage: F020
-    room: 0
-    index: 48
-    req_index: 1870
     short_name: Sky - Faron Pillar - Floria Waterfall Statue Dive
   \Sky\South West\Lanayru Pillar\First Time Dive:
     type: exit
     vanilla: Lanayru Mine - First Time Entrance
     stage: F020
-    room: 0
-    index: 2
     pillar-province: Lanayru Province
-    req_index: 1871
     short_name: Sky - Lanayru Pillar - First Time Dive
   \Sky\South West\Lanayru Pillar\Lanayru Mine Entry Statue Dive:
     type: exit
     vanilla: Lanayru Mine - Statue Entrance
     stage: F020
-    room: 0
-    index: 56
-    req_index: 1872
     short_name: Sky - Lanayru Pillar - Lanayru Mine Entry Statue Dive
   \Sky\South West\Lanayru Pillar\Desert Entrance Statue Dive:
     type: exit
     vanilla: Lanayru Desert - Desert Entrance Statue Entrance
     stage: F020
-    room: 0
-    index: 57
-    req_index: 1873
     short_name: Sky - Lanayru Pillar - Desert Entrance Statue Dive
   \Sky\South West\Lanayru Pillar\West Desert Statue Dive:
     type: exit
     vanilla: Lanayru Desert - West Desert Statue Entrance
     stage: F020
-    room: 0
-    index: 58
-    req_index: 1874
     short_name: Sky - Lanayru Pillar - West Desert Statue Dive
   \Sky\South West\Lanayru Pillar\North Desert Statue Dive:
     type: exit
     vanilla: Lanayru Desert - North Desert Statue Entrance
     stage: F020
-    room: 0
-    index: 59
-    req_index: 1875
     short_name: Sky - Lanayru Pillar - North Desert Statue Dive
   \Sky\South West\Lanayru Pillar\Stone Cache Statue Dive:
     type: exit
     vanilla: Lanayru Desert - Stone Cache Statue Entrance
     stage: F020
-    room: 0
-    index: 60
-    req_index: 1876
     short_name: Sky - Lanayru Pillar - Stone Cache Statue Dive
   \Sky\South West\Lanayru Pillar\Desert Gorge Statue Dive:
     type: exit
     vanilla: Temple of Time - Desert Gorge Statue Entrance
     stage: F020
-    room: 0
-    index: 61
-    req_index: 1877
     short_name: Sky - Lanayru Pillar - Desert Gorge Statue Dive
   \Sky\South West\Lanayru Pillar\Temple of Time Statue Dive:
     type: exit
     vanilla: Temple of Time - Temple of Time Statue Entrance
     stage: F020
-    room: 0
-    index: 62
-    req_index: 1878
     short_name: Sky - Lanayru Pillar - Temple of Time Statue Dive
   \Sky\South West\Lanayru Pillar\Ancient Harbour Statue Dive:
     type: exit
     vanilla: Lanayru Sand Sea Docks - Statue Entrance
     stage: F020
-    room: 0
-    index: 63
-    req_index: 1879
     short_name: Sky - Lanayru Pillar - Ancient Harbour Statue Dive
   \Sky\South West\Lanayru Pillar\Skipper's Retreat Statue Dive:
     type: exit
     vanilla: Skipper's Retreat - Statue Entrance
     stage: F020
-    room: 0
-    index: 64
-    req_index: 1880
     short_name: Sky - Lanayru Pillar - Skipper's Retreat Statue Dive
   \Sky\South West\Lanayru Pillar\Shipyard Statue Dive:
     type: exit
     vanilla: Shipyard - Statue Entrance
     stage: F020
-    room: 0
-    index: 65
-    req_index: 1881
     short_name: Sky - Lanayru Pillar - Shipyard Statue Dive
   \Sky\South West\Lanayru Pillar\Pirate Stronghold Statue Dive:
     type: exit
     vanilla: Pirate Stronghold - Statue Entrance
     stage: F020
-    room: 0
-    index: 66
-    req_index: 1882
     short_name: Sky - Lanayru Pillar - Pirate Stronghold Statue Dive
   \Sky\South West\Lanayru Pillar\Lanayru Gorge Statue Dive:
     type: exit
     vanilla: Lanayru Gorge - Statue Entrance
-    req_index: 1883
     short_name: Sky - Lanayru Pillar - Lanayru Gorge Statue Dive
   \Sky\Around Skyloft\Exit to Thunderhead:
     type: exit
     vanilla: Thunderhead - Entrance
     stage: F020
-    room: 0
-    index: 25
-    req_index: 1884
     short_name: Sky - Exit to Thunderhead
   \Sky\Thunderhead\Exit:
     type: exit
     vanilla: Sky - Entrance from Thunderhead
     stage: F023
-    room: 0
-    index: 1
-    req_index: 1885
     short_name: Thunderhead - Exit
   \Sky\Thunderhead\Isle of Songs\Inside\Exit:
     type: exit
     vanilla: Isle of Songs - Entrance from Inside
     stage: F010r
-    room: 0
-    index: 0
-    req_index: 1886
     short_name: Isle of Songs - Exit
   \Sky\Thunderhead\Isle of Songs\Exit to Inside:
     type: exit
     vanilla: Isle of Songs - Entrance
     stage: F023
-    room: 0
-    index: 2
-    req_index: 1887
     short_name: Isle of Songs - Exit to Inside
   \Faron\Sealed Grounds\Spiral\Upper Part\Statue Exit:
     type: exit
     vanilla: Sky - Faron Pillar - Entrance
     stage: F401
-    room: 1
-    index: 19
-    req_index: 1888
     short_name: Sealed Grounds Spiral - Statue Exit
   \Faron\Sealed Grounds\Spiral\Door Exit:
     type: exit
     vanilla: Sealed Temple - Main Entrance
     stage: F401
-    room: 1
-    index: 0
-    req_index: 1889
     short_name: Sealed Grounds Spiral - Door Exit
   \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Exit to Behind the Temple:
     type: exit
     vanilla: Behind the Temple - Shortcut Entrance from Spiral
     stage: F401
-    room: 1
-    index: 1
-    req_index: 1890
     short_name: Sealed Grounds Spiral - Shortcut Exit to Behind the Temple
   \Faron\Sealed Grounds\Sealed Temple\Main Exit:
     type: exit
     vanilla: Sealed Grounds Spiral - Door Entrance
     stage: F402
-    room: 2
-    index: 0
-    req_index: 1891
     short_name: Sealed Temple - Main Exit
   \Faron\Sealed Grounds\Sealed Temple\Side Exit:
     type: exit
     vanilla: Behind the Temple - Door Entrance
     stage: F402
-    room: 2
-    index: 1
-    req_index: 1892
     short_name: Sealed Temple - Side Exit
   \Faron\Sealed Grounds\Sealed Temple\Gate of Time Exit:
     type: exit
     vanilla: Hylia's Temple - Gate of Time Entrance
     stage: F402
-    room: 2
-    index: 5
-    req_index: 1893
     short_name: Sealed Temple - Gate of Time Exit
   \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Exit:
     type: exit
     vanilla: Sealed Temple - Gate of Time Entrance
     stage: F404
-    room: 2
-    index: 1
-    req_index: 1894
     short_name: Hylia's Temple - Gate of Time Exit
   \Faron\Sealed Grounds\Behind the Temple\Statue Exit:
     type: exit
     vanilla: Sky - Faron Pillar - Entrance
     stage: F400
-    room: 0
-    index: 5
-    req_index: 1895
     short_name: Behind the Temple - Statue Exit
   \Faron\Sealed Grounds\Behind the Temple\Shortcut Exit to Spiral:
     type: exit
     vanilla: Sealed Grounds Spiral - Shortcut Entrance from Behind the Temple
     stage: F400
-    room: 0
-    index: 0
-    req_index: 1896
     short_name: Behind the Temple - Shortcut Exit to Spiral
   \Faron\Sealed Grounds\Behind the Temple\Door Exit:
     type: exit
     vanilla: Sealed Temple - Side Entrance
     stage: F400
-    room: 0
-    index: 1
-    req_index: 1897
     short_name: Behind the Temple - Door Exit
   \Faron\Sealed Grounds\Behind the Temple\Exit to Faron Woods:
     type: exit
     vanilla: Faron Woods - Entrance from Behind the Temple
     stage: F400
-    room: 0
-    index: 2
-    req_index: 1898
     short_name: Behind the Temple - Exit to Faron Woods
   \Faron\Faron Woods\Shared Statue Exit:
     type: exit
     vanilla: Sky - Faron Pillar - Entrance
     stage: F100
-    room: 0
-    index: 10
-    req_index: 1899
     short_name: Faron Woods - Shared Statue Exit
   \Faron\Faron Woods\Entry\Exit to Behind the Temple:
     type: exit
     vanilla: Behind the Temple - Entrance from Faron Woods
     stage: F100
-    room: 0
-    index: 0
-    req_index: 1900
     short_name: Faron Woods - Exit to Behind the Temple
   \Faron\Faron Woods\Ledge To Deep Woods\Exit to Deep Woods:
     type: exit
     vanilla: Deep Woods - Entrance from Faron Woods
     stage: F100
-    room: 0
-    index: 1
-    req_index: 1901
     short_name: Faron Woods - Exit to Deep Woods
   \Faron\Faron Woods\Lake Floria Dive:
     type: exit
     vanilla: Lake Floria - Dive from Faron Woods
     stage: F100
-    room: 0
-    index: 9
-    req_index: 1902
     short_name: Faron Woods - Lake Floria Dive
   \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Exit to Floria Waterfall:
     type: exit
     vanilla: Floria Waterfall - Entrance from Faron Woods
     stage: F100
-    room: 0
-    index: 11
-    req_index: 1903
     short_name: Faron Woods - Shortcut Exit to Floria Waterfall
   \Faron\Faron Woods\Trial Gate Exit:
     type: exit
     vanilla: Faron Silent Realm - Entrance
-    req_index: 1904
     short_name: Faron Woods - Trial Gate Exit
   \Faron\Faron Silent Realm\Exit:
     type: exit
     vanilla: Faron Woods - Trial Gate Entrance
-    req_index: 1905
     short_name: Faron Silent Realm - Exit
   \Faron\Faron Woods\Great Tree\Platforms\Lower Exit to Great Tree:
     type: exit
     vanilla: Great Tree - Lower Entrance from Platforms
     stage: F100
-    room: 0
-    index: 3
-    req_index: 1906
     short_name: Great Tree - Platforms - Lower Exit to Great Tree
   \Faron\Faron Woods\Great Tree\Platforms\Upper Exit to Great Tree:
     type: exit
     vanilla: Great Tree - Upper Entrance from Platforms
     stage: F100
-    room: 0
-    index: 4
-    req_index: 1907
     short_name: Great Tree - Platforms - Upper Exit to Great Tree
   \Faron\Faron Woods\Great Tree\Top\Top Exit to Great Tree:
     type: exit
     vanilla: Great Tree - Entrance from Top
     stage: F100
-    room: 0
-    index: 5
-    req_index: 1908
     short_name: Great Tree - Top Exit to Great Tree
   \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Exit:
     type: exit
     vanilla: Great Tree - Underwater Tunnel Entrance
     stage: F100
-    room: 0
-    index: 6
-    req_index: 1909
     short_name: Great Tree - Underwater Hole Exit
   \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Exit to Platforms:
     type: exit
     vanilla: Great Tree - Platforms - Lower Entrance from Great Tree
     stage: F100_1
-    room: 0
-    index: 1
-    req_index: 1910
     short_name: Great Tree - Lower Exit to Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Upper Exit to Platforms:
     type: exit
     vanilla: Great Tree - Platforms - Upper Entrance from Great Tree
     stage: F100_1
-    room: 0
-    index: 2
-    req_index: 1911
     short_name: Great Tree - Upper Exit to Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Exit to Top:
     type: exit
     vanilla: Great Tree - Top Entrance from Great Tree
     stage: F100_1
-    room: 0
-    index: 3
-    req_index: 1912
     short_name: Great Tree - Exit to Top
   \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Exit:
     type: exit
     vanilla: Great Tree - Underwater Hole Entrance
     stage: F100_1
-    room: 0
-    index: 4
-    req_index: 1913
     short_name: Great Tree - Underwater Tunnel Exit
   \Faron\Faron Woods\Great Tree\Upper Area\Exit to Flooded Great Tree:
     type: exit
     vanilla: Flooded Great Tree - Entrance
-    req_index: 1914
     short_name: Great Tree - Exit to Flooded Great Tree
   \Faron\Flooded Faron Woods\Flooded Great Tree\Exit:
     type: exit
     vanilla: Entrance from Flooded Great Tree
-    req_index: 1915
     short_name: Flooded Great Tree - Exit
   \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Upper Flooded Faron Woods:
     type: exit
     vanilla: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
-    req_index: 1916
     short_name: Flooded Great Tree - Exit to Upper Flooded Faron Woods
   \Faron\Flooded Faron Woods\Flooded Great Tree\Exit to Lower Flooded Faron Woods:
     type: exit
     vanilla: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
-    req_index: 1917
     short_name: Flooded Great Tree - Exit to Lower Flooded Faron Woods
   \Faron\Flooded Faron Woods\Exit to Upper Flooded Great Tree:
     type: exit
     vanilla: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
-    req_index: 1918
     short_name: Flooded Faron Woods - Exit to Upper Flooded Great Tree
   \Faron\Flooded Faron Woods\Exit to Lower Flooded Great Tree:
     type: exit
     vanilla: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
-    req_index: 1919
     short_name: Flooded Faron Woods - Exit to Lower Flooded Great Tree
   \Faron\Faron Woods\Deep Woods\Shared Statue Exit:
     type: exit
     vanilla: Sky - Faron Pillar - Entrance
     stage: F101
-    room: 0
-    index: 2
-    req_index: 1920
     short_name: Deep Woods - Shared Statue Exit
   \Faron\Faron Woods\Deep Woods\Entry\Exit to Faron Woods:
     type: exit
     vanilla: Faron Woods - Entrance from Deep Woods
     stage: F101
-    room: 0
-    index: 0
-    req_index: 1921
     short_name: Deep Woods - Exit to Faron Woods
   \Faron\Faron Woods\Deep Woods\Exit to Skyview Temple:
     type: exit
     vanilla: Skyview Temple - Main Entrance
     stage: F101
-    room: 0
-    index: 1
-    req_index: 1922
     short_name: Deep Woods - Exit to Skyview Temple
   \Faron\Lake Floria\Below Rock\Emerged Area\Statue Exit:
     type: exit
     vanilla: Sky - Faron Pillar - Entrance
     stage: F102
-    room: 3
-    index: 0
-    req_index: 1923
     short_name: Lake Floria - Below Rock - Statue Exit
   \Faron\Lake Floria\Below Rock\Exit to Farore's Lair:
     type: exit
     vanilla: Farore's Lair - Entrance from Lake Floria
     stage: F102
-    room: 4
-    index: 0
-    req_index: 1924
     short_name: Lake Floria - Exit to Farore's Lair
   \Faron\Lake Floria\Farore's Lair\Exit to Lake Floria:
     type: exit
     vanilla: Lake Floria - Entrance from Farore's Lair
     stage: F102_2
-    room: 0
-    index: 0
-    req_index: 1925
     short_name: Farore's Lair - Exit to Lake Floria
   \Faron\Lake Floria\Farore's Lair\Exit to Waterfall:
     type: exit
     vanilla: Floria Waterfall - Entrance from Farore's Lair
     stage: F102_2
-    room: 0
-    index: 1
-    req_index: 1926
     short_name: Farore's Lair - Exit to Waterfall
   \Faron\Lake Floria\Waterfall\Statue Exit:
     type: exit
     vanilla: Sky - Faron Pillar - Entrance
     stage: F102_1
-    room: 0
-    index: 3
-    req_index: 1927
     short_name: Floria Waterfall - Statue Exit
   \Faron\Lake Floria\Waterfall\Exit to Farore's Lair:
     type: exit
     vanilla: Farore's Lair - Entrance from Waterfall
     stage: F102_1
-    room: 0
-    index: 0
-    req_index: 1928
     short_name: Floria Waterfall - Exit to Farore's Lair
   \Faron\Lake Floria\Waterfall\Exit to Ancient Cistern:
     type: exit
     vanilla: Ancient Cistern - Main Entrance
     stage: F102_1
-    room: 0
-    index: 1
-    req_index: 1929
     short_name: Floria Waterfall - Exit to Ancient Cistern
   \Faron\Lake Floria\Waterfall\Exit to Faron Woods:
     type: exit
     vanilla: Faron Woods - Shortcut Entrance from Floria Waterfall
     stage: F102_1
-    room: 0
-    index: 2
-    req_index: 1930
     short_name: Floria Waterfall - Exit to Faron Woods
   \Skyview\Main\Entry\Main Exit:
     type: exit
     vanilla: Deep Woods - Entrance from Skyview Temple
-    req_index: 1931
     short_name: Skyview Temple - Main Exit
   \Skyview\Main\Last Room\After Rope\Boss Door Exit:
     type: exit
     vanilla: Skyview Temple - Boss Room - Entrance from Dungeon
-    req_index: 1932
     short_name: Skyview Temple - Boss Door Exit
   \Skyview\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Skyview Temple - Boss Door Entrance
-    req_index: 1933
     short_name: Skyview Temple - Boss Room - Exit to Dungeon
   \Skyview\Boss Room\Exit to Spring:
     type: exit
     vanilla: Skyview Temple - Spring - Entrance
-    req_index: 1934
     short_name: Skyview Temple - Boss Room - Exit to Spring
   \Skyview\Spring\Exit:
     type: exit
     vanilla: Skyview Temple - Boss Room - Entrance from Spring
-    req_index: 1935
     short_name: Skyview Temple - Spring - Exit
   \Ancient Cistern\Main\Main Room\Main Exit:
     type: exit
     vanilla: Floria Waterfall - Entrance from Ancient Cistern
-    req_index: 1936
     short_name: Ancient Cistern - Main Exit
   \Ancient Cistern\Main\Inside Statue\Boss Door Exit:
     type: exit
     vanilla: Ancient Cistern - Boss Room - Entrance from Dungeon
-    req_index: 1937
     short_name: Ancient Cistern - Boss Door Exit
   \Ancient Cistern\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Ancient Cistern - Boss Door Entrance
-    req_index: 1938
     short_name: Ancient Cistern - Boss Room - Exit to Dungeon
   \Ancient Cistern\Boss Room\Exit to Flame Room:
     type: exit
     vanilla: Ancient Cistern - Flame Room - Entrance
-    req_index: 1939
     short_name: Ancient Cistern - Boss Room - Exit to Flame Room
   \Ancient Cistern\Flame Room\Exit:
     type: exit
     vanilla: Ancient Cistern - Boss Room - Entrance from Flame Room
-    req_index: 1940
     short_name: Ancient Cistern - Flame Room - Exit
   \Eldin\Volcano\Entry\Volcano Entrance Statue Exit:
     type: exit
     vanilla: Sky - Eldin Pillar - Entrance
     stage: F200
-    room: 0
-    index: 0
-    req_index: 1941
     short_name: Eldin Volcano - Volcano Entrance Statue Exit
   \Eldin\Volcano\East\Volcano East / Volcano Ascent Statue Exit:
     type: exit
     vanilla: Sky - Eldin Pillar - Entrance
     stage: F200
-    room: 2
-    index: 2
-    req_index: 1942
     short_name: Eldin Volcano - Volcano East / Volcano Ascent Statue Exit
   \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Exit:
     type: exit
     vanilla: Sky - Eldin Pillar - Entrance
     stage: F200
-    room: 4
-    index: 2
-    req_index: 1943
     short_name: Eldin Volcano - Temple Entrance Statue Exit
   \Eldin\Volcano\East\Dive to Mogma Turf:
     type: exit
     vanilla: Mogma Turf - Entrance
     stage: F200
-    room: 2
-    index: 1
-    req_index: 1944
     short_name: Eldin Volcano - Dive to Mogma Turf
   \Eldin\Volcano\Near Temple Entrance\Exit to Earth Temple:
     type: exit
     vanilla: Earth Temple - Main Entrance
     stage: F200
-    room: 4
-    index: 0
-    req_index: 1945
     short_name: Eldin Volcano - Exit to Earth Temple
   \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Exit:
     type: exit
     vanilla: Thrill Digger Cave - Entrance
     stage: F200
-    room: 4
-    index: 1
-    req_index: 1946
     short_name: Eldin Volcano - Thrill Digger Cave Exit
   \Eldin\Volcano\Hot Cave\Exit to Summit:
     type: exit
     vanilla: Volcano Summit - Entrance from Eldin Volcano
     stage: F200
-    room: 5
-    index: 1
-    req_index: 1947
     short_name: Eldin Volcano - Exit to Summit
   \Eldin\Volcano\Ascent\Trial Gate Exit:
     type: exit
     vanilla: Eldin Silent Realm - Entrance
-    req_index: 1948
     short_name: Eldin Volcano - Trial Gate Exit
   \Eldin\Volcano\Past Slide\Vent Exit near Ascent:
     type: exit
     vanilla: Eldin Volcano - Vent Entrance near Hot Cave
-    req_index: 1949
     short_name: Eldin Volcano - Vent Exit near Ascent
   \Eldin\Volcano\First Room\Exit to Bokoblin Base:
     type: exit
     vanilla: Bokoblin Base - Entrance
-    req_index: 1950
     short_name: Eldin Volcano - Exit to Bokoblin Base
   \Eldin\Bokoblin Base\Prison\Exit:
     type: exit
     vanilla: Entrance from Bokoblin Base
-    req_index: 1951
     short_name: Bokoblin Base - Exit
   \Eldin\Mogma Turf\Pre Vent\First Vent:
     type: exit
     vanilla: Eldin Volcano - First Vent from Mogma Turf
     stage: F210
-    room: 0
-    index: 0
-    req_index: 1952
     short_name: Mogma Turf - First Vent
   \Eldin\Mogma Turf\Past Vent\Second Vent:
     type: exit
     vanilla: Eldin Volcano - Second Vent from Mogma Turf
     stage: F210
-    room: 0
-    index: 1
-    req_index: 1953
     short_name: Mogma Turf - Second Vent
   \Eldin\Volcano\Thrill Digger Cave\Exit:
     type: exit
     vanilla: Eldin Volcano - Thrill Digger Cave Entrance
     stage: F211
-    room: 0
-    index: 0
-    req_index: 1954
     short_name: Thrill Digger Cave - Exit
   \Eldin\Eldin Silent Realm\Exit:
     type: exit
     vanilla: Eldin Volcano - Trial Gate Entrance
-    req_index: 1955
     short_name: Eldin Silent Realm - Exit
   \Eldin\Volcano Summit\Exit to Eldin Volcano:
     type: exit
     vanilla: Eldin Volcano - Entrance from Summit
     stage: F201_1
-    room: 0
-    index: 0
-    req_index: 1956
     short_name: Volcano Summit - Exit to Eldin Volcano
   \Eldin\Volcano Summit\Exit to Waterfall:
     type: exit
     vanilla: Volcano Summit - Waterfall - Entrance
     stage: F201_1
-    room: 0
-    index: 1
-    req_index: 1957
     short_name: Volcano Summit - Exit to Waterfall
   \Eldin\Volcano Summit\Exit to Outside Fire Sanctuary:
     type: exit
     vanilla: Outside Fire Sanctuary - Entrance from Summit
     stage: F201_1
-    room: 0
-    index: 2
-    req_index: 1958
     short_name: Volcano Summit - Exit to Outside Fire Sanctuary
   \Eldin\Volcano Summit\Waterfall\Exit:
     type: exit
     vanilla: Volcano Summit - Entrance from Waterfall
     stage: F201_4
-    room: 0
-    index: 0
-    req_index: 1959
     short_name: Volcano Summit - Waterfall - Exit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Exit:
     type: exit
     vanilla: Sky - Eldin Pillar - Entrance
     stage: F201_3
-    room: 0
-    index: 2
-    req_index: 1960
     short_name: Outside Fire Sanctuary - Statue Exit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Exit to Summit:
     type: exit
     vanilla: Volcano Summit - Entrance from Outside Fire Sanctuary
     stage: F201_3
-    room: 0
-    index: 0
-    req_index: 1961
     short_name: Outside Fire Sanctuary - Exit to Summit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Exit to Fire Sanctuary:
     type: exit
     vanilla: Fire Sanctuary - Main Entrance
     stage: F201_3
-    room: 0
-    index: 1
-    req_index: 1962
     short_name: Outside Fire Sanctuary - Exit to Fire Sanctuary
   \Earth Temple\Main\First Room\Main Exit:
     type: exit
     vanilla: Eldin Volcano - Entrance from Earth Temple
-    req_index: 1963
     short_name: Earth Temple - Main Exit
   \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Exit:
     type: exit
     vanilla: Earth Temple - Boss Room - Entrance from Dungeon
-    req_index: 1964
     short_name: Earth Temple - Boss Door Exit
   \Earth Temple\Boss Room\Entry\Exit to Dungeon:
     type: exit
     vanilla: Earth Temple - Boss Door Entrance
-    req_index: 1965
     short_name: Earth Temple - Boss Room - Exit to Dungeon
   \Earth Temple\Boss Room\Slope\Exit to Spring:
     type: exit
     vanilla: Earth Temple - Spring - Entrance
-    req_index: 1966
     short_name: Earth Temple - Boss Room - Exit to Spring
   \Earth Temple\Spring\Exit:
     type: exit
     vanilla: Earth Temple - Boss Room - Entrance from Spring
-    req_index: 1967
     short_name: Earth Temple - Spring - Exit
   \Fire Sanctuary\Main\Front of Boss Door\Statue Exit:
     type: exit
     vanilla: Sky - Eldin Pillar - Entrance
     stage: D201
-    room: 10
-    index: 3
-    req_index: 1968
     short_name: Fire Sanctuary - Statue Exit
   \Fire Sanctuary\Main\First Room\Main Exit:
     type: exit
     vanilla: Outside Fire Sanctuary - Entrance from Fire Sanctuary
-    req_index: 1969
     short_name: Fire Sanctuary - Main Exit
   \Fire Sanctuary\Main\First Room\Past Water Plant\Exit to Second Room:
     type: exit
     vanilla: Fire Sanctuary - Second Room - Entrance from First Room
-    req_index: 1970
     short_name: Fire Sanctuary - First Room - Exit to Second Room
   \Fire Sanctuary\Main\Second Room\Outside Section\Exit to First Room:
     type: exit
     vanilla: Fire Sanctuary - First Room - Entrance from Second Room
-    req_index: 1971
     short_name: Fire Sanctuary - Second Room - Exit to First Room
   \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Exit to West of Boss Door:
     type: exit
     vanilla: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight Room
-    req_index: 1972
     short_name: Fire Sanctuary - Magmanos Fight Room - Exit to West of Boss Door
   \Fire Sanctuary\Main\West of Boss Door\Entry\Exit to Magmanos Fight Room:
     type: exit
     vanilla: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss Door
-    req_index: 1973
     short_name: Fire Sanctuary - West of Boss Door - Exit to Magmanos Fight Room
   \Fire Sanctuary\Main\Front of Boss Door\Boss Door Exit:
     type: exit
     vanilla: Fire Sanctuary - Boss Room - Entrance from Dungeon
-    req_index: 1974
     short_name: Fire Sanctuary - Boss Door Exit
   \Fire Sanctuary\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Fire Sanctuary - Boss Door Entrance
-    req_index: 1975
     short_name: Fire Sanctuary - Boss Room - Exit to Dungeon
   \Fire Sanctuary\Boss Room\Exit to Flame Room:
     type: exit
     vanilla: Fire Sanctuary - Flame Room - Entrance
-    req_index: 1976
     short_name: Fire Sanctuary - Boss Room - Exit to Flame Room
   \Fire Sanctuary\Flame Room\Exit:
     type: exit
     vanilla: Fire Sanctuary - Boss Room - Entrance from Flame Room
-    req_index: 1977
     short_name: Fire Sanctuary - Flame Room - Exit
   \Lanayru\Mine\Entry\Statue Exit:
     type: exit
     vanilla: Sky - Lanayru Pillar - Entrance
     stage: F300_1
-    room: 0
-    index: 0
-    req_index: 1978
     short_name: Lanayru Mine - Statue Exit
   \Lanayru\Mine\Entry\Caves Entrance\Exit to Caves:
     type: exit
     vanilla: Lanayru Caves - Entrance from Mine
     stage: F300_1
-    room: 0
-    index: 1
-    req_index: 1979
     short_name: Lanayru Mine - Exit to Caves
   \Lanayru\Mine\End\In Minecart\Exit to Desert:
     type: exit
     vanilla: Lanayru Desert - Entrance from Mine
     stage: F300_1
-    room: 2
-    index: 0
-    req_index: 1980
     short_name: Lanayru Mine - Exit to Desert
   \Lanayru\Desert\Shared Statue Exit:
     type: exit
     vanilla: Sky - Lanayru Pillar - Entrance
     stage: F300
-    room: 0
-    index: 6
-    req_index: 1981
     short_name: Lanayru Desert - Shared Statue Exit
   \Lanayru\Desert\North Part\Lightning Node Exit:
     type: exit
     vanilla: Lightning Node - Entrance
     stage: F300
-    room: 0
-    index: 0
-    req_index: 1982
     short_name: Lanayru Desert - Lightning Node Exit
   \Lanayru\Desert\Entry\Exit to Mine:
     type: exit
     vanilla: Lanayru Mine - Entrance from Desert
     stage: F300
-    room: 0
-    index: 1
-    req_index: 1983
     short_name: Lanayru Desert - Exit to Mine
   \Lanayru\Desert\East\Fire Node Exit:
     type: exit
     vanilla: Fire Node - Entrance
     stage: F300
-    room: 0
-    index: 2
-    req_index: 1984
     short_name: Lanayru Desert - Fire Node Exit
   \Lanayru\Desert\Near South Exit to Temple of Time\South Exit to Temple of Time:
     type: exit
     vanilla: Temple of Time - South Entrance from Desert
     stage: F300
-    room: 0
-    index: 3
-    req_index: 1985
     short_name: Lanayru Desert - South Exit to Temple of Time
   \Lanayru\Desert\North Part\North Exit to Temple of Time:
     type: exit
     vanilla: Temple of Time - North Entrance from Desert
     stage: F300
-    room: 0
-    index: 4
-    req_index: 1986
     short_name: Lanayru Desert - North Exit to Temple of Time
   \Lanayru\Desert\Top of LMF\Exit to Lanayru Mining Facility:
     type: exit
     vanilla: Lanayru Mining Facility - Main Entrance
     stage: F300
-    room: 0
-    index: 5
-    req_index: 1987
     short_name: Lanayru Desert - Exit to Lanayru Mining Facility
   \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Exit to Caves:
     type: exit
     vanilla: Lanayru Caves - Entrance from Desert
     stage: F300
-    room: 0
-    index: 8
-    req_index: 1988
     short_name: Lanayru Desert - Exit to Caves
   \Lanayru\Desert\North Part\Trial Gate Exit:
     type: exit
     vanilla: Lanayru Silent Realm - Entrance
-    req_index: 1989
     short_name: Lanayru Desert - Trial Gate Exit
   \Lanayru\Lanayru Silent Realm\Exit:
     type: exit
     vanilla: Lanayru Desert - Trial Gate Entrance
-    req_index: 1990
     short_name: Lanayru Silent Realm - Exit
   \Lanayru\Desert\North Part\Lightning Node\Present\Exit:
     type: exit
     vanilla: Lanayru Desert - Lightning Node Entrance
     stage: F300_2
-    room: 0
-    index: 0
-    req_index: 1991
     short_name: Lightning Node - Exit
   \Lanayru\Desert\East\Fire Node\Present\Exit:
     type: exit
     vanilla: Lanayru Desert - Fire Node Entrance
     stage: F300_3
-    room: 0
-    index: 0
-    req_index: 1992
     short_name: Fire Node - Exit
   \Lanayru\Temple of Time\Shared Statue Exit:
     type: exit
     vanilla: Sky - Lanayru Pillar - Entrance
     stage: F300_4
-    room: 0
-    index: 2
-    req_index: 1993
     short_name: Temple of Time - Shared Statue Exit
   \Lanayru\Temple of Time\South East\South Exit to Desert:
     type: exit
     vanilla: Lanayru Desert - South Entrance from Temple of Time
     stage: F300_4
-    room: 0
-    index: 0
-    req_index: 1994
     short_name: Temple of Time - South Exit to Desert
   \Lanayru\Temple of Time\North East\North Exit to Desert:
     type: exit
     vanilla: Lanayru Desert - North Entrance from Temple of Time
     stage: F300_4
-    room: 0
-    index: 1
-    req_index: 1995
     short_name: Temple of Time - North Exit to Desert
   \Lanayru\Temple of Time\Inside\Exit to Lanayru Mining Facility:
     type: exit
     subtype: vanilla
     stage: F300_4
-    room: 0
-    index: 4
-    req_index: 1996
     short_name: Temple of Time - Exit to Lanayru Mining Facility
   \Lanayru\Caves\Exit to Mine:
     type: exit
     vanilla: Lanayru Mine - Entrance from Caves
     stage: F303
-    room: 0
-    index: 0
-    req_index: 1997
     short_name: Lanayru Caves - Exit to Mine
   \Lanayru\Caves\Exit to Desert:
     type: exit
     vanilla: Lanayru Desert - Entrance from Caves
     stage: F303
-    room: 0
-    index: 1
-    req_index: 1998
     short_name: Lanayru Caves - Exit to Desert
   \Lanayru\Caves\Past Door to Lanayru Sand Sea\Exit to Lanayru Sand Sea:
     type: exit
     vanilla: Lanayru Sand Sea Docks - Entrance from Caves
     stage: F303
-    room: 0
-    index: 2
-    req_index: 1999
     short_name: Lanayru Caves - Exit to Lanayru Sand Sea
   \Lanayru\Caves\Past Crawlspace\Exit to Gorge:
     type: exit
     vanilla: Lanayru Gorge - Entrance
-    req_index: 2000
     short_name: Lanayru Caves - Exit to Gorge
   \Lanayru\Lanayru Sand Sea\Gorge\Exit:
     type: exit
     vanilla: Lanayru Caves - Entrance from Gorge
-    req_index: 2001
     short_name: Lanayru Gorge - Exit
   \Lanayru\Lanayru Sand Sea\Gorge\Statue Exit:
     type: exit
     vanilla: Sky - Lanayru Pillar - Entrance
-    req_index: 2002
     short_name: Lanayru Gorge - Statue Exit
   \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Exit:
     type: exit
     vanilla: Lanayru Sand Sea Docks - Dock Entrance
     stage: F301_1
-    room: 0
-    index: 0
-    req_index: 2003
     short_name: Lanayru Sand Sea - Ancient Harbour Dock Exit
   \Lanayru\Lanayru Sand Sea\Sandship Dock Exit:
     type: exit
     vanilla: Sandship - Main Entrance
     stage: F301_1
-    room: 0
-    index: 1
-    req_index: 2004
     short_name: Lanayru Sand Sea - Sandship Dock Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Exit:
     type: exit
     vanilla: Skipper's Retreat - Dock Entrance
     stage: F301_1
-    room: 0
-    index: 2
-    req_index: 2005
     short_name: Lanayru Sand Sea - Skipper's Retreat Dock Exit
   \Lanayru\Lanayru Sand Sea\Shipyard Dock Exit:
     type: exit
     vanilla: Shipyard - Dock Entrance
     stage: F301_1
-    room: 0
-    index: 3
-    req_index: 2006
     short_name: Lanayru Sand Sea - Shipyard Dock Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Exit:
     type: exit
     vanilla: Pirate Stronghold - Dock Entrance
     stage: F301_1
-    room: 0
-    index: 4
-    req_index: 2007
     short_name: Lanayru Sand Sea - Pirate Stronghold Dock Exit
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Exit:
     type: exit
     vanilla: Sky - Lanayru Pillar - Entrance
     stage: F301
-    room: 0
-    index: 3
-    req_index: 2008
     short_name: Lanayru Sand Sea Docks - Statue Exit
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Exit to Sandship:
     type: exit
     vanilla: Sandship - Main Entrance
     stage: F301
-    room: 0
-    index: 0
-    req_index: 2009
     short_name: Lanayru Sand Sea Docks - Exit to Sandship
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Exit to Caves:
     type: exit
     vanilla: Lanayru Caves - Entrance from Lanayru Sand Sea
     stage: F301
-    room: 0
-    index: 1
-    req_index: 2010
     short_name: Lanayru Sand Sea Docks - Exit to Caves
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Exit:
     type: exit
     vanilla: Lanayru Sand Sea - Ancient Harbour Dock Entrance
     stage: F301
-    room: 0
-    index: 2
-    req_index: 2011
     short_name: Lanayru Sand Sea Docks - Dock Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Exit:
     type: exit
     vanilla: Sky - Lanayru Pillar - Entrance
     stage: F301_3
-    room: 0
-    index: 1
-    req_index: 2012
     short_name: Skipper's Retreat - Statue Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Exit:
     type: exit
     vanilla: Lanayru Sand Sea - Skipper's Retreat Dock Entrance
     stage: F301_3
-    room: 0
-    index: 2
-    req_index: 2013
     short_name: Skipper's Retreat - Dock Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Exit:
     type: exit
     vanilla: Skipper's Retreat - Shack - Entrance
     stage: F301_3
-    room: 0
-    index: 3
-    req_index: 2014
     short_name: Skipper's Retreat - Shack Exit
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Exit:
     type: exit
     vanilla: Skipper's Retreat - Shack Entrance
     stage: F301_5
-    room: 0
-    index: 0
-    req_index: 2015
     short_name: Skipper's Retreat - Shack - Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Statue Exit:
     type: exit
     vanilla: Sky - Lanayru Pillar - Entrance
     stage: F301_4
-    room: 0
-    index: 1
-    req_index: 2016
     short_name: Shipyard - Statue Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Dock Exit:
     type: exit
     vanilla: Lanayru Sand Sea - Shipyard Dock Entrance
     stage: F301_4
-    room: 0
-    index: 2
-    req_index: 2017
     short_name: Shipyard - Dock Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Exit:
     type: exit
     vanilla: Shipyard - Construction Bay - Upper Entrance
     stage: F301_4
-    room: 0
-    index: 3
-    req_index: 2018
     short_name: Shipyard - Construction Bay Upper Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Exit:
     type: exit
     vanilla: Shipyard - Construction Bay - Lower Entrance
     stage: F301_4
-    room: 0
-    index: 4
-    req_index: 2019
     short_name: Shipyard - Construction Bay Lower Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Exit:
     type: exit
     vanilla: Shipyard - Construction Bay Lower Entrance
     stage: F301_7
-    room: 0
-    index: 0
-    req_index: 2020
     short_name: Shipyard - Construction Bay - Lower Exit
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Exit:
     type: exit
     vanilla: Shipyard - Construction Bay Upper Entrance
     stage: F301_7
-    room: 0
-    index: 1
-    req_index: 2021
     short_name: Shipyard - Construction Bay - Upper Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Exit:
     type: exit
     vanilla: Sky - Lanayru Pillar - Entrance
     stage: F301_6
-    room: 0
-    index: 3
-    req_index: 2022
     short_name: Pirate Stronghold - Statue Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Exit:
     type: exit
     vanilla: Lanayru Sand Sea - Pirate Stronghold Dock Entrance
     stage: F301_6
-    room: 0
-    index: 0
-    req_index: 2023
     short_name: Pirate Stronghold - Dock Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Exit:
     type: exit
     vanilla: Pirate Stronghold - Inside - First Door Entrance
     stage: F301_6
-    room: 0
-    index: 1
-    req_index: 2024
     short_name: Pirate Stronghold - Side Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Exit:
     type: exit
     vanilla: Pirate Stronghold - Inside - Second Door Entrance
     stage: F301_6
-    room: 0
-    index: 2
-    req_index: 2025
     short_name: Pirate Stronghold - Top Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Exit:
     type: exit
     vanilla: Pirate Stronghold - Side Entrance
     stage: F301_2
-    room: 1
-    index: 0
-    req_index: 2026
     short_name: Pirate Stronghold - Inside - First Door Exit
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Exit:
     type: exit
     vanilla: Pirate Stronghold - Top Entrance
     stage: F301_2
-    room: 1
-    index: 2
-    req_index: 2027
     short_name: Pirate Stronghold - Inside - Second Door Exit
   \Lanayru Mining Facility\Main\First Room\Main Exit:
     type: exit
     vanilla: Lanayru Desert - Entrance from Lanayru Mining Facility
-    req_index: 2028
     short_name: Lanayru Mining Facility - Main Exit
   \Lanayru Mining Facility\Main\First Hub\Exit to Big Hub:
     type: exit
     vanilla: Lanayru Mining Facility - Big Hub - Entrance from First Hub
-    req_index: 2029
     short_name: Lanayru Mining Facility - First Hub - Exit to Big Hub
   \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Exit to Big Hub:
     type: exit
     vanilla: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes Room
-    req_index: 2030
     short_name: Lanayru Mining Facility - Hop Across Boxes Room - Exit to Big Hub
   \Lanayru Mining Facility\Main\Armos Fight Room\Exit to Big Hub:
     type: exit
     vanilla: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
-    req_index: 2031
     short_name: Lanayru Mining Facility - Armos Fight Room - Exit to Big Hub
   \Lanayru Mining Facility\Main\Big Hub\Entry\Exit to First Hub:
     type: exit
     vanilla: Lanayru Mining Facility - First Hub - Entrance from Big Hub
-    req_index: 2032
     short_name: Lanayru Mining Facility - Big Hub - Exit to First Hub
   \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Exit to Hop Across Boxes Room:
     type: exit
     vanilla: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big Hub
-    req_index: 2033
     short_name: Lanayru Mining Facility - Big Hub - Exit to Hop Across Boxes Room
   \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Exit to Armos Fight Room:
     type: exit
     vanilla: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
-    req_index: 2034
     short_name: Lanayru Mining Facility - Big Hub - Exit to Armos Fight Room
   \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Exit:
     type: exit
     vanilla: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
-    req_index: 2035
     short_name: Lanayru Mining Facility - Boss Door Exit
   \Lanayru Mining Facility\Boss Room\Exit to Dungeon:
     type: exit
     vanilla: Lanayru Mining Facility - Boss Door Entrance
-    req_index: 2036
     short_name: Lanayru Mining Facility - Boss Room - Exit to Dungeon
   \Lanayru Mining Facility\Boss Room\After Sand Drain\Exit to Hall of Ancient Robots:
     type: exit
     vanilla: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
       Room
-    req_index: 2037
     short_name: Lanayru Mining Facility - Boss Room - Exit to Hall of Ancient Robots
   \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Exit to Boss Room:
     type: exit
     vanilla: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient Robots
-    req_index: 2038
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Boss Room
   \Lanayru Mining Facility\Hall of Ancient Robots\End\Exit to Temple of Time:
     type: exit
     subtype: vanilla
     vanilla: Temple of Time - Entrance from Lanayru Mining Facility
     stage: F300_5
-    room: 0
-    index: 1
-    req_index: 2039
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Exit to Temple
       of Time
   \Sandship\Main\Deck\Main Exit:
     type: exit
     vanilla: Lanayru Sand Sea - Sandship Dock Entrance
-    req_index: 2040
     short_name: Sandship - Main Exit
   \Sandship\Main\Before Boss Door\Boss Door one-way Exit:
     type: exit
     vanilla: Sandship - Boss Room - Entrance
-    req_index: 2041
     short_name: Sandship - Boss Door one-way Exit
   \Sky Keep\Main\First Room\Bottom Exit:
     type: exit
     vanilla: Skyloft - Entrance from Sky Keep
-    req_index: 2042
     short_name: Sky Keep - First Room - Bottom Exit
 entrances:
   \Skyloft\Upper Skyloft\Knight Academy\Link's Room\Start Entrance:
     type: entrance
     province: The Sky
-    allowed-time-of-day: DayOnly
-    statue-name: Link's Room
     stage: F001r
-    room: 1
-    layer: 0
-    entrance: 5
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2043
     short_name: Skyloft - Knight Academy - Start Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Zelda's Room\Chimney:
     type: entrance
     province: The Sky
     stage: F001r
-    room: 6
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2044
     short_name: Skyloft - Knight Academy - Chimney
   \Skyloft\Upper Skyloft\Knight Academy\Lower Right Door Entrance:
     type: entrance
     province: The Sky
     stage: F001r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2046
     short_name: Skyloft - Knight Academy - Lower Right Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Lower Left Door Entrance:
     type: entrance
     province: The Sky
     stage: F001r
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2048
     short_name: Skyloft - Knight Academy - Lower Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Upper Right Door Entrance:
     type: entrance
     province: The Sky
     stage: F001r
-    room: 0
-    layer: 0
-    entrance: 3
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2050
     short_name: Skyloft - Knight Academy - Upper Right Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy\Upper Left Door Entrance:
     type: entrance
     province: The Sky
     stage: F001r
-    room: 0
-    layer: 0
-    entrance: 4
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2052
     short_name: Skyloft - Knight Academy - Upper Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Lower Right Door Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 4
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2054
     short_name: Skyloft - Knight Academy Lower Right Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Lower Left Door Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 5
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2056
     short_name: Skyloft - Knight Academy Lower Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Upper Left Door Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 23
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2058
     short_name: Skyloft - Knight Academy Upper Left Door Entrance
   \Skyloft\Upper Skyloft\Knight Academy Upper Right Door Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 24
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2060
     short_name: Skyloft - Knight Academy Upper Right Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Right Door Entrance:
     type: entrance
     province: The Sky
     stage: F009r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2062
     short_name: Sparring Hall - Right Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall\Left Door Entrance:
     type: entrance
     province: The Sky
     stage: F009r
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2064
     short_name: Sparring Hall - Left Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall Left Door Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 21
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2066
     short_name: Skyloft - Sparring Hall Left Door Entrance
   \Skyloft\Upper Skyloft\Sparring Hall Right Door Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 26
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2068
     short_name: Skyloft - Sparring Hall Right Door Entrance
   \Skyloft\Upper Skyloft\Goddess Statue\Entrance:
     type: entrance
     province: The Sky
     stage: F008r
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2070
     short_name: Goddess Statue - Entrance
   \Skyloft\Upper Skyloft\Goddess Statue Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 6
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2072
     short_name: Goddess Statue Entrance
   \Skyloft\Central Skyloft\Waterfall Cave\Upper Entrance:
     type: entrance
     province: The Sky
     stage: D000
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2074
     short_name: Waterfall Cave - Upper Entrance
   \Skyloft\Central Skyloft\Waterfall Cave\Lower Entrance:
     type: entrance
     province: The Sky
     stage: D000
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2076
     short_name: Waterfall Cave - Lower Entrance
   \Skyloft\Central Skyloft\Waterfall Cave Upper Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 7
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2078
     short_name: Waterfall Cave Upper Entrance
   \Skyloft\Central Skyloft\Past Waterfall Cave\Waterfall Cave Lower Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 8
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2080
     short_name: Waterfall Cave Lower Entrance
   \Skyloft\Central Skyloft\Bazaar\North Entrance:
     type: entrance
     province: The Sky
     stage: F004r
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2082
     short_name: Bazaar - North Entrance
   \Skyloft\Central Skyloft\Bazaar\South Entrance:
     type: entrance
     province: The Sky
     stage: F004r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2083
     short_name: Bazaar - South Entrance
   \Skyloft\Central Skyloft\Bazaar\West Entrance:
     type: entrance
     province: The Sky
     stage: F004r
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2084
     short_name: Bazaar - West Entrance
   \Skyloft\Central Skyloft\Bazaar North Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2085
     short_name: Bazaar North Entrance
   \Skyloft\Central Skyloft\Bazaar South Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 3
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2087
     short_name: Bazaar South Entrance
   \Skyloft\Central Skyloft\Bazaar West Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 20
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2089
     short_name: Bazaar West Entrance
   \Skyloft\Beedle's Shop\Day Entrance:
     type: entrance
     province: The Sky
     stage: F002r
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2091
     short_name: Beedle's Shop - Day Entrance
   \Skyloft\Beedle's Shop\Night Entrance:
     type: entrance
     province: The Sky
-    allowed-time-of-day: NightOnly
     stage: F002r
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 1
     allowed_time_of_day: 2
-    req_index: 2093
     short_name: Beedle's Shop - Night Entrance
   \Skyloft\Central Skyloft\Entrance from Beedle's Shop:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2094
     short_name: Skyloft - Entrance from Beedle's Shop
   \Skyloft\Skyloft Silent Realm\Entrance:
     type: entrance
     province: The Sky
     can-start-at: false
-    tod: 0
     allowed_time_of_day: 3
-    req_index: 2096
     short_name: Skyloft Silent Realm - Entrance
   \Skyloft\Central Skyloft\Trial Gate Entrance:
     type: entrance
     province: The Sky
     can-start-at: false
-    tod: 0
     allowed_time_of_day: 3
-    req_index: 2098
     short_name: Skyloft - Trial Gate Entrance
   \Skyloft\Central Skyloft\Near Temple Entrance\Entrance from Sky Keep:
     type: entrance
     province: The Sky
     can-start-at: false
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 53
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2100
     short_name: Skyloft - Entrance from Sky Keep
   \Skyloft\Central Skyloft\Orielle and Parrow's House\Entrance:
     type: entrance
     province: The Sky
     stage: F005r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2101
     short_name: Orielle and Parrow's House - Entrance
   \Skyloft\Central Skyloft\Orielle and Parrow's House Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 30
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2103
     short_name: Orielle and Parrow's House Entrance
   \Skyloft\Central Skyloft\Peatrice's House\Entrance:
     type: entrance
     province: The Sky
     stage: F018r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2105
     short_name: Peatrice's House - Entrance
   \Skyloft\Central Skyloft\Peatrice's House Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 38
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2107
     short_name: Peatrice's House Entrance
   \Skyloft\Central Skyloft\Wryna's House\Entrance:
     type: entrance
     province: The Sky
     stage: F006r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2109
     short_name: Wryna's House - Entrance
   \Skyloft\Central Skyloft\Wryna's House Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 31
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2111
     short_name: Wryna's House Entrance
   \Skyloft\Skyloft Village\Bertie's House\Entrance:
     type: entrance
     province: The Sky
     stage: F014r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2113
     short_name: Bertie's House - Entrance
   \Skyloft\Skyloft Village\Bertie's House Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 34
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2115
     short_name: Bertie's House Entrance
   \Skyloft\Skyloft Village\Sparrot's House\Entrance:
     type: entrance
     province: The Sky
     stage: F013r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2117
     short_name: Sparrot's House - Entrance
   \Skyloft\Skyloft Village\Sparrot's House Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 33
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2119
     short_name: Sparrot's House Entrance
   \Skyloft\Skyloft Village\Mallara's House Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 36
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2121
     short_name: Skyloft - Mallara's House Entrance
   \Skyloft\Skyloft Village\Mallara's House\Entrance:
     type: entrance
     province: The Sky
     stage: F016r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2123
     short_name: Mallara's House - Entrance
   \Skyloft\Skyloft Village\Batreaux's House\Entrance:
     type: entrance
     province: The Sky
     stage: F012r
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2125
     short_name: Batreaux's House - Entrance
   \Skyloft\Skyloft Village\Batreaux's House Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 29
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2127
     short_name: Batreaux's House Entrance
   \Skyloft\Skyloft Village\Gondo's House\Entrance:
     type: entrance
     province: The Sky
     stage: F015r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2129
     short_name: Gondo's House - Entrance
   \Skyloft\Skyloft Village\Gondo's House Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 35
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2131
     short_name: Gondo's House Entrance
   \Skyloft\Skyloft Village\Rupin's House\Entrance:
     type: entrance
     province: The Sky
     stage: F017r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2133
     short_name: Rupin's House - Entrance
   \Skyloft\Skyloft Village\Rupin's House Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 37
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2135
     short_name: Rupin's House Entrance
   \Skyloft\Central Skyloft\Piper's House\Entrance:
     type: entrance
     province: The Sky
     stage: F007r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2137
     short_name: Piper's House - Entrance
   \Skyloft\Central Skyloft\Piper's House Entrance:
     type: entrance
     province: The Sky
     stage: F000
-    room: 0
-    layer: 0
-    entrance: 32
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2139
     short_name: Piper's House Entrance
   \Skyloft\Central Skyloft\Entrance from Sky:
     type: entrance
     province: The Sky
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2141
     short_name: Skyloft - Entrance from Sky
   \Sky\Around Skyloft\Entrance from Skyloft:
     type: entrance
     province: The Sky
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2143
     short_name: Sky - Entrance from Skyloft
   \Sky\North East\Bamboo Island\Inside\Entrance:
     type: entrance
     province: The Sky
     stage: F019r
-    room: 0
-    layer: 1
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2144
     short_name: Bamboo Island - Inside - Entrance
   \Sky\North East\Bamboo Island\Entrance from Inside:
     type: entrance
     province: The Sky
     stage: F020
-    room: 0
-    layer: 0
-    entrance: 11
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2145
     short_name: Bamboo Island - Entrance from Inside
   \Sky\North East\Beedle's Island\Beedle's Ship Entrance:
     type: entrance
     province: The Sky
-    allowed-time-of-day: NightOnly
     stage: F020
-    room: 0
-    layer: 4
-    entrance: 0
-    tod: 1
     allowed_time_of_day: 2
-    req_index: 2146
     short_name: Sky - Beedle's Island - Beedle's Ship Entrance
   \Sky\North East\Eldin Pillar\Entrance:
     type: entrance
     province: The Sky
-    statue-name: Volcano Entry
     stage: F020
-    room: 0
-    layer: 0
-    entrance: 13
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2147
     short_name: Sky - Eldin Pillar - Entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Right Door Entrance:
     type: entrance
     province: The Sky
     stage: F011r
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2148
     short_name: Lumpy Pumpkin Building - Main Right Door Entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Main Left Door Entrance:
     type: entrance
     province: The Sky
     stage: F011r
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2150
     short_name: Lumpy Pumpkin Building - Main Left Door Entrance
   \Sky\South East\Lumpy Pumpkin\Lumpy Pumpkin Building\Back Door Entrance:
     type: entrance
     province: The Sky
     stage: F011r
-    room: 0
-    layer: 0
-    entrance: 3
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2152
     short_name: Lumpy Pumpkin Building - Back Door Entrance
   \Sky\South East\Lumpy Pumpkin\Main Left Door Entrance:
     type: entrance
     province: The Sky
     stage: F020
-    room: 0
-    layer: 0
-    entrance: 22
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2154
     short_name: Lumpy Pumpkin - Main Left Door Entrance
   \Sky\South East\Lumpy Pumpkin\Main Right Door Entrance:
     type: entrance
     province: The Sky
     stage: F020
-    room: 0
-    layer: 0
-    entrance: 23
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2156
     short_name: Lumpy Pumpkin - Main Right Door Entrance
   \Sky\South East\Lumpy Pumpkin\Back Door Entrance:
     type: entrance
     province: The Sky
     stage: F020
-    room: 0
-    layer: 0
-    entrance: 24
-    tod: 2
     allowed_time_of_day: 3
-    req_index: 2158
     short_name: Lumpy Pumpkin - Back Door Entrance
   \Sky\South East\Faron Pillar\Entrance:
     type: entrance
     province: The Sky
-    statue-name: Sealed Grounds
     stage: F020
-    room: 0
-    layer: 0
-    entrance: 12
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2160
     short_name: Sky - Faron Pillar - Entrance
   \Sky\South West\Lanayru Pillar\Entrance:
     type: entrance
     province: The Sky
     stage: F020
-    room: 0
-    layer: 0
-    entrance: 14
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2161
     short_name: Sky - Lanayru Pillar - Entrance
   \Sky\Around Skyloft\Entrance from Thunderhead:
     type: entrance
     province: The Sky
     can-start-at: false
     stage: F020
-    room: 0
-    layer: 0
-    entrance: 28
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2162
     short_name: Sky - Entrance from Thunderhead
   \Sky\Thunderhead\Entrance:
     type: entrance
     province: The Sky
     can-start-at: false
     stage: F023
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2163
     short_name: Thunderhead - Entrance
   \Sky\Thunderhead\Isle of Songs\Inside\Entrance:
     type: entrance
     province: The Sky
     can-start-at: false
     stage: F010r
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2164
     short_name: Isle of Songs - Entrance
   \Sky\Thunderhead\Isle of Songs\Entrance from Inside:
     type: entrance
     province: The Sky
     can-start-at: false
     stage: F023
-    room: 0
-    layer: 0
-    entrance: 4
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2165
     short_name: Isle of Songs - Entrance from Inside
   \Faron\Sealed Grounds\Spiral\Upper Part\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Faron Province
-    statue-name: Sealed Grounds
     stage: F401
-    room: 1
-    layer: 0
-    entrance: 8
-    tod: 2
-    flag-space: Sealed Grounds
-    flag: 35
-    vanilla-start-statue: true
     allowed_time_of_day: 1
-    req_index: 2166
     short_name: Sealed Grounds Spiral - Statue Entrance
   \Faron\Sealed Grounds\Spiral\Upper Part\From Behind the Temple\Shortcut Entrance from Behind the Temple:
     type: entrance
     province: Faron Province
     stage: F401
-    room: 1
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2167
     short_name: Sealed Grounds Spiral - Shortcut Entrance from Behind the Temple
   \Faron\Sealed Grounds\Spiral\Door Entrance:
     type: entrance
     province: Faron Province
     stage: F401
-    room: 1
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2168
     short_name: Sealed Grounds Spiral - Door Entrance
   \Faron\Sealed Grounds\Sealed Temple\Main Entrance:
     type: entrance
     province: Faron Province
     stage: F402
-    room: 2
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2169
     short_name: Sealed Temple - Main Entrance
   \Faron\Sealed Grounds\Sealed Temple\Side Entrance:
     type: entrance
     province: Faron Province
     stage: F402
-    room: 2
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2170
     short_name: Sealed Temple - Side Entrance
   \Faron\Sealed Grounds\Sealed Temple\Gate of Time Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: F402
-    room: 2
-    layer: 0
-    entrance: 11
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2171
     short_name: Sealed Temple - Gate of Time Entrance
   \Faron\Sealed Grounds\Hylia's Temple\Gate of Time Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: F404
-    room: 2
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2172
     short_name: Hylia's Temple - Gate of Time Entrance
   \Faron\Sealed Grounds\Behind the Temple\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Faron Province
-    statue-name: Behind the Temple
     stage: F400
-    room: 0
-    layer: 0
-    entrance: 10
-    tod: 2
-    flag-space: Sealed Grounds
-    flag: 31
     allowed_time_of_day: 1
-    req_index: 2173
     short_name: Behind the Temple - Statue Entrance
   \Faron\Sealed Grounds\Behind the Temple\Door Entrance:
     type: entrance
     province: Faron Province
     stage: F400
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2174
     short_name: Behind the Temple - Door Entrance
   \Faron\Sealed Grounds\Behind the Temple\Shortcut Entrance from Spiral:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: F400
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2175
     short_name: Behind the Temple - Shortcut Entrance from Spiral
   \Faron\Sealed Grounds\Behind the Temple\Entrance from Faron Woods:
     type: entrance
     province: Faron Province
     stage: F400
-    room: 0
-    layer: 0
-    entrance: 3
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2176
     short_name: Behind the Temple - Entrance from Faron Woods
   \Faron\Faron Woods\Entry\Faron Woods Entry Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Faron Province
-    statue-name: Faron Woods Entry
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 50
-    tod: 2
-    flag-space: Story
-    flag: 800
     allowed_time_of_day: 1
-    req_index: 2177
     short_name: Faron Woods - Faron Woods Entry Statue Entrance
   \Faron\Faron Woods\In the Woods Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Faron Province
-    statue-name: In the Woods
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 51
-    tod: 2
-    flag-space: Story
-    flag: 801
     allowed_time_of_day: 1
-    req_index: 2178
     short_name: Faron Woods - In the Woods Statue Entrance
   \Faron\Faron Woods\Viewing Platform Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Faron Province
-    statue-name: Viewing Platform
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 52
-    tod: 2
-    flag-space: Story
-    flag: 802
     allowed_time_of_day: 1
-    req_index: 2179
     short_name: Faron Woods - Viewing Platform Statue Entrance
   \Faron\Faron Woods\Great Tree\Top\The Great Tree Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Faron Province
-    statue-name: Great Tree Top
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 53
-    tod: 2
-    flag-space: Story
-    flag: 803
     allowed_time_of_day: 1
-    req_index: 2180
     short_name: Great Tree - The Great Tree Statue Entrance
   \Faron\Faron Woods\Entry\Entrance from Behind the Temple:
     type: entrance
     province: Faron Province
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2181
     short_name: Faron Woods - Entrance from Behind the Temple
   \Faron\Faron Woods\Ledge to Lake Floria\Shortcut Entrance from Floria Waterfall:
     type: entrance
     province: Faron Province
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 17
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2182
     short_name: Faron Woods - Shortcut Entrance from Floria Waterfall
   \Faron\Faron Woods\Ledge To Deep Woods\Entrance from Deep Woods:
     type: entrance
     province: Faron Province
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 45
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2183
     short_name: Faron Woods - Entrance from Deep Woods
   \Faron\Faron Woods\Trial Gate Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2184
     short_name: Faron Woods - Trial Gate Entrance
   \Faron\Faron Silent Realm\Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2185
     short_name: Faron Silent Realm - Entrance
   \Faron\Faron Woods\Great Tree\Platforms\Lower Entrance from Great Tree:
     type: entrance
     province: Faron Province
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 4
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2186
     short_name: Great Tree - Platforms - Lower Entrance from Great Tree
   \Faron\Faron Woods\Great Tree\Platforms\Upper Entrance from Great Tree:
     type: entrance
     province: Faron Province
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 5
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2187
     short_name: Great Tree - Platforms - Upper Entrance from Great Tree
   \Faron\Faron Woods\Great Tree\Top\Top Entrance from Great Tree:
     type: entrance
     province: Faron Province
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 6
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2188
     short_name: Great Tree - Top Entrance from Great Tree
   \Faron\Faron Woods\Great Tree\Near Underwater Hole\Underwater Hole Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: F100
-    room: 0
-    layer: 0
-    entrance: 7
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2189
     short_name: Great Tree - Underwater Hole Entrance
   \Faron\Faron Woods\Great Tree\Lower Area\Near Exit\Lower Entrance from Platforms:
     type: entrance
     province: Faron Province
     stage: F100_1
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2190
     short_name: Great Tree - Lower Entrance from Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Upper Entrance from Platforms:
     type: entrance
     province: Faron Province
     stage: F100_1
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2191
     short_name: Great Tree - Upper Entrance from Platforms
   \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Top:
     type: entrance
     province: Faron Province
     stage: F100_1
-    room: 0
-    layer: 0
-    entrance: 3
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2192
     short_name: Great Tree - Entrance from Top
   \Faron\Faron Woods\Great Tree\Lower Area\Underwater Tunnel Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: F100_1
-    room: 0
-    layer: 0
-    entrance: 4
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2193
     short_name: Great Tree - Underwater Tunnel Entrance
   \Faron\Faron Woods\Great Tree\Upper Area\Entrance from Flooded Great Tree:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2194
     short_name: Great Tree - Entrance from Flooded Great Tree
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2195
     short_name: Flooded Great Tree - Entrance
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Upper Flooded Faron Woods:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2196
     short_name: Flooded Great Tree - Entrance from Upper Flooded Faron Woods
   \Faron\Flooded Faron Woods\Flooded Great Tree\Entrance from Lower Flooded Faron Woods:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2197
     short_name: Flooded Great Tree - Entrance from Lower Flooded Faron Woods
   \Faron\Flooded Faron Woods\Entrance from Upper Flooded Great Tree:
     type: entrance
     allowed_time_of_day: 1
-    req_index: 2198
     short_name: Flooded Faron Woods - Entrance from Upper Flooded Great Tree
   \Faron\Flooded Faron Woods\Entrance from Lower Flooded Great Tree:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2199
     short_name: Flooded Faron Woods - Entrance from Lower Flooded Great Tree
   \Faron\Faron Woods\Deep Woods\Forest Temple Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Faron Province
-    statue-name: Forest Temple
     stage: F101
-    room: 0
-    layer: 0
-    entrance: 13
-    tod: 2
-    flag-space: Faron Woods
-    flag: 104
     allowed_time_of_day: 1
-    req_index: 2200
     short_name: Deep Woods - Forest Temple Statue Entrance
   \Faron\Faron Woods\Deep Woods\Deep Woods Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Faron Province
-    statue-name: Deep Woods
     stage: F101
-    room: 0
-    layer: 0
-    entrance: 14
-    tod: 2
-    flag-space: Faron Woods
-    flag: 103
     allowed_time_of_day: 1
-    req_index: 2201
     short_name: Deep Woods - Deep Woods Statue Entrance
   \Faron\Faron Woods\Deep Woods\Entry\Entrance from Faron Woods:
     type: entrance
     province: Faron Province
     stage: F101
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2202
     short_name: Deep Woods - Entrance from Faron Woods
   \Faron\Faron Woods\Deep Woods\Entrance from Skyview Temple:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: F101
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2203
     short_name: Deep Woods - Entrance from Skyview Temple
   \Faron\Lake Floria\Below Rock\Emerged Area\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Faron Province
-    statue-name: Lake Floria
     stage: F102
-    room: 3
-    layer: 0
-    entrance: 2
-    tod: 2
-    flag-space: Lake Floria
-    flag: 32
     allowed_time_of_day: 1
-    req_index: 2204
     short_name: Lake Floria - Below Rock - Statue Entrance
   \Faron\Lake Floria\Above Rock\Dive from Faron Woods:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: F102
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2205
     short_name: Lake Floria - Dive from Faron Woods
   \Faron\Lake Floria\Below Rock\Entrance from Farore's Lair:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: F102
-    room: 4
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2206
     short_name: Lake Floria - Entrance from Farore's Lair
   \Faron\Lake Floria\Farore's Lair\Entrance from Lake Floria:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: F102_2
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2207
     short_name: Farore's Lair - Entrance from Lake Floria
   \Faron\Lake Floria\Farore's Lair\Entrance from Waterfall:
     type: entrance
     province: Faron Province
     stage: F102_2
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2208
     short_name: Farore's Lair - Entrance from Waterfall
   \Faron\Lake Floria\Waterfall\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Faron Province
-    statue-name: Floria Waterfall
     stage: F102_1
-    room: 0
-    layer: 0
-    entrance: 5
-    tod: 2
-    flag-space: Lake Floria
-    flag: 33
     allowed_time_of_day: 1
-    req_index: 2209
     short_name: Floria Waterfall - Statue Entrance
   \Faron\Lake Floria\Waterfall\Entrance from Farore's Lair:
     type: entrance
     province: Faron Province
     stage: F102_1
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2210
     short_name: Floria Waterfall - Entrance from Farore's Lair
   \Faron\Lake Floria\Waterfall\Entrance from Ancient Cistern:
     type: entrance
     province: Faron Province
-    statue-name: Floria Waterfall
     stage: F102_1
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2211
     short_name: Floria Waterfall - Entrance from Ancient Cistern
   \Faron\Lake Floria\Waterfall\Entrance from Faron Woods:
     type: entrance
     province: Faron Province
     stage: F102_1
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2212
     short_name: Floria Waterfall - Entrance from Faron Woods
   \Skyview\Main\Entry\Main Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: D100
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2213
     short_name: Skyview Temple - Main Entrance
   \Skyview\Main\Last Room\After Rope\Boss Door Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2214
     short_name: Skyview Temple - Boss Door Entrance
   \Skyview\Boss Room\Entrance from Dungeon:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2215
     short_name: Skyview Temple - Boss Room - Entrance from Dungeon
   \Skyview\Boss Room\Entrance from Spring:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2216
     short_name: Skyview Temple - Boss Room - Entrance from Spring
   \Skyview\Spring\Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2217
     short_name: Skyview Temple - Spring - Entrance
   \Ancient Cistern\Main\Main Room\Main Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
     stage: D101
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2218
     short_name: Ancient Cistern - Main Entrance
   \Ancient Cistern\Main\Inside Statue\Boss Door Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2219
     short_name: Ancient Cistern - Boss Door Entrance
   \Ancient Cistern\Boss Room\Entrance from Dungeon:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2220
     short_name: Ancient Cistern - Boss Room - Entrance from Dungeon
   \Ancient Cistern\Boss Room\Entrance from Flame Room:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2221
     short_name: Ancient Cistern - Boss Room - Entrance from Flame Room
   \Ancient Cistern\Flame Room\Entrance:
     type: entrance
     province: Faron Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2222
     short_name: Ancient Cistern - Flame Room - Entrance
   \Eldin\Volcano\Entry\First Time Entrance:
     type: entrance
     province: Eldin Province
     stage: F200
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2223
     short_name: Eldin Volcano - First Time Entrance
   \Eldin\Volcano\Entry\Volcano Entrance Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Eldin Province
-    statue-name: Volcano Entry
     stage: F200
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
-    flag-space: Story
-    flag: 804
-    vanilla-start-statue: true
     allowed_time_of_day: 1
-    req_index: 2224
     short_name: Eldin Volcano - Volcano Entrance Statue Entrance
   \Eldin\Volcano\East\Volcano East Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Eldin Province
-    statue-name: Volcano East
     stage: F200
-    room: 2
-    layer: 0
-    entrance: 6
-    tod: 2
-    flag-space: Story
-    flag: 805
     allowed_time_of_day: 1
-    req_index: 2225
     short_name: Eldin Volcano - Volcano East Statue Entrance
   \Eldin\Volcano\Ascent\Volcano Ascent Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Eldin Province
-    statue-name: Volcano Ascent
     stage: F200
-    room: 2
-    layer: 0
-    entrance: 7
-    tod: 2
-    flag-space: Story
-    flag: 806
     allowed_time_of_day: 1
-    req_index: 2226
     short_name: Eldin Volcano - Volcano Ascent Statue Entrance
   \Eldin\Volcano\Near Temple Entrance\Temple Entrance Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Eldin Province
-    statue-name: Temple Entrance
     stage: F200
-    room: 4
-    layer: 0
-    entrance: 7
-    tod: 2
-    flag-space: Story
-    flag: 807
     allowed_time_of_day: 1
-    req_index: 2227
     short_name: Eldin Volcano - Temple Entrance Statue Entrance
   \Eldin\Volcano\East\First Vent from Mogma Turf:
     type: entrance
     province: Eldin Province
     stage: F200
-    room: 2
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2228
     short_name: Eldin Volcano - First Vent from Mogma Turf
   \Eldin\Volcano\Past Mogma Turf\Second Vent from Mogma Turf:
     type: entrance
     province: Eldin Province
     stage: F200
-    room: 2
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2229
     short_name: Eldin Volcano - Second Vent from Mogma Turf
   \Eldin\Volcano\Near Temple Entrance\Entrance from Earth Temple:
     type: entrance
     province: Eldin Province
     stage: F200
-    room: 4
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2230
     short_name: Eldin Volcano - Entrance from Earth Temple
   \Eldin\Volcano\Near Thrill Digger Cave\Thrill Digger Cave Entrance:
     type: entrance
     province: Eldin Province
     stage: F200
-    room: 4
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2231
     short_name: Eldin Volcano - Thrill Digger Cave Entrance
   \Eldin\Volcano\Hot Cave\Entrance from Summit:
     type: entrance
     province: Eldin Province
     can-start-at: false
     stage: F200
-    room: 5
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2232
     short_name: Eldin Volcano - Entrance from Summit
   \Eldin\Volcano\Ascent\Trial Gate Entrance:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2233
     short_name: Eldin Volcano - Trial Gate Entrance
   \Eldin\Volcano\Hot Cave\Vent Entrance near Hot Cave:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2234
     short_name: Eldin Volcano - Vent Entrance near Hot Cave
   \Eldin\Volcano\First Room\Entrance from Bokoblin Base:
     type: entrance
     province: Eldin Province
     stage: F200
-    room: 1
-    layer: 1
-    entrance: 5
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2235
     short_name: Eldin Volcano - Entrance from Bokoblin Base
   \Eldin\Bokoblin Base\Prison\Entrance:
     type: entrance
     province: Eldin Province
     stage: F202
-    room: 1
-    layer: 1
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2236
     short_name: Bokoblin Base - Entrance
   \Eldin\Mogma Turf\Pre Vent\Entrance:
     type: entrance
     province: Eldin Province
     stage: F210
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2237
     short_name: Mogma Turf - Entrance
   \Eldin\Volcano\Thrill Digger Cave\Entrance:
     type: entrance
     province: Eldin Province
     stage: F211
-    room: 0
-    layer: 1
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2238
     short_name: Thrill Digger Cave - Entrance
   \Eldin\Eldin Silent Realm\Entrance:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2239
     short_name: Eldin Silent Realm - Entrance
   \Eldin\Volcano Summit\Entrance from Outside Fire Sanctuary:
     type: entrance
     province: Eldin Province
     can-start-at: false
     stage: F201_1
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2240
     short_name: Volcano Summit - Entrance from Outside Fire Sanctuary
   \Eldin\Volcano Summit\Entrance from Waterfall:
     type: entrance
     province: Eldin Province
     can-start-at: false
     stage: F201_1
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2241
     short_name: Volcano Summit - Entrance from Waterfall
   \Eldin\Volcano Summit\Entrance from Eldin Volcano:
     type: entrance
     province: Eldin Province
     can-start-at: false
     stage: F201_1
-    room: 0
-    layer: 0
-    entrance: 4
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2242
     short_name: Volcano Summit - Entrance from Eldin Volcano
   \Eldin\Volcano Summit\Waterfall\Entrance:
     type: entrance
     province: Eldin Province
     can-start-at: false
     stage: F201_4
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2243
     short_name: Volcano Summit - Waterfall - Entrance
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Eldin Province
-    statue-name: Inside the Volcano
     stage: F201_3
-    room: 0
-    layer: 0
-    entrance: 3
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2244
     short_name: Outside Fire Sanctuary - Statue Entrance
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Before Thirsty Frogs\Entrance from Summit:
     type: entrance
     province: Eldin Province
     can-start-at: false
     stage: F201_3
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2245
     short_name: Outside Fire Sanctuary - Entrance from Summit
   \Eldin\Volcano Summit\Outside Fire Sanctuary\Entrance from Fire Sanctuary:
     type: entrance
     province: Eldin Province
     can-start-at: false
     stage: F201_3
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2246
     short_name: Outside Fire Sanctuary - Entrance from Fire Sanctuary
   \Earth Temple\Main\First Room\Main Entrance:
     type: entrance
     province: Eldin Province
     can-start-at: false
     stage: D200
-    room: 1
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2247
     short_name: Earth Temple - Main Entrance
   \Earth Temple\Main\Room with Slopes\Front of Boss Door\Boss Door Entrance:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2248
     short_name: Earth Temple - Boss Door Entrance
   \Earth Temple\Boss Room\Entry\Entrance from Dungeon:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2249
     short_name: Earth Temple - Boss Room - Entrance from Dungeon
   \Earth Temple\Boss Room\Slope\Entrance from Spring:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2250
     short_name: Earth Temple - Boss Room - Entrance from Spring
   \Earth Temple\Spring\Entrance:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2251
     short_name: Earth Temple - Spring - Entrance
   \Fire Sanctuary\Main\Front of Boss Door\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Eldin Province
     can-start-at: false
-    statue-name: Inside the Fire Sanctuary
     stage: D201
-    room: 10
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2252
     short_name: Fire Sanctuary - Statue Entrance
   \Fire Sanctuary\Main\First Room\Main Entrance:
     type: entrance
     province: Eldin Province
     can-start-at: false
     stage: D201
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2253
     short_name: Fire Sanctuary - Main Entrance
   \Fire Sanctuary\Main\First Room\Past Water Plant\Entrance from Second Room:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2254
     short_name: Fire Sanctuary - First Room - Entrance from Second Room
   \Fire Sanctuary\Main\Second Room\Outside Section\Entrance from First Room:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2255
     short_name: Fire Sanctuary - Second Room - Entrance from First Room
   \Fire Sanctuary\Main\Magmanos Fight Room\Lower Part\Entrance from West of Boss Door:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2256
     short_name: Fire Sanctuary - Magmanos Fight Room - Entrance from West of Boss
       Door
   \Fire Sanctuary\Main\West of Boss Door\Entry\Entrance from Magmanos Fight Room:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2257
     short_name: Fire Sanctuary - West of Boss Door - Entrance from Magmanos Fight
       Room
   \Fire Sanctuary\Main\Front of Boss Door\Boss Door Entrance:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2258
     short_name: Fire Sanctuary - Boss Door Entrance
   \Fire Sanctuary\Boss Room\Entrance from Dungeon:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2259
     short_name: Fire Sanctuary - Boss Room - Entrance from Dungeon
   \Fire Sanctuary\Boss Room\Entrance from Flame Room:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2260
     short_name: Fire Sanctuary - Boss Room - Entrance from Flame Room
   \Fire Sanctuary\Flame Room\Entrance:
     type: entrance
     province: Eldin Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2261
     short_name: Fire Sanctuary - Flame Room - Entrance
   \Lanayru\Mine\Entry\First Time Entrance:
     type: entrance
     province: Lanayru Province
     stage: F300_1
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2262
     short_name: Lanayru Mine - First Time Entrance
   \Lanayru\Mine\Entry\Caves Entrance\Entrance from Caves:
     type: entrance
     province: Lanayru Province
     stage: F300_1
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2263
     short_name: Lanayru Mine - Entrance from Caves
   \Lanayru\Mine\Entry\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: Lanayru Mine Entry
     stage: F300_1
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
-    flag-space: Lanayru Desert
-    flag: 68
-    vanilla-start-statue: true
     allowed_time_of_day: 1
-    req_index: 2264
     short_name: Lanayru Mine - Statue Entrance
   \Lanayru\Mine\End\In Minecart\Entrance from Desert:
     type: entrance
     province: Lanayru Province
     stage: F300_1
-    room: 2
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2265
     short_name: Lanayru Mine - Entrance from Desert
   \Lanayru\Desert\Entry\Desert Entrance Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: Desert Entrance
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 15
-    tod: 2
-    flag-space: Lanayru Desert
-    flag: 66
     allowed_time_of_day: 1
-    req_index: 2266
     short_name: Lanayru Desert - Desert Entrance Statue Entrance
   \Lanayru\Desert\West Part\West Desert Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: West Desert
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 16
-    tod: 2
-    flag-space: Lanayru Desert
-    flag: 51
     allowed_time_of_day: 1
-    req_index: 2267
     short_name: Lanayru Desert - West Desert Statue Entrance
   \Lanayru\Desert\North Part\North Desert Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: North Desert
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 17
-    tod: 2
-    flag-space: Lanayru Desert
-    flag: 67
     allowed_time_of_day: 1
-    req_index: 2268
     short_name: Lanayru Desert - North Desert Statue Entrance
   \Lanayru\Desert\East\Stone Cache Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: Stone Cache
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 18
-    tod: 2
-    flag-space: Lanayru Desert
-    flag: 2
     allowed_time_of_day: 1
-    req_index: 2269
     short_name: Lanayru Desert - Stone Cache Statue Entrance
   \Lanayru\Desert\Near South Exit to Temple of Time\South Entrance from Temple of Time:
     type: entrance
     province: Lanayru Province
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2270
     short_name: Lanayru Desert - South Entrance from Temple of Time
   \Lanayru\Desert\North Part\North Entrance from Temple of Time:
     type: entrance
     province: Lanayru Province
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2271
     short_name: Lanayru Desert - North Entrance from Temple of Time
   \Lanayru\Desert\Entry\Entrance from Mine:
     type: entrance
     province: Lanayru Province
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2272
     short_name: Lanayru Desert - Entrance from Mine
   \Lanayru\Desert\East\Fire Node Entrance:
     type: entrance
     province: Lanayru Province
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 3
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2273
     short_name: Lanayru Desert - Fire Node Entrance
   \Lanayru\Desert\Top of LMF\Entrance from Lanayru Mining Facility:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 5
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2274
     short_name: Lanayru Desert - Entrance from Lanayru Mining Facility
   \Lanayru\Desert\Near South Exit to Temple of Time\Ledge to Caves\Entrance from Caves:
     type: entrance
     province: Lanayru Province
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 6
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2275
     short_name: Lanayru Desert - Entrance from Caves
   \Lanayru\Desert\North Part\Lightning Node Entrance:
     type: entrance
     province: Lanayru Province
     stage: F300
-    room: 0
-    layer: 0
-    entrance: 7
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2276
     short_name: Lanayru Desert - Lightning Node Entrance
   \Lanayru\Desert\North Part\Trial Gate Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2277
     short_name: Lanayru Desert - Trial Gate Entrance
   \Lanayru\Lanayru Silent Realm\Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2278
     short_name: Lanayru Silent Realm - Entrance
   \Lanayru\Desert\North Part\Lightning Node\Present\Entrance:
     type: entrance
     province: Lanayru Province
     stage: F300_2
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2279
     short_name: Lightning Node - Entrance
   \Lanayru\Desert\East\Fire Node\Present\Entrance:
     type: entrance
     province: Lanayru Province
     stage: F300_3
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2280
     short_name: Fire Node - Entrance
   \Lanayru\Temple of Time\South East\Desert Gorge Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: Desert Gorge
     stage: F300_4
-    room: 0
-    layer: 0
-    entrance: 16
-    tod: 2
-    flag-space: Lanayru Desert
-    flag: 77
     allowed_time_of_day: 1
-    req_index: 2281
     short_name: Temple of Time - Desert Gorge Statue Entrance
   \Lanayru\Temple of Time\Inside\Temple of Time Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: Temple of Time
     stage: F300_4
-    room: 0
-    layer: 0
-    entrance: 17
-    tod: 2
-    flag-space: Lanayru Desert
-    flag: 78
     allowed_time_of_day: 1
-    req_index: 2282
     short_name: Temple of Time - Temple of Time Statue Entrance
   \Lanayru\Temple of Time\South East\South Entrance from Desert:
     type: entrance
     province: Lanayru Province
     stage: F300_4
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2283
     short_name: Temple of Time - South Entrance from Desert
   \Lanayru\Temple of Time\North East\North Entrance from Desert:
     type: entrance
     province: Lanayru Province
     stage: F300_4
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2284
     short_name: Temple of Time - North Entrance from Desert
   \Lanayru\Temple of Time\Inside\Entrance from Lanayru Mining Facility:
     type: entrance
@@ -13863,466 +12668,271 @@ entrances:
     province: Lanayru Province
     can-start-at: false
     stage: F300_4
-    room: 0
-    layer: 2
-    entrance: 5
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2285
     short_name: Temple of Time - Entrance from Lanayru Mining Facility
   \Lanayru\Caves\Entrance from Mine:
     type: entrance
     province: Lanayru Province
     stage: F303
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2286
     short_name: Lanayru Caves - Entrance from Mine
   \Lanayru\Caves\Entrance from Desert:
     type: entrance
     province: Lanayru Province
     stage: F303
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2287
     short_name: Lanayru Caves - Entrance from Desert
   \Lanayru\Caves\Past Door to Lanayru Sand Sea\Entrance from Lanayru Sand Sea:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: F303
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2288
     short_name: Lanayru Caves - Entrance from Lanayru Sand Sea
   \Lanayru\Caves\Past Crawlspace\Entrance from Gorge:
     type: entrance
     province: Lanayru Province
     stage: F303
-    room: 0
-    layer: 0
-    entrance: 3
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2289
     short_name: Lanayru Caves - Entrance from Gorge
   \Lanayru\Lanayru Sand Sea\Gorge\Entrance:
     type: entrance
     province: Lanayru Province
     stage: F302
-    room: 0
-    layer: 2
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2290
     short_name: Lanayru Gorge - Entrance
   \Lanayru\Lanayru Sand Sea\Gorge\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: Lanayru Gorge
     stage: F302
-    room: 0
-    layer: 0
-    entrance: 12
-    tod: 2
-    flag-space: Lanayru Gorge
-    flag: 12
     allowed_time_of_day: 1
-    req_index: 2291
     short_name: Lanayru Gorge - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour Dock Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_1
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2292
     short_name: Lanayru Sand Sea - Ancient Harbour Dock Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat Dock Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_1
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2293
     short_name: Lanayru Sand Sea - Skipper's Retreat Dock Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard Dock Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_1
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2294
     short_name: Lanayru Sand Sea - Shipyard Dock Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold Dock Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_1
-    room: 0
-    layer: 0
-    entrance: 3
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2295
     short_name: Lanayru Sand Sea - Pirate Stronghold Dock Entrance
   \Lanayru\Lanayru Sand Sea\Sandship Dock Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: F301_1
-    room: 0
-    layer: 0
-    entrance: 4
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2296
     short_name: Lanayru Sand Sea - Sandship Dock Entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: Ancient Harbour
     stage: F301
-    room: 0
-    layer: 0
-    entrance: 10
-    tod: 2
-    flag-space: Lanayru Sand Sea
-    flag: 10
     allowed_time_of_day: 1
-    req_index: 2297
     short_name: Lanayru Sand Sea Docks - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Near Exit to Caves\Entrance from Caves:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: F301
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2298
     short_name: Lanayru Sand Sea Docks - Entrance from Caves
   \Lanayru\Lanayru Sand Sea\Ancient Harbour\Dock Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2299
     short_name: Lanayru Sand Sea Docks - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: Skipper's Retreat
     stage: F301_3
-    room: 0
-    layer: 0
-    entrance: 10
-    tod: 2
-    flag-space: Lanayru Sand Sea
-    flag: 28
     allowed_time_of_day: 1
-    req_index: 2300
     short_name: Skipper's Retreat - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Dock Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_3
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2301
     short_name: Skipper's Retreat - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Top Part\Shack Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_3
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2302
     short_name: Skipper's Retreat - Shack Entrance
   \Lanayru\Lanayru Sand Sea\Skipper's Retreat\Shack\Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_5
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2303
     short_name: Skipper's Retreat - Shack - Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: Lanayru Shipyard
     stage: F301_4
-    room: 0
-    layer: 0
-    entrance: 10
-    tod: 2
-    flag-space: Lanayru Sand Sea
-    flag: 85
     allowed_time_of_day: 1
-    req_index: 2304
     short_name: Shipyard - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Dock Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_4
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2305
     short_name: Shipyard - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Lower Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: F301_4
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2306
     short_name: Shipyard - Construction Bay Lower Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay Upper Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: F301_4
-    room: 0
-    layer: 0
-    entrance: 4
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2307
     short_name: Shipyard - Construction Bay Upper Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Upper Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: F301_7
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2308
     short_name: Shipyard - Construction Bay - Upper Entrance
   \Lanayru\Lanayru Sand Sea\Shipyard\Construction Bay\Lower Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: F301_7
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2309
     short_name: Shipyard - Construction Bay - Lower Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Statue Entrance:
     type: entrance
     subtype: bird-statue-entrance
     province: Lanayru Province
-    statue-name: Pirate Stronghold
     stage: F301_6
-    room: 0
-    layer: 0
-    entrance: 10
-    tod: 2
-    flag-space: Lanayru Sand Sea
-    flag: 84
     allowed_time_of_day: 1
-    req_index: 2310
     short_name: Pirate Stronghold - Statue Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Dock Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_6
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2311
     short_name: Pirate Stronghold - Dock Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Side Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_6
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2312
     short_name: Pirate Stronghold - Side Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside the Shark Head\Top Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: F301_6
-    room: 0
-    layer: 0
-    entrance: 2
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2313
     short_name: Pirate Stronghold - Top Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\First Door Entrance:
     type: entrance
     province: Lanayru Province
     stage: F301_2
-    room: 1
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2314
     short_name: Pirate Stronghold - Inside - First Door Entrance
   \Lanayru\Lanayru Sand Sea\Pirate Stronghold\Inside\Second Door Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: F301_2
-    room: 1
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2315
     short_name: Pirate Stronghold - Inside - Second Door Entrance
   \Lanayru Mining Facility\Main\First Room\Main Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
     stage: D300
-    room: 0
-    layer: 0
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2316
     short_name: Lanayru Mining Facility - Main Entrance
   \Lanayru Mining Facility\Main\First Hub\Entrance from Big Hub:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2317
     short_name: Lanayru Mining Facility - First Hub - Entrance from Big Hub
   \Lanayru Mining Facility\Main\Hop Across Boxes Room\Near Exit\Entrance from Big Hub:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2318
     short_name: Lanayru Mining Facility - Hop Across Boxes Room - Entrance from Big
       Hub
   \Lanayru Mining Facility\Main\Armos Fight Room\Entrance from Big Hub:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2319
     short_name: Lanayru Mining Facility - Armos Fight Room - Entrance from Big Hub
   \Lanayru Mining Facility\Main\Big Hub\Entry\Entrance from First Hub:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2320
     short_name: Lanayru Mining Facility - Big Hub - Entrance from First Hub
   \Lanayru Mining Facility\Main\Big Hub\Near Exit to Hop Across Boxes Room\Entrance from Hop Across Boxes Room:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2321
     short_name: Lanayru Mining Facility - Big Hub - Entrance from Hop Across Boxes
       Room
   \Lanayru Mining Facility\Main\Big Hub\Past West Gate\Entrance from Armos Fight Room:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2322
     short_name: Lanayru Mining Facility - Big Hub - Entrance from Armos Fight Room
   \Lanayru Mining Facility\Main\Near Boss Door\Boss Door Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2323
     short_name: Lanayru Mining Facility - Boss Door Entrance
   \Lanayru Mining Facility\Boss Room\Entrance from Dungeon:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2324
     short_name: Lanayru Mining Facility - Boss Room - Entrance from Dungeon
   \Lanayru Mining Facility\Boss Room\After Sand Drain\Entrance from Hall of Ancient Robots:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2325
     short_name: Lanayru Mining Facility - Boss Room - Entrance from Hall of Ancient
       Robots
   \Lanayru Mining Facility\Hall of Ancient Robots\Entry\Entrance from Boss Room:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2326
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Boss
       Room
   \Lanayru Mining Facility\Hall of Ancient Robots\End\Entrance from Temple of Time:
@@ -14331,12 +12941,7 @@ entrances:
     can-start-at: false
     subtype: vanilla
     stage: F300_5
-    room: 0
-    layer: 0
-    entrance: 1
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2327
     short_name: Lanayru Mining Facility - Hall of Ancient Robots - Entrance from Temple
       of Time
   \Sandship\Main\Deck\Main Entrance:
@@ -14344,32 +12949,20 @@ entrances:
     province: Lanayru Province
     can-start-at: false
     stage: D301
-    room: 0
-    layer: 1
-    entrance: 0
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2328
     short_name: Sandship - Main Entrance
   \Sandship\Boss Room\Entrance:
     type: entrance
     province: Lanayru Province
     can-start-at: false
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2329
     short_name: Sandship - Boss Room - Entrance
   \Sky Keep\Main\First Room\Bottom Entrance:
     type: entrance
     province: The Sky
     can-start-at: false
     stage: D003_7
-    room: 0
-    layer: 0
-    entrance: 4
-    tod: 2
     allowed_time_of_day: 1
-    req_index: 2330
     short_name: Sky Keep - First Room - Bottom Entrance
 linked_entrances:
   silent_realms:

--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -498,22 +498,49 @@ class Areas:
                     reqs[area_bit] |= DNFInv(entrance)
 
     def to_dict(self):
+        def filter_values(data: Dict[str, dict], keys: List[str]):
+            return dict(
+                {
+                    id: dict({k: v for k, v in value.items() if k in keys})
+                    for id, value in data.items()
+                }
+            )
+
         return {
             "items": EXTENDED_ITEM.items_list,
             "areas": self.parent_area,
-            "checks": dict(
-                {
-                    id: dict(
-                        {k: v for k, v in check.items() if k in ["short_name", "type"]}
-                    )
-                    for id, check in self.checks.items()
-                }
+            "checks": filter_values(
+                self.checks, ["short_name", "type", "original item"]
             ),
             "gossip_stones": dict(
                 {k: v["short_name"] for k, v in self.gossip_stones.items()}
             ),
-            "exits": self.map_exits,
-            "entrances": self.map_entrances,
+            # NB "stage" should not really be needed in downstream consumers but it controls
+            # whether exits/entrances are available in Entrance Randomizer
+            "exits": filter_values(
+                self.map_exits,
+                [
+                    "type",
+                    "vanilla",
+                    "allowed_time_of_day",
+                    "subtype",
+                    "stage",
+                    "short_name",
+                    "pillar-province",
+                ],
+            ),
+            "entrances": filter_values(
+                self.map_entrances,
+                [
+                    "type",
+                    "can-start-at",
+                    "allowed_time_of_day",
+                    "subtype",
+                    "stage",
+                    "province",
+                    "short_name",
+                ],
+            ),
         }
 
     def __str__(self):


### PR DESCRIPTION
* Removes data only relevant to game patches (`room`, `index`, `layer`, ...) from the dump.
* `req_index` is easily reconstructed, as the `items` list in the dump can be inverted to get the requirement index for anything.
* Adds the `original item` key to checks. The immediate use case is that it allows the tracker to compute key semilogic when dungeon keys are not randomized.

This mostly aligns the dump with the [new-logic tracker's](https://robojumper.github.io/SS-Randomizer-Tracker/) type definitions at <https://github.com/robojumper/SS-Randomizer-Tracker/blob/new-logic-tracker/src/logic/UpstreamTypes.ts>. The dump can still be extended of course if there's a good reason for more data but e.g. #525 added more unneeded game data and it's unnecessary churn that makes it harder to review the actually relevant changes to the dump.