### PR TITLE
Improve element layout for better counter legibility

### DIFF
--- a/gui/dialogs/custom_theme/ui_custom_theme_dialog.py
+++ b/gui/dialogs/custom_theme/ui_custom_theme_dialog.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'custom_theme_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.0
+## Created by: Qt User Interface Compiler version 6.8.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -47,7 +47,7 @@ class Ui_CustomThemeDialog(object):
 
         self.widget_category_choice = QComboBox(self.custom_colors_tab)
         self.widget_category_choice.setObjectName(u"widget_category_choice")
-        sizePolicy = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.widget_category_choice.sizePolicy().hasHeightForWidth())
@@ -55,7 +55,7 @@ class Ui_CustomThemeDialog(object):
 
         self.hlay_widget_catergory.addWidget(self.widget_category_choice)
 
-        self.hspace_widget_category = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.hspace_widget_category = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.hlay_widget_catergory.addItem(self.hspace_widget_category)
 
@@ -69,7 +69,7 @@ class Ui_CustomThemeDialog(object):
         self.vlay_widget_name.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.widget_name_label = QLabel(self.custom_colors_tab)
         self.widget_name_label.setObjectName(u"widget_name_label")
-        sizePolicy1 = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Preferred)
+        sizePolicy1 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.widget_name_label.sizePolicy().hasHeightForWidth())
@@ -79,7 +79,7 @@ class Ui_CustomThemeDialog(object):
 
         self.vlay_widget_name.addWidget(self.widget_name_label)
 
-        self.vspace_widget_name = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.vspace_widget_name = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.vlay_widget_name.addItem(self.vspace_widget_name)
 
@@ -94,7 +94,7 @@ class Ui_CustomThemeDialog(object):
 
         self.vlay_color_light.addWidget(self.color_light_label)
 
-        self.vspace_color_light = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.vspace_color_light = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.vlay_color_light.addItem(self.vspace_color_light)
 
@@ -110,7 +110,7 @@ class Ui_CustomThemeDialog(object):
 
         self.vlay_color_dark.addWidget(self.color_dark_label)
 
-        self.vspace_color_dark = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.vspace_color_dark = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.vlay_color_dark.addItem(self.vspace_color_dark)
 
@@ -132,7 +132,7 @@ class Ui_CustomThemeDialog(object):
         self.vlay_demo_left.setObjectName(u"vlay_demo_left")
         self.demo_group_box = QGroupBox(self.demo_widgets_tab)
         self.demo_group_box.setObjectName(u"demo_group_box")
-        sizePolicy2 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         sizePolicy2.setHorizontalStretch(0)
         sizePolicy2.setVerticalStretch(0)
         sizePolicy2.setHeightForWidth(self.demo_group_box.sizePolicy().hasHeightForWidth())
@@ -150,8 +150,8 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_3 = QFrame(self.demo_group_box)
         self.demo_line_3.setObjectName(u"demo_line_3")
-        self.demo_line_3.setFrameShape(QFrame.HLine)
-        self.demo_line_3.setFrameShadow(QFrame.Sunken)
+        self.demo_line_3.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line_3.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_group_box.addWidget(self.demo_line_3)
 
@@ -162,8 +162,8 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_2 = QFrame(self.demo_group_box)
         self.demo_line_2.setObjectName(u"demo_line_2")
-        self.demo_line_2.setFrameShape(QFrame.HLine)
-        self.demo_line_2.setFrameShadow(QFrame.Sunken)
+        self.demo_line_2.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line_2.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_group_box.addWidget(self.demo_line_2)
 
@@ -174,13 +174,13 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line = QFrame(self.demo_group_box)
         self.demo_line.setObjectName(u"demo_line")
-        sizePolicy3 = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        sizePolicy3 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         sizePolicy3.setHorizontalStretch(0)
         sizePolicy3.setVerticalStretch(0)
         sizePolicy3.setHeightForWidth(self.demo_line.sizePolicy().hasHeightForWidth())
         self.demo_line.setSizePolicy(sizePolicy3)
-        self.demo_line.setFrameShape(QFrame.HLine)
-        self.demo_line.setFrameShadow(QFrame.Sunken)
+        self.demo_line.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_group_box.addWidget(self.demo_line)
 
@@ -191,8 +191,8 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_10 = QFrame(self.demo_group_box)
         self.demo_line_10.setObjectName(u"demo_line_10")
-        self.demo_line_10.setFrameShape(QFrame.HLine)
-        self.demo_line_10.setFrameShadow(QFrame.Sunken)
+        self.demo_line_10.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line_10.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_group_box.addWidget(self.demo_line_10)
 
@@ -203,8 +203,8 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_9 = QFrame(self.demo_group_box)
         self.demo_line_9.setObjectName(u"demo_line_9")
-        self.demo_line_9.setFrameShape(QFrame.HLine)
-        self.demo_line_9.setFrameShadow(QFrame.Sunken)
+        self.demo_line_9.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line_9.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_group_box.addWidget(self.demo_line_9)
 
@@ -215,8 +215,8 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_8 = QFrame(self.demo_group_box)
         self.demo_line_8.setObjectName(u"demo_line_8")
-        self.demo_line_8.setFrameShape(QFrame.HLine)
-        self.demo_line_8.setFrameShadow(QFrame.Sunken)
+        self.demo_line_8.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line_8.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_group_box.addWidget(self.demo_line_8)
 
@@ -227,8 +227,8 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_7 = QFrame(self.demo_group_box)
         self.demo_line_7.setObjectName(u"demo_line_7")
-        self.demo_line_7.setFrameShape(QFrame.HLine)
-        self.demo_line_7.setFrameShadow(QFrame.Sunken)
+        self.demo_line_7.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line_7.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_group_box.addWidget(self.demo_line_7)
 
@@ -239,8 +239,8 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_6 = QFrame(self.demo_group_box)
         self.demo_line_6.setObjectName(u"demo_line_6")
-        self.demo_line_6.setFrameShape(QFrame.HLine)
-        self.demo_line_6.setFrameShadow(QFrame.Sunken)
+        self.demo_line_6.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line_6.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_group_box.addWidget(self.demo_line_6)
 
@@ -252,8 +252,8 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_5 = QFrame(self.demo_group_box)
         self.demo_line_5.setObjectName(u"demo_line_5")
-        self.demo_line_5.setFrameShape(QFrame.HLine)
-        self.demo_line_5.setFrameShadow(QFrame.Sunken)
+        self.demo_line_5.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line_5.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_group_box.addWidget(self.demo_line_5)
 
@@ -265,8 +265,8 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_4 = QFrame(self.demo_group_box)
         self.demo_line_4.setObjectName(u"demo_line_4")
-        self.demo_line_4.setFrameShape(QFrame.HLine)
-        self.demo_line_4.setFrameShadow(QFrame.Sunken)
+        self.demo_line_4.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line_4.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_group_box.addWidget(self.demo_line_4)
 
@@ -277,7 +277,7 @@ class Ui_CustomThemeDialog(object):
 
         self.vlay_demo_group_box.addWidget(self.demo_dialogButtonBox)
 
-        self.vspace_demo = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.vspace_demo = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.vlay_demo_group_box.addItem(self.vspace_demo)
 
