### PR TITLE
update brres.py to support extracting External data

### DIFF
--- a/brresTools/brres.py
+++ b/brresTools/brres.py
@@ -17,6 +17,8 @@ SECTION_TYPES = [
     b"SCN0",
     b"PLT0",
     b"VIS0",
+    b"RASD", # Follows the Same Formats as others with 4-byte sig.
+    b"EXT ", # Not an actual sig, but used for data in external folder.
 ]
 
 
@@ -98,14 +100,10 @@ class BRRES:
             name_offset = struct.unpack(">L", data.read(4))[0]
             data_offset = struct.unpack(">L", data.read(4))[0]
 
-            data.seek(group_start_offset + name_offset)
+            data.seek(group_start_offset + name_offset - 4)
 
-            name = ""
-            while True:
-                part = data.read(1)
-                if part == b"\x00":
-                    break
-                name += str(part, "utf-8")
+            name_len = struct.unpack(">L", data.read(4))[0]
+            name = str(struct.unpack(f">{name_len}s", data.read(name_len))[0], "utf-8")
 
             data.seek(group_start_offset + data_offset)
 
@@ -114,6 +112,12 @@ class BRRES:
             if identifier in SECTION_TYPES:
                 entryNode = SubFileNode(
                     fileType=identifier,
+                    name=name,
+                    dataOffset=(group_start_offset + data_offset),
+                )
+            elif indexGroupNode.name == "External":
+                entryNode = SubFileNode(
+                    fileType=b"EXT ",
                     name=name,
                     dataOffset=(group_start_offset + data_offset),
                 )
@@ -126,6 +130,21 @@ class BRRES:
                 )
 
             indexGroupNode.add_child(entryNode)
+
+    def get_all_paths(self) -> list[str]:
+        def _get_all_paths(
+            group_node: IndexGroupNode, folder_path: str, name_list: list[str]
+        ):
+            for node in group_node.childNodes:
+                full_path = folder_path + "/" + node.name
+                if type(node) is SubFileNode:
+                    name_list.append(full_path)
+                if node.nodeType == "group":
+                    _get_all_paths(node, full_path, name_list)
+
+        str_list = []
+        _get_all_paths(self.rootGroupNode, "", str_list)
+        return str_list
 
     def get_file_node(self, path: str) -> SubFileNode:
         path = path.lstrip("/")
@@ -182,6 +201,16 @@ class BRRES:
                 raise Exception(f"Unsupported file type {file.nodeType}.")
             case b"VIS0":
                 raise Exception(f"Unsupported file type {file.nodeType}.")
+            case b"RASD":
+                # Usually found in External Folder, but follows the common
+                # signature pattern as other brres types
+                raise Exception(f"Unsupported file type {file.nodeType}.")
+            case b"EXT ":
+                # This just returns the bytes to be parsed from the caller.
+                # This is because data stored in the external folder can be of
+                #    any type. The Caller needs to truncate to the size needed
+                self.dataBuffer.seek(dataOffset)
+                return self.dataBuffer.read()
             case _:
                 raise FileNotFoundError(
                     f"Invalid subfile type {file.nodeType} in get_file_data."
@@ -222,6 +251,10 @@ class BRRES:
             case b"PLT0":
                 raise Exception(f"Unsupported file type {file.nodeType}.")
             case b"VIS0":
+                raise Exception(f"Unsupported file type {file.nodeType}.")
+            case b"RASD":
+                raise Exception(f"Unsupported file type {file.nodeType}.")
+            case b"EXT ":
                 raise Exception(f"Unsupported file type {file.nodeType}.")
             case _:
                 raise FileNotFoundError(

--- a/brresTools/brres.py
+++ b/brresTools/brres.py
@@ -17,8 +17,8 @@ SECTION_TYPES = [
     b"SCN0",
     b"PLT0",
     b"VIS0",
-    b"RASD", # Follows the Same Formats as others with 4-byte sig.
-    b"EXT ", # Not an actual sig, but used for data in external folder.
+    b"RASD",  # Follows the Same Formats as others with 4-byte sig.
+    b"EXT ",  # Not an actual sig, but used for data in external folder.
 ]
 
 


### PR DESCRIPTION
## What does this PR do?
- Adds External Folder support to brres.py
- Adds the `get_all_paths` for brres files
- slightly changes the name reading since the string pool gives the size of the string (no loop search for null term required)

## How do you test this changes?
brres modification *should* remain untouched. if texture replacement still works, this should be good to go.

## Notes
Only reason I wanted to update here is for any other program that may reference this file to do something.
