### PR TITLE
Beginner-Friendly Logic Updates

### DIFF
--- a/dump.yaml
+++ b/dump.yaml
@@ -8052,8 +8052,6 @@ areas:
             Open Trial Gate: "Goddess's Harp & \\Song of the Hero"
             \Can Collect Water: 'True'
             Crystal on Waterfall Island from the ground: \Quick Beetle
-            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: Night
-            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: Night
             \Skyloft\Central Skyloft\Waterfall Island\Crystal on Waterfall Island: "Night\
               \ & \\Skyloft\\Central Skyloft\\Crystal on Waterfall Island from the\
               \ ground"

--- a/dump.yaml
+++ b/dump.yaml
@@ -364,6 +364,7 @@ items:
 - Upgraded Skyward Strike option
 - FS Lava Flow option
 - No Random Puzzles option
+- One Demise
 - GoT Opening Requirement
 - GoT Raising Requirement
 - Horde Door Requirement
@@ -668,6 +669,8 @@ items:
 - \Complete Triforce
 - \Empty Bottle_
 - \Bottle
+- \Guardian Potion Plus
+- \Shield
 - \Can Collect Water
 - \Water Bottle
 - \Ancient Flower Farming
@@ -716,6 +719,8 @@ items:
 - \Can Defeat Stalfos
 - \Can Defeat Stalmaster
 - \Can Defeat Scervo/Dreadfuse
+- \Can Defeat Sentrobe
+- \Can Defeat Demise
 - \Ancient Cistern\Can Lower Statue
 - \Ancient Cistern\Can Freely Raise and Lower Statue
 - \Ancient Cistern\Main\Main Room\Lock Combination Knowledge
@@ -915,7 +920,6 @@ items:
 - \Faron\Faron Woods\Door to Lake Floria\Open Door to Lake Floria
 - \Faron\Faron Woods\Door to Lake Floria\Rupee on Platform near Floria Door
 - \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest\Chest inside Great Tree
-- \Faron\Faron Woods\Great Tree\Upper Area\Remove Void Plane
 - \Faron\Faron Woods\Great Tree\Top\Unlock Statue
 - \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree North Branch
 - \Faron\Faron Woods\Great Tree\Top\Rupee on Great Tree West Branch
@@ -1082,7 +1086,6 @@ items:
 - \Lanayru\Desert\Entry\High Ledge after Vines\Retrieve Party Wheel
 - \Lanayru\Desert\Entry\High Ledge after Vines\Chest near Party Wheel
 - \Lanayru\Desert\Near Caged Robot\Chest near Caged Robot
-- \Lanayru\Desert\Near Caged Robot\Goddess Cube near Caged Robot
 - \Lanayru\Desert\Near Caged Robot\Blow up Rock for Timeshift Stone
 - \Lanayru\Desert\Near Caged Robot\Rescue Caged Robot
 - \Lanayru\Desert\Near Caged Robot\Blow Statues to Sand Oasis Down
@@ -1092,6 +1095,7 @@ items:
 - \Lanayru\Desert\West Part\Push Minecart
 - \Lanayru\Desert\Near South Exit to Temple of Time\Push Minecart
 - \Lanayru\Desert\Top of West Wall\Chest near Sand Oasis
+- \Lanayru\Desert\Top of West Wall\Goddess Cube near Caged Robot
 - \Lanayru\Desert\Top of West Wall\Push Minecart
 - \Lanayru\Desert\Top of LMF\Chest on top of Lanayru Mining Facility
 - \Lanayru\Desert\North Part\Water Node
@@ -1339,7 +1343,6 @@ items:
 - \Skyloft\Central Skyloft\Shed Chest
 - \Skyloft\Central Skyloft\Shed Goddess Chest
 - \Skyloft\Central Skyloft\Open Trial Gate
-- \Skyloft\Central Skyloft\Waterfall Cave Crystals from above
 - \Skyloft\Central Skyloft\Crystal on Waterfall Island from the ground
 - \Skyloft\Central Skyloft\Open Cave Entrance
 - \Skyloft\Central Skyloft\Bird Nest\Item in Bird Nest