@@ -292,13 +292,13 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_separator_left = QFrame(self.demo_widgets_tab)
         self.demo_line_separator_left.setObjectName(u"demo_line_separator_left")
-        sizePolicy4 = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Expanding)
+        sizePolicy4 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
         sizePolicy4.setHorizontalStretch(0)
         sizePolicy4.setVerticalStretch(0)
         sizePolicy4.setHeightForWidth(self.demo_line_separator_left.sizePolicy().hasHeightForWidth())
         self.demo_line_separator_left.setSizePolicy(sizePolicy4)
-        self.demo_line_separator_left.setFrameShape(QFrame.VLine)
-        self.demo_line_separator_left.setFrameShadow(QFrame.Sunken)
+        self.demo_line_separator_left.setFrameShape(QFrame.Shape.VLine)
+        self.demo_line_separator_left.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.horizontalLayout_2.addWidget(self.demo_line_separator_left)
 
@@ -312,8 +312,8 @@ class Ui_CustomThemeDialog(object):
         self.demo_line_separator_right.setObjectName(u"demo_line_separator_right")
         sizePolicy4.setHeightForWidth(self.demo_line_separator_right.sizePolicy().hasHeightForWidth())
         self.demo_line_separator_right.setSizePolicy(sizePolicy4)
-        self.demo_line_separator_right.setFrameShape(QFrame.VLine)
-        self.demo_line_separator_right.setFrameShadow(QFrame.Sunken)
+        self.demo_line_separator_right.setFrameShape(QFrame.Shape.VLine)
+        self.demo_line_separator_right.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.horizontalLayout_2.addWidget(self.demo_line_separator_right)
 
@@ -326,8 +326,8 @@ class Ui_CustomThemeDialog(object):
 
         self.demo_line_11 = QFrame(self.demo_widgets_tab)
         self.demo_line_11.setObjectName(u"demo_line_11")
-        self.demo_line_11.setFrameShape(QFrame.HLine)
-        self.demo_line_11.setFrameShadow(QFrame.Sunken)
+        self.demo_line_11.setFrameShape(QFrame.Shape.HLine)
+        self.demo_line_11.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.vlay_demo_right.addWidget(self.demo_line_11)
 

--- a/gui/dialogs/tricks/ui_tricks_dialog.py
+++ b/gui/dialogs/tricks/ui_tricks_dialog.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'tricks_dialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.2
+## Created by: Qt User Interface Compiler version 6.8.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -47,7 +47,7 @@ class Ui_TricksDialog(object):
         self.disabled_tricks = QListView(TricksDialog)
         self.disabled_tricks.setObjectName(u"disabled_tricks")
         self.disabled_tricks.setEditTriggers(QAbstractItemView.NoEditTriggers)
-        self.disabled_tricks.setProperty("showDropIndicator", False)
+        self.disabled_tricks.setProperty(u"showDropIndicator", False)
         self.disabled_tricks.setSelectionMode(QAbstractItemView.MultiSelection)
         self.disabled_tricks.setSelectionRectVisible(False)
 
@@ -106,7 +106,7 @@ class Ui_TricksDialog(object):
         self.enabled_tricks = QListView(TricksDialog)
         self.enabled_tricks.setObjectName(u"enabled_tricks")
         self.enabled_tricks.setEditTriggers(QAbstractItemView.NoEditTriggers)
-        self.enabled_tricks.setProperty("showDropIndicator", False)
+        self.enabled_tricks.setProperty(u"showDropIndicator", False)
         self.enabled_tricks.setSelectionMode(QAbstractItemView.MultiSelection)
         self.enabled_tricks.setSelectionRectVisible(False)
 

--- a/gui/randogui.ui
+++ b/gui/randogui.ui
@@ -60,7 +60,7 @@
        <number>-6</number>
       </property>
       <property name="currentIndex">
-       <number>2</number>
+       <number>7</number>
       </property>
       <property name="usesScrollButtons">
        <bool>true</bool>
@@ -259,40 +259,36 @@
                 </widget>
                </item>
                <item>
-                <layout class="QHBoxLayout" name="hlay_star_count">
-                 <item>
-                  <widget class="QLabel" name="label_for_option_star_count">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>Number of stars</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="option_star_count">
-                   <property name="enabled">
-                    <bool>true</bool>
-                   </property>
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="maximum">
-                    <number>32767</number>
-                   </property>
-                   <property name="singleStep">
-                    <number>100</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+                <widget class="QLabel" name="label_for_option_star_count">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Number of stars</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="option_star_count">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="maximum">
+                  <number>32767</number>
+                 </property>
+                 <property name="singleStep">
+                  <number>100</number>
+                 </property>
+                </widget>
                </item>
                <item>
                 <widget class="QLabel" name="label_for_option_interface">
@@ -560,34 +556,30 @@
               </layout>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="hlay_req_dungeons">
-               <item>
-                <widget class="QLabel" name="label_for_option_required_dungeon_count">
-                 <property name="text">
-                  <string>Required Dungeons</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="option_required_dungeon_count">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>41</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+              <widget class="QLabel" name="label_for_option_required_dungeon_count">
+               <property name="text">
+                <string>Required Dungeons</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="option_required_dungeon_count">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+              </widget>
              </item>
              <item>
               <widget class="QCheckBox" name="option_triforce_required">
@@ -646,31 +638,27 @@
               </widget>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="hlay_demise_count">
-               <item>
-                <widget class="QLabel" name="label_for_option_demise_count">
-                 <property name="text">
-                  <string>Demise Count</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="option_demise_count">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>41</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+              <widget class="QLabel" name="label_for_option_demise_count">
+               <property name="text">
+                <string>Demise Count</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="option_demise_count">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+              </widget>
              </item>
              <item>
               <spacer name="vspace_completion">
@@ -1118,25 +1106,21 @@
               <widget class="QComboBox" name="option_bit_patches"/>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="hlay_peatrice_conversations">
-               <item>
-                <widget class="QLabel" name="label_for_option_peatrice_conversations">
-                 <property name="text">
-                  <string>Peatrice Conversations</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="option_peatrice_conversations">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+              <widget class="QLabel" name="label_for_option_peatrice_conversations">
+               <property name="text">
+                <string>Peatrice Conversations</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="option_peatrice_conversations">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
              </item>
              <item>
               <spacer name="vspace_vanilla_tweaks">
@@ -1251,34 +1235,33 @@
               </widget>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_9">
-               <property name="bottomMargin">
-                <number>0</number>
+              <widget class="QLabel" name="label_for_option_trial_treasure_amount">
+               <property name="text">
+                <string>Trial Treasure Amount</string>
                </property>
-               <item>
-                <widget class="QLabel" name="label_for_option_trial_treasure_amount">
-                 <property name="text">
-                  <string>Trial Treasure Amount</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="option_trial_treasure_amount">
-                 <property name="maximumSize">
-                  <size>
-                   <width>48</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                 <property name="minimum">
-                  <number>1</number>
-                 </property>
-                 <property name="maximum">
-                  <number>10</number>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="option_trial_treasure_amount">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>10</number>
+               </property>
+              </widget>
              </item>
              <item>
               <spacer name="vspace_silent_realms">
@@ -1334,37 +1317,33 @@
               </widget>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="hlay_damage_multiplier">
