### PR TITLE
remove unnecessary arcs from eldin

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -2524,6 +2524,18 @@ F200: # Eldin main area
       - story_flag: -1
         night: 0
         layer: 1
+  - name: Monster horn arc delete
+    type: oarcdelete
+    oarc: GetSozaiL
+    layer: 1
+  - name: Golden Skull arc delete
+    type: oarcdelete
+    oarc: GetSozaiO
+    layer: 1
+  - name: Key piece arc delete
+    type: oarcdelete
+    oarc: GetKeyKakera
+    layer: 1
   - name: intro cs
     type: objmove
     id: 0xFC26
@@ -2599,12 +2611,16 @@ F200: # Eldin main area
     destlayer: 0
     room: 2
     objtype: STAG
-  - name: Propeller delete # undo this when starting without scrapper repaired
+  - name: Propeller delete
     type: objdelete
     id: 0xFC2E
     layer: 0
     room: 4
     objtype: OBJ
+  - name: Propeller arc delete
+    type: oarcdelete
+    oarc: Pinwheel
+    layer: 0
   - name: Forced camera when draining lava before digging mitts
     type: objdelete
     id: 0xFCD6


### PR DESCRIPTION
## What does this PR do?
Removes some arcs from eldin to make it less likely to crash

## How do you test this changes?
Make sure eldin still works and I didn't delete something important by accident

## Notes
It's still possible for eldin to crash, but that can't be fixed without dynamically loading item arcs