@@ -2425,6 +2428,10 @@ areas:
     Empty Bottle_: Empty Bottle
     Bottle: "\\Pouch & \\Skyloft\\Central Skyloft\\Bazaar\\Item Check Access & \\\
       Empty Bottle_"
+    Guardian Potion Plus: "\\Bottle & \\Bug Net & \\Can Medium Rupee Farm & Emerald\
+      \ Tablet & Ruby Tablet"
+    Shield: "\\Pouch & \\Skyloft\\Central Skyloft\\Bazaar\\Item Check Access & \\\
+      Can Afford 50 Rupees"
     Can Collect Water: 'False'
     Water Bottle: "\\Bottle & \\Can Collect Water"
     Ancient Flower Farming: 'False'
@@ -2488,7 +2495,9 @@ areas:
     Can Defeat Cursed Bokoblins: "\\Sword | Bomb Bag"
     Can Defeat Stalfos: \Sword
     Can Defeat Stalmaster: \Sword
-    Can Defeat Scervo/Dreadfuse: \Sword
+    Can Defeat Scervo/Dreadfuse: "\\Sword & \\Shield"
+    Can Defeat Sentrobe: \Shield
+    Can Defeat Demise: "\\Sword & \\Shield & (One Demise | \\Guardian Potion Plus)"
   name: ''
   sub_areas:
     Ancient Cistern:
@@ -3939,7 +3948,7 @@ areas:
               hint_region: Sealed Grounds
               locations:
                 Zelda's Blessing: 'True'
-                Defeat Demise: "Horde Door Requirement & \\Sword"
+                Defeat Demise: "Horde Door Requirement & \\Sword & \\Shield"
               name: \Faron\Sealed Grounds\Hylia's Temple
               sub_areas: {}
               toplevel_alias: null
@@ -4246,16 +4255,11 @@ areas:
                   - Upper Entrance from Platforms
                   - Entrance from Top
                   exits:
-                    \Faron\Faron Woods\Great Tree\Lower Area: \Faron\Faron Woods\Great
-                      Tree\Upper Area\Remove Void Plane
-                    \Faron\Faron Woods\Great Tree\Lower Area\Path to Chest: \Faron\Faron
-                      Woods\Great Tree\Upper Area\Remove Void Plane
                     Exit to Flooded Great Tree: 'True'
                     Upper Exit to Platforms: 'True'
                     Exit to Top: 'True'
                   hint_region: Faron Woods
-                  locations:
-                    Remove Void Plane: \Can Defeat Moblins
+                  locations: {}
                   name: \Faron\Faron Woods\Great Tree\Upper Area
                   sub_areas: {}
                   toplevel_alias: null
@@ -5102,7 +5106,7 @@ areas:
             Exit to Flame Room: \Fire Sanctuary\Boss Room\Beat Ghirahim
           hint_region: Fire Sanctuary
           locations:
-            Beat Ghirahim: \Sword
+            Beat Ghirahim: "\\Goddess Sword & \\Shield"
             Heart Container: \Fire Sanctuary\Boss Room\Beat Ghirahim
           name: \Fire Sanctuary\Boss Room
           sub_areas: {}
@@ -5473,7 +5477,7 @@ areas:
                   \ - Minecart Jump Trick & \\Sword & (Bomb Bag | \\Beetle)"
                 \Lanayru Mining Facility\Main\Big Hub\Between Wind Gates: "\\Lanayru\
                   \ Mining Facility\\Main\\Near Boss Door\\Open Second Wind Gate &\
-                  \ \\Can Defeat Beamos"
+                  \ \\Can Defeat Beamos & \\Can Defeat Sentrobe"
               hint_region: Lanayru Mining Facility
               locations:
                 Get Minecart to Wind Gate: "Gust Bellows & \\Lanayru Mining Facility\\\
@@ -5788,7 +5792,6 @@ areas:
               hint_region: Lanayru Desert
               locations:
                 Chest near Caged Robot: 'True'