-               <item>
-                <widget class="QLabel" name="label_for_option_damage_multiplier">
-                 <property name="text">
-                  <string>Damage Taken Multiplier</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="option_damage_multiplier">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>41</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                 <property name="minimum">
-                  <number>1</number>
-                 </property>
-                 <property name="maximum">
-                  <number>255</number>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+              <widget class="QLabel" name="label_for_option_damage_multiplier">
+               <property name="text">
+                <string>Damage Taken Multiplier</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="option_damage_multiplier">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>255</number>
+               </property>
+              </widget>
              </item>
              <item>
               <spacer name="vspace_heromode_changes">
@@ -2073,97 +2052,78 @@
             <widget class="QComboBox" name="option_starting_sword"/>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="hlay_starting_tablets">
-             <item>
-              <widget class="QLabel" name="label_for_option_starting_tablet_count">
-               <property name="text">
-                <string>Starting Tablets</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="option_starting_tablet_count">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="hlay_starting_bottles">
-             <item>
-              <widget class="QLabel" name="label_for_option_starting_bottles">
-               <property name="text">
-                <string>Starting Empty Bottles</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="option_starting_bottles">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="hlay_starting_crystal_packs">
-             <item>
-              <widget class="QLabel" name="label_for_option_starting_crystal_packs">
-               <property name="text">
-                <string>Starting Gratitude Crystal Packs</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="option_starting_crystal_packs">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="hlay_starting_tadtones">
-             <property name="topMargin">
-              <number>0</number>
+            <widget class="QLabel" name="label_for_option_starting_tablet_count">
+             <property name="text">
+              <string>Starting Tablets</string>
              </property>
-             <item>
-              <widget class="QLabel" name="label_for_option_starting_tadtones">
-               <property name="text">
-                <string>Starting Groups of Tadtones</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="option_starting_tadtones">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="option_starting_tablet_count">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_for_option_starting_bottles">
+             <property name="text">
+              <string>Starting Empty Bottles</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="option_starting_bottles">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_for_option_starting_crystal_packs">
+             <property name="text">
+              <string>Starting Gratitude Crystal Packs</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="option_starting_crystal_packs">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_for_option_starting_tadtones">
+             <property name="text">
+              <string>Starting Groups of Tadtones</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="option_starting_tadtones">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QCheckBox" name="option_random_starting_item">
@@ -2207,66 +2167,62 @@
             </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="hlay_heart_options">
-             <item>
-              <widget class="QLabel" name="label_for_option_starting_heart_containers">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Heart Containers</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="option_starting_heart_containers">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>41</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_for_option_starting_heart_pieces">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Heart Pieces</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="option_starting_heart_pieces">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>41</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <widget class="QLabel" name="label_for_option_starting_heart_containers">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Heart Containers</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="option_starting_heart_containers">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_for_option_starting_heart_pieces">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Heart Pieces</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="option_starting_heart_pieces">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
            </item>
            <item>
             <layout class="QHBoxLayout" name="hlay_heart_display">
@@ -2533,8 +2489,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>98</width>
-               <height>46</height>
+               <width>577</width>
+               <height>471</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_34">
@@ -2754,31 +2710,27 @@
               </widget>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="hlay_font_size">
-               <item>
-                <widget class="QLabel" name="label_for_option_font_size">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Font Size</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="option_font_size">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+              <widget class="QLabel" name="label_for_option_font_size">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Font Size</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="option_font_size">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
              </item>
              <item>
               <widget class="QPushButton" name="reset_font_button">

--- a/gui/ui_randogui.py
+++ b/gui/ui_randogui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'randogui.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.6.2
+## Created by: Qt User Interface Compiler version 6.8.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -194,8 +194,6 @@ class Ui_MainWindow(object):
 
         self.vlay_cosmetics.addWidget(self.option_starry_skies)
 
-        self.hlay_star_count = QHBoxLayout()
-        self.hlay_star_count.setObjectName(u"hlay_star_count")
         self.label_for_option_star_count = QLabel(self.box_cosmetics)
         self.label_for_option_star_count.setObjectName(u"label_for_option_star_count")
         sizePolicy3 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Preferred)
@@ -204,7 +202,7 @@ class Ui_MainWindow(object):
         sizePolicy3.setHeightForWidth(self.label_for_option_star_count.sizePolicy().hasHeightForWidth())
         self.label_for_option_star_count.setSizePolicy(sizePolicy3)
 
-        self.hlay_star_count.addWidget(self.label_for_option_star_count)
+        self.vlay_cosmetics.addWidget(self.label_for_option_star_count)
 
         self.option_star_count = QSpinBox(self.box_cosmetics)
         self.option_star_count.setObjectName(u"option_star_count")
@@ -217,10 +215,7 @@ class Ui_MainWindow(object):
         self.option_star_count.setMaximum(32767)
         self.option_star_count.setSingleStep(100)
 
-        self.hlay_star_count.addWidget(self.option_star_count)
-
-
-        self.vlay_cosmetics.addLayout(self.hlay_star_count)
+        self.vlay_cosmetics.addWidget(self.option_star_count)
 
         self.label_for_option_interface = QLabel(self.box_cosmetics)
         self.label_for_option_interface.setObjectName(u"label_for_option_interface")
@@ -418,27 +413,19 @@ class Ui_MainWindow(object):
 
         self.vlay_completion.addLayout(self.vlay_got_dungeon_req)
 
-        self.hlay_req_dungeons = QHBoxLayout()
-        self.hlay_req_dungeons.setObjectName(u"hlay_req_dungeons")
         self.label_for_option_required_dungeon_count = QLabel(self.box_completion)
         self.label_for_option_required_dungeon_count.setObjectName(u"label_for_option_required_dungeon_count")
 
-        self.hlay_req_dungeons.addWidget(self.label_for_option_required_dungeon_count)
+        self.vlay_completion.addWidget(self.label_for_option_required_dungeon_count)
 
         self.option_required_dungeon_count = QSpinBox(self.box_completion)
         self.option_required_dungeon_count.setObjectName(u"option_required_dungeon_count")
         self.option_required_dungeon_count.setEnabled(True)
-        sizePolicy5 = QSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Fixed)
-        sizePolicy5.setHorizontalStretch(0)
-        sizePolicy5.setVerticalStretch(0)
-        sizePolicy5.setHeightForWidth(self.option_required_dungeon_count.sizePolicy().hasHeightForWidth())
-        self.option_required_dungeon_count.setSizePolicy(sizePolicy5)
-        self.option_required_dungeon_count.setMaximumSize(QSize(41, 16777215))
+        sizePolicy4.setHeightForWidth(self.option_required_dungeon_count.sizePolicy().hasHeightForWidth())
+        self.option_required_dungeon_count.setSizePolicy(sizePolicy4)
+        self.option_required_dungeon_count.setMaximumSize(QSize(16777215, 16777215))
 
-        self.hlay_req_dungeons.addWidget(self.option_required_dungeon_count)
-
-
-        self.vlay_completion.addLayout(self.hlay_req_dungeons)
+        self.vlay_completion.addWidget(self.option_required_dungeon_count)
 
         self.option_triforce_required = QCheckBox(self.box_completion)
         self.option_triforce_required.setObjectName(u"option_triforce_required")
