### PR TITLE
Fix Fence Hop Softlock

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -1806,6 +1806,45 @@ F100: # Faron main area
     objtype: PLY
     object:
       play_cutscene: -1
+  # Copied from HD
+  - name: Prevent Fence Hop Softlock 1
+    type: objadd
+    layer: 0
+    room: 0
+    objtype: STAG
+    object:
+      params1: 0xFFFFFFC4
+      params2: 0xFFFFFFFF
+      posx: -2900.0
+      posy: -423.59515380859375
+      posz: 9900.0
+      sizex: 3095.841552734375
+      sizey: 2680.0
+      sizez: 940.346923828125
+      anglex: 0
+      angley: 51976
+      anglez: 0
+      id: 0xFDFE
+      name: ActTag
+  - name: Prevent Fence Hop Softlock 2
+    type: objadd
+    layer: 0
+    room: 0
+    objtype: STAG
+    object:
+      params1: 0xFFFFFFC4
+      params2: 0xFFFFFFFF
+      posx: -2100.0
+      posy: -423.59515380859375
+      posz: 11000.0
+      sizex: 3231.169189453125
+      sizey: 2680.0
+      sizez: 1064.70703125
+      anglex: 0
+      angley: 57624
+      anglez: 0
+      id: 0xFDFF
+      name: ActTag
 F101: # Deep Woods
   - name: Layer override
     type: layeroverride


### PR DESCRIPTION
## What does this PR do?
Adds the 2 `ActTag` objects that were added to Faron in the HD remake. These prevent the player's respawn info from being updated. Specifically, this prevents the respawn info from being updated while the player is near or on the fence between Faron and Lake Floria.

## How do you test this changes?
I tried voiding out at various points along the fence and specifically tried to replicate the known softlock. I was unable to softlock and Link would respawn in front of the fence each time.

## Notes
The areas don't cover the outside of the bridge that leads to Lake Floria. It is possible to respawn on the outside of it but not softlock (as far as I know)