### PR TITLE
Fix Flag Collision w/ Eldin Trial Relic 1

### DIFF
--- a/checks.yaml
+++ b/checks.yaml
@@ -1858,52 +1858,52 @@ Skyloft Silent Realm - Relic 1:
   type: skyloft, silent realm
   Paths:
     # fake object name to handle them better
-    - stage/S000/r0/l2/Relic/102
+    - stage/S000/r0/l2/Relic/103
 Skyloft Silent Realm - Relic 2:
   original item: "Dusk Relic #2"
   type: skyloft, silent realm
   Paths:
-    - stage/S000/r0/l2/Relic/103
+    - stage/S000/r0/l2/Relic/104
 Skyloft Silent Realm - Relic 3:
   original item: "Dusk Relic #3"
   type: skyloft, silent realm
   Paths:
-    - stage/S000/r0/l2/Relic/104
+    - stage/S000/r0/l2/Relic/105
 Skyloft Silent Realm - Relic 4:
   original item: "Dusk Relic #4"
   type: skyloft, silent realm
   Paths:
-    - stage/S000/r0/l2/Relic/105
+    - stage/S000/r0/l2/Relic/106
 Skyloft Silent Realm - Relic 5:
   original item: "Dusk Relic #5"
   type: skyloft, silent realm
   Paths:
-    - stage/S000/r0/l2/Relic/106
+    - stage/S000/r0/l2/Relic/107
 Skyloft Silent Realm - Relic 6:
   original item: "Dusk Relic #6"
   type: skyloft, silent realm
   Paths:
-    - stage/S000/r0/l2/Relic/107
+    - stage/S000/r0/l2/Relic/108
 Skyloft Silent Realm - Relic 7:
   original item: "Dusk Relic #7"
   type: skyloft, silent realm
   Paths:
-    - stage/S000/r0/l2/Relic/108
+    - stage/S000/r0/l2/Relic/109
 Skyloft Silent Realm - Relic 8:
   original item: "Dusk Relic #8"
   type: skyloft, silent realm
   Paths:
-    - stage/S000/r0/l2/Relic/109
+    - stage/S000/r0/l2/Relic/110
 Skyloft Silent Realm - Relic 9:
   original item: "Dusk Relic #9"
   type: skyloft, silent realm
   Paths:
-    - stage/S000/r0/l2/Relic/110
+    - stage/S000/r0/l2/Relic/111
 Skyloft Silent Realm - Relic 10:
   original item: "Dusk Relic #10"
   type: skyloft, silent realm
   Paths:
-    - stage/S000/r0/l2/Relic/111
+    - stage/S000/r0/l2/Relic/112
 
 Faron Silent Realm - Trial Reward:
   original item: Water Dragon's Scale
@@ -1916,52 +1916,52 @@ Faron Silent Realm - Relic 1:
   original item: "Dusk Relic #11"
   type: faron, silent realm
   Paths:
-    - stage/S100/r0/l2/Relic/102
+    - stage/S100/r0/l2/Relic/103
 Faron Silent Realm - Relic 2:
   original item: "Dusk Relic #12"
   type: faron, silent realm
   Paths:
-    - stage/S100/r0/l2/Relic/103
+    - stage/S100/r0/l2/Relic/104
 Faron Silent Realm - Relic 3:
   original item: "Dusk Relic #13"
   type: faron, silent realm
   Paths:
-    - stage/S100/r0/l2/Relic/104
+    - stage/S100/r0/l2/Relic/105
 Faron Silent Realm - Relic 4:
   original item: "Dusk Relic #14"
   type: faron, silent realm
   Paths:
-    - stage/S100/r0/l2/Relic/105
+    - stage/S100/r0/l2/Relic/106
 Faron Silent Realm - Relic 5:
   original item: "Dusk Relic #15"
   type: faron, silent realm
   Paths:
-    - stage/S100/r0/l2/Relic/106
+    - stage/S100/r0/l2/Relic/107
 Faron Silent Realm - Relic 6:
   original item: "Dusk Relic #16"
   type: faron, silent realm
   Paths:
