### PR TITLE
Hintgen hotfix for tourney

### DIFF
--- a/hints/distributions/Remlits Tournament.json
+++ b/hints/distributions/Remlits Tournament.json
@@ -54,8 +54,8 @@
     "goal":      {"order": 2, "weight": 0.00, "fixed": 1, "copies": 1},
     "sots":      {"order": 3, "weight": 0.00, "fixed": 0, "copies": 1},
     "item":      {"order": 4, "weight": 0.00, "fixed": 2, "copies": 1},
-    "sometimes": {"order": 5, "weight": 1.00, "fixed": 4, "copies": 1},
-    "random":    {"order": 6, "weight": 0.00, "fixed": 0, "copies": 1},
+    "sometimes": {"order": 5, "weight": 100.00, "fixed": 6, "copies": 1},
+    "random":    {"order": 6, "weight": 0.01, "fixed": 0, "copies": 1},
     "junk":      {"order": 7, "weight": 0.00, "fixed": 0, "copies": 1}
   }
 }


### PR DESCRIPTION
Adds a small weight to random hints in case of very extreme hint situations on the remlits distribution that could cause seeds to fail.

Ideally in the future we handle this more generally, but in case of no fix in time, this hotfix should work