### PR TITLE
Change name of builds from "dist windows-latest"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,12 @@ jobs:
       - name: Copy Readme and changelog
         run: cp README.md CHANGELOG.md dist
         shell: bash
+      - uses: SebRollen/toml-action@v1.2.0
+        id: read_toml
+        with:
+          file: "pyproject.toml"
+          field: "tool.poetry.version"
       - uses: actions/upload-artifact@v4
         with:
-          name: dist ${{ matrix.os }}
+          name: Skyward Sword Randomizer v${{ steps.read_toml.outputs.value }}
           path: dist


### PR DESCRIPTION
## What does this PR do?
Changes the github actions builds from being named "dist windows-latest" to being named "Skyward Sword Randomizer v[version-number-from-pyproject.toml]"

## How do you test this changes?
I tested the change on a separate branch to make sure the build artifact was correctly named