@@ -480,23 +467,18 @@ class Ui_MainWindow(object):
 
         self.vlay_completion.addWidget(self.option_demise)
 
-        self.hlay_demise_count = QHBoxLayout()
-        self.hlay_demise_count.setObjectName(u"hlay_demise_count")
         self.label_for_option_demise_count = QLabel(self.box_completion)
         self.label_for_option_demise_count.setObjectName(u"label_for_option_demise_count")
 
-        self.hlay_demise_count.addWidget(self.label_for_option_demise_count)
+        self.vlay_completion.addWidget(self.label_for_option_demise_count)
 
         self.option_demise_count = QSpinBox(self.box_completion)
         self.option_demise_count.setObjectName(u"option_demise_count")
-        sizePolicy5.setHeightForWidth(self.option_demise_count.sizePolicy().hasHeightForWidth())
-        self.option_demise_count.setSizePolicy(sizePolicy5)
-        self.option_demise_count.setMaximumSize(QSize(41, 16777215))
+        sizePolicy4.setHeightForWidth(self.option_demise_count.sizePolicy().hasHeightForWidth())
+        self.option_demise_count.setSizePolicy(sizePolicy4)
+        self.option_demise_count.setMaximumSize(QSize(16777215, 16777215))
 
-        self.hlay_demise_count.addWidget(self.option_demise_count)
-
-
-        self.vlay_completion.addLayout(self.hlay_demise_count)
+        self.vlay_completion.addWidget(self.option_demise_count)
 
         self.vspace_completion = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
@@ -826,22 +808,17 @@ class Ui_MainWindow(object):
 
         self.vlay_vanilla_tweaks.addWidget(self.option_bit_patches)
 
-        self.hlay_peatrice_conversations = QHBoxLayout()
-        self.hlay_peatrice_conversations.setObjectName(u"hlay_peatrice_conversations")
         self.label_for_option_peatrice_conversations = QLabel(self.box_vanilla_tweaks)
         self.label_for_option_peatrice_conversations.setObjectName(u"label_for_option_peatrice_conversations")
 
-        self.hlay_peatrice_conversations.addWidget(self.label_for_option_peatrice_conversations)
+        self.vlay_vanilla_tweaks.addWidget(self.label_for_option_peatrice_conversations)
 
         self.option_peatrice_conversations = QSpinBox(self.box_vanilla_tweaks)
         self.option_peatrice_conversations.setObjectName(u"option_peatrice_conversations")
-        sizePolicy5.setHeightForWidth(self.option_peatrice_conversations.sizePolicy().hasHeightForWidth())
-        self.option_peatrice_conversations.setSizePolicy(sizePolicy5)
+        sizePolicy4.setHeightForWidth(self.option_peatrice_conversations.sizePolicy().hasHeightForWidth())
+        self.option_peatrice_conversations.setSizePolicy(sizePolicy4)
 
-        self.hlay_peatrice_conversations.addWidget(self.option_peatrice_conversations)
-
-
-        self.vlay_vanilla_tweaks.addLayout(self.hlay_peatrice_conversations)
+        self.vlay_vanilla_tweaks.addWidget(self.option_peatrice_conversations)
 
         self.vspace_vanilla_tweaks = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
@@ -903,11 +880,11 @@ class Ui_MainWindow(object):
         self.verticalLayout_trialshuffle.setObjectName(u"verticalLayout_trialshuffle")
         self.label_for_option_shuffle_trial_objects = QLabel(self.box_silent_realms)
         self.label_for_option_shuffle_trial_objects.setObjectName(u"label_for_option_shuffle_trial_objects")
-        sizePolicy6 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Preferred)
-        sizePolicy6.setHorizontalStretch(0)
-        sizePolicy6.setVerticalStretch(0)
-        sizePolicy6.setHeightForWidth(self.label_for_option_shuffle_trial_objects.sizePolicy().hasHeightForWidth())
-        self.label_for_option_shuffle_trial_objects.setSizePolicy(sizePolicy6)
+        sizePolicy5 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Preferred)
+        sizePolicy5.setHorizontalStretch(0)
+        sizePolicy5.setVerticalStretch(0)
+        sizePolicy5.setHeightForWidth(self.label_for_option_shuffle_trial_objects.sizePolicy().hasHeightForWidth())
+        self.label_for_option_shuffle_trial_objects.setSizePolicy(sizePolicy5)
 
         self.verticalLayout_trialshuffle.addWidget(self.label_for_option_shuffle_trial_objects)
 
@@ -924,24 +901,20 @@ class Ui_MainWindow(object):
 
         self.vlay_silent_realms.addWidget(self.option_treasuresanity_in_silent_realms)
 
-        self.horizontalLayout_9 = QHBoxLayout()
-        self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
-        self.horizontalLayout_9.setContentsMargins(-1, -1, -1, 0)
         self.label_for_option_trial_treasure_amount = QLabel(self.box_silent_realms)
         self.label_for_option_trial_treasure_amount.setObjectName(u"label_for_option_trial_treasure_amount")
 
-        self.horizontalLayout_9.addWidget(self.label_for_option_trial_treasure_amount)
+        self.vlay_silent_realms.addWidget(self.label_for_option_trial_treasure_amount)
 
         self.option_trial_treasure_amount = QSpinBox(self.box_silent_realms)
         self.option_trial_treasure_amount.setObjectName(u"option_trial_treasure_amount")
-        self.option_trial_treasure_amount.setMaximumSize(QSize(48, 16777215))
+        sizePolicy4.setHeightForWidth(self.option_trial_treasure_amount.sizePolicy().hasHeightForWidth())
+        self.option_trial_treasure_amount.setSizePolicy(sizePolicy4)
+        self.option_trial_treasure_amount.setMaximumSize(QSize(16777215, 16777215))
         self.option_trial_treasure_amount.setMinimum(1)
         self.option_trial_treasure_amount.setMaximum(10)
 
-        self.horizontalLayout_9.addWidget(self.option_trial_treasure_amount)
-
-
-        self.vlay_silent_realms.addLayout(self.horizontalLayout_9)
+        self.vlay_silent_realms.addWidget(self.option_trial_treasure_amount)
 
         self.vspace_silent_realms = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
@@ -976,25 +949,20 @@ class Ui_MainWindow(object):
 
         self.vlay_heromode_changes.addWidget(self.option_enable_heart_drops)
 
-        self.hlay_damage_multiplier = QHBoxLayout()
-        self.hlay_damage_multiplier.setObjectName(u"hlay_damage_multiplier")
         self.label_for_option_damage_multiplier = QLabel(self.box_heromode_changes)
         self.label_for_option_damage_multiplier.setObjectName(u"label_for_option_damage_multiplier")
 
-        self.hlay_damage_multiplier.addWidget(self.label_for_option_damage_multiplier)
+        self.vlay_heromode_changes.addWidget(self.label_for_option_damage_multiplier)
 
         self.option_damage_multiplier = QSpinBox(self.box_heromode_changes)
         self.option_damage_multiplier.setObjectName(u"option_damage_multiplier")
