### PR TITLE
Fix Lanayru Caves Chest being unbannable

### DIFF
--- a/dump.yaml
+++ b/dump.yaml
@@ -1199,6 +1199,7 @@ items:
 - \Sandship\Main\Deck\Captain's Cabin\Bars
 - \Sandship\Main\Deck\Captain's Cabin\Boss Key Chest
 - \Sandship\Main\Before Ship's Bow\Chest before 4-Door Corridor
+- \Sandship\Main\Ship's Bow\Defeat Scervo
 - \Sandship\Main\Ship's Bow\Chest after Scervo Fight
 - \Sandship\Main\Starboard Rooms\Switch
 - \Sandship\Main\Starboard Rooms\Generator
@@ -6786,10 +6787,12 @@ areas:
               can_sleep: false
               entrances: []
               exits:
-                \Sandship\Main\Before Ship's Bow: \Lanayru\Caves\Chest
+                \Sandship\Main\Before Ship's Bow: \Sandship\Main\Ship's Bow\Defeat
+                  Scervo
               hint_region: Sandship
               locations:
-                Chest after Scervo Fight: \Can Defeat Scervo/Dreadfuse
+                Defeat Scervo: \Can Defeat Scervo/Dreadfuse
+                Chest after Scervo Fight: \Sandship\Main\Ship's Bow\Defeat Scervo
               name: \Sandship\Main\Ship's Bow
               sub_areas: {}
               toplevel_alias: null

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -501,6 +501,9 @@ Lanayru Sand Sea:
       Item on Pillar: Beetle
       Activate Timeshift Stone: Can Hit Timeshift Stone in Minecart
       Thunder Dragon's Reward: Activate Timeshift Stone & Life Tree Fruit
+      # FIXME: These checks are not yet implemented, but when they are,
+      # make sure to not refer to "Thunder Dragon's Reward" here as mentioning
+      # checks in requirements should be avoided.
       Boss Rush -- 4 Bosses: Thunder Dragon's Reward & Impossible
       Boss Rush -- 8 Bosses: Thunder Dragon's Reward & Impossible
     exits:

--- a/logic/requirements/Sandship.yaml
+++ b/logic/requirements/Sandship.yaml
@@ -48,9 +48,10 @@ Main:
 
   Ship's Bow:
     exits:
-      Before Ship's Bow: Chest
+      Before Ship's Bow: Defeat Scervo
     locations:
-      Chest after Scervo Fight: Can Defeat Scervo/Dreadfuse
+      Defeat Scervo: Can Defeat Scervo/Dreadfuse
+      Chest after Scervo Fight: Defeat Scervo
 
   Corridor:
     exits:


### PR DESCRIPTION
## What does this PR do?

The exit "Ship's Bow" -> "Before Ship's Bow" is meant to require defeating Scervo and opening the Chest, but "Chest" here resolves to the Lanayru Caves chest, which causes seed generation to error out with "Cannot ban potentially inlined away requirement \Lanayru\Caves\Chest". This fixes the dependency to require defeating Scervo instead

## How do you test this changes?
- Tracker logic seems unchanged
- Generating a seed with Lanayru Caves Chest banned still works

## Notes
- Maybe it'd be useful to catch and reject these errors at logic parse time