-                Goddess Cube near Caged Robot: \Long Range Skyward Strike
                 Blow up Rock for Timeshift Stone: "Bomb Bag | \\Hook Beetle | Lanayru\
                   \ Desert - Ampilus Bomb Toss Trick"
                 Rescue Caged Robot: "\\Lanayru\\Desert\\Near Caged Robot\\Blow up\
@@ -5889,8 +5892,7 @@ areas:
               hint_region: Lanayru Desert
               locations:
                 Chest near Sand Oasis: 'True'
-                \Lanayru\Desert\Near Caged Robot\Goddess Cube near Caged Robot: \Goddess
-                  Sword
+                Goddess Cube near Caged Robot: \Goddess Sword
                 Push Minecart: 'True'
               name: \Lanayru\Desert\Top of West Wall
               sub_areas: {}
@@ -7712,8 +7714,8 @@ areas:
               locations:
                 Southwest Triple Island Upper Goddess Chest: \Eldin\Volcano\Entry\Goddess
                   Cube at Eldin Entrance
-                Southwest Triple Island Lower Goddess Chest: \Lanayru\Desert\Near
-                  Caged Robot\Goddess Cube near Caged Robot
+                Southwest Triple Island Lower Goddess Chest: \Lanayru\Desert\Top of
+                  West Wall\Goddess Cube near Caged Robot
                 Southwest Triple Island Cage Goddess Chest: "\\Lanayru\\Lanayru Sand\
                   \ Sea\\Skipper's Retreat\\Past Rock\\Goddess Cube in Skipper's Retreat\
                   \ & Clawshots"
@@ -8049,12 +8051,9 @@ areas:
               \ (\\Beetle | Whip)"
             Open Trial Gate: "Goddess's Harp & \\Song of the Hero"
             \Can Collect Water: 'True'
-            Waterfall Cave Crystals from above: \Beetle
             Crystal on Waterfall Island from the ground: \Quick Beetle
-            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: "Night\
-              \ & \\Skyloft\\Central Skyloft\\Waterfall Cave Crystals from above"
-            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: "Night\
-              \ & \\Skyloft\\Central Skyloft\\Waterfall Cave Crystals from above"
+            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal after Waterfall Cave: Night
+            \Skyloft\Central Skyloft\Past Waterfall Cave\Crystal in Loftwing Prison: Night
             \Skyloft\Central Skyloft\Waterfall Island\Crystal on Waterfall Island: "Night\
               \ & \\Skyloft\\Central Skyloft\\Crystal on Waterfall Island from the\
               \ ground"
@@ -8840,7 +8839,7 @@ areas:
             Exit to Spring: \Skyview\Boss Room\Beat Ghirahim
           hint_region: Skyview
           locations:
-            Beat Ghirahim: \Sword
+            Beat Ghirahim: "\\Sword & \\Shield"
             Heart Container: \Skyview\Boss Room\Beat Ghirahim
           name: \Skyview\Boss Room
           sub_areas: {}

--- a/dump.yaml
+++ b/dump.yaml
@@ -3948,7 +3948,7 @@ areas:
               hint_region: Sealed Grounds
               locations:
                 Zelda's Blessing: 'True'
-                Defeat Demise: "Horde Door Requirement & \\Sword & \\Shield"
+                Defeat Demise: "Horde Door Requirement & \\Can Defeat Demise"
               name: \Faron\Sealed Grounds\Hylia's Temple
               sub_areas: {}
               toplevel_alias: null

--- a/logic/constants.py
+++ b/logic/constants.py
@@ -31,6 +31,7 @@ NONLETHAL_HOT_CAVE = EIN("Nonlethal Hot Cave")
 UPGRADED_SKYWARD_STRIKE = EIN("Upgraded Skyward Strike option")
 FS_LAVA_FLOW_OPTION = EIN("FS Lava Flow option")
 NO_RANDOM_PUZZLES_OPTION = EIN("No Random Puzzles option")
+ONE_DEMISE = EIN("One Demise")
 
 GOT_OPENING_REQUIREMENT = EIN("GoT Opening Requirement")
 GOT_RAISING_REQUIREMENT = EIN("GoT Raising Requirement")