-    - stage/S100/r0/l2/Relic/107
+    - stage/S100/r0/l2/Relic/108
 Faron Silent Realm - Relic 7:
   original item: "Dusk Relic #17"
   type: faron, silent realm
   Paths:
-    - stage/S100/r0/l2/Relic/108
+    - stage/S100/r0/l2/Relic/109
 Faron Silent Realm - Relic 8:
   original item: "Dusk Relic #18"
   type: faron, silent realm
   Paths:
-    - stage/S100/r0/l2/Relic/109
+    - stage/S100/r0/l2/Relic/110
 Faron Silent Realm - Relic 9:
   original item: "Dusk Relic #19"
   type: faron, silent realm
   Paths:
-    - stage/S100/r0/l2/Relic/110
+    - stage/S100/r0/l2/Relic/111
 Faron Silent Realm - Relic 10:
   original item: "Dusk Relic #20"
   type: faron, silent realm
   Paths:
-    - stage/S100/r0/l2/Relic/111
+    - stage/S100/r0/l2/Relic/112
 
 Lanayru Silent Realm - Trial Reward:
   original item: Clawshots
@@ -1974,52 +1974,52 @@ Lanayru Silent Realm - Relic 1:
   original item: "Dusk Relic #21"
   type: lanayru, silent realm
   Paths:
-    - stage/S300/r0/l2/Relic/102
+    - stage/S300/r0/l2/Relic/103
 Lanayru Silent Realm - Relic 2:
   original item: "Dusk Relic #22"
   type: lanayru, silent realm
   Paths:
-    - stage/S300/r0/l2/Relic/103
+    - stage/S300/r0/l2/Relic/104
 Lanayru Silent Realm - Relic 3:
   original item: "Dusk Relic #23"
   type: lanayru, silent realm
   Paths:
-    - stage/S300/r0/l2/Relic/104
+    - stage/S300/r0/l2/Relic/105
 Lanayru Silent Realm - Relic 4:
   original item: "Dusk Relic #24"
   type: lanayru, silent realm
   Paths:
-    - stage/S300/r0/l2/Relic/105
+    - stage/S300/r0/l2/Relic/106
 Lanayru Silent Realm - Relic 5:
   original item: "Dusk Relic #25"
   type: lanayru, silent realm
   Paths:
-    - stage/S300/r0/l2/Relic/106
+    - stage/S300/r0/l2/Relic/107
 Lanayru Silent Realm - Relic 6:
   original item: "Dusk Relic #26"
   type: lanayru, silent realm
   Paths:
-    - stage/S300/r0/l2/Relic/107
+    - stage/S300/r0/l2/Relic/108
 Lanayru Silent Realm - Relic 7:
   original item: "Dusk Relic #27"
   type: lanayru, silent realm
   Paths:
-    - stage/S300/r0/l2/Relic/108
+    - stage/S300/r0/l2/Relic/109
 Lanayru Silent Realm - Relic 8:
   original item: "Dusk Relic #28"
   type: lanayru, silent realm
   Paths:
-    - stage/S300/r0/l2/Relic/109
+    - stage/S300/r0/l2/Relic/110
 Lanayru Silent Realm - Relic 9:
   original item: "Dusk Relic #29"
   type: lanayru, silent realm
   Paths:
-    - stage/S300/r0/l2/Relic/110
+    - stage/S300/r0/l2/Relic/111
 Lanayru Silent Realm - Relic 10:
   original item: "Dusk Relic #30"
   type: lanayru, silent realm
   Paths:
-    - stage/S300/r0/l2/Relic/111
+    - stage/S300/r0/l2/Relic/112
 
 Eldin Silent Realm - Trial Reward:
   original item: Fireshield Earrings
@@ -2032,49 +2032,49 @@ Eldin Silent Realm - Relic 1:
   original item: "Dusk Relic #31"
   type: eldin, silent realm
   Paths:
-    - stage/S200/r0/l2/Relic/102
+    - stage/S200/r0/l2/Relic/103
 Eldin Silent Realm - Relic 2:
   original item: "Dusk Relic #32"
   type: eldin, silent realm
   Paths:
