### PR TITLE
Unbork test suite, add logic settings tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,8 @@ jobs:
       - name: Build distribution
         run: python3 -mPyInstaller ssrando.spec
       - name: Run tests
+        run: python3 -mpytest -m "not iso"
+      - name: Run seed reproducibility check
         run: |
           python3 randoscript.py --noui --dry-run --seed=0
           cp -r logs logs_source

--- a/logic/inventory.py
+++ b/logic/inventory.py
@@ -58,6 +58,13 @@ class EXTENDED_ITEM(int, metaclass=MetaContainer):
     def get_item_name(cls, i: EXTENDED_ITEM) -> EXTENDED_ITEM_NAME:
         return cls.items_list[i]
 
+    @classmethod
+    def reset_for_test(cls):
+        """Only call this in test code. Resets the internal items list,
+        allowing tests to construct areas again"""
+        cls.items_list = list(extended_item_generator())  # type: ignore
+        cls.complete = False
+
     def __str__(self) -> str:
         return super().__repr__() + f" ({self.items_list[self]})"
 

--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -112,8 +112,8 @@ class Rando:
 
         self.randomised = False
 
-        def fun():
-            if not self.randomised:
+        def fun(**kwargs):
+            if not self.randomised and not kwargs.get("test_access_internals", False):
                 raise ValueError("Cannot extract hint logic before randomisation.")
             return LogicUtils(
                 areas,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,8 @@ pyinstaller = "^6.4.0"
 [tool.poetry.group.dev.dependencies]
 black = "^24.2.0"
 pytest = "^8.0.2"
+
+[tool.pytest.ini_options]
+markers = [
+    "iso: marks tests as requiring an extract (CI skips these with '-m \"not iso\"')",
+]

--- a/test/test_bzs.py
+++ b/test/test_bzs.py
@@ -6,6 +6,7 @@ import nlzss11
 
 
 @pytest.mark.parametrize("stage", ALL_STAGES)
+@pytest.mark.iso
 # @pytest.mark.parametrize("stage", ['F000'])
 def test_roundtrip(stage):
     with open(STAGEPATH / f"{stage}/{stage}_stg_l0.arc.LZ", "rb") as f:

--- a/test/test_logic.py
+++ b/test/test_logic.py
@@ -1,6 +1,8 @@
 import sys
 import os
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from ssrando import Randomizer
@@ -12,10 +14,11 @@ from logic.fill_algo_common import UserOutput
 import time
 import json
 
-areas = Areas(requirements, checks, hints, map_exits)
-useroutput = UserOutput(Exception, lambda s: None)
+# areas = Areas(requirements, checks, hints, map_exits)
+# useroutput = UserOutput(Exception, lambda s: None)
 
 
+@pytest.mark.skip(reason="broken, slow")
 def check_logs():
     opts = Options()
     opts.update_from_permalink("rQEAAASmAw==")
@@ -32,6 +35,7 @@ def check_logs():
         assert prog_spheres == should_prog_spheres
 
 
+@pytest.mark.skip(reason="broken, slow")
 def write_logs():
     opts = Options()
     opts.update_from_permalink("rQEAAASmAw==")
@@ -48,6 +52,7 @@ def write_logs():
         #     json.dump(prog_spheres, f, indent=2, sort_keys=True)
 
 
+@pytest.mark.skip(reason="broken, slow")
 def test_woth():
     opts = Options()
     opts.update_from_permalink("rQEAAASmAw==")
@@ -70,6 +75,7 @@ def test_woth():
         #     json.dump({'not':not_woth_prog, 'woth': woth_items}, f, indent=2)
 
 
+@pytest.mark.skip(reason="broken, slow")
 def test_barren():
     opts = Options()
     opts.update_from_permalink("rQEAAASmAw==")

--- a/test/test_msb.py
+++ b/test/test_msb.py
@@ -22,6 +22,7 @@ def get_all_msb():
     return all_msb
 
 
+@pytest.mark.iso
 def test_msb():
     for file, data in get_all_msb().items():
         print(f"testing {file}")

--- a/test/test_placement_file.py
+++ b/test/test_placement_file.py
@@ -1,6 +1,8 @@
 import sys
 import os
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from ssrando import Hints, Randomizer
@@ -11,6 +13,7 @@ from logic.fill_algo_common import UserOutput
 from yaml_files import requirements, checks, hints, map_exits
 
 
+@pytest.mark.skip(reason="broken, slow")
 def test_roundtrip():
     areas = Areas(requirements, checks, hints, map_exits)
     useroutput = UserOutput(Exception, lambda s: None)

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,0 +1,98 @@
+"""This file tests logic and option mapping behaviors to
+ensure that options have the desired impact on requirements."""
+
+import sys
+import os
+import random
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ssrando import Rando
+from options import Options
+from yaml_files import requirements, checks, hints, map_exits
+from logic.logic_input import Areas
+from logic.inventory import EXTENDED_ITEM
+
+
+@pytest.fixture
+def areas():
+    yield Areas(requirements, checks, hints, map_exits)
+    EXTENDED_ITEM.reset_for_test()
+
+
+def get_checks(areas, options):
+    rando = Rando(areas, options, random.Random(0))
+    logic = rando.extract_hint_logic(test_access_internals=True)
+    logic.fill_inventory_i()
+    return logic.accessible_checks()
+
+
+def test_gondo_upgrades(areas):
+    options = Options()
+    options.reset_to_default()
+    options.set_option(
+        "starting-items",
+        [
+            "Clawshots",
+            "Lanayru Caves Small Key",
+            "Progressive Beetle",
+            "Progressive Beetle",
+        ],
+    )
+    options.set_option("starting-tablet-count", 3)
+    options.set_option("rupeesanity", True)
+
+    # requires beetle
+    first_pillar_check = areas.short_to_full(
+        "Lanayru Sand Sea - Ancient Harbour - Rupee on First Pillar"
+    )
+    # requires quick beetle
+    crown_check = areas.short_to_full(
+        "Lanayru Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown"
+    )
+
+    # with gondo upgrades placed, we can't upgrade to Quick Beetle
+    options.set_option("gondo-upgrades", True)
+    accessible_checks = get_checks(areas, options)
+    assert first_pillar_check in accessible_checks
+    assert crown_check not in accessible_checks
+
+    # with gondo upgrades unplaced, we can farm flowers and hornet larvae
+    # to upgrade to quick beetle at gondo
+    options.set_option("gondo-upgrades", False)
+    accessible_checks = get_checks(areas, options)
+    assert first_pillar_check in accessible_checks
+    assert crown_check in accessible_checks
+
+
+def test_ban_caves_chest(areas):
+    options = Options()
+    options.reset_to_default()
+    options.set_option("excluded-locations", ["Lanayru Caves - Chest"])
+    # TODO this should not throw
+    with pytest.raises(ValueError):
+        get_checks(areas, options)
+
+
+def test_damage_multiplier(areas):
+    digspot_rbm_check = areas.short_to_full("Eldin Volcano - Digging Spot after Vents")
+
+    options = Options()
+    options.reset_to_default()
+    options.set_option("starting-tablet-count", 3)
+    options.set_option("starting-items", ["Progressive Slingshot", "Progressive Mitts"])
+    accessible_checks = get_checks(areas, options)
+    assert digspot_rbm_check in accessible_checks
+
+    options.set_option("damage-multiplier", 13)
+    accessible_checks = get_checks(areas, options)
+    assert digspot_rbm_check not in accessible_checks
+
+    options.set_option(
+        "starting-items",
+        ["Progressive Slingshot", "Progressive Mitts", "Fireshield Earrings"],
+    )
+    accessible_checks = get_checks(areas, options)
+    assert digspot_rbm_check in accessible_checks

--- a/test/test_u8.py
+++ b/test/test_u8.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 
 @pytest.mark.parametrize("stage", ALL_STAGES)
+@pytest.mark.iso
 # @pytest.mark.parametrize("stage", ['F000'])
 def test_roundtrip(stage):
     with open(STAGEPATH / f"{stage}" / f"{stage}_stg_l0.arc.LZ", "rb") as f:
@@ -24,6 +25,7 @@ def test_roundtrip(stage):
         assert roomdata == roomarc.to_buffer()
 
 
+@pytest.mark.iso
 def test_change_content():
     with open(STAGEPATH / "F000" / "F000_stg_l0.arc.LZ", "rb") as f:
         extracted_data = nlzss11.decompress(f.read())
@@ -37,6 +39,7 @@ def test_change_content():
     assert extracted_data == stagearc.to_buffer()
 
 
+@pytest.mark.iso
 def test_add_delete():
     with open(STAGEPATH / "F000" / "F000_stg_l0.arc.LZ", "rb") as f:
         extracted_data = nlzss11.decompress(f.read())


### PR DESCRIPTION
## What does this PR do?

Developers who want to add additional rando logic features (with additional settings)
have no way to verify that settings have the desired impact on requirements other than
generating a bunch of seeds and inferring likely requirements, which is error-prone.
The rando has a test suite, but the logic tests are broken and not run in CI.

This disables the broken tests, adds some modestly fast logic settings tests,
and runs them in CI (disabling tests that need an ISO extract for CI only).

## How do you test this changes?

`python -mpytest`

## Notes

The test scaffolding doesn't allow specific constructs like specific starting tables,
starting entrances, or specific required dungeons. This would be a reasonable
future extension, perhaps with tests for plandomizer.