@@ -53,6 +54,7 @@ LOGIC_OPTIONS = dict.fromkeys(
         UPGRADED_SKYWARD_STRIKE,
         FS_LAVA_FLOW_OPTION,
         NO_RANDOM_PUZZLES_OPTION,
+        ONE_DEMISE,
         GOT_OPENING_REQUIREMENT,
         GOT_RAISING_REQUIREMENT,
         HORDE_DOOR_REQUIREMENT,

--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -438,6 +438,7 @@ class Rando:
             UPGRADED_SKYWARD_STRIKE: self.options["upgraded-skyward-strike"],
             FS_LAVA_FLOW_OPTION: self.options["fs-lava-flow"],
             NO_RANDOM_PUZZLES_OPTION: not self.options["random-puzzles"],
+            ONE_DEMISE: self.options["demise-count"] == 1,
         }
 
         enabled_tricks = set(self.options["enabled-tricks-bitless"])

--- a/logic/requirements/Faron.yaml
+++ b/logic/requirements/Faron.yaml
@@ -42,7 +42,7 @@ Sealed Grounds:
       Gate of Time: Nothing
     locations:
       Zelda's Blessing: Nothing
-      Defeat Demise: Horde Door Requirement & Sword & Shield # for beginner friendliness
+      Defeat Demise: Horde Door Requirement & Can Defeat Demise
 
   Behind the Temple:
     exits:

--- a/logic/requirements/Faron.yaml
+++ b/logic/requirements/Faron.yaml
@@ -42,7 +42,7 @@ Sealed Grounds:
       Gate of Time: Nothing
     locations:
       Zelda's Blessing: Nothing
-      Defeat Demise: Horde Door Requirement & Sword
+      Defeat Demise: Horde Door Requirement & Sword & Shield # for beginner friendliness
 
   Behind the Temple:
     exits:
@@ -183,13 +183,9 @@ Faron Woods:
 
     Upper Area: # top with the moblin
       exits:
-        Lower Area: Remove Void Plane
-        Lower Area - Path to Chest: Remove Void Plane
         Exit to Flooded Great Tree: Nothing
         Upper Exit to Platforms: Nothing
         Exit to Top: Nothing
-      locations:
-        Remove Void Plane: Can Defeat Moblins
 
     Top:
       exits:

--- a/logic/requirements/Fire Sanctuary.yaml
+++ b/logic/requirements/Fire Sanctuary.yaml
@@ -233,7 +233,7 @@ Boss Room:
     Exit to Dungeon: Beat Ghirahim
     Exit to Flame Room: Beat Ghirahim
   locations:
-    Beat Ghirahim: Sword
+    Beat Ghirahim: Goddess Sword & Shield # for beginner friendliness
     Heart Container: Beat Ghirahim
 
 Flame Room:

--- a/logic/requirements/Lanayru Mining Facility.yaml
+++ b/logic/requirements/Lanayru Mining Facility.yaml
@@ -139,7 +139,7 @@ Main:
     exits:
       Boss Door: Lanayru Mining Facility Boss Key & Can Activate Minecart Timeshift Stone
       Big Hub - Near Boss Key Room Second Exit: LMF - Minecart Jump Trick & Sword & (Bomb Bag | Beetle)
-      Big Hub - Between Wind Gates: Open Second Wind Gate & Can Defeat Beamos
+      Big Hub - Between Wind Gates: Open Second Wind Gate & Can Defeat Beamos & Can Defeat Sentrobe
     locations:
       Get Minecart to Wind Gate: Gust Bellows & Can Activate Minecart Timeshift Stone
       Open Second Wind Gate: Get Minecart to Wind Gate & Gust Bellows

--- a/logic/requirements/Lanayru.yaml
+++ b/logic/requirements/Lanayru.yaml
@@ -93,7 +93,6 @@ Desert:
       Sand Oasis: Get Past Spume to Sand Oasis
     locations:
       Chest near Caged Robot: Nothing
-      Goddess Cube near Caged Robot: Long Range Skyward Strike # Also accessible elsewhere
       Blow up Rock for Timeshift Stone: Bomb Bag | Hook Beetle | Lanayru Desert - Ampilus Bomb Toss Trick
       Rescue Caged Robot: Blow up Rock for Timeshift Stone & Can Defeat Bokoblins
       Blow Statues to Sand Oasis Down: Hook Beetle
