### PR TITLE
Hint Importance & Barren Changes

### DIFF
--- a/gui/dialogs/custom_theme/ui_custom_theme_dialog.py
+++ b/gui/dialogs/custom_theme/ui_custom_theme_dialog.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'custom_theme_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.0
+## Created by: Qt User Interface Compiler version 6.6.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -47,7 +47,7 @@ class Ui_CustomThemeDialog(object):
 
         self.widget_category_choice = QComboBox(self.custom_colors_tab)
         self.widget_category_choice.setObjectName(u"widget_category_choice")
-        sizePolicy = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.widget_category_choice.sizePolicy().hasHeightForWidth())
@@ -55,7 +55,7 @@ class Ui_CustomThemeDialog(object):
 
         self.hlay_widget_catergory.addWidget(self.widget_category_choice)
 
-        self.hspace_widget_category = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.hspace_widget_category = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.hlay_widget_catergory.addItem(self.hspace_widget_category)
 
@@ -69,7 +69,7 @@ class Ui_CustomThemeDialog(object):
         self.vlay_widget_name.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.widget_name_label = QLabel(self.custom_colors_tab)
         self.widget_name_label.setObjectName(u"widget_name_label")
-        sizePolicy1 = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Preferred)
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.widget_name_label.sizePolicy().hasHeightForWidth())
@@ -79,7 +79,7 @@ class Ui_CustomThemeDialog(object):
 
         self.vlay_widget_name.addWidget(self.widget_name_label)
 
-        self.vspace_widget_name = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.vspace_widget_name = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.vlay_widget_name.addItem(self.vspace_widget_name)
 
@@ -94,7 +94,7 @@ class Ui_CustomThemeDialog(object):
 
         self.vlay_color_light.addWidget(self.color_light_label)
 
-        self.vspace_color_light = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.vspace_color_light = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.vlay_color_light.addItem(self.vspace_color_light)
 
@@ -110,7 +110,7 @@ class Ui_CustomThemeDialog(object):
 
         self.vlay_color_dark.addWidget(self.color_dark_label)
 
-        self.vspace_color_dark = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.vspace_color_dark = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.vlay_color_dark.addItem(self.vspace_color_dark)
 
@@ -132,7 +132,7 @@ class Ui_CustomThemeDialog(object):
         self.vlay_demo_left.setObjectName(u"vlay_demo_left")
         self.demo_group_box = QGroupBox(self.demo_widgets_tab)
         self.demo_group_box.setObjectName(u"demo_group_box")
-        sizePolicy2 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         sizePolicy2.setHorizontalStretch(0)
         sizePolicy2.setVerticalStretch(0)
         sizePolicy2.setHeightForWidth(self.demo_group_box.sizePolicy().hasHeightForWidth())
@@ -174,7 +174,7 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line = QFrame(self.demo_group_box)
         self.demo_line.setObjectName(u"demo_line")
-        sizePolicy3 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        sizePolicy3 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         sizePolicy3.setHorizontalStretch(0)
         sizePolicy3.setVerticalStretch(0)
         sizePolicy3.setHeightForWidth(self.demo_line.sizePolicy().hasHeightForWidth())
@@ -277,7 +277,7 @@ class Ui_CustomThemeDialog(object):
 
         self.vlay_demo_group_box.addWidget(self.demo_dialogButtonBox)
 
-        self.vspace_demo = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.vspace_demo = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.vlay_demo_group_box.addItem(self.vspace_demo)
 
@@ -292,7 +292,7 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_separator_left = QFrame(self.demo_widgets_tab)
         self.demo_line_separator_left.setObjectName(u"demo_line_separator_left")
-        sizePolicy4 = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Expanding)
+        sizePolicy4 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
         sizePolicy4.setHorizontalStretch(0)
         sizePolicy4.setVerticalStretch(0)
         sizePolicy4.setHeightForWidth(self.demo_line_separator_left.sizePolicy().hasHeightForWidth())

--- a/gui/dialogs/tricks/ui_tricks_dialog.py
+++ b/gui/dialogs/tricks/ui_tricks_dialog.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'tricks_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.2
+## Created by: Qt User Interface Compiler version 6.6.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -1660,6 +1660,13 @@
               </widget>
              </item>
              <item>
+              <widget class="QCheckBox" name="option_hint_importance">
+               <property name="text">
+                <string>Hint Importance</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <spacer name="vspace_stone_hints">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'randogui.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.2
+## Created by: Qt User Interface Compiler version 6.6.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -1184,6 +1184,11 @@ class Ui_MainWindow(object):
 
         self.vlay_stone_hints.addWidget(self.option_precise_item)
 
