### PR TITLE
Remove stray top-slot dowsing targets in mogma turf

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -3467,6 +3467,30 @@ F210: # Mogma Turf
     layer: 0
     room: 0
     objtype: OBJ
+  - name: Remove Zelda Dowsing Target 1
+    type: objdelete
+    id: 0xFC80
+    layer: 1
+    room: 0
+    objtype: STAG
+  - name: Remove Zelda Dowsing Target 2
+    type: objdelete
+    id: 0xFC81
+    layer: 1
+    room: 0
+    objtype: STAG
+  - name: Remove Zelda Dowsing Target 3
+    type: objdelete
+    id: 0xFC82
+    layer: 1
+    room: 0
+    objtype: STAG
+  - name: Remove Propeller Dowsing Target
+    type: objdelete
+    id: 0xFC6B
+    layer: 0
+    room: 0
+    objtype: STAG
 F211:
   - name: Remove thrill digger entry CS
     type: objpatch


### PR DESCRIPTION
## What does this PR do?
Removes some Zelda/Propeller Dowsing targets in Mogma Turf that caused phantom pings, particularly in the upper regions of the area.

## How do you test this changes?
I generated a seed with no pinging chests in Mogma Turf, ventured over there, dowsed all around the area, and got no pings.

## Notes
These were just targets I must have missed when going through and removing them when preparing for chest dowsing.