@@ -144,7 +143,7 @@ Desert:
       West Part: Nothing
     locations:
       Chest near Sand Oasis: Nothing
-      Near Caged Robot - Goddess Cube near Caged Robot: Goddess Sword
+      Goddess Cube near Caged Robot: Goddess Sword
       Push Minecart: Nothing
 
   Top of LMF:

--- a/logic/requirements/Skyloft.yaml
+++ b/logic/requirements/Skyloft.yaml
@@ -104,10 +104,9 @@ Central Skyloft:
       Baby Rattle from Beedle's Shop Trick & Day & Distance Activator & Gust Bellows & (Beetle | Whip)
     Open Trial Gate: Goddess's Harp & Song of the Hero
     General - Can Collect Water: Nothing
-    Waterfall Cave Crystals from above: Beetle
     Crystal on Waterfall Island from the ground: Quick Beetle
-    Past Waterfall Cave - Crystal after Waterfall Cave: Night & Waterfall Cave Crystals from above
-    Past Waterfall Cave - Crystal in Loftwing Prison: Night & Waterfall Cave Crystals from above
+    Past Waterfall Cave - Crystal after Waterfall Cave: Night
+    Past Waterfall Cave - Crystal in Loftwing Prison: Night
     Waterfall Island - Crystal on Waterfall Island: Night & Crystal on Waterfall Island from the ground
     Open Cave Entrance: Sword | Bomb Bag
 

--- a/logic/requirements/Skyloft.yaml
+++ b/logic/requirements/Skyloft.yaml
@@ -45,8 +45,7 @@ Upper Skyloft:
         Crystal in Link's Room: Night
 
     Zelda's Room:
-      entrance:
-        Unlocked Zelda's Room
+      entrance: Unlocked Zelda's Room
       exits:
         Chimney: Impossible
         Knight Academy: Nothing
@@ -100,13 +99,10 @@ Central Skyloft:
     Parrow's Crystals: Sky - Save Orielle & Day
     Shed Chest: Water Dragon's Scale
     Shed Goddess Chest: Water Dragon's Scale & Eldin - Goddess Cube on Sand Slide
-    Bird Nest - Item in Bird Nest:
-      Baby Rattle from Beedle's Shop Trick & Day & Distance Activator & Gust Bellows & (Beetle | Whip)
+    Bird Nest - Item in Bird Nest: Baby Rattle from Beedle's Shop Trick & Day & Distance Activator & Gust Bellows & (Beetle | Whip)
     Open Trial Gate: Goddess's Harp & Song of the Hero
     General - Can Collect Water: Nothing
     Crystal on Waterfall Island from the ground: Quick Beetle
-    Past Waterfall Cave - Crystal after Waterfall Cave: Night
-    Past Waterfall Cave - Crystal in Loftwing Prison: Night
     Waterfall Island - Crystal on Waterfall Island: Night & Crystal on Waterfall Island from the ground
     Open Cave Entrance: Sword | Bomb Bag
 
@@ -135,13 +131,11 @@ Central Skyloft:
       exits:
         Bazaar: Nothing
       locations:
-        Upgrade to Quick Beetle:
-          $ Hook Beetle &
+        Upgrade to Quick Beetle: $ Hook Beetle &
           Faron - Deep Woods - Hornet Larvae Farming &
           General - Ancient Flower Farming &
           Sky - Clean Cut Minigame # Golden Skull farming
-        Upgrade to Tough Beetle:
-          $ Quick Beetle &
+        Upgrade to Tough Beetle: $ Quick Beetle &
           Faron - Faron Woods - Amber Relic Farming &
           General - Ancient Flower Farming &
           Sky - Clean Cut Minigame # Goddess Plumes / Blue Bird Feathers farming

--- a/logic/requirements/Skyview.yaml
+++ b/logic/requirements/Skyview.yaml
@@ -162,7 +162,7 @@ Boss Room:
     Exit to Dungeon: Beat Ghirahim
     Exit to Spring: Beat Ghirahim
   locations:
