### PR TITLE
Prevent .gitignore from excluding custom_symbols/funcs from search tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ assets/default-link-data/*/metadata.json
 *.s
 # ignore any custom setting source files
 custom_*.*
+!/asm/**/custom_*.*


### PR DESCRIPTION
## What does this PR do?

VS Code / ripgrep's search is `.gitignore`-aware, so the rule above the added line excludes some legitimate source files. This adds an override for some actual source files that would otherwise be hidden from search tools.

## How do you test this changes?

VS Code search now finds the implementation of e.g. `fix_freestanding_item_y_offset`.

## Notes

The offending rule could also be made more specific if someone knows what files it's meant to match in the first place.