### PR TITLE
Prevent Setting Errors from Invalid Output Path

### DIFF
--- a/options.py
+++ b/options.py
@@ -175,8 +175,6 @@ class Options:
                 raise ValueError(f"Unknown choice for {option_name}: {option_value}.")
         elif option["type"] == "dirpath":
             path = Path(option_value).expanduser()
-            if not path.is_dir():
-                raise ValueError(f"Path {option_value} is not a directory.")
             option_value = path
         elif option["type"] == "string":
             if not isinstance(option_value, str):

--- a/ssrando.py
+++ b/ssrando.py
@@ -148,6 +148,13 @@ class Randomizer(BaseRandomizer):
         self.progress_callback = progress_callback
 
     def randomize(self):
+        # make sure the output path is valid if we're writing the patched game
+        if not (
+            self.options["dry-run"] or (dir := self.options["output-folder"]).is_dir()
+        ):
+            raise ValueError(
+                f"Path {dir} is not a directory. Please specify a valid output folder."
+            )
         useroutput = UserOutput(GenerationFailed, self.progress_callback)
         self.progress_callback("randomizing items...")
         self.rando.randomize(useroutput)


### PR DESCRIPTION
## What does this PR do?
The output path setting is now only validated upon randomization (if dry-run is off). This prevents the unexpected behavior that can result if a user generates directly to USB and then subsequently removes the USB, thereby preventing any future settings changes from saving as it constantly errors on saving the output path. It also means that this output path will remain when loaded from settings if the USB drive is not connected. 

## How do you test this changes?
I tried to generate to my USB without being connected, and it threw an error before randomization. I was still able to get a spoiler log with a dry run. I also launched the rando with said path in my settings file and it kept the path there.