-    Beat Ghirahim: Sword
+    Beat Ghirahim: Sword & Shield # for beginner friendliness
     Heart Container: Beat Ghirahim
 
 Spring:

--- a/logic/requirements/macros.yaml
+++ b/logic/requirements/macros.yaml
@@ -119,6 +119,14 @@ Empty Bottle_ : $ Empty Bottle x 1
 Bottle:
   Pouch & Skyloft - Item Check Access & Empty Bottle_
 
+Guardian Potion Plus:
+  Bottle & Bug Net & Can Medium Rupee Farm & Emerald Tablet & Ruby Tablet
+  # Potion costs 200R + 40 more for the upgrade
+  # The potion needs Faron Grasshoppers and Eldin Rollers
+
+Shield:
+  Pouch & Skyloft - Item Check Access & Can Afford 50 Rupees # Wooden Shield
+
 Can Collect Water: Impossible # To be completed locally
 
 Water Bottle: Bottle & Can Collect Water
@@ -276,5 +284,11 @@ Can Defeat Stalmaster:
   Sword
 
 Can Defeat Scervo/Dreadfuse:
-  Sword
-  # Could add Pouch for a shield
+  Sword & Shield # for beginner-friendliness
+
+Can Defeat Sentrobe:
+  Shield # for beginner-friendliness
+
+Can Defeat Demise:
+  Sword & Shield & (One Demise | Guardian Potion Plus)
+  # Require access to a Guardian Potion Plus if multiple demises are enabled


### PR DESCRIPTION
## What does this PR do?
Adds some suggested requirements to certain checks to be less tough on beginners. See [the suggestion in Discord](https://discord.com/channels/767090759773323264/1296119528291307565). The suggestions were as follows:

```
- Waterfall Cave Gratitude Crystals should require the ability to traverse (Bomb Bag or Sword) - this is for beginners
- Consider making Great Tree Chest only available with Bellows/Scale (so the jump down is out of logic) - again, for beginners
- Goddess Cube near Caged Robot should require Clawshots (no silly jump) - again, for beginners
- Scervo, G1, G2, and G3/Demise should logically require ability to purchase a shield - important for beginners (but for Scervo, also experienced runners!)
- Goddess Sword should be required for Ghirahim 2 - for everyone.
- Potentially add shield requirement for Shortcut Chest/BK Chest in LMF for killing the Sentrobe? - I think this is a decent change from HDR that is... again, beginner-friendly!
- Logical Bug Net and Bottle requirement for multiple Demises (to do potion upgrades)
```

## How do you test these changes?
I examined relevant locations using the web tracker (though I had to run it locally to account for one goddess cube being moved to a different area):
<img width="392" height="114" alt="image" src="https://github.com/user-attachments/assets/3b34cbd0-50b4-41f5-89e5-e91816255adf" />
<img width="392" height="114" alt="image" src="https://github.com/user-attachments/assets/0328ab22-4b99-4d16-a91e-e746db04d377" />
<img width="435" height="173" alt="image" src="https://github.com/user-attachments/assets/bdb162fa-9e12-4bb9-b426-d0218a98f3b9" />
<img width="398" height="224" alt="image" src="https://github.com/user-attachments/assets/19c23fe8-020c-43db-bec7-ffb4cd3c10db" />
<img width="765" height="249" alt="image" src="https://github.com/user-attachments/assets/91421544-64ad-45d1-b8bc-2e768028f552" />
<img width="761" height="323" alt="image" src="https://github.com/user-attachments/assets/f069b224-674f-41b6-86df-5f972ba82606" />
<img width="750" height="270" alt="image" src="https://github.com/user-attachments/assets/1bdfce0b-b0a5-4714-bebe-ff939859b20d" />
Defeat Demise doesn't appear on the tracker, but in a seed with no minigames, no scrap shop upgrades, and two Demises, `Progressive Bug Net` was a SotS item:
<img width="623" height="310" alt="image" src="https://github.com/user-attachments/assets/758388d8-8062-4513-a57b-407baa501ec7" />

## Notes
As I mentioned above, the tracker needs to be updated to properly support this version since the `Cube near Caged Robot` was moved to a different logical area so it is accessible only from the ledge with Clawshots.
