### PR TITLE
Weighted Starting Entrance Rando for fewer Skyloft starts

### DIFF
--- a/logic/logic_input.py
+++ b/logic/logic_input.py
@@ -358,6 +358,7 @@ class Areas:
                 EXTENDED_ITEM.items_list.append(full_address)
 
             entrance["short_name"] = partial_address
+            entrance["hint_region"] = self.areas[area_name].hint_region
             self.map_entrances[full_address] = entrance
 
         EXTENDED_ITEM.complete = True


### PR DESCRIPTION
## What does this PR do?
When using Starting Entrance Rando with Any or Any Surface Region, some areas are significantly more likely to be chosen because they have many dense entrances, e.g. Faron (Great Tree), Skyloft (all the house doors). This PR changes the weights so that entrances in regions with many entrances are significantly less likely to be picked and entrances in regions with few entrances are more likely to be picked, resulting in a more uniform choice of starting region.

## How do you test this changes?
I generated a bunch of (dry run) seeds.
I added some debug logging to verify that this makes Skyloft entrances less common.
