### PR TITLE
Remove and disallow ambiguity in logic files

### DIFF
--- a/dump.yaml
+++ b/dump.yaml
@@ -1109,7 +1109,7 @@ items:
 - \Lanayru\Desert\North Part\Lightning Node\Present\Timeshift Stone
 - \Lanayru\Desert\North Part\Lightning Node\Past\First Chest
 - \Lanayru\Desert\North Part\Lightning Node\Past\Second Chest
-- \Lanayru\Desert\North Part\Lightning Node\Past\Lightning Node
+- \Lanayru\Desert\North Part\Lightning Node\Past\Activate Lightning Node
 - \Lanayru\Desert\North Part\Lightning Node\Present from afar\Raised Chest near Generator
 - \Lanayru\Desert\East\Open Wall Shortcut
 - \Lanayru\Desert\East\Unlock Statue
@@ -1123,7 +1123,7 @@ items:
 - \Lanayru\Desert\East\Fire Node\Past after Void\Open Grate
 - \Lanayru\Desert\East\Fire Node\Past after Grate\Left Ending Chest
 - \Lanayru\Desert\East\Fire Node\Past after Grate\Right Ending Chest
-- \Lanayru\Desert\East\Fire Node\Past after Grate\Fire Node
+- \Lanayru\Desert\East\Fire Node\Past after Grate\Activate Fire Node
 - \Lanayru\Temple of Time\South East\Unlock Statue
 - \Lanayru\Temple of Time\Front\Gossip Stone in Temple of Time Area
 - \Lanayru\Temple of Time\Front\Blow up Rock for Timeshift Stone
@@ -5591,8 +5591,9 @@ areas:
       hint_region: null
       locations:
         All Three Nodes: "LMF Nodes On option | (\\Lanayru\\Desert\\North Part\\Water\
-          \ Node & \\Lanayru\\Desert\\North Part\\Lightning Node\\Past\\Lightning\
-          \ Node & \\Lanayru\\Desert\\East\\Fire Node\\Past after Grate\\Fire Node)"
+          \ Node & \\Lanayru\\Desert\\North Part\\Lightning Node\\Past\\Activate Lightning\
+          \ Node & \\Lanayru\\Desert\\East\\Fire Node\\Past after Grate\\Activate\
+          \ Fire Node)"
         Raise Lanayru Mining Facility: "Open LMF option | \\Lanayru\\Desert\\North\
           \ Part\\Activate Main Node"
         Can Navigate in Oasis: "\\Can Defeat Ampilus | \\Hook Beetle | \\Skyloft\\\
@@ -6013,7 +6014,7 @@ areas:
                       locations:
                         First Chest: 'True'
                         Second Chest: 'True'
-                        Lightning Node: \Sword
+                        Activate Lightning Node: \Sword
                       name: \Lanayru\Desert\North Part\Lightning Node\Past
                       sub_areas: {}
                       toplevel_alias: null
@@ -6156,7 +6157,7 @@ areas:
                       locations:
                         Left Ending Chest: 'True'
                         Right Ending Chest: 'True'
-                        Fire Node: \Sword
+                        Activate Fire Node: \Sword
                       name: \Lanayru\Desert\East\Fire Node\Past after Grate
                       sub_areas: {}
                       toplevel_alias: null
@@ -10971,10 +10972,10 @@ exits:
     type: exit
     vanilla: Farore's Lair - Entrance from Lake Floria
     stage: F102
-    short_name: Lake Floria - Exit to Farore's Lair
+    short_name: Lake Floria - Below Rock - Exit to Farore's Lair
   \Faron\Lake Floria\Farore's Lair\Exit to Lake Floria:
     type: exit
-    vanilla: Lake Floria - Entrance from Farore's Lair
+    vanilla: Lake Floria - Below Rock - Entrance from Farore's Lair
     stage: F102_2
     short_name: Farore's Lair - Exit to Lake Floria
   \Faron\Lake Floria\Farore's Lair\Exit to Waterfall:
@@ -12207,7 +12208,7 @@ entrances:
     can-start-at: false
     stage: F102
     allowed_time_of_day: 1
-    short_name: Lake Floria - Entrance from Farore's Lair
+    short_name: Lake Floria - Below Rock - Entrance from Farore's Lair
   \Faron\Lake Floria\Farore's Lair\Entrance from Lake Floria:
     type: entrance
     province: Faron Province

--- a/entrances.yaml
+++ b/entrances.yaml
@@ -2319,7 +2319,7 @@ Lake Floria - Dive from Faron Woods:
   entrance: 0
   tod: 2
 
-Lake Floria - Entrance from Farore's Lair:
+Lake Floria - Below Rock - Entrance from Farore's Lair:
   type: entrance
   province: Faron Province
   can-start-at: false
@@ -2330,7 +2330,7 @@ Lake Floria - Entrance from Farore's Lair:
   tod: 2
 
 
-Lake Floria - Exit to Farore's Lair:
+Lake Floria - Below Rock - Exit to Farore's Lair:
   type: exit
   vanilla: Farore's Lair - Entrance from Lake Floria
   stage: F102
@@ -2362,7 +2362,7 @@ Farore's Lair - Entrance from Waterfall:
 
 Farore's Lair - Exit to Lake Floria:
   type: exit
-  vanilla: Lake Floria - Entrance from Farore's Lair
+  vanilla: Lake Floria - Below Rock - Entrance from Farore's Lair
   stage: F102_2
   room: 0
   index: 0

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -1,6 +1,6 @@
 allowed-time-of-day: DayOnly
 macros:
-  All Three Nodes: LMF Nodes On option | (North Part - Water Node & Lightning Node - Lightning Node & East - Fire Node - Fire Node)
+  All Three Nodes: LMF Nodes On option | (North Part - Water Node & Lightning Node - Activate Lightning Node & East - Fire Node - Activate Fire Node)
   Raise Lanayru Mining Facility: Open LMF option | Desert - North Part - Activate Main Node
   Can Navigate in Oasis: Can Defeat Ampilus | Hook Beetle | Central Skyloft - Bazaar - Endurance Potion | Brakeslide Trick | Stuttersprint Trick
 
@@ -202,7 +202,7 @@ Desert:
         locations:
           First Chest: Nothing
           Second Chest: Nothing
-          Lightning Node: Sword
+          Activate Lightning Node: Sword
 
       Present from afar:
         exits:
@@ -265,7 +265,7 @@ Desert:
         locations:
           Left Ending Chest: Nothing
           Right Ending Chest: Nothing
-          Fire Node: Sword
+          Activate Fire Node: Sword
 
 Temple of Time:
   # NB: There are no hintable checks here but logic consumers


### PR DESCRIPTION
## What does this PR do?
The fundamental code changes and what they translate to functionally.

When an element in logic files is ambiguous, the parser will refuse it.
This also makes the lookup function clearer in code.

Caveats: some ambiguity is still allowed.
- If the name refers to something present in the same node, ambiguity is not checked (eg. if B requires A and A is already a location in the current node)
- If the element is not found at or below the current node, the search happens again at its parent, etc. So, if the element is ambiguous at the root but not where it's found, then it's fine