-        sizePolicy5.setHeightForWidth(self.option_damage_multiplier.sizePolicy().hasHeightForWidth())
-        self.option_damage_multiplier.setSizePolicy(sizePolicy5)
-        self.option_damage_multiplier.setMaximumSize(QSize(41, 16777215))
+        sizePolicy4.setHeightForWidth(self.option_damage_multiplier.sizePolicy().hasHeightForWidth())
+        self.option_damage_multiplier.setSizePolicy(sizePolicy4)
+        self.option_damage_multiplier.setMaximumSize(QSize(16777215, 16777215))
         self.option_damage_multiplier.setMinimum(1)
         self.option_damage_multiplier.setMaximum(255)
 
-        self.hlay_damage_multiplier.addWidget(self.option_damage_multiplier)
-
-
-        self.vlay_heromode_changes.addLayout(self.hlay_damage_multiplier)
+        self.vlay_heromode_changes.addWidget(self.option_damage_multiplier)
 
         self.vspace_heromode_changes = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
@@ -1072,7 +1040,7 @@ class Ui_MainWindow(object):
         self.included_locations = QListView(self.tab_logic_settings)
         self.included_locations.setObjectName(u"included_locations")
         self.included_locations.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
-        self.included_locations.setProperty("showDropIndicator", False)
+        self.included_locations.setProperty(u"showDropIndicator", False)
         self.included_locations.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
         self.included_locations.setSelectionRectVisible(False)
 
@@ -1089,11 +1057,11 @@ class Ui_MainWindow(object):
 
         self.include_location = QPushButton(self.tab_logic_settings)
         self.include_location.setObjectName(u"include_location")
-        sizePolicy7 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
-        sizePolicy7.setHorizontalStretch(0)
-        sizePolicy7.setVerticalStretch(0)
-        sizePolicy7.setHeightForWidth(self.include_location.sizePolicy().hasHeightForWidth())
-        self.include_location.setSizePolicy(sizePolicy7)
+        sizePolicy6 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        sizePolicy6.setHorizontalStretch(0)
+        sizePolicy6.setVerticalStretch(0)
+        sizePolicy6.setHeightForWidth(self.include_location.sizePolicy().hasHeightForWidth())
+        self.include_location.setSizePolicy(sizePolicy6)
 
         self.vlay_exclude_locations_controls.addWidget(self.include_location)
 
@@ -1103,8 +1071,8 @@ class Ui_MainWindow(object):
 
         self.exclude_location = QPushButton(self.tab_logic_settings)
         self.exclude_location.setObjectName(u"exclude_location")
-        sizePolicy7.setHeightForWidth(self.exclude_location.sizePolicy().hasHeightForWidth())
-        self.exclude_location.setSizePolicy(sizePolicy7)
+        sizePolicy6.setHeightForWidth(self.exclude_location.sizePolicy().hasHeightForWidth())
+        self.exclude_location.setSizePolicy(sizePolicy6)
 
         self.vlay_exclude_locations_controls.addWidget(self.exclude_location)
 
@@ -1143,7 +1111,7 @@ class Ui_MainWindow(object):
         self.excluded_locations = QListView(self.tab_logic_settings)
         self.excluded_locations.setObjectName(u"excluded_locations")
         self.excluded_locations.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
-        self.excluded_locations.setProperty("showDropIndicator", False)
+        self.excluded_locations.setProperty(u"showDropIndicator", False)
         self.excluded_locations.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
         self.excluded_locations.setSelectionRectVisible(False)
 
@@ -1335,7 +1303,7 @@ class Ui_MainWindow(object):
         sizePolicy1.setHeightForWidth(self.randomized_items.sizePolicy().hasHeightForWidth())
         self.randomized_items.setSizePolicy(sizePolicy1)
         self.randomized_items.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
-        self.randomized_items.setProperty("showDropIndicator", False)
+        self.randomized_items.setProperty(u"showDropIndicator", False)
         self.randomized_items.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
         self.randomized_items.setSelectionRectVisible(False)
 
@@ -1353,8 +1321,8 @@ class Ui_MainWindow(object):
 
         self.randomize_item = QPushButton(self.box_starting_items)
         self.randomize_item.setObjectName(u"randomize_item")
-        sizePolicy7.setHeightForWidth(self.randomize_item.sizePolicy().hasHeightForWidth())
-        self.randomize_item.setSizePolicy(sizePolicy7)
+        sizePolicy6.setHeightForWidth(self.randomize_item.sizePolicy().hasHeightForWidth())
+        self.randomize_item.setSizePolicy(sizePolicy6)
 
         self.vlay_starting_items_controls.addWidget(self.randomize_item)
 
@@ -1364,8 +1332,8 @@ class Ui_MainWindow(object):
 
         self.start_with_item = QPushButton(self.box_starting_items)
         self.start_with_item.setObjectName(u"start_with_item")
-        sizePolicy7.setHeightForWidth(self.start_with_item.sizePolicy().hasHeightForWidth())
-        self.start_with_item.setSizePolicy(sizePolicy7)
+        sizePolicy6.setHeightForWidth(self.start_with_item.sizePolicy().hasHeightForWidth())
+        self.start_with_item.setSizePolicy(sizePolicy6)
 
         self.vlay_starting_items_controls.addWidget(self.start_with_item)
 
@@ -1394,7 +1362,7 @@ class Ui_MainWindow(object):
         sizePolicy1.setHeightForWidth(self.starting_items.sizePolicy().hasHeightForWidth())
         self.starting_items.setSizePolicy(sizePolicy1)
         self.starting_items.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
-        self.starting_items.setProperty("showDropIndicator", False)
+        self.starting_items.setProperty(u"showDropIndicator", False)
         self.starting_items.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
         self.starting_items.setSelectionRectVisible(False)
 
@@ -1408,11 +1376,11 @@ class Ui_MainWindow(object):
 
         self.box_additional_options = QGroupBox(self.tab_starting_items)
         self.box_additional_options.setObjectName(u"box_additional_options")
-        sizePolicy8 = QSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
-        sizePolicy8.setHorizontalStretch(0)
-        sizePolicy8.setVerticalStretch(0)
-        sizePolicy8.setHeightForWidth(self.box_additional_options.sizePolicy().hasHeightForWidth())
-        self.box_additional_options.setSizePolicy(sizePolicy8)
+        sizePolicy7 = QSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+        sizePolicy7.setHorizontalStretch(0)
+        sizePolicy7.setVerticalStretch(0)
+        sizePolicy7.setHeightForWidth(self.box_additional_options.sizePolicy().hasHeightForWidth())
+        self.box_additional_options.setSizePolicy(sizePolicy7)
         self.verticalLayout_29 = QVBoxLayout(self.box_additional_options)
         self.verticalLayout_29.setObjectName(u"verticalLayout_29")
         self.label_for_option_starting_sword = QLabel(self.box_additional_options)
@@ -1425,83 +1393,62 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_29.addWidget(self.option_starting_sword)
 
-        self.hlay_starting_tablets = QHBoxLayout()
-        self.hlay_starting_tablets.setObjectName(u"hlay_starting_tablets")
         self.label_for_option_starting_tablet_count = QLabel(self.box_additional_options)
         self.label_for_option_starting_tablet_count.setObjectName(u"label_for_option_starting_tablet_count")
 
