### PR TITLE
Move boko base vc loadzone

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -3192,6 +3192,16 @@ F202: # Boko Base
       sizey: 2000
       sizez: 2000
       angle: 0
+  - name: Move loadzone into Boko Base Volcano Summit
+    type: objpatch
+    id: 0xFC22
+    layer: 1
+    room: 5
+    objtype: STAG
+    object:
+      posx: 13150
+      posy: 15000
+      posz: -23950
   - name: Patch jail pot to give Arrows
     type: objpatch
     id: 0x0849


### PR DESCRIPTION
## What does this PR do?
Patches the loadzone into Boko Base Volcano Summit to be in the same position as the Eldin Volcano Volcano Summit loadzone. Should make it impossible to perform the precise jumpslash over the Fi trigger preventing access without Fireshield Earrings

## How do you test this changes?
I tested to going through the loadzone from multiple angles and positions and it seems to be the same as the Eldin Volcano equivalent now. I don't know the setup for the trick so I didn't test that but the patch functionally works as expected :p