+        self.option_hint_importance = QCheckBox(self.box_stone_hints)
+        self.option_hint_importance.setObjectName(u"option_hint_importance")
+
+        self.vlay_stone_hints.addWidget(self.option_hint_importance)
+
         self.vspace_stone_hints = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.vlay_stone_hints.addItem(self.vspace_stone_hints)
@@ -2133,6 +2138,7 @@ class Ui_MainWindow(object):
         self.label_for_option_hint_distribution.setText(QCoreApplication.translate("MainWindow", u"Hint Distribution", None))
         self.option_cube_sots.setText(QCoreApplication.translate("MainWindow", u"Separate Cube SotS Hints", None))
         self.option_precise_item.setText(QCoreApplication.translate("MainWindow", u"Precise Item Hints", None))
+        self.option_hint_importance.setText(QCoreApplication.translate("MainWindow", u"Hint Importance", None))
         self.box_other_hints.setTitle(QCoreApplication.translate("MainWindow", u"Other Hints", None))
         self.label_for_option_song_hints.setText(QCoreApplication.translate("MainWindow", u"Song Hints", None))
         self.option_impa_sot_hint.setText(QCoreApplication.translate("MainWindow", u"Impa Stone of Trials Hint", None))

--- a/hints/hint_distribution.py
+++ b/hints/hint_distribution.py
@@ -328,14 +328,19 @@ class HintDistribution:
         silent_realm_checks_rev = SILENT_REALM_CHECKS_REV(self.areas.short_to_full)
         trial_rando = self.options["randomize-trials"]
 
+        if self.options["hint-importance"]:
+            importance = self.logic.get_importance_for_item(item)
+        else:
+            importance = HINT_IMPORTANCE.Null
+
         if trial_rando and loc in silent_realm_checks_rev:
             trial = silent_realm_checks_rev[loc]
             trial_gate = {
                 v: k for k, v in self.logic.randomized_trial_entrance.items()
             }[trial]
-            return TrialGateHint(loc, item, trial_gate)
+            return TrialGateHint(loc, item, importance, trial_gate)
         else:
-            return LocationHint("always", loc, item, text)
+            return LocationHint("always", loc, item, importance, text)
 
     def _create_sometimes_hint(self):
         if not self.sometimes_hints:
@@ -352,7 +357,12 @@ class HintDistribution:
             return self._create_sometimes_hint()
         self.hinted_locations.append(loc)
 
-        return LocationHint("sometimes", loc, item, text)
+        if self.options["hint-importance"]:
+            importance = self.logic.get_importance_for_item(item)
+        else:
+            importance = HINT_IMPORTANCE.Null
+
+        return LocationHint("sometimes", loc, item, importance, text)
 
     def _create_bk_hint(self):
         if not self.required_boss_keys:
@@ -369,7 +379,12 @@ class HintDistribution:
             return self._create_bk_hint()
         self.hinted_locations.append(loc)
 
-        return LocationHint("boss_key", loc, item, text)
+        if self.options["hint-importance"]:
+            importance = self.logic.get_importance_for_item(item)
+        else:
+            importance = HINT_IMPORTANCE.Null
+
+        return LocationHint("boss_key", loc, item, importance, text)
 
     def _create_item_hint(self):
         if not self.hintable_items:
@@ -382,14 +397,19 @@ class HintDistribution:
             return self._create_item_hint()
         self.hinted_locations.append(loc)
 
+        if self.options["hint-importance"]:
+            importance = self.logic.get_importance_for_item(item)
+        else:
+            importance = HINT_IMPORTANCE.Null
+
         if self.options["precise-item"]:
             text = self.areas.checks[loc].get("text")
-            return LocationHint("precise_item", loc, item, text)
+            return LocationHint("precise_item", loc, item, importance, text)
 
         if (zone_override := self.areas.checks[loc].get("cube_region")) is None:
             zone_override = self.areas.checks[loc]["hint_region"]
 