-        self.hlay_starting_tablets.addWidget(self.label_for_option_starting_tablet_count)
+        self.verticalLayout_29.addWidget(self.label_for_option_starting_tablet_count)
 
         self.option_starting_tablet_count = QSpinBox(self.box_additional_options)
         self.option_starting_tablet_count.setObjectName(u"option_starting_tablet_count")
-        sizePolicy5.setHeightForWidth(self.option_starting_tablet_count.sizePolicy().hasHeightForWidth())
-        self.option_starting_tablet_count.setSizePolicy(sizePolicy5)
+        sizePolicy4.setHeightForWidth(self.option_starting_tablet_count.sizePolicy().hasHeightForWidth())
+        self.option_starting_tablet_count.setSizePolicy(sizePolicy4)
         self.option_starting_tablet_count.setMaximumSize(QSize(16777215, 16777215))
 
-        self.hlay_starting_tablets.addWidget(self.option_starting_tablet_count)
+        self.verticalLayout_29.addWidget(self.option_starting_tablet_count)
 
-
-        self.verticalLayout_29.addLayout(self.hlay_starting_tablets)
-
-        self.hlay_starting_bottles = QHBoxLayout()
-        self.hlay_starting_bottles.setObjectName(u"hlay_starting_bottles")
         self.label_for_option_starting_bottles = QLabel(self.box_additional_options)
         self.label_for_option_starting_bottles.setObjectName(u"label_for_option_starting_bottles")
 
-        self.hlay_starting_bottles.addWidget(self.label_for_option_starting_bottles)
+        self.verticalLayout_29.addWidget(self.label_for_option_starting_bottles)
 
         self.option_starting_bottles = QSpinBox(self.box_additional_options)
         self.option_starting_bottles.setObjectName(u"option_starting_bottles")
-        sizePolicy5.setHeightForWidth(self.option_starting_bottles.sizePolicy().hasHeightForWidth())
-        self.option_starting_bottles.setSizePolicy(sizePolicy5)
+        sizePolicy4.setHeightForWidth(self.option_starting_bottles.sizePolicy().hasHeightForWidth())
+        self.option_starting_bottles.setSizePolicy(sizePolicy4)
 
-        self.hlay_starting_bottles.addWidget(self.option_starting_bottles)
+        self.verticalLayout_29.addWidget(self.option_starting_bottles)
 
-
-        self.verticalLayout_29.addLayout(self.hlay_starting_bottles)
-
-        self.hlay_starting_crystal_packs = QHBoxLayout()
-        self.hlay_starting_crystal_packs.setObjectName(u"hlay_starting_crystal_packs")
         self.label_for_option_starting_crystal_packs = QLabel(self.box_additional_options)
         self.label_for_option_starting_crystal_packs.setObjectName(u"label_for_option_starting_crystal_packs")
 
-        self.hlay_starting_crystal_packs.addWidget(self.label_for_option_starting_crystal_packs)
+        self.verticalLayout_29.addWidget(self.label_for_option_starting_crystal_packs)
 
         self.option_starting_crystal_packs = QSpinBox(self.box_additional_options)
         self.option_starting_crystal_packs.setObjectName(u"option_starting_crystal_packs")
-        sizePolicy5.setHeightForWidth(self.option_starting_crystal_packs.sizePolicy().hasHeightForWidth())
-        self.option_starting_crystal_packs.setSizePolicy(sizePolicy5)
+        sizePolicy4.setHeightForWidth(self.option_starting_crystal_packs.sizePolicy().hasHeightForWidth())
+        self.option_starting_crystal_packs.setSizePolicy(sizePolicy4)
 
-        self.hlay_starting_crystal_packs.addWidget(self.option_starting_crystal_packs)
+        self.verticalLayout_29.addWidget(self.option_starting_crystal_packs)
 
-
-        self.verticalLayout_29.addLayout(self.hlay_starting_crystal_packs)
-
-        self.hlay_starting_tadtones = QHBoxLayout()
-        self.hlay_starting_tadtones.setObjectName(u"hlay_starting_tadtones")
-        self.hlay_starting_tadtones.setContentsMargins(-1, 0, -1, -1)
         self.label_for_option_starting_tadtones = QLabel(self.box_additional_options)
         self.label_for_option_starting_tadtones.setObjectName(u"label_for_option_starting_tadtones")
 
-        self.hlay_starting_tadtones.addWidget(self.label_for_option_starting_tadtones)
+        self.verticalLayout_29.addWidget(self.label_for_option_starting_tadtones)
 
         self.option_starting_tadtones = QSpinBox(self.box_additional_options)
         self.option_starting_tadtones.setObjectName(u"option_starting_tadtones")
-        sizePolicy5.setHeightForWidth(self.option_starting_tadtones.sizePolicy().hasHeightForWidth())
-        self.option_starting_tadtones.setSizePolicy(sizePolicy5)
+        sizePolicy4.setHeightForWidth(self.option_starting_tadtones.sizePolicy().hasHeightForWidth())
+        self.option_starting_tadtones.setSizePolicy(sizePolicy4)
 
-        self.hlay_starting_tadtones.addWidget(self.option_starting_tadtones)
-
-
-        self.verticalLayout_29.addLayout(self.hlay_starting_tadtones)
+        self.verticalLayout_29.addWidget(self.option_starting_tadtones)
 
         self.option_random_starting_item = QCheckBox(self.box_additional_options)
         self.option_random_starting_item.setObjectName(u"option_random_starting_item")
-        sizePolicy9 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        sizePolicy9.setHorizontalStretch(0)
-        sizePolicy9.setVerticalStretch(0)
-        sizePolicy9.setHeightForWidth(self.option_random_starting_item.sizePolicy().hasHeightForWidth())
-        self.option_random_starting_item.setSizePolicy(sizePolicy9)
+        sizePolicy8 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        sizePolicy8.setHorizontalStretch(0)
+        sizePolicy8.setVerticalStretch(0)
+        sizePolicy8.setHeightForWidth(self.option_random_starting_item.sizePolicy().hasHeightForWidth())
+        self.option_random_starting_item.setSizePolicy(sizePolicy8)
 
         self.verticalLayout_29.addWidget(self.option_random_starting_item)
 
@@ -1525,40 +1472,35 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_29.addWidget(self.option_max_starting_treasures)
 
-        self.hlay_heart_options = QHBoxLayout()
-        self.hlay_heart_options.setObjectName(u"hlay_heart_options")
         self.label_for_option_starting_heart_containers = QLabel(self.box_additional_options)
         self.label_for_option_starting_heart_containers.setObjectName(u"label_for_option_starting_heart_containers")
-        sizePolicy6.setHeightForWidth(self.label_for_option_starting_heart_containers.sizePolicy().hasHeightForWidth())
-        self.label_for_option_starting_heart_containers.setSizePolicy(sizePolicy6)
+        sizePolicy5.setHeightForWidth(self.label_for_option_starting_heart_containers.sizePolicy().hasHeightForWidth())
+        self.label_for_option_starting_heart_containers.setSizePolicy(sizePolicy5)
 
-        self.hlay_heart_options.addWidget(self.label_for_option_starting_heart_containers)
+        self.verticalLayout_29.addWidget(self.label_for_option_starting_heart_containers)
 
         self.option_starting_heart_containers = QSpinBox(self.box_additional_options)
         self.option_starting_heart_containers.setObjectName(u"option_starting_heart_containers")
