### PR TITLE
Allow cleanly cancelling randomization

### DIFF
--- a/gui/guithreads.py
+++ b/gui/guithreads.py
@@ -6,10 +6,16 @@ from ssrando import Randomizer, StartupException
 from extractmanager import ExtractManager
 
 
+class GenerationCanceled(Exception):
+    def __str__(self):
+        return "Randomization was cancelled"
+
+
 class RandomizerThread(QThread):
     update_progress = Signal(str, int)
     error_abort = Signal(str)
     randomization_complete = Signal()
+    canceled = False
 
     def __init__(
         self, randomizer: Randomizer, extract_manager: ExtractManager, output_folder
@@ -23,6 +29,8 @@ class RandomizerThread(QThread):
 
     def create_ui_progress_callback(self, start_steps):
         def progress_cb(action, current_steps=None):
+            if self.canceled:
+                raise GenerationCanceled
             if not current_steps is None:
                 self.steps = start_steps + current_steps
             self.update_progress.emit(action, self.steps)

--- a/gui/randogui.py
+++ b/gui/randogui.py
@@ -385,6 +385,7 @@ class RandoGUI(QMainWindow):
             f"Randomizing - Hash: {self.rando.randomizer_hash}",
             "Initializing...",
             self.rando.get_total_progress_steps + extra_steps,
+            self.cancel_callback,
         )
         self.randomizer_thread = RandomizerThread(
             self.rando, self.extract_manager, self.options["output-folder"]
@@ -395,6 +396,9 @@ class RandoGUI(QMainWindow):
         )
         self.randomizer_thread.error_abort.connect(self.on_error)
         self.randomizer_thread.start()
+
+    def cancel_callback(self):
+        self.randomizer_thread.canceled = True
 
     def ui_progress_callback(
         self, current_action: str, completed_steps: int, total_steps: int = None


### PR DESCRIPTION
## What does this PR do?
Previously you could dismiss the progress dialog using ESC while randomization was ongoing, so you could have multiple randomization threads going on at the same time, usually resulting in a corrupt ISO.

This change allows randomization to be cleanly cancelled with a cancel button or the ESC key. This is achieved by throwing an exception in the progress callback after cancellation has been requested, which will fail the randomizer thread. The progress dialog is only ever manually closed by the main GUI thread after randomization has succeeded or failed.

## How do you test this changes?
* I tested on Windows
* I tested that the initial extraction progress dialog does **not** have a cancel button and cannot be cancelled via ESC.
* I tested that the randomization progress dialog has a cancel button.
* I tested that pressing this cancel button or hitting ESC makes randomization error out with a "Randomization was cancelled" error.
* I tested cancelling when the randomizer is generating hints, where it takes a few seconds for cancellation to go through. The progress dialog is not dismissed until the error popup appears.
* I tested cancelling randomization while files are being patched.

## Notes

Since hints generation does not call the progress callbacks, cancellation will take multiple seconds when hints are being generated. This could be improved by calling the progress callback when calculating the SotS items and generating hints, which would allow generation to be interrupted in this step.