-        return ZoneItemHint(loc, item, zone_override)
+        return ZoneItemHint(loc, item, importance, zone_override)
 
     def _create_random_hint(self):
         all_locations_without_hint = [
@@ -410,7 +430,12 @@ class HintDistribution:
             text = self.areas.checks[loc].get("text")
         self.hinted_locations.append(loc)
 
-        return LocationHint("random", loc, item, text)
+        if self.options["hint-importance"]:
+            importance = self.logic.get_importance_for_item(item)
+        else:
+            importance = HINT_IMPORTANCE.Null
+
+        return LocationHint("random", loc, item, importance, text)
 
     def _create_sots_goal_hint(self, goal_mode=False):
         if goal_mode:
@@ -466,10 +491,12 @@ class HintDistribution:
                     zone = LANAYRU_DESERT
                 elif zone == LANAYRU_GORGE:
                     zone = LANAYRU_SAND_SEA
-                return CubeSotsGoalHint(loc, item, zone, goal)
+                # Importance doesn't matter for SotS hints, so just pass in Null
+                return CubeSotsGoalHint(loc, item, HINT_IMPORTANCE.Null, zone, goal)
         else:
             zone = self.areas.checks[loc]["hint_region"]
-        return SotsGoalHint(loc, item, zone, goal)
+        # Importance doesn't matter for SotS hints, so just pass in Null
+        return SotsGoalHint(loc, item, HINT_IMPORTANCE.Null, zone, goal)
 
     def _create_sots_hint(self):
         return self._create_sots_goal_hint(goal_mode=False)

--- a/logic/logic_utils.py
+++ b/logic/logic_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from functools import cache
 from typing import List  # Only for typing purposes
+from hints.hint_types import HINT_IMPORTANCE
 
 from .logic import Logic, Placement, LogicSettings
 from .logic_input import Areas
@@ -252,7 +253,9 @@ class LogicUtils(Logic):
             [k for k, v in checks_per_region.items() if v == 0],
         )
 
-    def get_barren_regions(self, bit=EVERYTHING_UNBANNED_BIT):
+    def get_barren_regions(self, bit=None):
+        if bit is None:
+            bit = EXTENDED_ITEM[self.short_to_full(DEMISE)]
         return self._get_barren_regions(bit)
 
     def calculate_playthrough_progression_spheres(self):
@@ -313,3 +316,17 @@ class LogicUtils(Logic):
                 return 8
 
         return {k: dowse(v) for k, v in self.placement.locations.items()}
+
+    def get_importance_for_item(self, item):
+        # Skip trivially unrequired items
+        if item not in self.get_useful_items():
+            return HINT_IMPORTANCE.Null
+        # Then check if the item is SotS
+        if item in self.get_sots_items():
+            return HINT_IMPORTANCE.Required
+        # Then check if the item is considered useful for Demise; ultimately unrequired items will not count
+        elif item in self.get_useful_items(EXTENDED_ITEM[self.short_to_full(DEMISE)]):
+            return HINT_IMPORTANCE.PossiblyRequired
+        # The item must now be not required
+        else:
+            return HINT_IMPORTANCE.NotRequired

--- a/options.yaml
+++ b/options.yaml
@@ -1112,3 +1112,12 @@
   help: If enabled, the starting statue for each surface region will be randomized. All overworld statues
         except Inside the Volcano and Inside Fire Sanctuary may be chosen.
   ui: option_random_start_statues
+- name: Hint Importance
+  command: hint-importance
+  type: boolean
+  default: false
+  help: If enabled, location hints, item hints, and Direct song hints will tell if an item is required (a SotS item),
+        possibly required (a progress item that isn't SotS but unlocks useful locations), or not required
+        (a progress item that only unlocks ultimately useless locations and can be ignored). This text will not
+        appear for items that are trivially unrequired (i.e., junk items).
+  ui: option_hint_importance


### PR DESCRIPTION
## What does this PR do?
Adds an option for hint importance. This will add clarification in location, item, and direct song hints of whether an item is required (SotS), not required (only unlocks ultimately useless checks), or possibly required (any other progress item). This also changes the definition of a barren region to match that of "not required" or trivially unrequired items--simply checking for items useful to Demise rather than the "Everything unbanned bit". Basic and Advanced song hints also now use the importance definitions for their hints. 

## How do you test this changes?
- Generate seeds, verifying that
  - It is possible for regions that have items that appear in the playthrough to be barren, if those items only unlock barren locations
  - With hint importance, relevant hints get the correct importance.
  - The text shows up with correct formatting in-game.

## Notes
Currently, possibly required is a very weak label -- for instance, Batreaux 50 could lock every other crystal pack and those crystal packs would still be considered possibly required. Also, chest dowsing does NOT consider hint importance currently; I'm open to discussion on how to handle this.