-        sizePolicy9.setHeightForWidth(self.option_starting_heart_containers.sizePolicy().hasHeightForWidth())
-        self.option_starting_heart_containers.setSizePolicy(sizePolicy9)
-        self.option_starting_heart_containers.setMaximumSize(QSize(41, 16777215))
+        sizePolicy4.setHeightForWidth(self.option_starting_heart_containers.sizePolicy().hasHeightForWidth())
+        self.option_starting_heart_containers.setSizePolicy(sizePolicy4)
+        self.option_starting_heart_containers.setMaximumSize(QSize(16777215, 16777215))
 
-        self.hlay_heart_options.addWidget(self.option_starting_heart_containers)
+        self.verticalLayout_29.addWidget(self.option_starting_heart_containers)
 
         self.label_for_option_starting_heart_pieces = QLabel(self.box_additional_options)
         self.label_for_option_starting_heart_pieces.setObjectName(u"label_for_option_starting_heart_pieces")
-        sizePolicy6.setHeightForWidth(self.label_for_option_starting_heart_pieces.sizePolicy().hasHeightForWidth())
-        self.label_for_option_starting_heart_pieces.setSizePolicy(sizePolicy6)
+        sizePolicy5.setHeightForWidth(self.label_for_option_starting_heart_pieces.sizePolicy().hasHeightForWidth())
+        self.label_for_option_starting_heart_pieces.setSizePolicy(sizePolicy5)
 
-        self.hlay_heart_options.addWidget(self.label_for_option_starting_heart_pieces)
+        self.verticalLayout_29.addWidget(self.label_for_option_starting_heart_pieces)
 
         self.option_starting_heart_pieces = QSpinBox(self.box_additional_options)
         self.option_starting_heart_pieces.setObjectName(u"option_starting_heart_pieces")
-        sizePolicy9.setHeightForWidth(self.option_starting_heart_pieces.sizePolicy().hasHeightForWidth())
-        self.option_starting_heart_pieces.setSizePolicy(sizePolicy9)
-        self.option_starting_heart_pieces.setMaximumSize(QSize(41, 16777215))
+        sizePolicy4.setHeightForWidth(self.option_starting_heart_pieces.sizePolicy().hasHeightForWidth())
+        self.option_starting_heart_pieces.setSizePolicy(sizePolicy4)
+        self.option_starting_heart_pieces.setMaximumSize(QSize(16777215, 16777215))
 
-        self.hlay_heart_options.addWidget(self.option_starting_heart_pieces)
-
-
-        self.verticalLayout_29.addLayout(self.hlay_heart_options)
+        self.verticalLayout_29.addWidget(self.option_starting_heart_pieces)
 
         self.hlay_heart_display = QHBoxLayout()
         self.hlay_heart_display.setObjectName(u"hlay_heart_display")
@@ -1604,22 +1546,22 @@ class Ui_MainWindow(object):
         self.option_model_type_select = QComboBox(self.tab_cosmetics)
         self.option_model_type_select.setObjectName(u"option_model_type_select")
         self.option_model_type_select.setEnabled(True)
-        sizePolicy10 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
-        sizePolicy10.setHorizontalStretch(20)
-        sizePolicy10.setVerticalStretch(0)
-        sizePolicy10.setHeightForWidth(self.option_model_type_select.sizePolicy().hasHeightForWidth())
-        self.option_model_type_select.setSizePolicy(sizePolicy10)
+        sizePolicy9 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        sizePolicy9.setHorizontalStretch(20)
+        sizePolicy9.setVerticalStretch(0)
+        sizePolicy9.setHeightForWidth(self.option_model_type_select.sizePolicy().hasHeightForWidth())
+        self.option_model_type_select.setSizePolicy(sizePolicy9)
 
         self.hlay_type_options.addWidget(self.option_model_type_select)
 
         self.option_tunic_swap = QCheckBox(self.tab_cosmetics)
         self.option_tunic_swap.setObjectName(u"option_tunic_swap")
         self.option_tunic_swap.setEnabled(True)
-        sizePolicy11 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
-        sizePolicy11.setHorizontalStretch(40)
-        sizePolicy11.setVerticalStretch(0)
-        sizePolicy11.setHeightForWidth(self.option_tunic_swap.sizePolicy().hasHeightForWidth())
-        self.option_tunic_swap.setSizePolicy(sizePolicy11)
+        sizePolicy10 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        sizePolicy10.setHorizontalStretch(40)
+        sizePolicy10.setVerticalStretch(0)
+        sizePolicy10.setHeightForWidth(self.option_tunic_swap.sizePolicy().hasHeightForWidth())
+        self.option_tunic_swap.setSizePolicy(sizePolicy10)
 
         self.hlay_type_options.addWidget(self.option_tunic_swap)
 
@@ -1639,25 +1581,25 @@ class Ui_MainWindow(object):
 
         self.option_model_pack_select = QComboBox(self.tab_cosmetics)
         self.option_model_pack_select.setObjectName(u"option_model_pack_select")
-        sizePolicy12 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        sizePolicy12.setHorizontalStretch(20)
-        sizePolicy12.setVerticalStretch(0)
-        sizePolicy12.setHeightForWidth(self.option_model_pack_select.sizePolicy().hasHeightForWidth())
-        self.option_model_pack_select.setSizePolicy(sizePolicy12)
+        sizePolicy11 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        sizePolicy11.setHorizontalStretch(20)
+        sizePolicy11.setVerticalStretch(0)
+        sizePolicy11.setHeightForWidth(self.option_model_pack_select.sizePolicy().hasHeightForWidth())
+        self.option_model_pack_select.setSizePolicy(sizePolicy11)
 
         self.hlay_pack_options.addWidget(self.option_model_pack_select)
 
         self.button_randomize_all_colors = QPushButton(self.tab_cosmetics)
         self.button_randomize_all_colors.setObjectName(u"button_randomize_all_colors")
-        sizePolicy12.setHeightForWidth(self.button_randomize_all_colors.sizePolicy().hasHeightForWidth())
-        self.button_randomize_all_colors.setSizePolicy(sizePolicy12)
+        sizePolicy11.setHeightForWidth(self.button_randomize_all_colors.sizePolicy().hasHeightForWidth())
+        self.button_randomize_all_colors.setSizePolicy(sizePolicy11)
 
         self.hlay_pack_options.addWidget(self.button_randomize_all_colors)
 
         self.button_reset_all_colors = QPushButton(self.tab_cosmetics)
         self.button_reset_all_colors.setObjectName(u"button_reset_all_colors")
-        sizePolicy12.setHeightForWidth(self.button_reset_all_colors.sizePolicy().hasHeightForWidth())
-        self.button_reset_all_colors.setSizePolicy(sizePolicy12)
+        sizePolicy11.setHeightForWidth(self.button_reset_all_colors.sizePolicy().hasHeightForWidth())
+        self.button_reset_all_colors.setSizePolicy(sizePolicy11)
 
         self.hlay_pack_options.addWidget(self.button_reset_all_colors)
 
@@ -1696,19 +1638,19 @@ class Ui_MainWindow(object):
 
         self.label_for_color_presets = QLabel(self.tab_cosmetics)
         self.label_for_color_presets.setObjectName(u"label_for_color_presets")
