### PR TITLE
Allow saving the other Kikwis before Machi (HDR port)

### DIFF
--- a/patches.yaml
+++ b/patches.yaml
@@ -1855,6 +1855,50 @@ F100: # Faron main area
       anglez: 0
       id: 0xFDFF
       name: ActTag
+  - name: Always spawn Lopsa
+    type: objpatch
+    id: 0x56B5
+    layer: 1
+    room: 0
+    objtype: OBJ
+    object:
+      trigstoryfid: -1
+  - name: Always spawn Erla
+    type: objpatch
+    id: 0x5EB6
+    layer: 1
+    room: 0
+    objtype: OBJ
+    object:
+      trigstoryfid: -1
+  - name: Always spawn Oolo
+    type: objpatch
+    id: 0x0AB4
+    layer: 1
+    room: 0
+    objtype: OBJ
+    object:
+      trigstoryfid: -1
+  # These patches make it so that the bokos around Machi don't trigger a cutscene.
+  # This is necessary to allow the Kikwis to be saved in any order (specifically,
+  # triggering the Lopsa bokos breaks the Machi bokos and requires the area be reloaded).
+  # "If this seems like voodoo magic, that's because it is :p" - Esme
+  - name: Patch Machi boko 1
+    type: objpatch
+    id: 0x66CE
+    layer: 1
+    room: 0
+    objtype: OBJ
+    object:
+      params1: 0xF1FFFF20 # 0xF0... -> 0xF1...
+  - name: Patch Machi boko 2
+    type: objpatch
+    id: 0x66CF
+    layer: 1
+    room: 0
+    objtype: OBJ
+    object:
+      params1: 0xF1FFFF20 # 0xF0... -> 0xF1...
 F101: # Deep Woods
   - name: Layer override
     type: layeroverride


### PR DESCRIPTION
## What does this PR do?
Lopsa, Erla, and Oolo are available from the start in Faron Woods. They can be saved before Machi -- saving Machi spawns Bucha, allowing you to collect the reward.

## How do you test this changes?
I generated a new seed with the patches and was able to save the other Kikwis, then save Machi, then collect the reward.

## Notes
Ported from HD Rando, with object IDs adjusted to line up correctly.