-    - stage/S200/r0/l2/Relic/103
+    - stage/S200/r0/l2/Relic/104
 Eldin Silent Realm - Relic 3:
   original item: "Dusk Relic #33"
   type: eldin, silent realm
   Paths:
-    - stage/S200/r0/l2/Relic/104
+    - stage/S200/r0/l2/Relic/105
 Eldin Silent Realm - Relic 4:
   original item: "Dusk Relic #34"
   type: eldin, silent realm
   Paths:
-    - stage/S200/r0/l2/Relic/105
+    - stage/S200/r0/l2/Relic/106
 Eldin Silent Realm - Relic 5:
   original item: "Dusk Relic #35"
   type: eldin, silent realm
   Paths:
-    - stage/S200/r0/l2/Relic/106
+    - stage/S200/r0/l2/Relic/107
 Eldin Silent Realm - Relic 6:
   original item: "Dusk Relic #36"
   type: eldin, silent realm
   Paths:
-    - stage/S200/r0/l2/Relic/107
+    - stage/S200/r0/l2/Relic/108
 Eldin Silent Realm - Relic 7:
   original item: "Dusk Relic #37"
   type: eldin, silent realm
   Paths:
-    - stage/S200/r0/l2/Relic/108
+    - stage/S200/r0/l2/Relic/109
 Eldin Silent Realm - Relic 8:
   original item: "Dusk Relic #38"
   type: eldin, silent realm
   Paths:
-    - stage/S200/r0/l2/Relic/109
+    - stage/S200/r0/l2/Relic/110
 Eldin Silent Realm - Relic 9:
   original item: "Dusk Relic #39"
   type: eldin, silent realm
   Paths:
-    - stage/S200/r0/l2/Relic/110
+    - stage/S200/r0/l2/Relic/111
 Eldin Silent Realm - Relic 10:
   original item: "Dusk Relic #40"
   type: eldin, silent realm
   Paths:
-    - stage/S200/r0/l2/Relic/111
+    - stage/S200/r0/l2/Relic/112

--- a/eventpatches.yaml
+++ b/eventpatches.yaml
@@ -2394,12 +2394,6 @@
     flow:
       param2: 82 # Tadtones Scroll storyflag
       param3: 0 # set (not unset) flag
-250-ForestSiren:
-  - name: shorten fi text
-    type: flowpatch
-    index: 1
-    flow:
-      next: 78
 299-Demo:
   - name: Skip setting sword itemflag
     type: flowpatch

--- a/patches.yaml
+++ b/patches.yaml
@@ -182,6 +182,15 @@ global:
       - 83 # Cutscene showing the outside of the Fire Sanctuary
       - onlyif: Option "fs-lava-flow" Enabled
         flag: 64 # Blow up rock underground starting lava chase (back half lava flow)
+    Faron Silent Realm:
+      - 100 # Intro Fi Text + Spirit Vessel get
+    Lanayru Silent Realm:
+      - 101 # Intro Fi Text + Spirit Vessel get
+    Eldin Silent Realm:
+      - 102 # Intro Fi Text + Spirit Vessel get
+    Skyloft Silent Realm:
+      - 100 # Intro Fi Text + Spirit Vessel get (it seems to set both flags)
+      - 101
   objpackoarcadd: # Models to add to the global ObjectPack.arc.LZ file
     - GetSozaiL # Monster Horn (part of treasure)
     # - GetSozaiM # Evil Crystal (part of treasure), already part of objectpack


### PR DESCRIPTION
## What does this PR do?
Since Relic scene flags were delegated from 102-111, Relic 1 in Eldin Trial would disappear after the first load, as its flag (102) is shared by the flag set at the start of the trial. This offsets all flags by 1 to fix this issue.

## How do you test this changes?
I loaded into each silent realm, verifying that none of the scene flags set collided with a relic's scene flag, and verified that no items disappeared after a reload.

## Notes
Also sets the intro text flags as startflags for each silent realm, skipping the Spirit Vessel animation & question prompt