-        sizePolicy13 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
-        sizePolicy13.setHorizontalStretch(20)
-        sizePolicy13.setVerticalStretch(0)
-        sizePolicy13.setHeightForWidth(self.label_for_color_presets.sizePolicy().hasHeightForWidth())
-        self.label_for_color_presets.setSizePolicy(sizePolicy13)
+        sizePolicy12 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        sizePolicy12.setHorizontalStretch(20)
+        sizePolicy12.setVerticalStretch(0)
+        sizePolicy12.setHeightForWidth(self.label_for_color_presets.sizePolicy().hasHeightForWidth())
+        self.label_for_color_presets.setSizePolicy(sizePolicy12)
         self.label_for_color_presets.setAlignment(Qt.AlignmentFlag.AlignRight|Qt.AlignmentFlag.AlignTrailing|Qt.AlignmentFlag.AlignVCenter)
 
         self.gridLayout.addWidget(self.label_for_color_presets, 0, 0, 1, 1)
 
         self.color_presets_list = QComboBox(self.tab_cosmetics)
         self.color_presets_list.setObjectName(u"color_presets_list")
-        sizePolicy10.setHeightForWidth(self.color_presets_list.sizePolicy().hasHeightForWidth())
-        self.color_presets_list.setSizePolicy(sizePolicy10)
+        sizePolicy9.setHeightForWidth(self.color_presets_list.sizePolicy().hasHeightForWidth())
+        self.color_presets_list.setSizePolicy(sizePolicy9)
 
         self.gridLayout.addWidget(self.color_presets_list, 0, 1, 1, 3)
 
@@ -1731,7 +1673,7 @@ class Ui_MainWindow(object):
         self.scroll_area_colors.setAlignment(Qt.AlignmentFlag.AlignLeading|Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
         self.scroll_area_widget_contents_colors = QWidget()
         self.scroll_area_widget_contents_colors.setObjectName(u"scroll_area_widget_contents_colors")
-        self.scroll_area_widget_contents_colors.setGeometry(QRect(0, 0, 98, 46))
+        self.scroll_area_widget_contents_colors.setGeometry(QRect(0, 0, 577, 471))
         self.verticalLayout_34 = QVBoxLayout(self.scroll_area_widget_contents_colors)
         self.verticalLayout_34.setObjectName(u"verticalLayout_34")
         self.vlay_texture_colors = QVBoxLayout()
@@ -1848,11 +1790,11 @@ class Ui_MainWindow(object):
 
         self.option_font_family = QFontComboBox(self.box_font)
         self.option_font_family.setObjectName(u"option_font_family")
-        sizePolicy14 = QSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
-        sizePolicy14.setHorizontalStretch(0)
-        sizePolicy14.setVerticalStretch(0)
-        sizePolicy14.setHeightForWidth(self.option_font_family.sizePolicy().hasHeightForWidth())
-        self.option_font_family.setSizePolicy(sizePolicy14)
+        sizePolicy13 = QSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
+        sizePolicy13.setHorizontalStretch(0)
+        sizePolicy13.setVerticalStretch(0)
+        sizePolicy13.setHeightForWidth(self.option_font_family.sizePolicy().hasHeightForWidth())
+        self.option_font_family.setSizePolicy(sizePolicy13)
         self.option_font_family.setEditable(False)
         self.option_font_family.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContentsOnFirstShow)
         self.option_font_family.setWritingSystem(QFontDatabase.WritingSystem.Any)
@@ -1864,29 +1806,24 @@ class Ui_MainWindow(object):
 
         self.vlay_font.addWidget(self.option_font_family)
 
-        self.hlay_font_size = QHBoxLayout()
-        self.hlay_font_size.setObjectName(u"hlay_font_size")
         self.label_for_option_font_size = QLabel(self.box_font)
         self.label_for_option_font_size.setObjectName(u"label_for_option_font_size")
         sizePolicy.setHeightForWidth(self.label_for_option_font_size.sizePolicy().hasHeightForWidth())
         self.label_for_option_font_size.setSizePolicy(sizePolicy)
 
-        self.hlay_font_size.addWidget(self.label_for_option_font_size)
+        self.vlay_font.addWidget(self.label_for_option_font_size)
 
         self.option_font_size = QSpinBox(self.box_font)
         self.option_font_size.setObjectName(u"option_font_size")
-        sizePolicy9.setHeightForWidth(self.option_font_size.sizePolicy().hasHeightForWidth())
-        self.option_font_size.setSizePolicy(sizePolicy9)
+        sizePolicy4.setHeightForWidth(self.option_font_size.sizePolicy().hasHeightForWidth())
+        self.option_font_size.setSizePolicy(sizePolicy4)
 
-        self.hlay_font_size.addWidget(self.option_font_size)
-
-
-        self.vlay_font.addLayout(self.hlay_font_size)
+        self.vlay_font.addWidget(self.option_font_size)
 
         self.reset_font_button = QPushButton(self.box_font)
         self.reset_font_button.setObjectName(u"reset_font_button")
-        sizePolicy9.setHeightForWidth(self.reset_font_button.sizePolicy().hasHeightForWidth())
-        self.reset_font_button.setSizePolicy(sizePolicy9)
+        sizePolicy8.setHeightForWidth(self.reset_font_button.sizePolicy().hasHeightForWidth())
+        self.reset_font_button.setSizePolicy(sizePolicy8)
 
         self.vlay_font.addWidget(self.reset_font_button)
 
@@ -1952,11 +1889,11 @@ class Ui_MainWindow(object):
         self.option_description = QLabel(self.centralwidget)
         self.option_description.setObjectName(u"option_description")
         self.option_description.setEnabled(True)
-        sizePolicy15 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-        sizePolicy15.setHorizontalStretch(0)
-        sizePolicy15.setVerticalStretch(0)
-        sizePolicy15.setHeightForWidth(self.option_description.sizePolicy().hasHeightForWidth())
-        self.option_description.setSizePolicy(sizePolicy15)
+        sizePolicy14 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        sizePolicy14.setHorizontalStretch(0)
+        sizePolicy14.setVerticalStretch(0)
+        sizePolicy14.setHeightForWidth(self.option_description.sizePolicy().hasHeightForWidth())
+        self.option_description.setSizePolicy(sizePolicy14)
         self.option_description.setMinimumSize(QSize(0, 48))
         self.option_description.setStyleSheet(u"")
         self.option_description.setTextFormat(Qt.TextFormat.MarkdownText)
@@ -2027,7 +1964,7 @@ class Ui_MainWindow(object):
 
         self.retranslateUi(MainWindow)
 
-        self.tabWidget.setCurrentIndex(2)
+        self.tabWidget.setCurrentIndex(7)
         self.option_triforce_shuffle.setCurrentIndex(-1)
         self.option_randomize_entrances.setCurrentIndex(-1)
         self.option_chest_dowsing.setCurrentIndex(-1)


### PR DESCRIPTION
## What does this PR do?
This moves all the QSpinBox elements below their respective QLabel so they can take the whole width of their column to properly display their value.

## How do you test this changes?
Only by launching the rando app, given this is only UI changes. 

## Notes
This has already been tested by someone who had issues before.