### PR TITLE
Imp 2 cutscene improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Additions
 ### Changes
 - Show small key count when getting key
+- Removed Groose text regarding the Groosenator when entering the imp 2 fight
+- Impa's text after killing imp 2 now teleports you straight to the sealed temple, removing
+  the need to skyward strike the spile.
 ### Bugfixes
 
 ## 2.2.0

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -2952,6 +2952,60 @@
     index: 495
     flow:
       next: 492
+  - name: Teleport to Temple after Imp 2
+    type: flowadd
+    flow:
+      type: type3
+      subType: 1
+      param1: 0
+      param2: 0
+      next: -1
+      param3: 10
+  - name: Set Imp 2 Storyflag
+    type: flowadd
+    flow:
+      type: type3
+      subType: 1
+      param1: 0
+      param2: 132
+      next: Teleport to Temple after Imp 2
+      param3: 0
+  - name: Unset Imp Fight Storyflag
+    type: flowadd
+    flow:
+      type: type3
+      subType: 1
+      param1: 0
+      param2: 136
+      next: Set Imp 2 Storyflag
+      param3: 1
+  - name: Unset SG 0x08
+    type: flowadd
+    flow:
+      type: type3
+      subType: 1
+      param1: 11 # 0x08
+      param2: 10
+      next: Unset Imp Fight Storyflag
+      param3: 3
+  - name: Unlock door to ST
+    type: flowadd
+    flow:
+      type: type3
+      subType: 1
+      param1: 13 # 0x20
+      param2: 10
+      next: Unset SG 0x08
+      param3: 2
+  - name: Skip skyward striking the spile
+    type: flowpatch
+    index: 27
+    flow:
+      next: Unlock door to ST
+  - name: Impa imp 2 text
+    type: textpatch
+    index: 39
+    text: "Well done, <heroname>!\nYou can now travel to the <r<past>>."
 501-Inpa:
   - name: botg context text
     type: textadd

--- a/patches.yaml
+++ b/patches.yaml
@@ -5163,7 +5163,19 @@ F401: # Sealed grounds Whirlpool
     layer: 1
     room: 1
     objtype: OBJ
-  - name: Groosenator before imp 2
+  - name: Groosenator before imp 2 1 # At least one of these three removes the cutscene, not sure which
+    type: objdelete
+    id: 0xFC93
+    layer: 3
+    room: 1
+    objtype: OBJ
+  - name: Groosenator before imp 2 2
+    type: objdelete
+    id: 0xFC94
+    layer: 3
+    room: 1
+    objtype: OBJ
+  - name: Groosenator before imp 2 3
     type: objdelete
     id: 0xFC9D
     layer: 3


### PR DESCRIPTION
#BringBackImp2

## What does this PR do?
- Removes Groose's text regarding the Groosenator prior to the imp 2 fight
- Impa's text teleports Link directly to the sealed temple after killing imp 2, removing the need to skyward strike the spile 

## How do you test these changes?
Turn off skip imp2 :)
